### PR TITLE
Fix performance issue when loading files with many collections

### DIFF
--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -137,11 +137,13 @@ bool VGMRoot::CreateVirtFile(uint8_t *databuf,
 // to the RawFile
 bool VGMRoot::SetupNewRawFile(RawFile *newRawFile) {
   newRawFile->SetProPreRatio((float) 0.80);
+  this->UI_OnBeginLoadRawFile();
 
   if (newRawFile->processFlags & PF_USELOADERS)
     for (uint32_t i = 0; i < vLoader.size(); i++) {
       if (vLoader[i]->Apply(newRawFile) == DELETE_IT) {
         delete newRawFile;
+        this->UI_OnEndLoadRawFile();
         return true;
       }
     }
@@ -165,11 +167,13 @@ bool VGMRoot::SetupNewRawFile(RawFile *newRawFile) {
 
   if (newRawFile->containedVGMFiles.size() == 0) {
     delete newRawFile;
+    this->UI_OnEndLoadRawFile();
     return true;
   }
   newRawFile->SetProPreRatio(0.5);
   vRawFile.push_back(newRawFile);
   UI_AddRawFile(newRawFile);
+  this->UI_OnEndLoadRawFile();
   return true;
 }
 

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -57,6 +57,8 @@ class VGMRoot {
   virtual void UI_AddRawFile(RawFile *newFile) { }
   virtual void UI_CloseRawFile(RawFile *targFile) { }
 
+  virtual void UI_OnBeginLoadRawFile() { }
+  virtual void UI_OnEndLoadRawFile() { }
   virtual void UI_OnBeginScan() { }
   virtual void UI_SetScanInfo() { }
   virtual void UI_OnEndScan() { }

--- a/src/main/formats/CPSTrackV1.cpp
+++ b/src/main/formats/CPSTrackV1.cpp
@@ -319,7 +319,7 @@ bool CPSTrackV1::ReadEvent(void) {
           loopOffset[loopNum] = 0;
         }
         else {
-          printf("%X JUMPING TO %X\n", curOffset, jump);
+//          printf("%X JUMPING TO %X\n", curOffset, jump);
           curOffset = jump;
         }
         break;
@@ -350,7 +350,7 @@ bool CPSTrackV1::ReadEvent(void) {
             curOffset += 2;
             AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Break", L"", CLR_LOOP);
 
-            printf("%X LOOP BREAK JUMPING TO %X\n", curOffset, jump);
+//            printf("%X LOOP BREAK JUMPING TO %X\n", curOffset, jump);
             if (((CPSSeq *) parentSeq)->fmt_version <= VER_CPS1_425) {
               curOffset = jump;
             }
@@ -374,8 +374,7 @@ bool CPSTrackV1::ReadEvent(void) {
           jump = curOffset + 2 + (short)GetShortBE(curOffset);
         }
 
-        printf("%X LOOP ALWAYS JUMPING TO %X\n", curOffset, jump);
-        //        curOffset += 2;
+//        printf("%X LOOP ALWAYS JUMPING TO %X\n", curOffset, jump);
         bool bResult = AddLoopForever(beginOffset, 3);
         curOffset = jump;
 
@@ -401,16 +400,12 @@ bool CPSTrackV1::ReadEvent(void) {
         AddUnknown(beginOffset, curOffset - beginOffset, L"Reg9 Event (unknown to MAME)");
         break;
 
-      case 0x1A :    //master(?) vol
-      {
-        //curOffset++;
+      case 0x1A : {
         vol = GetByte(curOffset++);
         AddGenericEvent(beginOffset, curOffset - beginOffset, L"Master Volume", L"", CLR_UNKNOWN);
         //this->AddMasterVol(beginOffset, curOffset-beginOffset, vol);
-        //AddVolume(beginOffset, curOffset-beginOffset, vool);
         break;
       }
-        //AddUnknown(beginOffset, curOffset-beginOffset);
 
       //Vibrato depth...
       case 0x1B : {

--- a/src/ui/qt/QtVGMRoot.cpp
+++ b/src/ui/qt/QtVGMRoot.cpp
@@ -43,6 +43,16 @@ void QtVGMRoot::UI_CloseRawFile(RawFile*) {
   this->UI_RemovedRawFile();
 }
 
+void QtVGMRoot::UI_OnBeginLoadRawFile() {
+  if (rawFileLoadRecurseStack++ == 0)
+    this->UI_BeganLoadingRawFile();
+}
+
+void QtVGMRoot::UI_OnEndLoadRawFile() {
+  if (--rawFileLoadRecurseStack == 0)
+    this->UI_EndedLoadingRawFile();
+}
+
 void QtVGMRoot::UI_OnBeginScan() {
 }
 

--- a/src/ui/qt/QtVGMRoot.h
+++ b/src/ui/qt/QtVGMRoot.h
@@ -22,6 +22,8 @@ public:
   void UI_AddRawFile(RawFile* newFile) override;
   void UI_CloseRawFile(RawFile* targFile) override;
 
+  void UI_OnBeginLoadRawFile() override;
+  void UI_OnEndLoadRawFile() override;
   void UI_OnBeginScan() override;
   void UI_SetScanInfo() override;
   void UI_OnEndScan() override;
@@ -42,7 +44,12 @@ public:
                                           const std::wstring& extension = L"") override;
   std::wstring UI_GetSaveDirPath(const std::wstring& suggestedDir = L"") override;
 
+private:
+  int rawFileLoadRecurseStack = 0;
+
 signals:
+  void UI_BeganLoadingRawFile();
+  void UI_EndedLoadingRawFile();
   void UI_AddedRawFile();
   void UI_RemovedRawFile();
   void UI_AddedVGMFile();

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -24,10 +24,27 @@ static const QIcon &VGMCollIcon() {
  * VGMCollListViewModel
  */
 VGMCollListViewModel::VGMCollListViewModel(QObject *parent) : QAbstractListModel(parent) {
+  connect(&qtVGMRoot, &QtVGMRoot::UI_BeganLoadingRawFile,
+          [=]() {
+            resettingModel = true;
+            beginResetModel();
+          });
+  connect(&qtVGMRoot, &QtVGMRoot::UI_EndedLoadingRawFile,
+          [=]() {
+            endResetModel();
+            resettingModel = false;
+          });
+
   connect(&qtVGMRoot, &QtVGMRoot::UI_AddedVGMColl,
-          [=]() { dataChanged(index(0, 0), index(rowCount() - 1, 0)); });
+          [=]() {
+            if (!resettingModel)
+              dataChanged(index(0, 0), index(rowCount() - 1, 0));
+          });
   connect(&qtVGMRoot, &QtVGMRoot::UI_RemovedVGMColl,
-          [=]() { dataChanged(index(0, 0), index(rowCount() - 1, 0)); });
+          [=]() {
+            if (!resettingModel)
+              dataChanged(index(0, 0), index(rowCount() - 1, 0));
+          });
 }
 
 int VGMCollListViewModel::rowCount(const QModelIndex &) const {

--- a/src/ui/qt/workarea/VGMCollListView.h
+++ b/src/ui/qt/workarea/VGMCollListView.h
@@ -19,6 +19,9 @@ public:
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
   Qt::ItemFlags flags(const QModelIndex &index) const override;
+
+private:
+  bool resettingModel = false;
 };
 
 class VGMCollNameEditor : public QStyledItemDelegate {


### PR DESCRIPTION
I was finding that, on all platforms, dropping multiple mame roms into the app would bring it to a standstill as it loaded collections. Profiling showed that it was the UI rendering of listview items bringing things to a crawl.  The problem is that we're telling the QListView that all rows have changed whenever a new collection is added, and some mame roms add thousands of collections:

In VGMCollListViewModel:
```
  connect(&qtVGMRoot, &QtVGMRoot::UI_AddedVGMColl,
          [=]() { dataChanged(index(0, 0), index(rowCount() - 1, 0));
  });
```

We could potentially fix this a number of ways: add an index to the UI_AddedVGMColl callback so that we only `dateChanged()` that index, assume the new collection is appended at the last index, or wait until the load is complete then reload the model. I went with the last option.

This adds callbacks in Root to tell us when a RawFile is being loaded. We hook these up to some signals in QtVGMRoot that tell our VGMCollListViewModel to call `beginResetModel()` and `endResetModel()` when the loading begins/ends respectively. Since we can still add collections manually, we keep that connect block but prevent it from running during a raw file load.

Related note: we might want to move loading to a background thread.

Sorry about the code clean-up in CPSTrackV1.

## How Has This Been Tested?
Tested on MacOS build. Confirmed it's fixed the performance issue. Tested manual collection creation. Tested deleting collections.