### PR TITLE
Improvement to HexView splitter behavior and font increase/decrease

### DIFF
--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -33,9 +33,9 @@ HexView::HexView(VGMFile* vgmfile, QWidget *parent) :
   lineCache.setMaxCost(NUM_CACHED_LINE_PIXMAPS);
 
   double appFontPointSize = QApplication::font().pointSizeF();
-  QFont font("Roboto Mono", appFontPointSize + 2);
+  QFont font("Roboto Mono", appFontPointSize);
   // Call setPointSizeF, as QFont() doesn't accept a float size value
-  font.setPointSizeF(appFontPointSize + 2.0);
+  font.setPointSizeF(appFontPointSize);
 
   this->setFont(font);
   this->setFocusPolicy(Qt::StrongFocus);

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -33,9 +33,9 @@ HexView::HexView(VGMFile* vgmfile, QWidget *parent) :
   lineCache.setMaxCost(NUM_CACHED_LINE_PIXMAPS);
 
   double appFontPointSize = QApplication::font().pointSizeF();
-  QFont font("Roboto Mono", appFontPointSize);
+  QFont font("Roboto Mono", appFontPointSize + 1);
   // Call setPointSizeF, as QFont() doesn't accept a float size value
-  font.setPointSizeF(appFontPointSize);
+  font.setPointSizeF(appFontPointSize + 1.0);
 
   this->setFont(font);
   this->setFocusPolicy(Qt::StrongFocus);

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -20,6 +20,7 @@ public:
   explicit HexView(VGMFile* vgmfile, QWidget *parent = nullptr);
   void setSelectedItem(VGMItem* item);
   void setFont(QFont& font);
+  int getVirtualWidth();
 
 protected:
   bool event(QEvent *event) override;
@@ -35,7 +36,6 @@ protected:
 
 private:
   int getVirtualHeight();
-  int getVirtualWidth();
   int getTotalLines();
   int getOffsetFromPoint(QPoint pos);
   void resizeOverlays(int height);

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -54,7 +54,12 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
           });
 
   connect(new QShortcut(QKeySequence::ZoomIn, this), &QShortcut::activated, [&] {
-    updateHexViewFont(0.5);
+    updateHexViewFont(+0.5);
+  });
+
+  QShortcut* shortcutEqual = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Equal), this);
+  connect(shortcutEqual, &QShortcut::activated, [&] {
+    updateHexViewFont(+0.5);
   });
 
   connect(new QShortcut(QKeySequence::ZoomOut, this), &QShortcut::activated, [&] {

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -34,7 +34,12 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
 
   m_splitter->addWidget(m_hexScrollArea);
   m_splitter->addWidget(m_treeview);
-  m_splitter->setSizes(QList<int>() << 900 << 270);
+  m_splitter->setSizes(QList<int>{hexViewWidth(), treeViewMinimumWidth});
+  m_splitter->setStretchFactor(0, 0);
+  m_splitter->setStretchFactor(1, 1);
+  m_hexScrollArea->setMaximumWidth(hexViewWidth());
+  m_treeview->setMinimumWidth(treeViewMinimumWidth);
+
 
 
   connect(m_hexview, &HexView::selectionChanged, this, &VGMFileView::onSelectionChange);
@@ -49,18 +54,45 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
           });
 
   connect(new QShortcut(QKeySequence::ZoomIn, this), &QShortcut::activated, [&] {
-    auto font = m_hexview->font();
-    font.setPointSizeF(font.pointSizeF() + 0.5);
-    m_hexview->setFont(font);
+    updateHexViewFont(0.5);
   });
 
   connect(new QShortcut(QKeySequence::ZoomOut, this), &QShortcut::activated, [&] {
-    auto font = m_hexview->font();
-    font.setPointSizeF(font.pointSizeF() - 0.5);
-    m_hexview->setFont(font);
+    updateHexViewFont(-0.5);
   });
 
   setWidget(m_splitter);
