### PR TITLE
Improve CPS format, add portamento time, portamento control, and small cleanup

### DIFF
--- a/src/main/MidiFile.h
+++ b/src/main/MidiFile.h
@@ -45,6 +45,8 @@ typedef enum {
   MIDIEVENT_SUSTAIN,
   MIDIEVENT_PORTAMENTO,
   MIDIEVENT_PORTAMENTOTIME,
+  MIDIEVENT_PORTAMENTOTIMEFINE,
+  MIDIEVENT_PORTAMENTOCONTROL,
   MIDIEVENT_MONO,
   MIDIEVENT_LFO,
   MIDIEVENT_VIBRATO,
@@ -109,6 +111,9 @@ class MidiTrack {
   void InsertPortamento(uint8_t channel, bool bOn, uint32_t absTime);
   void AddPortamentoTime(uint8_t channel, uint8_t time);
   void InsertPortamentoTime(uint8_t channel, uint8_t time, uint32_t absTime);
+  void AddPortamentoTimeFine(uint8_t channel, uint8_t time);
+  void InsertPortamentoTimeFine(uint8_t channel, uint8_t time, uint32_t absTime);
+  void AddPortamentoControl(uint8_t channel, uint8_t key);
   void AddMono(uint8_t channel);
   void InsertMono(uint8_t channel, uint32_t absTime);
 
@@ -221,6 +226,8 @@ class MidiEvent {
   MidiEvent(MidiTrack *thePrntTrk, uint32_t absoluteTime, uint8_t theChannel, int8_t thePriority);
   virtual ~MidiEvent(void);
   virtual MidiEventType GetEventType() = 0;
+  bool IsMetaEvent();
+  bool IsSysexEvent();
   void WriteVarLength(std::vector<uint8_t> &buf, uint32_t value);
   //virtual void PrepareWrite(void/*vector<MidiEvent*> & aEvents*/);
   virtual uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) = 0;
@@ -337,6 +344,22 @@ class PortamentoTimeEvent
   virtual MidiEventType GetEventType() { return MIDIEVENT_PORTAMENTOTIME; }
 };
 
+class PortamentoTimeFineEvent
+    : public ControllerEvent {
+public:
+  PortamentoTimeFineEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t time)
+      : ControllerEvent(prntTrk, channel, absoluteTime, 37, time, PRIORITY_MIDDLE) { }
+  virtual MidiEventType GetEventType() { return MIDIEVENT_PORTAMENTOTIMEFINE; }
+};
+
+class PortamentoControlEvent
+    : public ControllerEvent {
+public:
+  PortamentoControlEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t key)
+      : ControllerEvent(prntTrk, channel, absoluteTime, 84, key, PRIORITY_MIDDLE) { }
+  virtual MidiEventType GetEventType() { return MIDIEVENT_PORTAMENTOCONTROL; }
+};
+
 class PanEvent
     : public ControllerEvent {
  public:
@@ -426,7 +449,7 @@ class MonoEvent
     : public ControllerEvent {
  public:
   MonoEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime)
-      : ControllerEvent(prntTrk, channel, absoluteTime, 126, 127, PRIORITY_MIDDLE) { }
+      : ControllerEvent(prntTrk, channel, absoluteTime, 126, 0, PRIORITY_HIGHER) { }
   virtual MidiEventType GetEventType() { return MIDIEVENT_MONO; }
 };
 

--- a/src/main/SeqTrack.cpp
+++ b/src/main/SeqTrack.cpp
@@ -1120,6 +1120,23 @@ void SeqTrack::AddPortamentoTimeNoItem(uint8_t time) {
     pMidiTrack->AddPortamentoTime(channel, time);
 }
 
