### PR TITLE
Fix CPS release rate of 0 bug

### DIFF
--- a/bin/mame_roms.xml
+++ b/bin/mame_roms.xml
@@ -606,7 +606,7 @@
     </game>
     <game name="ssf2" format="CPS" fmt_version="1.03">
         <romgroup type="audiocpu" load_method="append" seq_table="0x7C15" instr_table="0x6C00" num_instr_banks="1" samp_table="0x7410">
-            <rom>ssf.01a</rom>
+            <rom>ssf-01a</rom>
         </romgroup>
         <romgroup type="qsound"  load_method="append">
             <rom>ssf.q01</rom>

--- a/src/main/formats/CPSInstr.cpp
+++ b/src/main/formats/CPSInstr.cpp
@@ -466,7 +466,7 @@ bool CPSInstr::LoadInstr() {
     rgn->sustain_time = (Sr == 0xFFFF) ? 0 : ticks * QSOUND_TICK_FREQ;
     rgn->sustain_time = LinAmpDecayTimeToLinDBDecayTime(rgn->sustain_time, 0x800);
 
-    ticks = Rr ? 0xFFFF / Rr : 0;
+    ticks = Rr ? 0xFFFF / Rr : 0xFFFF;
     rgn->release_time = (Rr == 0xFFFF) ? 0 : ticks * QSOUND_TICK_FREQ;
     rgn->release_time = LinAmpDecayTimeToLinDBDecayTime(rgn->release_time, 0x800);
 


### PR DESCRIPTION
Minor bug: seems a release rate of 0 means infinite release, not no release.

Also fix up ssf2 mame_roms.xml definition.

Will merge this on my own since it is too minor to warrant review.