### PR TITLE
VGMFileListView multi select and deletion

### DIFF
--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -109,7 +109,7 @@ void VGMFileListModel::RemoveVGMFile() {
  */
 
 VGMFileListView::VGMFileListView(QWidget *parent) : QTableView(parent) {
-  setSelectionMode(QAbstractItemView::SingleSelection);
+  setSelectionMode(QAbstractItemView::ExtendedSelection);
   setSelectionBehavior(QAbstractItemView::SelectRows);
   setAlternatingRowColors(true);
   setShowGrid(false);
@@ -206,11 +206,22 @@ void VGMFileListView::keyPressEvent(QKeyEvent *input) {
         return;
 
       QModelIndexList list = selectionModel()->selectedRows();
-      for (auto &index : list) {
-        auto file = qtVGMRoot.vVGMFile[index.row()];
-        file->OnClose();
+
+      std::vector<VGMFile*> selectedFiles;
+      selectedFiles.reserve(list.size());
+      for (const auto &index : list) {
+        if (index.isValid()) {
+          selectedFiles.push_back(qtVGMRoot.vVGMFile[index.row()]);
+        }
       }
 
+      pRoot->UI_BeginRemoveVGMFiles();
+      for (auto vgmfile : selectedFiles) {
+        vgmfile->OnClose();
+      }
+      pRoot->UI_EndRemoveVGMFiles();
+
+      this->clearSelection();
       return;
     }
 


### PR DESCRIPTION
Enable multiple selection in VGMFileListView, fix logic for deleting all selected files. 

The old for loop was broken because the file pointed to by `index` changed with every onClose() call.  What I wouldn't do for a simple map() function instead of reserving space for a vector and looping to populate it. I know about std::transform, but that is just unreadable.

## Motivation and Context
Might as well allow multi selection.

## How Has This Been Tested?
Tested on MacOS, selections of various size.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
