### PR TITLE
RFC: New MusicPlayer playback logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,9 @@ jobs:
           sudo apt clean
           sudo apt update
           sudo apt install -y pkg-config qt515base qt515svg qt515wayland libjack-dev libsndfile1-dev libpulse-dev libglib2.0-dev ninja-build libgl1-mesa-dev
-          wget https://github.com/FluidSynth/fluidsynth/archive/v2.1.9.zip
-          unzip v2.1.9.zip
-          cd fluidsynth-2.1.9
+          wget https://github.com/FluidSynth/fluidsynth/archive/v2.2.5.zip
+          unzip v2.2.5.zip
+          cd fluidsynth-2.2.5
           mkdir build && cd build
           cmake -DCMAKE_C_COMPILER="gcc-10" -DCMAKE_CXX_COMPILER="g++-10" -Denable-network=off -Denable-ipv6=off -DCMAKE_INSTALL_PREFIX=/usr/ -DLIB_INSTALL_DIR=lib -GNinja ..
           cmake --build . --config "Release" --parallel

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/gsl-lite"
                  "${CMAKE_CURRENT_BINARY_DIR}/gsl-lite" EXCLUDE_FROM_ALL)
 
-set(FluidSynth_FIND_VERSION "2.0.0")
+set(FluidSynth_FIND_VERSION "2.2.0")
 find_package(FluidSynth)
 if(FluidSynth_FOUND AND "${FluidSynth_VERSION}" MATCHES "2(.)*")
   message(STATUS "Using FluidSynth ${FluidSynth_VERSION}")

--- a/src/ui/qt/MusicPlayer.cpp
+++ b/src/ui/qt/MusicPlayer.cpp
@@ -386,10 +386,6 @@ void MusicPlayer::processMidiFile(std::unique_ptr<MidiFile> midi) {
     return;
   }
 
-  /* We want events in their absolute time order, sorted by priority */
-  std::stable_sort(std::begin(events), std::end(events), PriorityCmp());
-  std::stable_sort(std::begin(events), std::end(events), AbsTimeCmp());
-
   /* Default to 120 BPM */
   auto ppqn = midi->GetPPQN();
   fluid_sequencer_set_time_scale(m_sequencer.get(), 1000000.0 * (ppqn / 500000.0));

--- a/src/ui/qt/MusicPlayer.cpp
+++ b/src/ui/qt/MusicPlayer.cpp
@@ -442,11 +442,6 @@ void MusicPlayer::processMidiFile(std::unique_ptr<MidiFile> midi) {
         break;
       }
 
-      case MIDIEVENT_MASTERVOL: {
-        // todo: this needs to be done with some sort of callback to change the synth gain at a
-        // specific tick count
-      }
-
       case MIDIEVENT_MODULATION: {
         auto modulation = dynamic_cast<ModulationEvent *>(event);
         fluid_event_modulation(seq_event, channel, modulation->dataByte);
@@ -482,6 +477,7 @@ void MusicPlayer::processMidiFile(std::unique_ptr<MidiFile> midi) {
       default:
       /* These 3 events are not useful when listening to the track */
       case MIDIEVENT_ENDOFTRACK:
+      case MIDIEVENT_MASTERVOL:
       case MIDIEVENT_TEXT: {
         delete_fluid_event(seq_event);
         continue;

--- a/src/ui/qt/MusicPlayer.cpp
+++ b/src/ui/qt/MusicPlayer.cpp
@@ -229,25 +229,26 @@ void MusicPlayer::makeSequencer() {
 }
 
 bool MusicPlayer::playing() const {
-  return m_sequencer != nullptr;
+  return m_sequencer != nullptr && elapsedTicks() <= totalTicks();
 }
 
-void MusicPlayer::seek(int position) {
+void MusicPlayer::seek(int) {
   /* TODO: Reimplement */
   return;
 }
 
 bool MusicPlayer::toggle() {
   /* TODO: Implement pausing */
-
   if (!m_sequencer) {
     return false;
   }
 
-  m_sequencer = nullptr;
-  statusChange(false);
+  if (playing()) {
+    stop();
+  }
 
-  return false;
+  statusChange(true);
+  return true;
 }
 
 void MusicPlayer::stop() {
@@ -302,7 +303,9 @@ bool MusicPlayer::playCollection(VGMColl *coll) {
 
   auto midi = std::unique_ptr<MidiFile>(seq->ConvertToMidi());
   processMidiFile(std::move(midi));
+
   statusChange(true);
+  m_active_coll = coll;
 
   return true;
 }


### PR DESCRIPTION
This replaces the current playback logic in MusicPlayer with a custom sequencer using `fluid_sequencer_t`.

## Description
The MIDI player was replaced with an instance of a sequencer. All the events from the MIDI file are mapped onto FluidSynth events and are scheduled to play at their initial tick.

All of that dynamic casting isn't pretty; it's not strictly necessary so it can be changed to static_cast, which is faster. I will do that once all the MIDI events are implemented and we don't risk mis-casting.

Pausing and seeking will be tricky to implement, as they require manually stepping the synth - and this is not supported when using the synth like we do.

The master volume event remains unimplemented as FluidSynth only has limited SysEx support.

## Motivation and Context
This new mechanism allows us to define custom channel mappings and to interact with the underlying synth directly,
letting us bypass limitations imposed by Standard MIDI.

## How Has This Been Tested?
By playing back various files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## TODO:
- [x] Implement MIDI events 
- [x] Implement proper bank select (fixes #264)
- [x] Improve the situation with #197
- [ ] ~~Implement global volume event~~
- [x] Bypass MIDI channel 10 (fixes #289)
- [ ] Implement pausing
- [ ] Implement seeking

