### PR TITLE
Add MenuManager and integrate it into VGMFileListView

### DIFF
--- a/src/main/VGMFile.cpp
+++ b/src/main/VGMFile.cpp
@@ -41,8 +41,7 @@ bool VGMFile::OnClose() {
   return true;
 }
 
-bool VGMFile::OnSaveAsRaw() {
-  string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name));
+bool VGMFile::OnSaveAsRaw(const std::string &filepath) {
   if (filepath.length() != 0) {
     bool result;
     uint8_t *buf = new uint8_t[unLength];        //create a buffer the size of the file

--- a/src/main/VGMFile.h
+++ b/src/main/VGMFile.h
@@ -9,6 +9,10 @@ class Format;
 
 enum FileType { FILETYPE_UNDEFINED, FILETYPE_SEQ, FILETYPE_INSTRSET, FILETYPE_SAMPCOLL, FILETYPE_MISC };
 
+// *******
+// VGMFile
+// *******
+
 class VGMFile:
     public VGMContainerItem {
  public:
@@ -28,7 +32,7 @@ class VGMFile:
   const std::string *GetName(void) const;
 
   bool OnClose();
-  bool OnSaveAsRaw();
+  bool OnSaveAsRaw(const std::string &filepath);
   bool OnSaveAllAsRaw();
 
   bool LoadVGMFile();

--- a/src/main/VGMInstrSet.cpp
+++ b/src/main/VGMInstrSet.cpp
@@ -85,24 +85,6 @@ bool VGMInstrSet::LoadInstrs() {
   return true;
 }
 
-
-bool VGMInstrSet::OnSaveAsDLS(void) {
-  string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), "dls");
-  if (filepath.length() != 0) {
-    return SaveAsDLS(filepath.c_str());
-  }
-  return false;
-}
-
-bool VGMInstrSet::OnSaveAsSF2(void) {
-  string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), "sf2");
-  if (filepath.length() != 0) {
-    return SaveAsSF2(filepath);
-  }
-  return false;
-}
-
-
 bool VGMInstrSet::SaveAsDLS(const std::string &filepath) {
   DLSFile dlsfile;
   bool dlsCreationSucceeded = false;

--- a/src/main/VGMInstrSet.h
+++ b/src/main/VGMInstrSet.h
@@ -41,9 +41,6 @@ class VGMInstrSet:
 
   virtual FileType GetFileType() { return FILETYPE_INSTRSET; }
 
-
-  bool OnSaveAsDLS(void);
-  bool OnSaveAsSF2(void);
   virtual bool SaveAsDLS(const std::string &filepath);
   virtual bool SaveAsSF2(const std::string &filepath);
 

--- a/src/main/VGMSampColl.cpp
+++ b/src/main/VGMSampColl.cpp
@@ -90,11 +90,11 @@ VGMSamp *VGMSampColl::AddSamp(uint32_t offset, uint32_t length, uint32_t dataOff
   return newSamp;
 }
 
-bool VGMSampColl::OnSaveAllAsWav() {
-  string dirpath = pRoot->UI_GetSaveDirPath();
+bool VGMSampColl::SaveAllAsWav(const string& dirpath) {
   if (dirpath.length() != 0) {
     for (uint32_t i = 0; i < samples.size(); i++) {
-      string filepath = dirpath + "/" + ConvertToSafeFileName(samples[i]->name) + ".wav";
+      string filename = ConvertToSafeFileName(*GetName()) + " - " + ConvertToSafeFileName(samples[i]->name) + ".wav";
+      string filepath = dirpath + "/" + filename;
       samples[i]->SaveAsWav(filepath);
     }
     return true;

--- a/src/main/VGMSampColl.h
+++ b/src/main/VGMSampColl.h
@@ -25,7 +25,8 @@ class VGMSampColl:
   VGMSamp *AddSamp(uint32_t offset, uint32_t length, uint32_t dataOffset, uint32_t dataLength,
                    uint8_t nChannels = 1, uint16_t bps = 16, uint32_t theRate = 0,
                    std::string name = "Sample");
-  bool OnSaveAllAsWav();
+
+  bool SaveAllAsWav(const string& dirpath);
 
  protected:
   void LoadOnInstrMatch() { bLoadOnInstrSetMatch = true; }

--- a/src/main/VGMSeq.cpp
+++ b/src/main/VGMSeq.cpp
@@ -9,6 +9,10 @@
 
 using namespace std;
 
+// ******
+// VGMSeq
+// ******
+
 VGMSeq::VGMSeq(const string &format, RawFile *file, uint32_t offset, uint32_t length, string name)
     : VGMFile(FILETYPE_SEQ, format, file, offset, length, name),
       midi(NULL),
@@ -317,14 +321,6 @@ void VGMSeq::AddInstrumentRef(uint32_t progNum) {
     aInstrumentsUsed.push_back(progNum);
   }
 }
-
-bool VGMSeq::OnSaveAsMidi(void) {
-  string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), "mid");
-  if (filepath.length() != 0)
-    return SaveAsMidi(filepath);
-  return false;
-}
-
 
 bool VGMSeq::SaveAsMidi(const std::string &filepath) {
   MidiFile *midi = this->ConvertToMidi();

--- a/src/main/VGMSeq.h
+++ b/src/main/VGMSeq.h
@@ -75,7 +75,6 @@ class VGMSeq: public VGMFile {
     bAlwaysWriteInitialMono = true;
   }
 
-  bool OnSaveAsMidi(void);
   virtual bool SaveAsMidi(const std::string &filepath);
 
   virtual bool HasActiveTracks();

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -62,6 +62,10 @@ add_executable(
   SequencePlayer.cpp
   SequencePlayer.h
   main_ui.cpp
+  services/MenuManager.cpp
+  services/MenuManager.h
+  services/commands/SaveCommands.h
+  services/commands/GeneralCommands.h
   util/Colors.h
   util/Helpers.cpp
   util/Helpers.h

--- a/src/ui/qt/QtVGMRoot.cpp
+++ b/src/ui/qt/QtVGMRoot.cpp
@@ -5,11 +5,11 @@
  */
 
 #include <QApplication>
-#include <QStandardPaths>
 #include <QFileDialog>
 #include <QString>
 #include "QtVGMRoot.h"
 #include "VGMFileTreeView.h"
+#include "util/UIHelpers.h"
 
 QtVGMRoot qtVGMRoot;
 
@@ -107,45 +107,9 @@ std::string QtVGMRoot::UI_GetOpenFilePath(const std::string&, const std::string&
 
 std::string QtVGMRoot::UI_GetSaveFilePath(const std::string& suggested_filename,
                                            const std::string& extension) {
-  static auto selected_dir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
-  QFileDialog dialog(QApplication::activeWindow());
-  dialog.setFileMode(QFileDialog::AnyFile);
-  dialog.selectFile(QString::fromStdString(suggested_filename));
-  dialog.setDirectory(selected_dir);
-  dialog.setAcceptMode(QFileDialog::AcceptSave);
-
-  if (extension == "mid") {
-    dialog.setDefaultSuffix("mid");
-    dialog.setNameFilter("Standard MIDI (*.mid)");
-  } else if (extension == "dls") {
-    dialog.setDefaultSuffix("dls");
-    dialog.setNameFilter("Downloadable Sound (*.dls)");
-  } else if (extension == "sf2") {
-    dialog.setDefaultSuffix("sf2");
-    dialog.setNameFilter("SoundFont\u00AE 2 (*.sf2)");
-  } else {
-    dialog.setNameFilter("All files (*)");
-  }
-
-  if (dialog.exec()) {
-    selected_dir = dialog.directory().absolutePath();
-    return dialog.selectedFiles().at(0).toStdString();
-  } else {
-    return {};
-  }
+  return OpenSaveFileDialog(suggested_filename, extension);
 }
 
 std::string QtVGMRoot::UI_GetSaveDirPath(const std::string&) {
-  static auto selected_dir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
-  QFileDialog dialog(QApplication::activeWindow());
-  dialog.setFileMode(QFileDialog::FileMode::Directory);
-  dialog.setOption(QFileDialog::ShowDirsOnly, true);
-  dialog.setDirectory(selected_dir);
-
-  if (dialog.exec()) {
-    selected_dir = dialog.directory().absolutePath();
-    return dialog.selectedFiles().at(0).toStdString();
-  } else {
-    return {};
-  }
+  return OpenSaveDirDialog();
 }

--- a/src/ui/qt/services/MenuManager.cpp
+++ b/src/ui/qt/services/MenuManager.cpp
@@ -43,7 +43,7 @@ template<typename T, typename Base>
 void MenuManager::RegisterCommands(const vector<shared_ptr<Command>>& commands) {
   commandsForType[typeid(T)] = commands;
 
-  if constexpr (!is_same<T, Base>::value && is_convertible<T*, Base*>::value) {
+  if constexpr (is_convertible<T*, Base*>::value) {
     auto checkFunc = [](void* base) -> bool { return dynamic_cast<T*>(static_cast<Base*>(base)) != nullptr; };
     auto typeErasedCheckFunc = static_cast<CheckFunc<void>>(checkFunc);
     commandsForCheckedType[typeid(Base)].emplace_back(typeErasedCheckFunc, commands);

--- a/src/ui/qt/services/MenuManager.cpp
+++ b/src/ui/qt/services/MenuManager.cpp
@@ -1,0 +1,70 @@
+/*
+* VGMTrans (c) 2002-2023
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+ */
+
+#include "MenuManager.h"
+#include "services/commands/GeneralCommands.h"
+#include "services/commands/SaveCommands.h"
+
+MenuManager::MenuManager() {
+  RegisterCommands<VGMSeq>({
+      make_shared<CloseVGMFileCommand>(),
+      make_shared<CommandSeparator>(),
+      make_shared<SaveAsMidiCommand>(),
+      make_shared<SaveAsOriginalFormatCommand>(),
+  });
+  RegisterCommands<VGMInstrSet>({
+      make_shared<CloseVGMFileCommand>(),
+      make_shared<CommandSeparator>(),
+      make_shared<SaveAsSF2Command>(),
+      make_shared<SaveAsDLSCommand>(),
+      make_shared<SaveAsOriginalFormatCommand>(),
+  });
+  RegisterCommands<VGMSampColl>({
+      make_shared<CloseVGMFileCommand>(),
+      make_shared<CommandSeparator>(),
+      make_shared<SaveWavBatchCommand>(),
+      make_shared<SaveAsOriginalFormatCommand>(),
+  });
+  RegisterCommands<VGMFile>({
+      make_shared<CloseVGMFileCommand>(),
+      make_shared<CommandSeparator>(),
+      make_shared<SaveAsOriginalFormatCommand>(),
+  });
+
+  RegisterCommands<RawFile>({
+      make_shared<CloseVGMFileCommand>(),
+  });
+}
+
+template<typename T>
+void MenuManager::RegisterCommand(shared_ptr<Command> command) {
+  commandsForType[typeid(T)].push_back(command);
+
+  if constexpr (is_convertible<T*, VGMItem*>::value) {
+    auto checkFunc = [](VGMItem* item) -> bool { return dynamic_cast<T*>(item) != nullptr; };
+    auto it = find_if(
+        commandsForCheckedType.begin(), commandsForCheckedType.end(),
+        [&checkFunc](const CheckedTypeEntry& entry) { return &entry.first == &checkFunc; });
+
+    if (it != commandsForCheckedType.end()) {
+      // Add command to the existing entry
+      it->second.push_back(command);
+    } else {
+      // Create a new entry
+      commandsForCheckedType.emplace_back(checkFunc, CommandsList{command});
+    }
+  }
+}
+
+template<typename T>
+void MenuManager::RegisterCommands(const vector<shared_ptr<Command>>& commands) {
+  commandsForType[typeid(T)] = commands;
+
+  if constexpr (is_convertible<T*, VGMItem*>::value) {
+    auto checkFunc = [](VGMItem* item) -> bool { return dynamic_cast<T*>(item) != nullptr; };
+    commandsForCheckedType.emplace_back(checkFunc, commands);
+  }
+}

--- a/src/ui/qt/services/MenuManager.h
+++ b/src/ui/qt/services/MenuManager.h
@@ -1,0 +1,292 @@
+/*
+* VGMTrans (c) 2002-2023
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+ */
+
+#pragma once
+
+#include "common.h"
+#include <typeindex>
+#include <typeinfo>
+#include <QMenu>
+#include "Root.h"
+#include "util/UIHelpers.h"
+
+#include <ghc/filesystem.hpp>
+
+namespace fs = ghc::filesystem;
+
+class VGMItem;
+class VGMFile;
+class VGMSeq;
+class VGMInstrSet;
+class VGMSampColl;
+class RawFile;
+class CommandSeparator;
+
+/**
+ * Represents the type of value a property holds in a CommandContext's PropertyMap.
+ */
+enum class PropertySpecValueType {
+  Path,           ///< Represents a file path or directory path if an ItemList property is present with > 1 items
+  DirPath,        ///< Represents a directory path
+  ItemList,       ///< Represents a list of items, such as selected files in the VGMFileListView
+};
+
+/**
+ * A variant type used to store different types of property values in a PropertyMap
+ */
+using PropertyValue = variant<
+    int,
+    float,
+    string,
+    shared_ptr<vector<VGMFile*>>,
+    shared_ptr<vector<VGMSeq*>>,
+    shared_ptr<vector<VGMInstrSet*>>,
+    shared_ptr<vector<VGMSampColl*>>,
+    shared_ptr<vector<RawFile*>>
+>;
+
+using PropertyMap = map<string, PropertyValue>;
+
+/**
+ * The base class for a command context. The command context provides an interface for commands
+ * to receive data. CommandContexts are created indirectly by CommandContextFactories via the CreateContext() method.
+ */
+class CommandContext {
+public:
+  virtual ~CommandContext() = default;
+};
+
+/**
+ * PropertySpecifications specify the keys and values types required for the PropertyMap that will
+ * be passed into a CommandContextFactory's CreateContext() method. A CommandContextFactory will
+ * expose these specifications via the GetPropertySpecifications() method
+ */
+struct PropertySpecification {
+  string key;
+  PropertySpecValueType valueType;
+  string description;
+  PropertyValue defaultValue;
+};
+
+using PropertySpecifications = vector<PropertySpecification>;
+
+/**
+ * The base class of a factory for creating CommandContext objects. Implementations of this class are responsible
+ * for creating a CommandContext that will be passed into a Command's Execute() method. It does this via the
+ * CreateContext() method, which expects a PropertyMap. The key and value types required to be set in the PropertyMap
+ * are given via the GetPropertySpecifications() method.
+ */
+class CommandContextFactory {
+public:
+  virtual ~CommandContextFactory() = default;
+
+  /**
+   * Creates a CommandContext object based on the provided properties.
+   * @param properties A map of properties to be used for context creation.
+   * @return A shared pointer to the created CommandContext object.
+   */
+  [[nodiscard]] virtual shared_ptr<CommandContext> CreateContext(const PropertyMap& properties) const = 0;
+
+  /**
+   * Retrieves the specifications for the properties required to be set in the PropertyMap passed to CreateContext().
+   * @return A list of property specifications.
+   */
+  [[nodiscard]] virtual PropertySpecifications GetPropertySpecifications() const = 0;
+};
+
+
+/**
+ * Base class for all commands. A Command is the same thing as a menu action. The GetContextFactory() method
+ * provides a factory that can be used to generate the CommandContext required by the Execute method.
+ */
+class Command {
+public:
+  virtual ~Command() = default;
+
+  /**
+   * Executes the command within the given context.
+   * @param context A reference to the CommandContext which will provide the data needed to execute the command.
+   */
+  virtual void Execute(CommandContext& context) = 0;
+
+  /**
+   * Retrieves the name of the command to appear in the UI. Commands must use unique Names, or they will
+   * break the behavior of batch command processing (an example of batch processing is
+   * selecting multiple sequences and executing the "Save to MIDI" command).
+   * @return The name of the command.
+   */
+  [[nodiscard]] virtual string Name() const = 0;
+
+  /**
+   * Gets the factory for creating a command context specific to this command.
+   * @return A shared pointer to the CommandContextFactory.
+   */
+  [[nodiscard]] virtual shared_ptr<CommandContextFactory> GetContextFactory() const = 0;
+};
+
+
+/**
+ * MenuManager is the service responsible for the registration and retrieval of commands.
+ */
+ class MenuManager {
+public:
+  using CheckFunc = function<bool(VGMItem*)>;
+  using CommandsList = vector<shared_ptr<Command>>;
+  using CheckedTypeEntry = pair<CheckFunc, CommandsList>;
+
+  MenuManager();
+
+  /**
+   * Registers a command for the template parameter type.
+   * @param command The command to be registered.
+   */
+  template<typename T>
+  void RegisterCommand(shared_ptr<Command> command);
+
+  /**
+   * Registers multiple commands at once for the template parameter type.
+   * @param commands A vector of commands to be registered.
+   */
+  template<typename T>
+  void RegisterCommands(const vector<shared_ptr<Command>>& commands);
+
+  /**
+   * Retrieves the list of commands suitable for a given item.
+   * @param item The VGMItem for which commands are requested.
+   * @return A vector of shared pointers to the commands.
+   */
+  template<typename T>
+  vector<std::shared_ptr<Command>> GetCommands(T* item) {
+    if (!item) {
+      return {}; // Return empty vector if item is nullptr
+    }
+
+    std::type_index typeIndex(typeid(*item));
+
+    // Check direct type associations first
+    auto it = commandsForType.find(typeIndex);
+    if (it != commandsForType.end()) {
+      return it->second;
+    }
+
+    // Special handling for VGMItem types
+    auto vgmItem = dynamic_cast<VGMItem*>(item);
+    if (vgmItem) {
+      // Check for matches using full class hierarchy
+      for (const auto& pair : commandsForCheckedType) {
+        if (pair.first(vgmItem)) {
+          return pair.second;
+        }
+      }
+    }
+
+    // Return empty vector if no commands are found
+    return {};
+  }
+
+  /**
+ * Given a list of objects, returns the list of Commands shared by all the instance types, as registered in the
+ * MenuManager.
+ * @param items The list of objects for which to find common Commands
+ * @param commandManager A reference to a MenuManager
+ * @return A list of commands shared by all items, ordered as they are in the first item's Command registry.
+   */
+  template <typename T>
+  vector<shared_ptr<Command>> FindCommonCommands(const vector<T*>& items) {
+    if (items.empty()) {
+      return {};
+    }
+
+    vector<shared_ptr<Command>> commonCommands;
+    // Get commands of the first file as the reference order
+    auto referenceCommands = GetCommands(items.front());
+
+    // Iterate over each command in the reference list
+    for (const auto& refCmd : referenceCommands) {
+      string refCmdName = refCmd->Name();
+      bool isCommon = true;
+
+      // Check if this command is present in all other files
+      for (auto* item : items) {
+        auto commands = GetCommands(item);
+        if (none_of(commands.begin(), commands.end(),
+                    [&refCmdName](const shared_ptr<Command>& cmd) { return cmd->Name() == refCmdName; })) {
+          isCommon = false;
+          break;
+        }
+      }
+
+      if (isCommon) {
+        commonCommands.push_back(refCmd);
+      }
+    }
+    return commonCommands;
+  }
+
+  template <typename T>
+  QMenu* CreateMenuForItems(shared_ptr<vector<T*>> selectedFiles) {
+
+    auto menu = new QMenu();
+    if (selectedFiles->empty()) {
+      return nullptr;
+    }
+    auto commands = FindCommonCommands(*selectedFiles);
+
+    for (const auto& command : commands) {
+
+      // Handle CommandSeparator
+      if (dynamic_cast<CommandSeparator*>(command.get()) != nullptr) {
+        menu->addSeparator();
+        continue;
+      }
+
+      auto contextFactory = command->GetContextFactory();
+      auto propSpecs = contextFactory->GetPropertySpecifications();
+
+      menu->addAction(command->Name().c_str(), [this, command, selectedFiles, propSpecs, contextFactory] {
+        PropertyMap propMap;
+        for (const auto& propSpec : propSpecs) {
+
+          bool isDirPath = false;
+          switch (propSpec.valueType) {
+            case PropertySpecValueType::DirPath:
+              isDirPath = true;
+            case PropertySpecValueType::Path:
+              if (isDirPath || selectedFiles->size() > 1) {
+                fs::path dirpath = fs::path(OpenSaveDirDialog());
+                if (dirpath.string().empty()) {
+                  return;
+                }
+                propMap.insert({ propSpec.key, dirpath });
+              } else {
+                auto suggestedFileName = ConvertToSafeFileName(*(*selectedFiles)[0]->GetName());
+                auto fileExtension = get<string>(propSpec.defaultValue);
+                auto path = OpenSaveFileDialog(suggestedFileName, string2wstring(fileExtension));
+                if (path.empty()) {
+                  return;
+                }
+                propMap.insert({ propSpec.key, path });
+              }
+              break;
+            case PropertySpecValueType::ItemList:
+              propMap.insert({ propSpec.key, selectedFiles });
+              break;
+          }
+        }
+        auto context = contextFactory->CreateContext(propMap);
+        if (!context) {
+          return;
+        }
+        command->Execute(*context);
+      });
+    }
+    return menu;
+  }
+
+private:
+  map<type_index, vector<shared_ptr<Command>>> commandsForType;
+  vector<CheckedTypeEntry> commandsForCheckedType;
+};

--- a/src/ui/qt/services/MenuManager.h
+++ b/src/ui/qt/services/MenuManager.h
@@ -260,7 +260,7 @@ public:
                 if (dirpath.string().empty()) {
                   return;
                 }
-                propMap.insert({ propSpec.key, dirpath });
+                propMap.insert({ propSpec.key, dirpath.generic_string() });
               } else {
                 auto suggestedFileName = ConvertToSafeFileName(*(*selectedFiles)[0]->GetName());
                 auto fileExtension = get<string>(propSpec.defaultValue);

--- a/src/ui/qt/services/MenuManager.h
+++ b/src/ui/qt/services/MenuManager.h
@@ -246,7 +246,7 @@ public:
       auto contextFactory = command->GetContextFactory();
       auto propSpecs = contextFactory->GetPropertySpecifications();
 
-      menu->addAction(command->Name().c_str(), [this, command, selectedFiles, propSpecs, contextFactory] {
+      menu->addAction(command->Name().c_str(), [command, selectedFiles, propSpecs, contextFactory] {
         PropertyMap propMap;
         for (const auto& propSpec : propSpecs) {
 
@@ -264,7 +264,7 @@ public:
               } else {
                 auto suggestedFileName = ConvertToSafeFileName(*(*selectedFiles)[0]->GetName());
                 auto fileExtension = get<string>(propSpec.defaultValue);
-                auto path = OpenSaveFileDialog(suggestedFileName, string2wstring(fileExtension));
+                auto path = OpenSaveFileDialog(suggestedFileName, fileExtension);
                 if (path.empty()) {
                   return;
                 }

--- a/src/ui/qt/services/commands/GeneralCommands.h
+++ b/src/ui/qt/services/commands/GeneralCommands.h
@@ -1,0 +1,119 @@
+/*
+* VGMTrans (c) 2002-2023
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+ */
+
+#pragma once
+
+#include "services/MenuManager.h"
+#include "VGMFile.h"
+
+class CommandSeparator : public Command {
+public:
+  CommandSeparator() = default;
+
+  void Execute(CommandContext&) override {}
+
+  [[nodiscard]] shared_ptr<CommandContextFactory> GetContextFactory() const override { return nullptr; }
+  [[nodiscard]] string Name() const override { return "separator"; }
+};
+
+/**
+ * A command context that provides a vector of pointers
+ */
+template <typename T>
+class ItemListCommandContext : public CommandContext {
+private:
+  shared_ptr<vector<T*>> items{};
+
+public:
+  ItemListCommandContext() = default;
+
+  void SetItems(shared_ptr<vector<T*>> f) {
+    items = f;
+  }
+
+  [[nodiscard]] const vector<T*>& GetItems() const { return *items; }
+};
+
+/**
+ * A command context factory to construct a context providing a vector of pointers
+ */
+template <typename T>
+class ItemListContextFactory : public CommandContextFactory {
+public:
+  explicit ItemListContextFactory() : CommandContextFactory() {}
+
+  [[nodiscard]] shared_ptr<CommandContext> CreateContext(const PropertyMap& properties) const override {
+    auto context = make_shared<ItemListCommandContext<T>>();
+
+    if (properties.find("items") == properties.end()) {
+      return nullptr;
+    }
+
+    auto files = get<shared_ptr<vector<T*>>>(properties.at("items"));
+    context->SetItems(files);
+    return context;
+  }
+
+  [[nodiscard]] PropertySpecifications GetPropertySpecifications() const override {
+    return {
+        {"items", PropertySpecValueType::ItemList, "Vector of files", static_cast<shared_ptr<vector<T*>>>(nullptr)},
+    };
+  }
+};
+
+/**
+ * The base Command class for a "Close" command. Receives a vector of pointers to the instances to close
+ */
+template <typename TClosable>
+class CloseCommand : public Command {
+private:
+  shared_ptr<ItemListContextFactory<TClosable>> contextFactory;
+
+public:
+  CloseCommand()
+      : contextFactory(make_shared<ItemListContextFactory<TClosable>>()) {}
+
+  void Execute(CommandContext& context) override {
+    auto& vgmContext = dynamic_cast<ItemListCommandContext<TClosable>&>(context);
+    const auto& files = vgmContext.GetItems();
+
+    for (auto file : files) {
+      auto specificFile = dynamic_cast<TClosable*>(file);
+      Close(specificFile);
+    }
+  }
+
+  [[nodiscard]] shared_ptr<CommandContextFactory> GetContextFactory() const override {
+    return contextFactory;
+  }
+
+  virtual void Close(TClosable* specificFile) const = 0;
+  [[nodiscard]] string Name() const override { return "Close"; }
+};
+
+/**
+ * A command for closing a VGMFile
+ */
+class CloseVGMFileCommand : public CloseCommand<VGMFile> {
+public:
+  CloseVGMFileCommand() : CloseCommand<VGMFile>() {}
+
+  void Close(VGMFile* file) const override {
+    file->OnClose();
+  }
+};
+
+/**
+ * A command for closing a RawFile
+ */
+class CloseRawFileCommand : public CloseCommand<RawFile> {
+public:
+  CloseRawFileCommand() : CloseCommand<RawFile>() {}
+
+  void Close(RawFile* file) const override {
+    file->close();
+  }
+};

--- a/src/ui/qt/services/commands/SaveCommands.h
+++ b/src/ui/qt/services/commands/SaveCommands.h
@@ -22,7 +22,7 @@ template <typename TSavable>
 class SaveCommandContext : public CommandContext {
 private:
   shared_ptr<vector<TSavable*>> items{};
-  wstring path;
+  string path;
 
 public:
   SaveCommandContext() = default;
@@ -31,11 +31,11 @@ public:
     items = f;
   }
   void SetSavePath(const string& p) {
-    path = string2wstring(p);
+    path = p;
   }
 
   [[nodiscard]] const vector<TSavable*>& GetItems() const { return *items; }
-  [[nodiscard]] const wstring& GetPath() const { return path; }
+  [[nodiscard]] const string& GetPath() const { return path; }
 };
 
 /**
@@ -130,9 +130,9 @@ public:
       // and the Save() function still expects a file path, so we construct file paths for each file using GetName()
       auto specificFile = dynamic_cast<TSavable*>(file);
       if (specificFile) {
-        auto fileExtension = string2wstring((GetExtension() == "") ? "" : (string(".") + GetExtension()));
+        auto fileExtension = (GetExtension() == "") ? "" : (string(".") + GetExtension());
         fs::path filePath = path / fs::path(*file->GetName() + fileExtension);
-        Save(filePath.wstring(), specificFile);
+        Save(filePath.generic_string(), specificFile);
       }
     }
   }
@@ -143,14 +143,14 @@ public:
   }
 
   [[nodiscard]] virtual std::string GetExtension() const = 0;
-  virtual void Save(const wstring& path, TSavable* specificFile) const = 0;
+  virtual void Save(const string& path, TSavable* specificFile) const = 0;
 };
 
 class SaveAsOriginalFormatCommand : public SaveCommand<VGMFile> {
 public:
   SaveAsOriginalFormatCommand() : SaveCommand<VGMFile>(false) {}
 
-  void Save(const wstring& path, VGMFile* file) const override {
+  void Save(const string& path, VGMFile* file) const override {
     file->OnSaveAsRaw(path);
   }
   [[nodiscard]] string Name() const override { return "Save as original format"; }
@@ -162,7 +162,7 @@ class SaveAsMidiCommand : public SaveCommand<VGMSeq, VGMFile> {
 public:
   SaveAsMidiCommand() : SaveCommand<VGMSeq, VGMFile>(false) {}
 
-  void Save(const wstring& path, VGMSeq* seq) const override {
+  void Save(const string& path, VGMSeq* seq) const override {
     seq->SaveAsMidi(path);
   }
   [[nodiscard]] string Name() const override { return "Save as MIDI"; }
@@ -174,7 +174,7 @@ class SaveAsDLSCommand : public SaveCommand<VGMInstrSet, VGMFile> {
 public:
   SaveAsDLSCommand() : SaveCommand<VGMInstrSet, VGMFile>(false) {}
 
-  void Save(const wstring& path, VGMInstrSet* instrSet) const override {
+  void Save(const string& path, VGMInstrSet* instrSet) const override {
     instrSet->SaveAsDLS(path);
   }
   [[nodiscard]] string Name() const override { return "Save as DLS"; }
@@ -186,7 +186,7 @@ class SaveAsSF2Command : public SaveCommand<VGMInstrSet, VGMFile> {
 public:
   SaveAsSF2Command() : SaveCommand<VGMInstrSet, VGMFile>(false) {}
 
-  void Save(const wstring& path, VGMInstrSet* instrSet) const override {
+  void Save(const string& path, VGMInstrSet* instrSet) const override {
     instrSet->SaveAsSF2(path);
   }
   [[nodiscard]] string Name() const override { return "Save as SF2"; }
@@ -198,7 +198,7 @@ class SaveWavBatchCommand : public SaveCommand<VGMSampColl, VGMFile> {
 public:
   SaveWavBatchCommand() : SaveCommand<VGMSampColl, VGMFile>(true) {}
 
-  void Save(const wstring& path, VGMSampColl* sampColl) const override {
+  void Save(const string& path, VGMSampColl* sampColl) const override {
     sampColl->SaveAllAsWav(path);
   }
   [[nodiscard]] string Name() const override { return "Save all samples as WAV"; }

--- a/src/ui/qt/services/commands/SaveCommands.h
+++ b/src/ui/qt/services/commands/SaveCommands.h
@@ -1,0 +1,206 @@
+/*
+* VGMTrans (c) 2002-2023
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+ */
+
+#pragma once
+
+#include <ghc/filesystem.hpp>
+
+#include "services/MenuManager.h"
+#include "VGMSeq.h"
+#include "VGMInstrSet.h"
+#include "VGMSampColl.h"
+
+namespace fs = ghc::filesystem;
+
+/**
+ * A command context for saving files. Provides a list of items to save and a path to save them to.
+ */
+template <typename TSavable>
+class SaveCommandContext : public CommandContext {
+private:
+  shared_ptr<vector<TSavable*>> items{};
+  wstring path;
+
+public:
+  SaveCommandContext() = default;
+
+  void SetItems(shared_ptr<vector<TSavable*>> f) {
+    items = f;
+  }
+  void SetSavePath(const string& p) {
+    path = string2wstring(p);
+  }
+
+  [[nodiscard]] const vector<TSavable*>& GetItems() const { return *items; }
+  [[nodiscard]] const wstring& GetPath() const { return path; }
+};
+
+/**
+ * A command context factory for saving files. Will construct a context that provides a list of items and a path
+ * to save them to.
+ * @param alwaysSaveToDir Indicates that the command will expect a directory path always. Otherwise, a file path should
+ * be provided when files contains a single item, and a directory path if files is multiple items.
+ */
+template <typename TSavable>
+class SaveCommandContextFactory : public CommandContextFactory {
+private:
+  bool alwaysSaveToDir;
+  std::string fileExtension;
+
+public:
+  explicit SaveCommandContextFactory(bool alwaysSaveToDir, std::string fileExtension = "") :
+        CommandContextFactory(),
+        alwaysSaveToDir(alwaysSaveToDir),
+        fileExtension(std::move(fileExtension)) {}
+
+  void SetFileExtension(const std::string& extension) {
+    fileExtension = extension;
+  }
+
+  [[nodiscard]] shared_ptr<CommandContext> CreateContext(const PropertyMap& properties) const override {
+    auto context = make_shared<SaveCommandContext<TSavable>>();
+
+    if (properties.find("files") == properties.end() || properties.find("filePath") == properties.end()) {
+      return nullptr;
+    }
+
+    auto files = get<shared_ptr<vector<TSavable*>>>(properties.at("files"));
+    context->SetItems(files);
+    context->SetSavePath(get<string>(properties.at("filePath")));
+    return context;
+  }
+
+  [[nodiscard]] PropertySpecifications GetPropertySpecifications() const override {
+    auto filePathValueType = (alwaysSaveToDir) ? PropertySpecValueType::DirPath : PropertySpecValueType::Path;
+    return {
+        {"filePath", filePathValueType, "Path to the file or directory", fileExtension},
+        {"files", PropertySpecValueType::ItemList, "Vector of files", static_cast<shared_ptr<vector<TSavable*>>>(nullptr)},
+    };
+  }
+};
+
+
+/**
+ * The base Command class for a Save command. The context provides a list of items to save and a path
+ * to save them to.
+ * @param alwaysSaveToDir Indicates that the command will expect a directory path always. Otherwise, a file path should
+ * be expected when files contains a single item, and a directory path if files is multiple items.
+ */
+template <typename TSavable, typename TInContext = TSavable>
+class SaveCommand : public Command {
+private:
+  shared_ptr<SaveCommandContextFactory<TInContext>> contextFactory;
+  bool alwaysSaveToDir;
+
+public:
+  explicit SaveCommand(bool alwaysSaveToDir = false)
+      : contextFactory(make_shared<SaveCommandContextFactory<TInContext>>(alwaysSaveToDir)),
+        alwaysSaveToDir(alwaysSaveToDir) {
+  }
+
+  void Execute(CommandContext& context) override {
+    auto& vgmContext = dynamic_cast<SaveCommandContext<TInContext>&>(context);
+    const auto& files = vgmContext.GetItems();
+    const auto& path = vgmContext.GetPath();
+
+    if (alwaysSaveToDir) {
+      // alwaysSaveToDir indicates we were given a directory path and Save() also expects a directory path
+      for (auto file : files) {
+        auto specificFile = dynamic_cast<TSavable*>(file);
+        if (specificFile) {
+          Save(path, specificFile);
+        }
+        return;
+      }
+    }
+    if (files.size() == 1) {
+      // In this case, path is a file path
+      auto file = dynamic_cast<TSavable*>(files[0]);
+      if (file) {
+        Save(path, file);
+        return;
+      }
+    }
+
+    for (auto file : files) {
+      // If alwaysSaveToDir is not set and there are multiple files, the path given is to a directory
+      // and the Save() function still expects a file path, so we construct file paths for each file using GetName()
+      auto specificFile = dynamic_cast<TSavable*>(file);
+      if (specificFile) {
+        auto fileExtension = string2wstring((GetExtension() == "") ? "" : (string(".") + GetExtension()));
+        fs::path filePath = path / fs::path(*file->GetName() + fileExtension);
+        Save(filePath.wstring(), specificFile);
+      }
+    }
+  }
+
+  [[nodiscard]] shared_ptr<CommandContextFactory> GetContextFactory() const override {
+    contextFactory->SetFileExtension(GetExtension());
+    return contextFactory;
+  }
+
+  [[nodiscard]] virtual std::string GetExtension() const = 0;
+  virtual void Save(const wstring& path, TSavable* specificFile) const = 0;
+};
+
+class SaveAsOriginalFormatCommand : public SaveCommand<VGMFile> {
+public:
+  SaveAsOriginalFormatCommand() : SaveCommand<VGMFile>(false) {}
+
+  void Save(const wstring& path, VGMFile* file) const override {
+    file->OnSaveAsRaw(path);
+  }
+  [[nodiscard]] string Name() const override { return "Save as original format"; }
+  [[nodiscard]] string GetExtension() const override { return ""; }
+};
+
+
+class SaveAsMidiCommand : public SaveCommand<VGMSeq, VGMFile> {
+public:
+  SaveAsMidiCommand() : SaveCommand<VGMSeq, VGMFile>(false) {}
+
+  void Save(const wstring& path, VGMSeq* seq) const override {
+    seq->SaveAsMidi(path);
+  }
+  [[nodiscard]] string Name() const override { return "Save as MIDI"; }
+  [[nodiscard]] string GetExtension() const override { return "mid"; }
+};
+
+
+class SaveAsDLSCommand : public SaveCommand<VGMInstrSet, VGMFile> {
+public:
+  SaveAsDLSCommand() : SaveCommand<VGMInstrSet, VGMFile>(false) {}
+
+  void Save(const wstring& path, VGMInstrSet* instrSet) const override {
+    instrSet->SaveAsDLS(path);
+  }
+  [[nodiscard]] string Name() const override { return "Save as DLS"; }
+  [[nodiscard]] string GetExtension() const override { return "dls"; }
+};
+
+
+class SaveAsSF2Command : public SaveCommand<VGMInstrSet, VGMFile> {
+public:
+  SaveAsSF2Command() : SaveCommand<VGMInstrSet, VGMFile>(false) {}
+
+  void Save(const wstring& path, VGMInstrSet* instrSet) const override {
+    instrSet->SaveAsSF2(path);
+  }
+  [[nodiscard]] string Name() const override { return "Save as SF2"; }
+  [[nodiscard]] string GetExtension() const override { return "sf2"; }
+};
+
+
+class SaveWavBatchCommand : public SaveCommand<VGMSampColl, VGMFile> {
+public:
+  SaveWavBatchCommand() : SaveCommand<VGMSampColl, VGMFile>(true) {}
+
+  void Save(const wstring& path, VGMSampColl* sampColl) const override {
+    sampColl->SaveAllAsWav(path);
+  }
+  [[nodiscard]] string Name() const override { return "Save all samples as WAV"; }
+  [[nodiscard]] string GetExtension() const override { return "wav"; }
+};

--- a/src/ui/qt/util/UIHelpers.cpp
+++ b/src/ui/qt/util/UIHelpers.cpp
@@ -58,21 +58,21 @@ std::string OpenSaveDirDialog() {
 }
 
 
-std::string OpenSaveFileDialog(const std::wstring& suggested_filename, const std::wstring& extension) {
+std::string OpenSaveFileDialog(const std::string& suggested_filename, const std::string& extension) {
   static auto selected_dir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
   QFileDialog dialog(QApplication::activeWindow());
   dialog.setFileMode(QFileDialog::AnyFile);
-  dialog.selectFile(QString::fromStdWString(suggested_filename));
+  dialog.selectFile(QString::fromStdString(suggested_filename));
   dialog.setDirectory(selected_dir);
   dialog.setAcceptMode(QFileDialog::AcceptSave);
 
-  if (extension == L"mid") {
+  if (extension == "mid") {
     dialog.setDefaultSuffix("mid");
     dialog.setNameFilter("Standard MIDI (*.mid)");
-  } else if (extension == L"dls") {
+  } else if (extension == "dls") {
     dialog.setDefaultSuffix("dls");
     dialog.setNameFilter("Downloadable Sound (*.dls)");
-  } else if (extension == L"sf2") {
+  } else if (extension == "sf2") {
     dialog.setDefaultSuffix("sf2");
     dialog.setNameFilter("SoundFont\u00AE 2 (*.sf2)");
   } else {

--- a/src/ui/qt/util/UIHelpers.cpp
+++ b/src/ui/qt/util/UIHelpers.cpp
@@ -10,6 +10,9 @@
 #include <QGraphicsScene>
 #include <QGraphicsPixmapItem>
 #include <QPainter>
+#include <QFileDialog>
+#include <QStandardPaths>
+#include <QApplication>
 
 QScrollArea* getContainingScrollArea(QWidget* widget) {
   QWidget* viewport = widget->parentWidget();
@@ -36,4 +39,50 @@ void applyEffectToPixmap(QPixmap &src, QPixmap &tgt, QGraphicsEffect *effect, in
   tgt.fill(Qt::transparent);
   QPainter ptr(&tgt);
   scene.render(&ptr, QRectF(), QRectF(-extent, -extent, src.width() + extent*2, src.height() + extent*2));
+}
+
+
+std::string OpenSaveDirDialog() {
+  static auto selected_dir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
+  QFileDialog dialog(QApplication::activeWindow());
+  dialog.setFileMode(QFileDialog::FileMode::Directory);
+  dialog.setOption(QFileDialog::ShowDirsOnly, true);
+  dialog.setDirectory(selected_dir);
+
+  if (dialog.exec()) {
+    selected_dir = dialog.directory().absolutePath();
+    return dialog.selectedFiles().at(0).toStdString();
+  } else {
+    return {};
+  }
+}
+
+
+std::string OpenSaveFileDialog(const std::wstring& suggested_filename, const std::wstring& extension) {
+  static auto selected_dir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
+  QFileDialog dialog(QApplication::activeWindow());
+  dialog.setFileMode(QFileDialog::AnyFile);
+  dialog.selectFile(QString::fromStdWString(suggested_filename));
+  dialog.setDirectory(selected_dir);
+  dialog.setAcceptMode(QFileDialog::AcceptSave);
+
+  if (extension == L"mid") {
+    dialog.setDefaultSuffix("mid");
+    dialog.setNameFilter("Standard MIDI (*.mid)");
+  } else if (extension == L"dls") {
+    dialog.setDefaultSuffix("dls");
+    dialog.setNameFilter("Downloadable Sound (*.dls)");
+  } else if (extension == L"sf2") {
+    dialog.setDefaultSuffix("sf2");
+    dialog.setNameFilter("SoundFont\u00AE 2 (*.sf2)");
+  } else {
+    dialog.setNameFilter("All files (*)");
+  }
+
+  if (dialog.exec()) {
+    selected_dir = dialog.directory().absolutePath();
+    return dialog.selectedFiles().at(0).toStdString();
+  } else {
+    return {};
+  }
 }

--- a/src/ui/qt/util/UIHelpers.h
+++ b/src/ui/qt/util/UIHelpers.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <string>
+
 class QScrollArea;
 class QWidget;
 class QPixmap;
@@ -13,3 +15,6 @@ class QGraphicsEffect;
 
 QScrollArea* getContainingScrollArea(QWidget* widget);
 void applyEffectToPixmap(QPixmap &src, QPixmap &tgt, QGraphicsEffect *effect, int extent = 0);
+
+std::string OpenSaveFileDialog(const std::wstring& suggested_filename, const std::wstring& extension);
+std::string OpenSaveDirDialog();

--- a/src/ui/qt/util/UIHelpers.h
+++ b/src/ui/qt/util/UIHelpers.h
@@ -16,5 +16,5 @@ class QGraphicsEffect;
 QScrollArea* getContainingScrollArea(QWidget* widget);
 void applyEffectToPixmap(QPixmap &src, QPixmap &tgt, QGraphicsEffect *effect, int extent = 0);
 
-std::string OpenSaveFileDialog(const std::wstring& suggested_filename, const std::wstring& extension);
+std::string OpenSaveFileDialog(const std::string& suggested_filename, const std::string& extension);
 std::string OpenSaveDirDialog();

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -169,7 +169,7 @@ void VGMFileListView::itemMenu(const QPoint &pos) {
       selectedFiles->push_back(qtVGMRoot.vVGMFile[index.row()]);
     }
   }
-  auto menu = menuManager.CreateMenuForItems(selectedFiles);
+  auto menu = menuManager.CreateMenuForItems<VGMItem>(selectedFiles);
   menu->exec(mapToGlobal(pos));
   menu->deleteLater();
 }

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -26,7 +26,7 @@ VGMFileListModel::VGMFileListModel(QObject *parent) : QAbstractTableModel(parent
 
 QVariant VGMFileListModel::data(const QModelIndex &index, int role) const {
   if (!index.isValid()) {
-    return {};
+    return QVariant();
   }
 
   VGMFile *vgmfile = qtVGMRoot.vVGMFile.at(static_cast<unsigned long>(index.row()));

--- a/src/ui/qt/workarea/VGMFileListView.h
+++ b/src/ui/qt/workarea/VGMFileListView.h
@@ -11,6 +11,8 @@
 #include <QKeyEvent>
 #include <QSortFilterProxyModel>
 
+#include "services/MenuManager.h"
+
 #include "VGMFile.h"
 
 class VGMFileListModel : public QAbstractTableModel {
@@ -53,6 +55,8 @@ class VGMFileListView final : public QTableView {
     void keyPressEvent(QKeyEvent *input) override;
     void itemMenu(const QPoint &pos);
     void resizeColumns();
+
+    MenuManager menuManager;
 
     VGMFileListModel *view_model;
 };


### PR DESCRIPTION
As [promised](https://github.com/vgmtrans/vgmtrans/pull/417#issuecomment-1858931378), this PR adds batch conversion so that when multiple VGMFiles are selected, they can all be saved in a single command. But wait, there's more! I didn't just tack this on to VGMFileListView. I wrote a generalized solution that will hopefully make it easy to create menus for any type across the entire app.

## The core classes: <br>MenuManager, Command, CommandContext, and CommandContextFactory

This PR introduces a new "service" for menu generation called `MenuManager`. The idea is that you can register a set of "Commands" to any type you so desire, where a `Command` represents a menu action, and then pass an instance of any type to `MenuManager::GetCommands()` to retrieve the eligible `Command`s of the object. The Command object, in turn, can execute the action.

Commands require data, of course. For example, the command "Save as MIDI" needs to know what file(s) to save and what path to save them to. Hence, we need to know not only what Commands an object can execute but also the data required by them and a decoupled mechanism for passing data to them. Enter the `CommandContext` class, which provides data to the `Command`.

To actually run a command, the `Command` class provides the `Execute()` method which requires a `CommandContext` parameter. A `Command` subclass knows to expect a specific `CommandContext` subclass, and will dynamic_cast the parameter to the expected type. So to use a command, we need to create the appropriate CommandContext and populate it with data. To do so, the Command provides the `GetContextFactory()` method, which returns a subclassed `CommandContextFactory` instance. 

A `CommandContextFactory` provides both the information on the data required by a `CommandContext` and the means to create it. The method `CreateContext()` takes a `PropertyMap` - a key/value map - and returns the specialized CommandContext. The `GetPropertySpecifications()` method returns a list of `PropertySpecification`s that detail the keys and corresponding value types expected to be entered into the PropertyMap passed to `CreateContext()`.

Ok, so the process is:

1. At app startup, register Commands for types by calling `MenuManager::RegisterCommands()`
2. Get the Commands for an object by calling `MenuManager::GetCommands()`
3. To use a Command, first generate the CommandContextFactory by calling `Command::GetContextFactory()`
4. Get the specifications of required properties by calling `CommandContextFactory::GetPropertySpecifications()`
5. Populate a `PropertyMap` with the required properties.
6. Create a `CommandContext` by calling `CommandContextFactory::CreateContext()` with the populated `PropertyMap`
7. Execute the command by calling `Command::Execute()` with the `CommandContext`.

## CreateMenuForItems() and FindCommonCommands()

"Wait a second," you say, "I've been hoodwinked. Why, for all this devastatingly technical jibber jabber, you still haven't addressed the promised batch conversion feature." Now you just slow down there, and quit with those damned accusations. This PR does indeed address batch conversions. Why I wrote a couple functions for that very purpose.

There's the `MenuManager::FindCommonCommands()` function, which takes a vector of instance pointers and returns a vector of commands common to all of the instances. For example, if I pass a list of three VGMInstrSet instances, it will return commands including conversion to DLS and SF2, because they all offer that functionality. If I pass a VGMInstrSet and a VGMSeq, it will only give me the commands to close the files or save them in their original format.

I've also written the `MenuManager::CreateMenuForItems()`, which uses `FindCommonCommands()` to generate a QMenu. It also accepts a vector a instance pointers.

## Handling Polymorphism in Command Registration

One of the difficulties I ran into is that C++ offers limited RTTI (run-time type information). Specifically, while we can get the type name of an instance using typeid(), we cannot get its class hierarchy. In our use case, it's important that we be able to register commands to a common parent class, like VGMSeq, VGMInstrSet, and VGMSampColl. But if `typeid()` will only tell us that a VGMFile instance is a `RareSnesSeq` and not a `VGMSeq`, what are we to do?

My solution is to have two registries within MenuManager. The first is a simple map of type_index to a vector of Command which we will always check first. The second is a vector of pairs, where the first value is a function that tests whether an instance can be dynamic_cast to a type, and the second is the vector of Commands for that type. This is obviously slower than the map lookup, since we need to execute every test function until we get a match, but it works. The other downside is that we need to limit this functionality to a specific base class, as we can't use `dynamic_cast` on a void*; it must know the base class. For our needs, this functionality works on VGMItem*. Of course, we could expand this to more base types if needed.

## Services and Dependency Injection

You'll notice that I called MenuManager a "service" and put it in a new "services" directory. The idea here is to move away from using singletons - especially the VGMRoot singleton - and toward dependency injection. I'm not actually using dependency injection in this PR; the MenuManager is owned by VGMFileList because I didn't want to increase the scope of this PR. Howeve,r the way this is structured allows us to use MenuManager as an injected dependency. I'm calling these injected dependencies "services" but I'm open to using another term.

## Is this an example of overengineering?

I wrestled with this concern. I don't think so. A major problem with the app is that most functionality is hidden behind right-click context menus. This is poor design. Users will be confused and/or never discover functionality. We should be updating the application menu with the same contextual menu items as a right click. I think this will make it easier to do that across the app.

## How Has This Been Tested?
Tested on MacOS Sonoma x64/arm64 and Windows 10.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
