### PR TITLE
Fix crashes on quit related to static destruction order

### DIFF
--- a/src/main/Format.cpp
+++ b/src/main/Format.cpp
@@ -4,9 +4,9 @@
 
 using namespace std;
 
-FormatMap &Format::registry() {
-  static FormatMap registry;
-  return registry;
+FormatMap& Format::registry() {
+  static FormatMap* registry = new FormatMap();
+  return *registry;
 }
 
 Format::Format(const string &formatName) :
@@ -22,6 +22,13 @@ Format::~Format(void) {
     delete matcher;
 }
 
+void Format::DeleteFormatRegistry() {
+  for (auto& pair : registry()) {
+    delete pair.second;
+  }
+  registry().clear();
+}
+
 Format *Format::GetFormatFromName(const string &name) {
   FormatMap::iterator findIt = registry().find(name);
   if (findIt == registry().end())
@@ -33,15 +40,6 @@ bool Format::OnNewFile(VGMFile *file) {
   if (!matcher)
     return false;
   return matcher->OnNewFile(file);
-  //switch (file->GetFileType())
-  //{
-  //case FILETYPE_SEQ:
-  //	return OnNewSeq((VGMSeq*)file);
-  //case FILETYPE_INSTRSET:
-  //	return OnNewInstrSet((VGMInstrSet*)file);
-  //case FILETYPE_SAMPCOLL:
-  //	return OnNewSampColl((VGMSampColl*)file);
-  //}
 }
 
 VGMColl *Format::NewCollection() {

--- a/src/main/Format.h
+++ b/src/main/Format.h
@@ -15,13 +15,13 @@ class Matcher;
 class VGMScanner;
 
 #define DECLARE_FORMAT(_name_)               \
-  _name_##Format _name_##FormatRegisterThis; \
+  const _name_##Format* _name_##Format::_name_##FormatInstance = new _name_##Format(); \
   const std::string _name_##Format::name = #_name_;
 
 #define BEGIN_FORMAT(_name_)                                \
   class _name_##Format : public Format {                    \
   public:                                                   \
-    static const _name_##Format _name_##FormatRegisterThis; \
+    static const _name_##Format* _name_##FormatInstance;    \
     static const std::string name;                          \
     _name_##Format() : Format(#_name_) { Init(); }          \
     virtual const std::string &GetName() { return name; }
@@ -53,15 +53,16 @@ protected:
 
 public:
   Format(const std::string &scannerName);
-  virtual ~Format(void);
+  virtual ~Format();
 
   static Format *GetFormatFromName(const std::string &name);
+  static void DeleteFormatRegistry();
 
-  virtual bool Init(void);
+  virtual bool Init();
   virtual const std::string &GetName() = 0;
-  virtual VGMScanner *NewScanner() { return NULL; }
-  VGMScanner &GetScanner() { return *scanner; }
-  virtual Matcher *NewMatcher() { return NULL; }
+  virtual VGMScanner *NewScanner() { return nullptr; }
+  VGMScanner &GetScanner() const { return *scanner; }
+  virtual Matcher *NewMatcher() { return nullptr; }
   virtual VGMColl *NewCollection();
   virtual bool OnNewFile(VGMFile *file);
   virtual bool OnCloseFile(VGMFile *file);

--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -33,6 +33,7 @@ VGMRoot::~VGMRoot(void) {
   DeleteVect<RawFile>(vRawFile);
   DeleteVect<VGMFile>(vVGMFile);
   DeleteVect<LogItem>(vLogItem);
+  Format::DeleteFormatRegistry();
 }
 
 // initializes the VGMRoot class by pushing every VGMScanner and

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -94,8 +94,6 @@ class VGMRoot {
 
   std::vector<VGMLoader *> vLoader;
   std::vector<VGMScanner *> vScanner;
-  //std::map<uint32_t, Format*> fmt_map;
-  //std::vector<Format*> vFormats;
 };
 
 extern VGMRoot *pRoot;


### PR DESCRIPTION
When quitting the app, if a file was ever loaded into the app, MacOS would report a crash after quitting. Looking into the crash logs, it became clear this is caused by the destruction order of static objects. Specifically, the VGMRoot object, the FormatMap registry object, and all of the Format objects are declared statically. The destructor of VGMRoot references these other static instances at some point down the stack trace, but they might be destroyed before VGMRoot is.

To fix the issue, I made the FormatMap registry and Format instances into static pointers, ensuring that they'll be destroyed after VGMRoot (upon app exit, or when we delete them ourselves).

It's unclear to me if best practice is to actually delete all of these instances on close of the app, as we're mostly doing, given that the OS presumably will do all of this for us sans the performance hit of manual deletion. Put another way, do we really need to do anything in ~VGMRoot? For consistency, I added a method to delete all of the formats from the map.

## How Has This Been Tested?
Ran this on MacOS.
