### PR TITLE
Use system WindowText color for MarqueeLabel (respects light/dark mode)

### DIFF
--- a/src/ui/qt/util/MarqueeLabel.cpp
+++ b/src/ui/qt/util/MarqueeLabel.cpp
@@ -6,6 +6,7 @@
 
 #include "MarqueeLabel.h"
 #include <QPainter>
+#include <QApplication>
 
 MarqueeLabel::MarqueeLabel(QWidget *parent) : QWidget(parent) {
   m_static_text.setTextFormat(Qt::PlainText);
@@ -84,6 +85,8 @@ void MarqueeLabel::updateText() {
 
 void MarqueeLabel::paintEvent(QPaintEvent *) {
   QPainter p(this);
+  QPalette palette = QApplication::palette();
+  p.setPen(palette.color(QPalette::WindowText));
   if (m_scroll_enabled) {
     int x = std::min(-m_scroll_pos, 0) + m_margin_left;
     while (x < width()) {


### PR DESCRIPTION
Images attached:

Before:
<img width="813" alt="Screenshot 2023-12-13 at 9 55 16 PM" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/653ccdf3-8c25-4f22-85df-2bf3876c6f8c">
<img width="806" alt="Screenshot 2023-12-13 at 9 53 19 PM" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/0f52bdee-e819-456a-a5db-37f3589dff65">

After:
<img width="811" alt="Screenshot 2023-12-13 at 9 45 12 PM" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/90638095-8f17-436f-aa5a-4f8dcde5c5f6">
<img width="810" alt="Screenshot 2023-12-13 at 9 45 33 PM" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/a0a811d6-2406-4029-8869-d0e7a96eea57">

Update:
Tested on Windows and working fine. The app doesn't respect Windows dark mode in general, though.