### PR TITLE
CPS Portamento fix... again

### DIFF
--- a/src/main/SeqTrack.cpp
+++ b/src/main/SeqTrack.cpp
@@ -1394,7 +1394,6 @@ void SeqTrack::AddGlobalTranspose(uint32_t offset, uint32_t length, int8_t semit
     AddEvent(new TransposeSeqEvent(this, semitones, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
     parentSeq->midi->globalTrack.InsertGlobalTranspose(GetTime(), semitones);
-  //pMidiTrack->(channel, transpose);
 }
 
 void SeqTrack::AddMarker(uint32_t offset,

--- a/src/main/formats/CPSTrackV1.cpp
+++ b/src/main/formats/CPSTrackV1.cpp
@@ -75,8 +75,8 @@ bool CPSTrackV1::ReadEvent(void) {
       else {
         if (bPrevNoteTie) {
           if (key != prevTieNote) {
-            AddNoteOffNoItem(prevTieNote);
             AddNoteByDur(beginOffset, curOffset - beginOffset, key, 127, absDur);
+            AddNoteOffNoItem(prevTieNote);
             InsertPortamentoNoItem(false, GetTime()+absDur);
           }
           else {


### PR DESCRIPTION
In CPS format, when a tied note ends via the occurrence of a new non-tied note, write the new note's ON event before the previous note's OFF event to allow portamento effect.

I think it's finally all solved, knock on wood.