### PR TITLE
Simplify ReadVarLen

### DIFF
--- a/src/main/SeqTrack.cpp
+++ b/src/main/SeqTrack.cpp
@@ -206,7 +206,8 @@ uint32_t SeqTrack::ReadVarLen(uint32_t &offset) {
     c &= 0x7F;
     value = (value << 7) + c;
   }
-
+  if(c>value):
+    return c;
   return value;
 }
 

--- a/src/main/SeqTrack.cpp
+++ b/src/main/SeqTrack.cpp
@@ -200,15 +200,11 @@ void SeqTrack::AddTime(uint32_t AddDelta) {
 
 uint32_t SeqTrack::ReadVarLen(uint32_t &offset) {
   uint32_t value = 0;
-  uint8_t c;
+  uint8_t c = 0;
 
-  if (IsValidOffset(offset) && (value = GetByte(offset++)) & 0x80) {
-    value &= 0x7F;
-    do {
-      if (!IsValidOffset(offset))
-        break;
-      value = (value << 7) + ((c = GetByte(offset++)) & 0x7F);
-    } while (c & 0x80);
+  while (IsValidOffset(offset) && (c = GetByte(offset++)) & 0x80) {
+    c &= 0x7F;
+    value = (value << 7) + c;
   }
 
   return value;


### PR DESCRIPTION
The previous code was really confusing and redundant. I fixed it.

The code is equivalent, but much less confusing.

What it does now:
Uses a while loop to check while if the 0x80 flag is set (variable length number). If so, left shift by 7, and then add the current 7 bits ( & 0x7F).

What it used to do:
The same thing, except it unrolled the first layer of the loop.