### PR TITLE
Added drumkit/percussion support to the AkaoSnes format.

### DIFF
--- a/src/main/SF2File.cpp
+++ b/src/main/SF2File.cpp
@@ -85,7 +85,18 @@ SF2File::SF2File(SynthFile *synthfile)
     memset(&presetHdr, 0, sizeof(sfPresetHeader));
     memcpy(presetHdr.achPresetName, instr->name.c_str(), min((unsigned long) instr->name.length(), (unsigned long) 20));
     presetHdr.wPreset = (uint16_t) instr->ulInstrument;
-    presetHdr.wBank = (uint16_t) instr->ulBank;
+
+    // Despite being a 16-bit value, SF2 only supports banks up to 127. Since
+    // it's pretty common to have either MSB or LSB be 0, we'll use whatever
+    // one is not zero, with preference for MSB.
+    uint16_t bank16 = (uint16_t)instr->ulBank;
+
+    if ((bank16 & 0xFF00) == 0) {
+      presetHdr.wBank = bank16 & 0x7F;
+    }
+    else {
+      presetHdr.wBank = (bank16 >> 8) & 0x7F;
+    }
     presetHdr.wPresetBagNdx = (uint16_t) i;
     presetHdr.dwLibrary = 0;
     presetHdr.dwGenre = 0;

--- a/src/main/formats/AkaoSnesInstr.h
+++ b/src/main/formats/AkaoSnesInstr.h
@@ -11,11 +11,14 @@
 class AkaoSnesInstrSet:
     public VGMInstrSet {
  public:
+  static const uint32_t DRUMKIT_PROGRAM = (0x7F << 14);
+
   AkaoSnesInstrSet(RawFile *file,
                    AkaoSnesVersion ver,
                    uint32_t spcDirAddr,
                    uint16_t addrTuningTable,
                    uint16_t addrADSRTable,
+                   uint16_t addrDrumKitTable,
                    const std::wstring &name = L"AkaoSnesInstrSet");
   virtual ~AkaoSnesInstrSet(void);
 
@@ -28,6 +31,7 @@ class AkaoSnesInstrSet:
   uint32_t spcDirAddr;
   uint16_t addrTuningTable;
   uint16_t addrADSRTable;
+  uint16_t addrDrumKitTable;
   std::vector<uint8_t> usedSRCNs;
 };
 
@@ -57,6 +61,34 @@ class AkaoSnesInstr
   uint16_t addrADSRTable;
 };
 
+// *************
+// AkaoSnesDrumKit
+// *************
+
+class AkaoSnesDrumKit
+  : public VGMInstr {
+public:
+  AkaoSnesDrumKit(VGMInstrSet *instrSet,
+                  AkaoSnesVersion ver,
+                  uint32_t programNum,
+                  uint32_t spcDirAddr,
+                  uint16_t addrTuningTable,
+                  uint16_t addrADSRTable,
+                  uint16_t addrDrumKitTable,
+                  const std::wstring &name = L"AkaoSnesDrumKit");
+  virtual ~AkaoSnesDrumKit(void);
+
+  virtual bool LoadInstr();
+
+  AkaoSnesVersion version;
+
+protected:
+  uint32_t spcDirAddr;
+  uint16_t addrTuningTable;
+  uint16_t addrADSRTable;
+  uint16_t addrDrumKitTable;
+};
+
 // ***********
 // AkaoSnesRgn
 // ***********
@@ -64,15 +96,42 @@ class AkaoSnesInstr
 class AkaoSnesRgn
     : public VGMRgn {
  public:
-  AkaoSnesRgn(AkaoSnesInstr *instr,
+  AkaoSnesRgn(VGMInstr *instr,
               AkaoSnesVersion ver,
-              uint8_t srcn,
-              uint32_t spcDirAddr,
-              uint16_t addrTuningTable,
-              uint16_t addrADSRTable);
+              uint16_t addrTuningTable);
   virtual ~AkaoSnesRgn(void);
 
+  bool InitializeRegion(uint8_t srcn,
+                        uint32_t spcDirAddr,
+                        uint16_t addrADSRTable);
   virtual bool LoadRgn();
 
   AkaoSnesVersion version;
+};
+
+// ***********
+// AkaoSnesDrumKitRgn
+// ***********
+
+class AkaoSnesDrumKitRgn
+  : public AkaoSnesRgn {
+public:
+  // We need some space to move for unityKey, since we might need it to go
+  // less than the current note, so we add this to all the percussion notes.
+  // This value can be anything from 0 to 127, but being near the middle of
+  // the range gives it a decent chance of not going out of range in either
+  // direction.
+  static const uint8_t KEY_BIAS = 60;
+
+  AkaoSnesDrumKitRgn(AkaoSnesDrumKit *instr,
+                     AkaoSnesVersion ver,
+                     uint16_t addrTuningTable);
+  virtual ~AkaoSnesDrumKitRgn(void);
+
+  bool InitializePercussionRegion(uint8_t srcn,
+                                  uint32_t spcDirAddr,
+                                  uint16_t addrADSRTable,
+                                  uint16_t addrDrumKitTable);
+
+  uint8_t srcn;
 };

