### PR TITLE
Use beginResetModel/endResetModel for batch deletion of collections

### DIFF
--- a/src/ui/qt/QtVGMRoot.cpp
+++ b/src/ui/qt/QtVGMRoot.cpp
@@ -87,9 +87,11 @@ void QtVGMRoot::UI_RemoveVGMColl(VGMColl*) {
 }
 
 void QtVGMRoot::UI_BeginRemoveVGMFiles() {
+  this->UI_BeganRemovingVGMFiles();
 }
 
 void QtVGMRoot::UI_EndRemoveVGMFiles() {
+  this->UI_EndedRemovingVGMFiles();
 }
 
 void QtVGMRoot::UI_AddItem(VGMItem* item, VGMItem* parent, const std::wstring& itemName,

--- a/src/ui/qt/QtVGMRoot.h
+++ b/src/ui/qt/QtVGMRoot.h
@@ -50,6 +50,8 @@ private:
 signals:
   void UI_BeganLoadingRawFile();
   void UI_EndedLoadingRawFile();
+  void UI_BeganRemovingVGMFiles();
+  void UI_EndedRemovingVGMFiles();
   void UI_AddedRawFile();
   void UI_RemovedRawFile();
   void UI_AddedVGMFile();

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -24,16 +24,21 @@ static const QIcon &VGMCollIcon() {
  * VGMCollListViewModel
  */
 VGMCollListViewModel::VGMCollListViewModel(QObject *parent) : QAbstractListModel(parent) {
-  connect(&qtVGMRoot, &QtVGMRoot::UI_BeganLoadingRawFile,
-          [=]() {
-            resettingModel = true;
-            beginResetModel();
-          });
-  connect(&qtVGMRoot, &QtVGMRoot::UI_EndedLoadingRawFile,
-          [=]() {
-            endResetModel();
-            resettingModel = false;
-          });
+  auto startResettingModel = [=]() {
+    resettingModel = true;
+    beginResetModel();
+  };
+
+  auto endResettingModel = [=]() {
+    endResetModel();
+    resettingModel = false;
+  };
+
+  connect(&qtVGMRoot, &QtVGMRoot::UI_BeganLoadingRawFile, startResettingModel);
+  connect(&qtVGMRoot, &QtVGMRoot::UI_EndedLoadingRawFile, endResettingModel);
+  connect(&qtVGMRoot, &QtVGMRoot::UI_BeganRemovingVGMFiles, startResettingModel);
+  connect(&qtVGMRoot, &QtVGMRoot::UI_EndedRemovingVGMFiles, endResettingModel);
+
 
   connect(&qtVGMRoot, &QtVGMRoot::UI_AddedVGMColl,
           [=]() {


### PR DESCRIPTION
This is the counterpart to #405 for batch deletion of collections (when deleting a raw file, for example). Vastly improves performance for the same reasons discussed before.

