### PR TITLE
CI: Add FreeBSD 14.0 and remove FreeBSD 12.4.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,6 @@ task:
     name: FreeBSD
     freebsd_instance:
         matrix:
-            image_family: freebsd-12-4
             image_family: freebsd-13-2
 
     install_script: pwd && ls -la && pkg update --force && pkg install -y cmake ninja qt6-base qt6-svg minizip


### PR DESCRIPTION
FreeBSD 12.4 is EOL at the end of 2023, and FreeBSD 14.0 was released recently.

## Description
Add FreeBSD 14 and remove FreeBSD 12
<!--- Describe your changes in detail -->

## Motivation and Context
FreeBSD 14 is released now. FreeBSD 12 is retired.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Will be tested via CI in pull request workflow.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
