### PR TITLE
Add UI_GetResourceDirPath() and update MAMELoader to use it

### DIFF
--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -304,3 +304,7 @@ void VGMRoot::AddLogItem(LogItem *theLog) {
   vLogItem.push_back(theLog);
   UI_AddLogItem(theLog);
 }
+
+const std::wstring VGMRoot::UI_GetResourceDirPath() {
+  return std::wstring(fs::current_path().generic_wstring());
+}

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -50,6 +50,7 @@ class VGMRoot {
     vLoader.push_back(new T());
   }
 
+  virtual const std::wstring UI_GetResourceDirPath();
   virtual void UI_SetRootPtr(VGMRoot **theRoot) = 0;
   virtual void UI_PreExit() { }
   virtual void UI_Exit() = 0;

--- a/src/main/common.h
+++ b/src/main/common.h
@@ -34,7 +34,7 @@ uint32_t StringToHex(const std::string &str);
 
 std::wstring ConvertToSafeFileName(const std::wstring &str);
 
-inline std::string wstring2string(std::wstring &wstr) {
+inline std::string wstring2string(const std::wstring &wstr) {
   char *mbs = new char[wstr.length() * MB_CUR_MAX + 1];
   wcstombs(mbs, wstr.c_str(), wstr.length() * MB_CUR_MAX + 1);
   std::string str(mbs);

--- a/src/main/loaders/MAMELoader.cpp
+++ b/src/main/loaders/MAMELoader.cpp
@@ -47,7 +47,10 @@ MAMELoader::~MAMELoader() {
 }
 
 int MAMELoader::LoadXML() {
-  TiXmlDocument doc("mame_roms.xml");
+  const wstring xmlFilePath = pRoot->UI_GetResourceDirPath() + L"mame_roms.xml";
+  string xmlFilePathString = wstring2string(xmlFilePath);
+
+  TiXmlDocument doc(xmlFilePathString);
   if (!doc.LoadFile())        //if loading the xml file fails
   {
     return 1;

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -131,9 +131,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set_source_files_properties("${CMAKE_CURRENT_LIST_DIR}/resources/appicon.icns"
                               PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
-  target_sources(vgmtrans PRIVATE "${CMAKE_SOURCE_DIR}/bin/mame_roms.xml")
-  set_source_files_properties("${CMAKE_SOURCE_DIR}/bin/mame_roms.xml"
-                              PROPERTIES MACOSX_PACKAGE_LOCATION MacOS)
+  add_custom_command(TARGET vgmtrans
+          POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_directory
+          "${CMAKE_SOURCE_DIR}/bin"
+          "${BUNDLE_PATH}/Contents/Resources")
 
   get_target_property(BASS_DLL_LOCATION BASS::BASS
                       IMPORTED_LOCATION)

--- a/src/ui/qt/QtVGMRoot.cpp
+++ b/src/ui/qt/QtVGMRoot.cpp
@@ -13,6 +13,18 @@
 
 QtVGMRoot qtVGMRoot;
 
+const std::wstring QtVGMRoot::UI_GetResourceDirPath() {
+#if defined(Q_OS_WIN)
+  return (QApplication::applicationDirPath() + "/").toStdWString();
+#elif defined(Q_OS_OSX)
+  return (QApplication::applicationDirPath() + "/../Resources/").toStdWString();
+#elif defined(Q_OS_LINUX)
+  return (QApplication::applicationDirPath() + "/").toStdWString();
+#else
+  return (QApplication::applicationDirPath() + "/").toStdWString();
+#endif
+}
+
 void QtVGMRoot::UI_SetRootPtr(VGMRoot** theRoot) {
   *theRoot = &qtVGMRoot;
 }

--- a/src/ui/qt/QtVGMRoot.h
+++ b/src/ui/qt/QtVGMRoot.h
@@ -15,6 +15,7 @@ class QtVGMRoot final : public QObject, public VGMRoot {
 public:
   ~QtVGMRoot() override = default;
 
+  const std::wstring UI_GetResourceDirPath();
   void UI_SetRootPtr(VGMRoot** theRoot) override;
   void UI_PreExit() override;
   void UI_Exit() override;


### PR DESCRIPTION
Also updates the CMakeLists to copy entire /bin directory to bundle's /Contents/Resources directory on MacOS.

## Description
Currently MacOS fails to load the mame_roms.xml file because the default working directory when opening a Mac application is the system root. This adds a system-specific function to get the path to the application's resource directory, which for all other platforms is the same path as the executable, at least for now.

## Motivation and Context
This fixes the MAME loader on MacOS

## Testing
Tested on MacOS Sonoma, Windows 10, and Ubuntu 22.

