### PR TITLE
Upgrade macOS builds to Qt6, native M1 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,23 +6,60 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  macos_x64:
-    name: macOS (Intel)
+  macos_arm64:
+    name: macOS (Apple Silicon)
     runs-on: macos-12
-    env:
-      osx_min_ver: "11.0"
-      osx_arch: "x86_64"
     steps:
       - uses: actions/checkout@v3
       - name: "Install dependencies"
         run: |
-          brew upgrade qt@5 ninja || brew install qt@5 ninja
+          brew upgrade || brew install ninja
+          brew install \
+            --force-bottle \
+            --ignore-dependencies \
+            "$(brew fetch --deps --bottle-tag=arm64_monterey qt@6)"
+
           echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
           echo "/usr/local/bin" >> $GITHUB_PATH
       - name: "Prepare build"
         run: |
-          cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ env.osx_min_ver }} \
-                -DCMAKE_OSX_ARCHITECTURES=${{ env.osx_arch }} \
+          # CMAKE_PREFIX_PATH:
+          # On homebrew for arm, the default path is /opt/homebrew
+          # On Intel macs, it's /usr/local
+          # CMAKE_OSX_ARCHITECTURE:
+          # For arm, it's arm64. This selects the appropriate SDK
+          # CMAKE_SYSTEM_PROCESSOR:
+          # Has to be set so that CMake knows if we're cross-compiling
+          cmake \
+                -D CMAKE_PREFIX_PATH="/opt/homebrew;/usr/local/opt/qt"  \
+                -D CMAKE_OSX_ARCHITECTURES=arm64 \
+                -D CMAKE_SYSTEM_PROCESSOR=arm64 \
+                -D CMAKE_BUILD_TYPE=Release \
+                -G Ninja \
+                -B build
+      - name: "Build project"
+        run: cmake --build build --config "Release" --parallel
+      - working-directory: "build"
+        name: "Package DMG (macOS)"
+        run: /usr/local/opt/qt6/bin/macdeployqt bin/VGMTrans.app -dmg -always-overwrite
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: VGMTrans-AppleSilicon-${{ github.sha }}-${{ env.BRANCH }}-${{ runner.os }}.dmg
+          path: "build/bin/VGMTrans.dmg"
+  macos_x64:
+    name: macOS (Intel)
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Install dependencies"
+        run: |
+          brew upgrade qt@6 ninja || brew install qt@6 ninja
+          echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
+          echo "/usr/local/bin" >> $GITHUB_PATH
+      - name: "Prepare build"
+        run: |
+          cmake \
                 -DCMAKE_BUILD_TYPE=Release \
                 -G Ninja \
                 -B build
@@ -30,11 +67,11 @@ jobs:
         run: cmake --build build --config "Release" --parallel
       - working-directory: "build"
         name: "Package DMG (macOS)"
-        run: /usr/local/opt/qt5/bin/macdeployqt bin/VGMTrans.app -dmg -always-overwrite
+        run: /usr/local/opt/qt6/bin/macdeployqt bin/VGMTrans.app -dmg -always-overwrite
       - name: "Upload artifact"
         uses: actions/upload-artifact@v3
         with:
-          name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-${{ env.osx_arch }}-${{ runner.os }}.dmg
+          name: VGMTrans-Intel-${{ github.sha }}-${{ env.BRANCH }}-${{ runner.os }}.dmg
           path: "build/bin/VGMTrans.dmg"
   Ubuntu:
     runs-on: ubuntu-20.04

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -52,9 +52,9 @@ elseif(${Qt_VERSION_MAJOR} EQUAL 5)
                     "${CMAKE_CURRENT_LIST_DIR}/resources/resources.qrc")
 endif()
 
-if(WIN32)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   set(GUI_TYPE WIN32)
-elseif(APPLE)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(GUI_TYPE MACOSX_BUNDLE)
 endif()
 
@@ -117,12 +117,19 @@ target_link_libraries(
   PRIVATE g_options
           g_warnings
           vgmtranscore
+          Qt${Qt_VERSION_MAJOR}::Gui
           Qt${Qt_VERSION_MAJOR}::Widgets
           Qt${Qt_VERSION_MAJOR}::Svg
           gsl-lite
           BASS::MIDI)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  if (${Qt_VERSION} EQUAL 6)
+    # Workaround macdeployqt not copying the DBus framework
+    find_package(Qt6 COMPONENTS DBus REQUIRED)
+    target_link_libraries(vgmtrans PRIVATE Qt::DBus)
+  endif()
+
   set(BUNDLE_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VGMTrans.app")
 
   set_target_properties(

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -124,7 +124,7 @@ target_link_libraries(
           BASS::MIDI)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  if (${Qt_VERSION} EQUAL 6)
+  if (${Qt_VERSION_MAJOR} EQUAL 6)
     # Workaround macdeployqt not copying the DBus framework
     find_package(Qt6 COMPONENTS DBus REQUIRED)
     target_link_libraries(vgmtrans PRIVATE Qt::DBus)

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -4,7 +4,12 @@ add_subdirectory("${PROJECT_SOURCE_DIR}/lib/gsl-lite"
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/bass"
                  "${CMAKE_CURRENT_BINARY_DIR}/bass" EXCLUDE_FROM_ALL)
 
-if(APPLE)
+if(POLICY CMP0084)
+  # Disable Qt{3,4} fallback
+  cmake_policy(SET CMP0084 NEW)
+endif()
+
+if(CMAKE_SYSTEN_NAME MATCHES "Darwin" AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
   # Homebrew installs Qt (up to at least 5.9.1) in /usr/local/qt*, ensure it can
   # be found by CMake since it is not in the default /usr/local prefix.
   if(EXISTS /usr/local/opt/qt5)


### PR DESCRIPTION
## Description
Adds a new build job for compiling a Apple Silicon version of VGMTrans so that it can be run without Rosetta.
Note that these builds would need to be re-signed by users that want to run them locally as we don't have a codesigning certificate.
In bumping the runner version of Qt to Qt6, I needed to explicitly link to `Qt::DBus` to workaround a problem with `macdeployqt` not copying the relevant Framework in the App Bundle.
The CI no longer sets the minimum macOS version, as that's inforced by the Qt version we're using. Users compiling locally can still target older macOS versions.

## Motivation and Context
See #370.

## How Has This Been Tested?
Tested on macOS Ventura 13.5 with both Qt5 and Qt6.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