+void SeqTrack::AddPortamentoTime14Bit(uint32_t offset, uint32_t length, uint16_t time, const std::wstring &sEventName) {
+  OnEvent(offset, length);
+
+  if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
+    AddEvent(new PortamentoTimeSeqEvent(this, time, offset, length, sEventName));
+  AddPortamentoTime14BitNoItem(time);
+}
+
+void SeqTrack::AddPortamentoTime14BitNoItem(uint16_t time) {
+  if (readMode == READMODE_CONVERT_TO_MIDI) {
+    uint8_t lsb = time & 127;
+    uint8_t msb = (time >> 7) & 127;
+    pMidiTrack->AddPortamentoTimeFine(channel, lsb);
+    pMidiTrack->AddPortamentoTime(channel, msb);
+  }
+}
+
 void SeqTrack::InsertPortamentoTime(uint32_t offset,
                                     uint32_t length,
                                     uint8_t time,
@@ -1129,10 +1146,18 @@ void SeqTrack::InsertPortamentoTime(uint32_t offset,
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
     AddEvent(new PortamentoTimeSeqEvent(this, time, offset, length, sEventName));
-  else if (readMode == READMODE_CONVERT_TO_MIDI)
+  InsertPortamentoTimeNoItem(time, absTime);
+}
+
+void SeqTrack::InsertPortamentoTimeNoItem(uint8_t time, uint32_t absTime) {
+  if (readMode == READMODE_CONVERT_TO_MIDI)
     pMidiTrack->InsertPortamentoTime(channel, time, absTime);
 }
 
+void SeqTrack::AddPortamentoControlNoItem(uint8_t key) {
+  if (readMode == READMODE_CONVERT_TO_MIDI)
+    pMidiTrack->AddPortamentoControl(channel, key);
+}
 
 /*void InsertNoteOnEvent(int8_t key, int8_t vel, uint32_t absTime);
 void AddNoteOffEvent(int8_t key);

--- a/src/main/SeqTrack.h
+++ b/src/main/SeqTrack.h
@@ -120,6 +120,10 @@ class SeqTrack:
   void AddPortamentoTime(uint32_t offset, uint32_t length, uint8_t time, const std::wstring &sEventName = L"Portamento Time");
   void AddPortamentoTimeNoItem(uint8_t time);
   void InsertPortamentoTime(uint32_t offset, uint32_t length, uint8_t time, uint32_t absTime, const std::wstring &sEventName = L"Portamento Time");
+  void InsertPortamentoTimeNoItem(uint8_t time, uint32_t absTime);
+  void AddPortamentoTime14Bit(uint32_t offset, uint32_t length, uint16_t time, const std::wstring &sEventName = L"Portamento Time");
+  void AddPortamentoTime14BitNoItem(uint16_t time);
+  void AddPortamentoControlNoItem(uint8_t key);
   void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, const std::wstring &sEventName = L"Program Change");
   void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, uint8_t chan, const std::wstring &sEventName = L"Program Change");
   void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, bool requireBank, const std::wstring &sEventName = L"Program Change");

--- a/src/main/VGMSeq.h
+++ b/src/main/VGMSeq.h
@@ -76,6 +76,10 @@ class VGMSeq: public VGMFile {
     initialTempoBPM = tempoBPM;
   }
 
+  void AlwaysWriteInitialMonoMode() {
+    bAlwaysWriteInitialMono = true;
+  }
+
   bool OnSaveAsMidi(void);
   virtual bool SaveAsMidi(const std::wstring &filepath);
 


### PR DESCRIPTION
I've made changes to the CPS format to better (perhaps even properly) handle portamento, and use a simple 8bit pitch bend range value as FluidSynth ignores the finetune LSB byte. In the process:

* I added support for Portamento Time LSB controller events.
* I added support for Portamento Control events (even though I wound up not using them)
* I made some small changes related to monophonic tracks

There's just one change at the bottom of MidiFile.cpp that I was slightly concerned might cause issues - there's conditional logic to not record prevKey when writing notes on a monophonic MidiTrack. However, I don't see other formats even marking the monophonic flags for tracks or seqs, and I'm pretty sure I was being dumb when I originally wrote that code. At any rate, the change there is needed to allow notes to slightly overlap, enabling a legato portamento slide.