### PR TITLE
Add SysexEvent class and update CPS portamento handling

### DIFF
--- a/src/main/SeqTrack.cpp
+++ b/src/main/SeqTrack.cpp
@@ -166,6 +166,8 @@ void SeqTrack::AddInitialMidiEvents(int trackNum) {
     pMidiTrack->AddGM2Reset();
     if (parentSeq->bAlwaysWriteInitialTempo)
       pMidiTrack->AddTempoBPM(parentSeq->initialTempoBPM);
+    if (parentSeq->portamentoTimeMode != PortamentoTimeMode::kUndefined)
+      AddPortamentoTimeModeNoItem(parentSeq->portamentoTimeMode);
   }
   if (parentSeq->bAlwaysWriteInitialVol)
     AddVolNoItem(parentSeq->initialVol);
@@ -1152,6 +1154,11 @@ void SeqTrack::InsertPortamentoTime(uint32_t offset,
 void SeqTrack::InsertPortamentoTimeNoItem(uint8_t time, uint32_t absTime) {
   if (readMode == READMODE_CONVERT_TO_MIDI)
     pMidiTrack->InsertPortamentoTime(channel, time, absTime);
+}
+
+void SeqTrack::AddPortamentoTimeModeNoItem(PortamentoTimeMode mode) {
+  if (readMode == READMODE_CONVERT_TO_MIDI)
+    pMidiTrack->AddPortamentoTimeMode(mode);
 }
 
 void SeqTrack::AddPortamentoControlNoItem(uint8_t key) {

--- a/src/main/SeqTrack.h
+++ b/src/main/SeqTrack.h
@@ -123,6 +123,7 @@ class SeqTrack:
   void InsertPortamentoTimeNoItem(uint8_t time, uint32_t absTime);
   void AddPortamentoTime14Bit(uint32_t offset, uint32_t length, uint16_t time, const std::wstring &sEventName = L"Portamento Time");
   void AddPortamentoTime14BitNoItem(uint16_t time);
+  void AddPortamentoTimeModeNoItem(PortamentoTimeMode mode);
   void AddPortamentoControlNoItem(uint8_t key);
   void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, const std::wstring &sEventName = L"Program Change");
   void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, uint8_t chan, const std::wstring &sEventName = L"Program Change");

--- a/src/main/VGMSeq.cpp
+++ b/src/main/VGMSeq.cpp
@@ -26,6 +26,7 @@ VGMSeq::VGMSeq(const string &format, RawFile *file, uint32_t offset, uint32_t le
       bAlwaysWriteInitialPitchBendRange(false),
       bAlwaysWriteInitialMono(false),
       bAllowDiscontinuousTrackData(false),
+      portamentoTimeMode(PortamentoTimeMode::kUndefined),
       bLoadTickByTick(false),
       bIncTickAfterProcessingTracks(true),
       initialVol(100),                    //GM standard (dls1 spec p16)
@@ -43,6 +44,7 @@ VGMSeq::VGMSeq(const string &format, RawFile *file, uint32_t offset, uint32_t le
 VGMSeq::~VGMSeq(void) {
   DeleteVect<SeqTrack>(aTracks);
   DeleteVect<ISeqSlider>(aSliders);
+  delete midi;
 }
 
 bool VGMSeq::Load() {

--- a/src/main/VGMSeq.h
+++ b/src/main/VGMSeq.h
@@ -20,6 +20,12 @@ enum class PanVolumeCorrectionMode : uint8_t {
   kAdjustExpressionController
 };
 
+enum class PortamentoTimeMode : uint8_t {
+  kDurationInMs = 0,
+  kCentsPerSecond,
+  kUndefined
+};
+
 class VGMSeq: public VGMFile {
  public:
   BEGIN_MENU_SUB(VGMSeq, VGMFile)
@@ -80,6 +86,10 @@ class VGMSeq: public VGMFile {
     bAlwaysWriteInitialMono = true;
   }
 
+  void AlwaysWritePortamentoTimeMode(PortamentoTimeMode mode) {
+    portamentoTimeMode = mode;
+  }
+
   bool OnSaveAsMidi(void);
   virtual bool SaveAsMidi(const std::wstring &filepath);
 
@@ -115,6 +125,7 @@ class VGMSeq: public VGMFile {
   bool bAlwaysWriteInitialPitchBendRange;
   bool bAlwaysWriteInitialMono;
   bool bAllowDiscontinuousTrackData;
+  PortamentoTimeMode portamentoTimeMode;
 
   // True if each tracks in a sequence needs to be loaded simultaneously in tick by tick, as the real music player does.
   // Pros:

--- a/src/main/formats/CPSSeq.cpp
+++ b/src/main/formats/CPSSeq.cpp
@@ -19,7 +19,9 @@ CPSSeq::CPSSeq(RawFile *file, uint32_t offset, CPSFormatVer fmtVersion, wstring 
   HasMonophonicTracks();
   AlwaysWriteInitialVol(127);
   AlwaysWriteInitialMonoMode();
-  AlwaysWritePortamentoTimeMode(PortamentoTimeMode::kCentsPerSecond);
+  // While we still use the BASS audio library, we won't call the PortamentoTimeMode Sysex event
+  // because BASS insists the first sysex data byte be the length of the data, which is non-standard
+//  AlwaysWritePortamentoTimeMode(PortamentoTimeMode::kCentsPerSecond);
 }
 
 CPSSeq::~CPSSeq(void) {

--- a/src/main/formats/CPSSeq.cpp
+++ b/src/main/formats/CPSSeq.cpp
@@ -19,6 +19,7 @@ CPSSeq::CPSSeq(RawFile *file, uint32_t offset, CPSFormatVer fmtVersion, wstring 
   HasMonophonicTracks();
   AlwaysWriteInitialVol(127);
   AlwaysWriteInitialMonoMode();
+  AlwaysWritePortamentoTimeMode(PortamentoTimeMode::kCentsPerSecond);
 }
 
 CPSSeq::~CPSSeq(void) {

--- a/src/main/formats/CPSTrackV1.cpp
+++ b/src/main/formats/CPSTrackV1.cpp
@@ -65,7 +65,7 @@ bool CPSTrackV1::ReadEvent(void) {
         }
         else if (key != prevTieNote) {
           AddNoteOn(beginOffset, curOffset - beginOffset, key, 127, L"Note On (tied)");
-          InsertNoteOffNoItem(prevTieNote, GetTime()+2);
+          InsertNoteOffNoItem(prevTieNote, GetTime());
         }
         else
           AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", L"", CLR_NOTEON);
@@ -75,7 +75,7 @@ bool CPSTrackV1::ReadEvent(void) {
       else {
         if (bPrevNoteTie) {
           if (key != prevTieNote) {
-            InsertNoteOffNoItem(prevTieNote, GetTime()+2);
+            InsertNoteOffNoItem(prevTieNote, GetTime());
             AddNoteByDur(beginOffset, curOffset - beginOffset, key, 127, absDur);
           }
           else {

--- a/src/main/formats/CPSTrackV1.cpp
+++ b/src/main/formats/CPSTrackV1.cpp
@@ -74,9 +74,8 @@ bool CPSTrackV1::ReadEvent(void) {
       }
       else {
         if (bPrevNoteTie) {
-          AddPortamentoNoItem(false);
           if (key != prevTieNote) {
-            AddNoteOffNoItem(prevTieNote);
+            InsertNoteOffNoItem(prevTieNote, GetTime()+2);
             AddNoteByDur(beginOffset, curOffset - beginOffset, key, 127, absDur);
           }
           else {
@@ -84,6 +83,7 @@ bool CPSTrackV1::ReadEvent(void) {
             delta -= absDur;
             AddNoteOff(beginOffset, curOffset - beginOffset, prevTieNote, L"Note Off (tied)");
           }
+          AddPortamentoNoItem(false);
         }
         else {
           AddNoteByDur(beginOffset, curOffset - beginOffset, key, 127, absDur);

--- a/src/main/formats/CPSTrackV1.cpp
+++ b/src/main/formats/CPSTrackV1.cpp
@@ -65,7 +65,7 @@ bool CPSTrackV1::ReadEvent(void) {
         }
         else if (key != prevTieNote) {
           AddNoteOn(beginOffset, curOffset - beginOffset, key, 127, L"Note On (tied)");
-          InsertNoteOffNoItem(prevTieNote, GetTime());
+          AddNoteOffNoItem(prevTieNote);
         }
         else
           AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", L"", CLR_NOTEON);
@@ -75,7 +75,7 @@ bool CPSTrackV1::ReadEvent(void) {
       else {
         if (bPrevNoteTie) {
           if (key != prevTieNote) {
-            InsertNoteOffNoItem(prevTieNote, GetTime());
+            AddNoteOffNoItem(prevTieNote);
             AddNoteByDur(beginOffset, curOffset - beginOffset, key, 127, absDur);
           }
           else {


### PR DESCRIPTION
* Add SysexEvent class to simplify defining sysex midi events
* Update Reset events to use SysexEvent
* Add PortamentoTimeMode event for usage in upcoming VST playback
* Add portamentoTimeMode property to VGMSeq
* Improve portamento implementation again in CPS format
* delete midi in VGMSeq destructor
* rename MastVolEvent -> MasterVolEvent