### PR TITLE
remove high dpi scaling and pixmaps for Qt version < 6

### DIFF
--- a/src/ui/qt/main_ui.cpp
+++ b/src/ui/qt/main_ui.cpp
@@ -13,11 +13,6 @@
 #include "QtVGMRoot.h"
 
 int main(int argc, char *argv[]) {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-  QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-  QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
-
   QCoreApplication::setOrganizationName("VGMTrans");
   QCoreApplication::setApplicationName("VGMTrans");
 


### PR DESCRIPTION
When running Windows 10 on a 4k monitor with 150% display size (the default), the app looks huge. Removing `setAttribute(Qt::AA_EnableHighDpiScaling);` fixes the issue.

I'm curious if there is another configuration that prompted the use of these settings. For me, running on a high dpi monitor, it seems to be conflicting with the default method Windows' uses to scale up.