### PR TITLE
DLSFile: Add missing header

### DIFF
--- a/src/main/DLSFile.cpp
+++ b/src/main/DLSFile.cpp
@@ -6,7 +6,6 @@
 
 #include "pch.h"
 #include <algorithm>
-#include <memory>
 #include <numeric>
 #include "DLSFile.h"
 #include "VGMInstrSet.h"

--- a/src/main/DLSFile.h
+++ b/src/main/DLSFile.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "common.h"
+#include <memory>
 #include "RiffFile.h"
 
 struct Loop;


### PR DESCRIPTION
This fixes a compile error (at least on my Linux system with GCC)

I initially added this in the AUR package but with a note to upstream this :frog: