### PR TITLE
Upgrade to Qt6, drop Qt5 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,10 @@ jobs:
         run: cmake --build build --config "Release" --parallel
       - working-directory: "build"
         name: "Package DMG (macOS)"
-        run: /usr/local/opt/qt6/bin/macdeployqt bin/VGMTrans.app -dmg -always-overwrite
+        run: |
+          /usr/local/opt/qt6/bin/macdeployqt \
+            bin/VGMTrans.app \
+            -verbose=3 -dmg -always-overwrite -appstore-compliant
       - name: "Upload artifact"
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  macos_x64:
-    name: macOS (Intel)
-    runs-on: macos-12
+  x86_64-apple-darwin:
+    name: macOS 11.x+, Intel
+    runs-on: macos-13
     env:
       osx_min_ver: "11.0"
       osx_arch: "x86_64"
@@ -16,13 +16,17 @@ jobs:
       - uses: actions/checkout@v3
       - name: "Install dependencies"
         run: |
-          brew upgrade qt@5 ninja || brew install qt@5 ninja
+          brew install -f --overwrite python@3.12 llvm@17 qt@6 ninja
           echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
           echo "/usr/local/bin" >> $GITHUB_PATH
       - name: "Prepare build"
         run: |
+          export LDFLAGS="-L/usr/local/opt/llvm/lib"
+          export CPPFLAGS="-I/usr/local/opt/llvm/include"
           cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ env.osx_min_ver }} \
                 -DCMAKE_OSX_ARCHITECTURES=${{ env.osx_arch }} \
+                -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang \
+                -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ \
                 -DCMAKE_BUILD_TYPE=Release \
                 -G Ninja \
                 -B build
@@ -30,15 +34,15 @@ jobs:
         run: cmake --build build --config "Release" --parallel
       - working-directory: "build"
         name: "Package DMG (macOS)"
-        run: /usr/local/opt/qt5/bin/macdeployqt bin/VGMTrans.app -dmg -always-overwrite
+        run: /usr/local/opt/qt6/bin/macdeployqt bin/VGMTrans.app -dmg -always-overwrite
       - name: "Upload artifact"
         uses: actions/upload-artifact@v3
         with:
           name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-${{ env.osx_arch }}-${{ runner.os }}.dmg
           path: "build/bin/VGMTrans.dmg"
-  Ubuntu:
+  x86_64-pc-linux-gnu:
     runs-on: ubuntu-20.04
-    name: Linux
+    name: Linux, x64
     steps:
       - uses: actions/checkout@v3
       - name: "Set environment variables"
@@ -48,15 +52,32 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16
+          sudo ./llvm.sh 17
+          sudo add-apt-repository ppa:okirby/qt6-backports
           sudo apt-get update && sudo apt-get upgrade -y
-          sudo apt-get install -y pkg-config clang-16 lld-16 ninja-build \
-            qtbase5-dev libqt5svg5-dev libqt5svg5 libqt5waylandclient5 libqt5waylandclient5-dev libqt5waylandcompositor5 libqt5waylandcompositor5-dev libgl1-mesa-dev \
+          sudo apt-get install -y pkg-config \
+            clang-17 lld-17 ninja-build \
+            qt6-base-dev libqt6svg6-dev libqt6svg6 \
+            qt6-tools-dev qt6-tools-dev-tools libgl1-mesa-dev \
             libjack-dev libsndfile1-dev libpulse-dev
+          echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.bash_profile
       - name: "Prepare build"
-        run: cmake -DCMAKE_C_COMPILER="clang-16" -DCMAKE_CXX_COMPILER="clang++-16" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -GNinja -B build
+        run: |
+          export LDFLAGS="-L/usr/local/opt/llvm/lib"
+          export CPPFLAGS="-I/usr/local/opt/llvm/include"
+          cmake \
+            -DCMAKE_C_COMPILER=clang-17 \
+            -DCMAKE_CXX_COMPILER=clang++-17 \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_BUILD_TYPE=Release \
+            -GNinja \
+            -B build
       - name: "Build project"
-        run: cmake --build build --config "Release" --parallel
+        run: |
+         cmake \
+          --build build \
+          --config "Release" \
+          --parallel
       - name: "Make AppImage"
         working-directory: "build"
         run: |
@@ -75,7 +96,8 @@ jobs:
           echo "Creating AppImage"
           ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/VGMTrans.desktop \
             -executable=appdir/usr/lib/libbass.so -executable=appdir/usr/lib/libbassmidi.so \
-            -appimage -extra-plugins=platforms/,wayland-shell-integration/,wayland-decoration-client/ \
+            -appimage -extra-plugins=platforms/,platformthemes/ \
+            -qmake=/usr/lib/qt6/bin/qmake6 \
             -verbose=10
           mv VGMTrans*.AppImage VGMTrans.AppImage
       - name: "Upload artifact"
@@ -83,9 +105,9 @@ jobs:
         with:
           name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-x86_64-${{ runner.os }}.AppImage
           path: "build/VGMTrans.AppImage"
-  Windows:
+  x86_64-pc-windows-msvc:
     runs-on: windows-2022
-    name: Windows
+    name: Windows, x64
     steps:
        - uses: actions/checkout@v3
          with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "win-deps"]
 	path = lib/vgmtrans-ext-win
-	url = https://github.com/vgmtrans/vgmtrans-ext-win
+	url = ../vgmtrans-ext-win

--- a/lib/filesystem/CMakeLists.txt
+++ b/lib/filesystem/CMakeLists.txt
@@ -32,7 +32,6 @@ endif()
 if(CMAKE_CXX_STANDARD LESS 11)
     message(FATAL_ERROR "CMAKE_CXX_STANDARD is less than 11, ghc::filesystem only works with C++11 and above.")
 endif()
-message(STATUS "CMAKE_CXX_COMPILE_FEATURES: ${CMAKE_CXX_COMPILE_FEATURES}")
 
 add_library(ghc_filesystem INTERFACE)
 target_include_directories(ghc_filesystem INTERFACE

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -180,8 +180,12 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
       --no-compiler-runtime --no-system-d3d-compiler --no-opengl-sw
       "$<TARGET_FILE:vgmtrans>")
 
-  file(WRITE "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/qt.conf"
-       "[Paths]\r\nPlugins = ./QtPlugins")
+  add_custom_command(
+    TARGET vgmtrans
+    POST_BUILD
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_LIST_DIR}/qt.conf"
+      "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
   get_target_property(BASS_DLL_LOCATION BASS::BASS IMPORTED_LOCATION)
   add_custom_command(

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -19,10 +19,13 @@ endif()
 if(NOT Qt6_DIR AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
   message(STATUS "Using vendored Qt6")
   set(Qt6_DIR
-      "${CMAKE_SOURCE_DIR}/lib/vgmtrans-ext-win/qt6.6.1-x86_64-pc-windows-msvc/lib/cmake/Qt6")
+      "${CMAKE_SOURCE_DIR}/lib/vgmtrans-ext-win/qt6.6.1-x86_64-pc-windows-msvc/lib/cmake/Qt6"
+  )
   if(NOT EXISTS "${Qt6_DIR}")
     message(SEND_ERROR "Could not find `${Qt6_DIR}`")
-    message(SEND_ERROR "Did you forget to run `git submodule update --init --recursive`?")
+    message(
+      SEND_ERROR
+        "Did you forget to run `git submodule update --init --recursive`?")
   endif()
 endif()
 
@@ -96,6 +99,12 @@ target_link_libraries(
           gsl-lite
           BASS::MIDI)
 
+# Workaround macdeployqt not correctly deploying QtDbus
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  find_package(Qt6 REQUIRED COMPONENTS DBus)
+  target_link_libraries(vgmtrans PUBLIC Qt::DBus)
+endif()
+
 set_target_properties(vgmtrans PROPERTIES AUTOMOC ON)
 qt_add_resources(UI_RESOURCES
                  "${CMAKE_CURRENT_LIST_DIR}/resources/resources.qrc")
@@ -168,7 +177,8 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
       --plugindir="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/QtPlugins"
       --libdir="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
       $<IF:$<CONFIG:Debug>,--debug,--release> --no-translations
-      --no-compiler-runtime --no-system-d3d-compiler --no-opengl-sw "$<TARGET_FILE:vgmtrans>")
+      --no-compiler-runtime --no-system-d3d-compiler --no-opengl-sw
+      "$<TARGET_FILE:vgmtrans>")
 
   file(WRITE "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/qt.conf"
        "[Paths]\r\nPlugins = ./QtPlugins")

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -38,7 +38,7 @@ message(STATUS "Using Qt ${Qt6_VERSION}")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   set(GUI_TYPE MACOSX_BUNDLE)
-elseif(CMAKE_SYSTEM_BAME STREQUAL "Windows")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set(GUI_TYPE WIN32)
 endif()
 

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -35,6 +35,8 @@ message(STATUS "Using Qt ${Qt6_VERSION}")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   set(GUI_TYPE MACOSX_BUNDLE)
+elseif(CMAKE_SYSTEM_BAME STREQUAL "Windows")
+  set(GUI_TYPE WIN32)
 endif()
 
 add_executable(

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -1,67 +1,45 @@
+# ~~~
+# Dependencies
+# ~~~
+
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/gsl-lite"
                  "${CMAKE_CURRENT_BINARY_DIR}/gsl-lite" EXCLUDE_FROM_ALL)
 
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/bass"
                  "${CMAKE_CURRENT_BINARY_DIR}/bass" EXCLUDE_FROM_ALL)
 
-if(APPLE)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   # Homebrew installs Qt (up to at least 5.9.1) in /usr/local/qt*, ensure it can
   # be found by CMake since it is not in the default /usr/local prefix.
-  if(EXISTS /usr/local/opt/qt5)
-    list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
-  endif()
-
   if(EXISTS /usr/local/opt/qt6)
     list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt6")
   endif()
 endif()
 
-if(Qt6_DIR)
-  set(Qt_DIR "${Qt6_DIR}")
-elseif(Qt5_DIR)
-  set(Qt_DIR "${Qt5_DIR}")
+if(NOT Qt6_DIR AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  message(STATUS "Using vendored Qt6")
+  set(Qt6_DIR
+      "${CMAKE_SOURCE_DIR}/lib/vgmtrans-ext-win/qt6.6.1-x86_64-pc-windows-msvc/lib/cmake/Qt6")
+  if(NOT EXISTS "${Qt6_DIR}")
+    message(SEND_ERROR "Could not find `${Qt6_DIR}`")
+    message(SEND_ERROR "Did you forget to run `git submodule update --init --recursive`?")
+  endif()
 endif()
 
-if(NOT Qt_DIR AND MSVC)
-  set(Qt_DIR
-      "${CMAKE_SOURCE_DIR}/lib/vgmtrans-ext-win/qt5-msvc2019-x64/lib/cmake/Qt5")
-  set(Qt5_DIR ${Qt_DIR})
-  message(STATUS "Using Qt5 fallback")
-endif()
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Svg)
+message(STATUS "Using Qt ${Qt6_VERSION}")
 
-find_package(
-  Qt NAMES Qt6 Qt5
-  COMPONENTS Gui Widgets Svg
-  REQUIRED)
-find_package(
-  Qt${Qt_VERSION_MAJOR} 5.9
-  COMPONENTS Gui Widgets Svg
-  REQUIRED)
-message(STATUS "Using Qt ${Qt_VERSION}")
+# ~~~
+# Build
+# ~~~
 
-# Workaround for QTBUG-57886
-set_property(TARGET Qt${Qt_VERSION_MAJOR}::Core
-             PROPERTY INTERFACE_COMPILE_FEATURES "")
-
-set(CMAKE_AUTOMOC ON)
-if(${Qt_VERSION_MAJOR} EQUAL 6)
-  qt6_add_resources(UI_RESOURCES
-                    "${CMAKE_CURRENT_LIST_DIR}/resources/resources.qrc")
-elseif(${Qt_VERSION_MAJOR} EQUAL 5)
-  qt5_add_resources(UI_RESOURCES
-                    "${CMAKE_CURRENT_LIST_DIR}/resources/resources.qrc")
-endif()
-
-if(WIN32)
-  set(GUI_TYPE WIN32)
-elseif(APPLE)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   set(GUI_TYPE MACOSX_BUNDLE)
 endif()
 
 add_executable(
   vgmtrans
   ${GUI_TYPE}
-  ${UI_RESOURCES}
   About.cpp
   About.h
   IconBar.cpp
@@ -111,11 +89,19 @@ target_link_libraries(
   PRIVATE g_options
           g_warnings
           vgmtranscore
-          Qt${Qt_VERSION_MAJOR}::Widgets
-          Qt${Qt_VERSION_MAJOR}::Svg
+          Qt::Widgets
+          Qt::Svg
           gsl-lite
           BASS::MIDI)
 
+set_target_properties(vgmtrans PROPERTIES AUTOMOC ON)
+qt_add_resources(UI_RESOURCES
+                 "${CMAKE_CURRENT_LIST_DIR}/resources/resources.qrc")
+target_sources(vgmtrans PRIVATE ${UI_RESOURCES})
+
+# ~~~
+# Install & package
+# ~~~
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(BUNDLE_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VGMTrans.app")
 
@@ -131,24 +117,24 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set_source_files_properties("${CMAKE_CURRENT_LIST_DIR}/resources/appicon.icns"
                               PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
-  add_custom_command(TARGET vgmtrans
-          POST_BUILD
-          COMMAND ${CMAKE_COMMAND} -E copy_directory
-          "${CMAKE_SOURCE_DIR}/bin"
-          "${BUNDLE_PATH}/Contents/Resources")
+  add_custom_command(
+    TARGET vgmtrans
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/bin"
+            "${BUNDLE_PATH}/Contents/Resources")
 
-  get_target_property(BASS_DLL_LOCATION BASS::BASS
-                      IMPORTED_LOCATION)
-  add_custom_command(TARGET vgmtrans
-                      POST_BUILD
-                      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BASS_DLL_LOCATION}"
-                      "${BUNDLE_PATH}/Contents/MacOS/")
-  get_target_property(BASSMIDI_DLL_LOCATION BASS::MIDI
-                      IMPORTED_LOCATION)
-  add_custom_command(TARGET vgmtrans
-                      POST_BUILD
-                      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BASSMIDI_DLL_LOCATION}"
-                      "${BUNDLE_PATH}/Contents/MacOS/")
+  get_target_property(BASS_DLL_LOCATION BASS::BASS IMPORTED_LOCATION)
+  add_custom_command(
+    TARGET vgmtrans
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BASS_DLL_LOCATION}"
+            "${BUNDLE_PATH}/Contents/MacOS/")
+  get_target_property(BASSMIDI_DLL_LOCATION BASS::MIDI IMPORTED_LOCATION)
+  add_custom_command(
+    TARGET vgmtrans
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BASSMIDI_DLL_LOCATION}"
+            "${BUNDLE_PATH}/Contents/MacOS/")
 elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
   # Make sure the executable ends up in the binary directory without any
   # additional folders