--- a/src/main/formats/AkaoSnesScanner.h
+++ b/src/main/formats/AkaoSnesScanner.h
@@ -32,4 +32,5 @@ class AkaoSnesScanner:
   static BytePattern ptnLoadInstrV1;
   static BytePattern ptnLoadInstrV2;
   static BytePattern ptnLoadInstrV3;
+  static BytePattern ptnReadPercussionTableV4;
 };

--- a/src/main/formats/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnesSeq.cpp
@@ -674,7 +674,12 @@ bool AkaoSnesTrack::ReadEvent(void) {
       if (noteIndex < 12) {
         uint8_t note = octave * 12 + noteIndex;
 
-        AddNoteByDur(beginOffset, curOffset - beginOffset, percussion ? (noteIndex + AkaoSnesDrumKitRgn::KEY_BIAS) : note, vel, dur);
+        if (percussion) {
+          AddNoteByDur(beginOffset, curOffset - beginOffset, noteIndex + AkaoSnesDrumKitRgn::KEY_BIAS - transpose, vel, dur, L"Percussion Note with Duration");
+        }
+        else {
+          AddNoteByDur(beginOffset, curOffset - beginOffset, note, vel, dur);
+        }
 
         AddTime(len);
       }

--- a/src/main/formats/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnesSeq.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "AkaoSnesSeq.h"
+#include "AkaoSnesInstr.h"
 #include "ScaleConversion.h"
 
 DECLARE_FORMAT(AkaoSnes);
@@ -574,6 +575,8 @@ void AkaoSnesTrack::ResetVars(void) {
   loopLevel = 0;
   slur = false;
   legato = false;
+  percussion = false;
+  nonPercussionProgram = 0;
 
   ignoreMasterVolumeProgNum = 0xff;
 }
@@ -671,9 +674,8 @@ bool AkaoSnesTrack::ReadEvent(void) {
       if (noteIndex < 12) {
         uint8_t note = octave * 12 + noteIndex;
 
-        // TODO: percussion note
+        AddNoteByDur(beginOffset, curOffset - beginOffset, percussion ? (noteIndex + AkaoSnesDrumKitRgn::KEY_BIAS) : note, vel, dur);
 
-        AddNoteByDur(beginOffset, curOffset - beginOffset, note, vel, dur);
         AddTime(len);
       }
       else if (noteIndex == parentSeq->STATUS_NOTEINDEX_TIE) {
@@ -1013,6 +1015,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_PROGCHANGE: {
       uint8_t newProg = GetByte(curOffset++);
       AddProgramChange(beginOffset, curOffset - beginOffset, newProg);
+      nonPercussionProgram = newProg;
       break;
     }
 
@@ -1460,6 +1463,8 @@ bool AkaoSnesTrack::ReadEvent(void) {
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
+      percussion = true;
+      AddProgramChangeNoItem(AkaoSnesInstrSet::DRUMKIT_PROGRAM, true);
       break;
     }
 
@@ -1470,6 +1475,8 @@ bool AkaoSnesTrack::ReadEvent(void) {
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
+      percussion = false;
+      AddProgramChangeNoItem(nonPercussionProgram, true);
       break;
     }
 

--- a/src/main/formats/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnesSeq.h
@@ -142,6 +142,8 @@ class AkaoSnesTrack
   uint8_t onetimeDuration;
   bool slur;
   bool legato;
+  bool percussion;
+  uint8_t nonPercussionProgram;
 
   uint8_t loopLevel;
   uint8_t loopIncCount[AKAOSNES_LOOP_LEVEL_MAX];


### PR DESCRIPTION
The commit comment on bf25c3c has more details, but this adds percussion support to the AkaoSnes format (which was previously listed in the source as "TODO: percussion note"). As far as I've found, the percussion table is used in Chrono Trigger, Front Mission, and Front Mission - Gun Hazard.

Some percussion is implemented using the SPC700 white noise capability, and this commit doesn't fix that, but it does fix major parts of a lot of the songs from those games.