### PR TITLE
Improve VGMFileListView Headers

### DIFF
--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -128,7 +128,14 @@ VGMFileListView::VGMFileListView(QWidget *parent) : QTableView(parent) {
   header_hor->setDefaultAlignment(Qt::AlignLeft | Qt::AlignVCenter);
   header_hor->setSectionResizeMode(1, QHeaderView::Fixed);
   header_hor->setStyleSheet("QHeaderView::section { padding-left: 6px; }");
-  setColumnWidth(1, 60);
+
+  // set the "Format" section header size
+  QFont headerFont = header_hor->font();
+  QFontMetrics fm(headerFont);
+  QVariant headerTextVariant = view_model->headerData(1, Qt::Horizontal, Qt::DisplayRole);
+  auto headerText = headerTextVariant.isValid() ? headerTextVariant.toString() : "Format";
+  int textWidth = fm.horizontalAdvance(headerText);
+  setColumnWidth(1, textWidth + 45);
 
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 

--- a/src/ui/qt/workarea/VGMFileListView.h
+++ b/src/ui/qt/workarea/VGMFileListView.h
@@ -54,5 +54,5 @@ class VGMFileListView final : public QTableView {
     void itemMenu(const QPoint &pos);
     void resizeColumns();
 
-        VGMFileListModel *view_model;
+    VGMFileListModel *view_model;
 };

--- a/src/ui/qt/workarea/VGMFileListView.h
+++ b/src/ui/qt/workarea/VGMFileListView.h
@@ -42,9 +42,17 @@ class VGMFileListView final : public QTableView {
     void requestVGMFileView(QModelIndex index);
     void removeVGMFile(VGMFile *file);
 
+   protected:
+    void scrollContentsBy(int dx, int dy) override;
+    void resizeEvent(QResizeEvent *event) override;
+
+   private slots:
+    void onHeaderSectionResized(int index, int oldSize, int newSize);
+
    private:
     void keyPressEvent(QKeyEvent *input) override;
     void itemMenu(const QPoint &pos);
+    void resizeColumns();
 
-    VGMFileListModel *view_model;
+        VGMFileListModel *view_model;
 };


### PR DESCRIPTION
This improves the appearance and resizing behavior of the VGMFileListView. There are a few issues I want to fix:

1. The headers are spaced evenly and cannot be resized
2. Resizing should expand/contract the Name header instead of both headers evenly
3. There is a little splitter at the right edge of the Format section header
<img width="264" alt="Screenshot 2023-12-13 at 11 40 35 PM" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/afb6bea1-f942-415c-955f-1259f774d090">

This fixes the above problems. I've also added logic so that the splitter resizes both sections so that their widths sum to the full header width.

The initial width of the Format section header is set by calculating the width of the "Format" text itself and adding some padding. This is necessary as the font will be different per platform.

I disable the horizontal scroll bar and override the scrollContentsBy() event so that horizontal scrolling is impossible. this is necessary to get rid of the extraneous splitter, as it could otherwise scroll into view.

Tested on MacOS and Windows.

Windows
<img width="147" alt="Capture" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/913ec484-062e-41dc-ae6a-a0f0b59ca1be">

Mac:
<img width="266" alt="Screenshot 2023-12-13 at 11 31 05 PM" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/b70298c4-7226-4914-b443-831761893a69">