@@ -180,26 +166,24 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
       --plugindir="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/QtPlugins"
       --libdir="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
       $<IF:$<CONFIG:Debug>,--debug,--release> --no-translations
-      --no-compiler-runtime --no-angle --no-opengl-sw "$<TARGET_FILE:vgmtrans>")
+      --no-compiler-runtime --no-system-d3d-compiler --no-opengl-sw "$<TARGET_FILE:vgmtrans>")
 
   file(WRITE "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/qt.conf"
        "[Paths]\r\nPlugins = ./QtPlugins")
 
-  get_target_property(BASS_DLL_LOCATION BASS::BASS
-                      IMPORTED_LOCATION)
+  get_target_property(BASS_DLL_LOCATION BASS::BASS IMPORTED_LOCATION)
   add_custom_command(
     TARGET vgmtrans
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BASS_DLL_LOCATION}"
             "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
-  get_target_property(BASSMIDI_DLL_LOCATION BASS::MIDI
-                      IMPORTED_LOCATION)
+  get_target_property(BASSMIDI_DLL_LOCATION BASS::MIDI IMPORTED_LOCATION)
   add_custom_command(
-  TARGET vgmtrans
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BASSMIDI_DLL_LOCATION}"
-    "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+    TARGET vgmtrans
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BASSMIDI_DLL_LOCATION}"
+            "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD|OpenBSD|Linux")
   install(TARGETS vgmtrans DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
   install(

--- a/src/ui/qt/main_ui.cpp
+++ b/src/ui/qt/main_ui.cpp
@@ -9,6 +9,7 @@
 #include <QtPlugin>
 #include <QFile>
 #include <QFontDatabase>
+#include <QStyleFactory>
 #include "MainWindow.h"
 #include "QtVGMRoot.h"
 
@@ -17,6 +18,9 @@ int main(int argc, char *argv[]) {
   QCoreApplication::setApplicationName("VGMTrans");
 
   QApplication app(argc, argv);
+  #ifdef _WIN32
+  app.setStyle(QStyleFactory::create("fusion"));
+  #endif
   qtVGMRoot.Init();
 
   QFontDatabase::addApplicationFont(":/fonts/Roboto_Mono/RobotoMono-VariableFont_wght.ttf");

--- a/src/ui/qt/qt.conf
+++ b/src/ui/qt/qt.conf
@@ -1,0 +1,5 @@
+[Paths]
+Plugins = ./QtPlugins
+
+[Platforms]
+WindowsArguments = fontengine=freetype


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Closes #370 
- drops support for Qt5
- upgrades CI and vendored Windows submodule to Qt6
- uses clang 17 on macOS & Linux
- bumps macos runner to 13.0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Qt6 brings improvements around performance, accessibility, features. It has better behaviour with Wayland on Linux and fully supports dark mode on Windows. 
CI now uses Clang 17 on both Linux and macOS. This results on better performance on both platforms.

## How Has This Been Tested?
Confirmed working:
- macOS 12, M1, built locally
- macOS 12, M1 using Rosetta, built CI
- Windows 11, x64, built locally
- Windows 11, x64, built on CI

Linux builds might have issues due to Wayland but I will work on #356 soon, so we can leave it for now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
