### PR TITLE
[NinSnes] Don't increment the timer after EVENT_END ($00 VCMD)

### DIFF
--- a/src/main/VGMSeq.cpp
+++ b/src/main/VGMSeq.cpp
@@ -27,6 +27,7 @@ VGMSeq::VGMSeq(const string &format, RawFile *file, uint32_t offset, uint32_t le
       bAlwaysWriteInitialMono(false),
       bAllowDiscontinuousTrackData(false),
       bLoadTickByTick(false),
+      bIncTickAfterProcessingTracks(true),
       initialVol(100),                    //GM standard (dls1 spec p16)
       initialExpression(127),            //''
       initialReverb(40),                //GM standard
@@ -215,8 +216,10 @@ void VGMSeq::LoadTracksMain(long stopTime) {
         itrSlider = itrNextSlider;
       }
 
-      time++;
-
+      if (bIncTickAfterProcessingTracks == true) {
+        time++;
+      }
+      bIncTickAfterProcessingTracks = true;
       if (readMode == READMODE_CONVERT_TO_MIDI) {
         for (uint32_t trackNum = 0; trackNum < nNumTracks; trackNum++) {
           if (aTracks[trackNum]->pMidiTrack != NULL) {

--- a/src/main/VGMSeq.h
+++ b/src/main/VGMSeq.h
@@ -123,7 +123,8 @@ class VGMSeq: public VGMFile {
   //     It can be used anyway, but it is useless and annoys you, in most cases.
   bool bLoadTickByTick;
   
-  // There may be a rare case when you do not want to increment the tick counter after processing a tick because you want to go to a new section.
+  // There may be a rare case when you do not want to increment the tick counter after
+  // processing a tick because you want to go to a new section.
   bool bIncTickAfterProcessingTracks;
 
   uint8_t initialVol;

--- a/src/main/VGMSeq.h
+++ b/src/main/VGMSeq.h
@@ -122,6 +122,9 @@ class VGMSeq: public VGMFile {
   //     because a track must pause the parsing every time a parser encounters to delta time event.
   //     It can be used anyway, but it is useless and annoys you, in most cases.
   bool bLoadTickByTick;
+  
+  // There may be a rare case when you do not want to increment the tick counter after processing a tick because you want to go to a new section.
+  bool bIncTickAfterProcessingTracks;
 
   uint8_t initialVol;
   uint8_t initialExpression;

--- a/src/main/formats/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnesSeq.cpp
@@ -838,6 +838,7 @@ bool NinSnesTrack::ReadEvent(void) {
 
         parentSeq->InactivateAllTracks();
         bContinue = false;
+        parentSeq->bIncTickAfterProcessingTracks = false;
       }
       else {
         uint32_t eventLength = curOffset - beginOffset;

--- a/src/main/formats/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnesSeq.cpp
@@ -906,9 +906,10 @@ bool NinSnesTrack::ReadEvent(void) {
       break;
     }
 
-    case EVENT_REST:
+    case EVENT_REST: {
       AddRest(beginOffset, curOffset - beginOffset, shared->spcNoteDuration);
       break;
+    }
 
     case EVENT_PERCUSSION_NOTE: {
       uint8_t noteNumber = statusByte - parentSeq->STATUS_PERCUSSION_NOTE_MIN;

--- a/src/main/formats/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnesSeq.cpp
@@ -1753,7 +1753,7 @@ bool NinSnesTrack::ReadEvent(void) {
       AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
       pRoot->AddLogItem(new LogItem(std::wstring(L"Unknown Event - ") + desc.str(),
                                     LOG_LEVEL_ERR,
-                                    std::wstring(L"AkaoSnesSeq")));
+                                    std::wstring(L"NinSnesSeq")));
       bContinue = false;
       break;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Had to create a new track variable that will skip incrementing the timer when set to true. The timer is incremented when all tracks are done processing, which EVENT_END forces to happen. However, the timer is then incremented, and thus incurs a one tick delay. This normally does not happen (Yoshikazu Yao's later builds, not yet supported, is a possible exception because there is some sort of two-pass system in there, but it could also be caused by lag, which vgmtrans does not need to emulate), as I recall that the next section is then immediately processed in at least some of the cases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This merge request closes #155.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
My test environment is:
* Operating System+version: macOS Catalina 10.15.7
* VGMTrans version: 1.1

This is my test case that I used (mostly because I had used a low enough tempo that I could clearly hear the tick delay... and it's also my own creation at that, straight out of the original source Kankichi-kun variant):
* Game ROM/music dump name and sha256: [SoftWave.spc](https://github.com/vgmtrans/vgmtrans/files/9863639/SoftWave-000.spc.zip) using original N-SPC/Kankichi-kun source build, SHA256 is 23d439bfd3c6d9696b6fd6b1817071347ec7a2de87d8ed53ac9dbe11381b51cc

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