+}
+
+int VGMFileView::hexViewWidth() {
+  return m_hexview->getVirtualWidth() + hexViewPadding;
+}
+
+void VGMFileView::updateHexViewFont(qreal sizeIncrement) {
+  // Increment the font size until it has an actual effect on width
+  QFont font = m_hexview->font();
+  QFontMetricsF fontMetrics(font);
+  qreal origWidth = fontMetrics.horizontalAdvance("A");
+  qreal fontSize = font.pointSizeF();
+  do {
+    fontSize += sizeIncrement;
+    font.setPointSizeF(fontSize);
+    fontMetrics = QFontMetricsF(font);
+  } while (fontMetrics.horizontalAdvance("A") == origWidth);
+
+  // Updating the font will shrink or expand the maximum possible width of the hex view
+  int actualWidthBeforeResize = m_splitter->sizes()[0];
+  int fullWidthBeforeResize = hexViewWidth();
+
+  m_hexview->setFont(font);
+  m_hexScrollArea->setMaximumWidth(hexViewWidth());
+
+  // We'll scale the hex view size such that approximately the same portion of text will be visible
+  float percentHexViewVisible = static_cast<float>(actualWidthBeforeResize) / static_cast<float>(fullWidthBeforeResize);
+  int fullWidthAfterResize = hexViewWidth();
+  int widthChange = fullWidthAfterResize - fullWidthBeforeResize;
+  int newWidth = actualWidthBeforeResize + static_cast<int>(round(static_cast<float>(widthChange) * percentHexViewVisible));
+  m_splitter->setSizes(QList<int>{newWidth, treeViewMinimumWidth});
 }
 
 void VGMFileView::closeEvent(QCloseEvent *) {

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -74,11 +74,14 @@ void VGMFileView::updateHexViewFont(qreal sizeIncrement) {
   QFontMetricsF fontMetrics(font);
   qreal origWidth = fontMetrics.horizontalAdvance("A");
   qreal fontSize = font.pointSizeF();
-  do {
+  for (int i = 0; i < 3; i++) {
     fontSize += sizeIncrement;
     font.setPointSizeF(fontSize);
     fontMetrics = QFontMetricsF(font);
-  } while (fontMetrics.horizontalAdvance("A") == origWidth);
+    if (fontMetrics.horizontalAdvance("A") != origWidth) {
+      break;
+    }
+  }
 
   // Updating the font will shrink or expand the maximum possible width of the hex view
   int actualWidthBeforeResize = m_splitter->sizes()[0];

--- a/src/ui/qt/workarea/VGMFileView.h
+++ b/src/ui/qt/workarea/VGMFileView.h
@@ -22,8 +22,12 @@ public:
   explicit VGMFileView(VGMFile *vgmFile);
 
 private:
+  static constexpr int hexViewPadding = 15;  // Extra horizontal padding for view's max width
+  static constexpr int treeViewMinimumWidth = 235;
+
   void closeEvent(QCloseEvent *closeEvent) override;
-  void markEvents();
+  int hexViewWidth();
+  void updateHexViewFont(qreal sizeIncrement);
 
   VGMFileTreeView* m_treeview{};
   VGMFile* m_vgmfile{};


### PR DESCRIPTION
Resizing the app window causes both hex view and tree view to resize 1:1. I've added logic to limit the maximum width of the hex view so that it doesn't expand beyond the ASCII text column, allowing extra space to be devoted to the tree view. 

I also added logic so that increasing/decreasing the font size will make the hex view proportionally grow/shrink, so if you've repositioned the splitter to, say, hide the ASCII view, you won't need to reposition it after a font size change.

Also, I found that increasing/decreasing the font size in increments of 0.5 was sometimes having no effect, as Qt seems inexact about font sizing. I added some logic to increment the font size until there is an actual change in character width.

I also decreased the default font size a bit.

## How Has This Been Tested?
Tested on Mac and Windows
