### PR TITLE
[core] Fix MP2kScanner.(h|cpp) compile.

### DIFF
--- a/src/main/formats/MP2kScanner.cpp
+++ b/src/main/formats/MP2kScanner.cpp
@@ -198,14 +198,14 @@ std::optional<size_t> MP2kScanner::DetectMP2K(RawFile *file) {
             continue;
         }
 
-        int validsongcount = 0;
-        for (int songindex = 0; validsongcount < 1; songindex++) {
-            uint32_t songaddroffset = songtable_ofs_tmp + (songindex * 8);
+        u32 validsongcount = 0;
+        for (u32 songindex = 0; validsongcount < 1; songindex++) {
+            u32 songaddroffset = songtable_ofs_tmp + (songindex * 8);
             if (!IsValidOffset(songaddroffset + 4 - 1, file->size())) {
                 break;
             }
 
-            uint32_t songaddr = file->GetWord(songaddroffset);
+            u32 songaddr = file->GetWord(songaddroffset);
             if (songaddr == 0) {
                 continue;
             }
@@ -234,7 +234,7 @@ std::optional<size_t> MP2kScanner::DetectMP2K(RawFile *file) {
         return std::nullopt;
     }
 
-    uint32_t main_ofs_tmp = select_song - file->begin();
+    u32 main_ofs_tmp = select_song - file->begin();
     if (!IsValidOffset(main_ofs_tmp + 2 - 1, file->size())) {
         return std::nullopt;
     }
@@ -264,16 +264,16 @@ std::optional<size_t> MP2kScanner::DetectMP2K(RawFile *file) {
     return main_ofs - (valid_m16 ? 16 : 32);
 }
 
-bool MP2kScanner::IsValidOffset(uint32_t offset, uint32_t romsize) {
+bool MP2kScanner::IsValidOffset(u32 offset, u32 romsize) {
     return (offset < romsize);
 }
 
-bool MP2kScanner::IsGBAROMAddress(uint32_t address) {
-    uint8_t region = (address >> 24) & 0xFE;
+bool MP2kScanner::IsGBAROMAddress(u32 address) {
+    u8 region = (address >> 24) & 0xFE;
     return (region == 8);
 }
 
-uint32_t MP2kScanner::GBAAddressToOffset(uint32_t address) {
+u32 MP2kScanner::GBAAddressToOffset(u32 address) {
     if (!IsGBAROMAddress(address)) {
         L_WARN("Address {:#x} is not a ROM address", address);
     }

--- a/src/main/formats/MP2kScanner.h
+++ b/src/main/formats/MP2kScanner.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Scanner.h"
+#include "common.h"
 #include <optional>
 
 /* Scanner for the MP2K (aka Sappy) GBA format */
@@ -16,7 +17,7 @@ class MP2kScanner final : public VGMScanner {
 
    private:
     std::optional<size_t> DetectMP2K(RawFile *file);
-    static bool IsValidOffset(uint32_t offset, uint32_t romsize);
-    static bool IsGBAROMAddress(uint32_t address);
-    static uint32_t GBAAddressToOffset(uint32_t address);
+    static bool IsValidOffset(u32 offset, u32 romsize);
+    static bool IsGBAROMAddress(u32 address);
+    static u32 GBAAddressToOffset(u32 address);
 };


### PR DESCRIPTION
Change use of uint32_t to u32 and include common.h.

<!--- Provide a general summary of your changes in the Title above -->

## Description
In trying to build, I encountered an error with the type uint32_t not being declared in MP2kScanner.h and in investigating i discovered that in many places in MP2kScanner.cpp, u32 declared in common.h is used, so to make the code compile and make it consistent with the rest of the module, I changed it to use the equivalent u32 type.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes a compile failure with the particular module.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Program compiles and runs, however I don't know what games use this particular format nor do I likely have them on hand so someone more familiar with this format would have to test functionality.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
