### PR TITLE
Use duration portamento time on CPS

### DIFF
--- a/src/main/MidiFile.cpp
+++ b/src/main/MidiFile.cpp
@@ -637,7 +637,14 @@ void MidiTrack::AddMarker(uint8_t channel,
   aEvents.push_back(new MarkerEvent(this, channel, GetDelta(), markername, databyte1, databyte2, priority));
 }
 
-
+void MidiTrack::InsertMarker(uint8_t channel,
+                  const string &markername,
+                  uint8_t databyte1,
+                  uint8_t databyte2,
+                  int8_t priority,
+                  uint32_t absTime) {
+  aEvents.push_back(new MarkerEvent(this, channel, absTime, markername, databyte1, databyte2, priority));
+}
 
 //  *********
 //  MidiEvent

--- a/src/main/MidiFile.h
+++ b/src/main/MidiFile.h
@@ -175,6 +175,12 @@ class MidiTrack {
                  uint8_t databyte1,
                  uint8_t databyte2,
                  int8_t priority = PRIORITY_MIDDLE);
+  void InsertMarker(uint8_t channel,
+                    const std::string &markername,
+                    uint8_t databyte1,
+                    uint8_t databyte2,
+                    int8_t priority,
+                    uint32_t absTime);
 
  public:
   MidiFile *parentSeq;

--- a/src/main/SeqTrack.cpp
+++ b/src/main/SeqTrack.cpp
@@ -1408,8 +1408,24 @@ void SeqTrack::AddMarker(uint32_t offset,
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
     AddEvent(new MarkerSeqEvent(this, markername, databyte1, databyte2, offset, length, sEventName, color));
-  else if (readMode == READMODE_CONVERT_TO_MIDI)
+  AddMarkerNoItem(markername, databyte1, databyte2, priority);
+}
+
+void SeqTrack::AddMarkerNoItem(const string &markername,
+                               uint8_t databyte1,
+                               uint8_t databyte2,
+                               int8_t priority) {
+  if (readMode == READMODE_CONVERT_TO_MIDI)
     pMidiTrack->AddMarker(channel, markername, databyte1, databyte2, priority);
+}
+
+void SeqTrack::InsertMarkerNoItem(uint32_t absTime,
+                                  const string &markername,
+                                  uint8_t databyte1,
+                                  uint8_t databyte2,
+                                  int8_t priority) {
+  if (readMode == READMODE_CONVERT_TO_MIDI)
+    pMidiTrack->InsertMarker(channel, markername, databyte1, databyte2, priority, absTime);
 }
 
 // when in FIND_DELTA_LENGTH mode, returns true until we've hit the max number of loops defined in options

--- a/src/main/SeqTrack.h
+++ b/src/main/SeqTrack.h
@@ -146,6 +146,8 @@ class SeqTrack:
 
   void AddGlobalTranspose(uint32_t offset, uint32_t length, int8_t semitones, const std::wstring &sEventName = L"Global Transpose");
   void AddMarker(uint32_t offset, uint32_t length, const std::string &markername, uint8_t databyte1, uint8_t databyte2, const std::wstring &sEventName, int8_t priority = 0, EventColor color = CLR_MISC);
+  void AddMarkerNoItem(const string &markername, uint8_t databyte1, uint8_t databyte2, int8_t priority);
+  void InsertMarkerNoItem(uint32_t absTime, const string &markername, uint8_t databyte1, uint8_t databyte2, int8_t priority);
 
   bool AddLoopForever(uint32_t offset, uint32_t length, const std::wstring &sEventName = L"Loop Forever");
 

--- a/src/main/formats/CPSSeq.cpp
+++ b/src/main/formats/CPSSeq.cpp
@@ -22,9 +22,6 @@ CPSSeq::CPSSeq(RawFile *file, uint32_t offset, CPSFormatVer fmtVersion, wstring 
   // Until we add CPS3 vibrato and pitch bend using markers, set the default pitch bend range here
   if (fmt_version >= VER_200)
     AlwaysWriteInitialPitchBendRange(12, 0);
-  // While we still use the BASS audio library, we won't call the PortamentoTimeMode Sysex event
-  // because BASS insists the first sysex data byte be the length of the data, which is non-standard
-//  AlwaysWritePortamentoTimeMode(PortamentoTimeMode::kCentsPerSecond);
 }
 
 CPSSeq::~CPSSeq(void) {

--- a/src/main/formats/CPSTrackV1.cpp
+++ b/src/main/formats/CPSTrackV1.cpp
@@ -23,6 +23,7 @@ void CPSTrackV1::ResetVars() {
   noteState = 0;
   bank = 0;
   portamentoCentsPerSec = 0;
+  prevPortamentoDuration = 0;
   memset(loop, 0, sizeof(loop));
   memset(loopOffset, 0, sizeof(loopOffset));
   SeqTrack::ResetVars();
@@ -40,6 +41,10 @@ void CPSTrackV1::CalculateAndAddPortamentoTimeNoItem(int8_t noteDistance) {
     uint16_t centDistance = abs(noteDistance) * 100;
     durationInMillis = (static_cast<double>(centDistance) / static_cast<double>(portamentoCentsPerSec)) * 1000.0;
   }
+  if (durationInMillis == prevPortamentoDuration) {
+    return;
+  }
+  prevPortamentoDuration = durationInMillis;
   AddPortamentoTime14BitNoItem(durationInMillis);
 }
 

--- a/src/main/formats/CPSTrackV1.h
+++ b/src/main/formats/CPSTrackV1.h
@@ -25,4 +25,5 @@ private:
   uint8_t loop[4];
   uint32_t loopOffset[4];    //used for detecting infinite loops
   int16_t portamentoCentsPerSec;
+  uint16_t prevPortamentoDuration;
 };

--- a/src/main/formats/CPSTrackV1.h
+++ b/src/main/formats/CPSTrackV1.h
@@ -15,13 +15,14 @@ public:
 
 private:
   CPSFormatVer GetVersion() { return ((CPSSeq *) this->parentSeq)->fmt_version; }
+  void CalculateAndAddPortamentoTimeNoItem(int8_t noteDistance);
 
   bool bPrevNoteTie;
   uint8_t prevTieNote;
-  uint8_t origTieNote;
   uint8_t curDeltaTable;
   uint8_t noteState;
   uint8_t bank;
   uint8_t loop[4];
   uint32_t loopOffset[4];    //used for detecting infinite loops
+  int16_t portamentoCentsPerSec;
 };


### PR DESCRIPTION
Turns out this was not as hard to implement I thought it would be.

This changes the CPS driver to express portamento time as a duration in milliseconds in order to increase compatibility with midi players/instruments. MIDI does not define a standard for interpreting portamento time, but millisecond duration is how Fluidsynth does it. BASS does something similar, but there are audible differences, both in terms of timing and more generally when it decides to apply portamento. (It appears [BASS doesn't support](https://www.un4seen.com/doc/#bassmidi/BASS_MIDI_StreamEvent.html) controller 37 - portamento time fine - though I don't think this entirely accounts for the timing difference).

When comparing this version using Fluidsynth against the prior portamento time-as-rate implementation, I haven't yet detected a difference. 

I also threw in some MarkerEvent related methods that I added in the course of solving this. The change doesn't use them, but I figure we keep them.