### PR TITLE
Add initial portamento value to CPS, update to use decacents per second

### DIFF
--- a/src/main/formats/CPSTrackV1.cpp
+++ b/src/main/formats/CPSTrackV1.cpp
@@ -29,7 +29,7 @@ void CPSTrackV1::ResetVars() {
 
 void CPSTrackV1::AddInitialMidiEvents(int trackNum) {
   SeqTrack::AddInitialMidiEvents(trackNum);
-  AddPortamentoTime14BitNoItem(0x3FFF);
+  AddPortamentoTime14BitNoItem(0);
 }
 
 
@@ -238,13 +238,18 @@ bool CPSTrackV1::ReadEvent(void) {
       break;
       case 0x0D : {
         // Portamento: take the rate value, left shift it 1.  This value * (100/256) is increment in cents every 1/(250/4) seconds until we hit target key.
+        // A portamento rate value of 0 means instantaneous slide
         uint8_t portamentoRate = GetByte(curOffset++);
-        auto centsPerSecond = static_cast<uint16_t>(static_cast<double>(portamentoRate) * 2 * (100.0/256.0) * (256.0/4.0));
-        auto decacentsPerSecond = std::min(static_cast<uint16_t>(centsPerSecond / 10), static_cast<uint16_t>(0x3FFF));
-        if (portamentoRate == 0) {
-          decacentsPerSecond = 0x3FFF;
+        uint16_t value = 0;
+        // the rate is represented as decacents per second, but is passed in on an inverse 14 bit scale (from 0-0x3FFF)
+        // value of 0 means a rate of 0x3FFF decacents per second - the fastest slide
+        // value of 0x3FFF means 0 decacents per second - no slide
+        if (portamentoRate != 0) {
+          auto centsPerSecond = static_cast<uint16_t>(static_cast<double>(portamentoRate) * 2 * (100.0/256.0) * (256.0/4.0));
+          auto decacentsPerSecond = std::min(static_cast<uint16_t>(centsPerSecond / 10), static_cast<uint16_t>(0x3FFF));
+          value = 0x3FFF - decacentsPerSecond;
         }
-        AddPortamentoTime14Bit(beginOffset, curOffset - beginOffset, decacentsPerSecond);
+        AddPortamentoTime14Bit(beginOffset, curOffset - beginOffset, value);
         break;
       }
 

--- a/src/main/formats/CPSTrackV1.h
+++ b/src/main/formats/CPSTrackV1.h
@@ -10,6 +10,7 @@ class CPSTrackV1
 public:
   CPSTrackV1(CPSSeq *parentSeq, long offset = 0, long length = 0);
   virtual void ResetVars();
+  virtual void AddInitialMidiEvents(int trackNum);
   virtual bool ReadEvent(void);
 
 private:


### PR DESCRIPTION
Use decacents per sec instead of cents per sec for portamento timing, aligning with a [change to the fluidsynth fork](https://github.com/mikelow/fluidsynth/commit/b02801e03b410fc24e10af42f1fd160f9c46da93) used by the [vst plugin](https://github.com/mikelow/juicysfplugin)

The reason for this change is to allow faster portamento slides than cents per second allows. CPS sequences often use a portamento time of 0, which emulates a legato effect (no slide, but no attack phase) - effectively the same as instantaneous portamento. A [trill between 5ths](https://www.youtube.com/watch?v=tc7nRcTfB5g) at maximum cents per second value (16,383) still causes audible slide.

I investigated using legato pedal events when CPS sets portamento time to 0, but the default MIDI behavior, at least as implemented in fluidsynth, is not as desired (I believe notes must overlap to have this effect). The other downside would be that introducing the legato pedal state on top of portamento on/off state adds complexity. Better to just use very fast portamento.