### PR TITLE
use dataChanged() on raw file removal, for now

### DIFF
--- a/src/ui/qt/workarea/RawFileListView.cpp
+++ b/src/ui/qt/workarea/RawFileListView.cpp
@@ -45,8 +45,7 @@ void RawFileListViewModel::AddRawFile() {
 void RawFileListViewModel::RemoveRawFile() {
   int position = static_cast<int>(qtVGMRoot.vRawFile.size());
   if (position >= 0) {
-    beginRemoveRows(QModelIndex(), position, position);
-    endRemoveRows();
+    dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1));
   }
 }
 


### PR DESCRIPTION
For some reason (probably related to fiddling with the installed build tools) I started seeing exceptions thrown on the Windows build in RawFileListViewModel::RemoveRawFile() upon loading a file that gets unpacked. It looks like we are trying to remove rows at an index that doesn't necessarily exist. The code in this function is odd in that there's no guarantee a removed RawFile will be at the last index, and besides this, it appears that we're supposed to:
1. Call beginRemoveRows()
2. Remove the rows from the data source
3. Call endRemoveRows()

At any rate, we have the same non-adherence in AddRawFile() and it's not causing a fuss, possibly because in that case, the last index is actually what is updated every time.

Anyway, for now, I've just added a dataChanged() in place of begin/endRemoveRows() and it makes the issue go away.

## How Has This Been Tested?
Ran it on Windows 10.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
