### PR TITLE
Replace all instances of wide chars with normal ass chars

### DIFF
--- a/src/main/DLSFile.cpp
+++ b/src/main/DLSFile.cpp
@@ -137,7 +137,7 @@ int DLSFile::WriteDLSToBuffer(vector<uint8_t> &buf) {
 }
 
 // I should probably make this function part of a parent class for both Midi and DLS file
-bool DLSFile::SaveDLSFile(const std::wstring &filepath) {
+bool DLSFile::SaveDLSFile(const std::string &filepath) {
   vector<uint8_t> dlsBuf;
   WriteDLSToBuffer(dlsBuf);
   return pRoot->UI_WriteBufferToFile(filepath, dlsBuf.data(), static_cast<uint32_t>(dlsBuf.size()));

--- a/src/main/DLSFile.h
+++ b/src/main/DLSFile.h
@@ -108,7 +108,7 @@ public:
   uint32_t GetSize() override;
 
   int WriteDLSToBuffer(std::vector<uint8_t> &buf);
-  bool SaveDLSFile(const std::wstring &filepath);
+  bool SaveDLSFile(const std::string &filepath);
 
 private:
   std::vector<std::unique_ptr<DLSInstr>> m_instrs;

--- a/src/main/ExtensionDiscriminator.cpp
+++ b/src/main/ExtensionDiscriminator.cpp
@@ -11,13 +11,13 @@ ExtensionDiscriminator::~ExtensionDiscriminator(void) {
 }
 
 
-int ExtensionDiscriminator::AddExtensionScannerAssoc(std::wstring extension, VGMScanner *scanner) {
+int ExtensionDiscriminator::AddExtensionScannerAssoc(std::string extension, VGMScanner *scanner) {
   mScannerExt[extension].push_back(scanner);
   return true;
 }
 
-std::list<VGMScanner *> *ExtensionDiscriminator::GetScannerList(std::wstring extension) {
-  std::map<std::wstring, std::list<VGMScanner *> >::iterator iter = mScannerExt.find(StringToLower(extension));
+std::list<VGMScanner *> *ExtensionDiscriminator::GetScannerList(std::string extension) {
+  std::map<std::string, std::list<VGMScanner *> >::iterator iter = mScannerExt.find(StringToLower(extension));
   if (iter == mScannerExt.end())
     return NULL;
   else

--- a/src/main/ExtensionDiscriminator.h
+++ b/src/main/ExtensionDiscriminator.h
@@ -9,10 +9,10 @@ class ExtensionDiscriminator {
   ExtensionDiscriminator(void);
   ~ExtensionDiscriminator(void);
 
-  int AddExtensionScannerAssoc(std::wstring extension, VGMScanner *);
-  std::list<VGMScanner *> *GetScannerList(std::wstring extension);
+  int AddExtensionScannerAssoc(std::string extension, VGMScanner *);
+  std::list<VGMScanner *> *GetScannerList(std::string extension);
 
-  std::map<std::wstring, std::list<VGMScanner *> > mScannerExt;
+  std::map<std::string, std::list<VGMScanner *> > mScannerExt;
   static ExtensionDiscriminator &instance() {
     static ExtensionDiscriminator instance;
     return instance;

--- a/src/main/LogItem.cpp
+++ b/src/main/LogItem.cpp
@@ -2,17 +2,17 @@
 
 #include "LogItem.h"
 
-LogItem::LogItem(const std::wstring &text, LogLevel level, const std::wstring &source) :
+LogItem::LogItem(const std::string &text, LogLevel level, const std::string &source) :
     text(text),
     source(source),
     level(level) {
 }
 
-std::wstring LogItem::GetText() const {
-  return std::wstring(text);
+std::string LogItem::GetText() const {
+  return std::string(text);
 }
 
-const wchar_t *LogItem::GetCText() const {
+const char* LogItem::GetCText() const {
   return text.c_str();
 }
 
@@ -20,10 +20,10 @@ LogLevel LogItem::GetLogLevel() const {
   return level;
 }
 
-std::wstring LogItem::GetSource() const {
-  return std::wstring(source);
+std::string LogItem::GetSource() const {
+  return std::string(source);
 }
 
-const wchar_t *LogItem::GetCSource() const {
+const char* LogItem::GetCSource() const {
   return source.c_str();
 }

--- a/src/main/LogItem.h
+++ b/src/main/LogItem.h
@@ -6,16 +6,16 @@ enum LogLevel { LOG_LEVEL_ERR, LOG_LEVEL_WARN, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG }
 
 class LogItem {
  public:
-  LogItem(const std::wstring &text, LogLevel level, const std::wstring &source);
+  LogItem(const std::string &text, LogLevel level, const std::string &source);
 
-  std::wstring GetText() const;
-  const wchar_t *GetCText() const;
+  std::string GetText() const;
+  const char* GetCText() const;
   LogLevel GetLogLevel() const;
-  std::wstring GetSource() const;
-  const wchar_t *GetCSource() const;
+  std::string GetSource() const;
+  const char* GetCSource() const;
 
  protected:
-  std::wstring text;
-  std::wstring source;
+  std::string text;
+  std::string source;
   LogLevel level;
 };

--- a/src/main/Matcher.h
+++ b/src/main/Matcher.h
@@ -315,33 +315,33 @@ class GetIdMatcher:
 // ***************
 
 class FilenameMatcher:
-    public SimpleMatcher<std::wstring> {
+    public SimpleMatcher<std::string> {
  public:
   FilenameMatcher(Format *format, bool bRequiresSampColl = false)
       : SimpleMatcher(format, bRequiresSampColl) { }
 
-  virtual bool GetSeqId(VGMSeq *seq, std::wstring &id) {
+  virtual bool GetSeqId(VGMSeq *seq, std::string &id) {
     RawFile *rawfile = seq->GetRawFile();
     id = rawfile->GetParRawFileFullPath();
-    if (id == L"")        //wonder if empty() is equivalent?
+    if (id == "")        //wonder if empty() is equivalent?
       id = rawfile->GetFullPath();
-    return (id != L"");
+    return (id != "");
   }
 
-  virtual bool GetInstrSetId(VGMInstrSet *instrset, std::wstring &id) {
+  virtual bool GetInstrSetId(VGMInstrSet *instrset, std::string &id) {
     RawFile *rawfile = instrset->GetRawFile();
     id = rawfile->GetParRawFileFullPath();
-    if (id == L"")        //wonder if empty() is equivalent?
+    if (id == "")        //wonder if empty() is equivalent?
       id = rawfile->GetFullPath();
-    return (id != L"");
+    return (id != "");
   }
 
-  virtual bool GetSampCollId(VGMSampColl *sampcoll, std::wstring &id) {
+  virtual bool GetSampCollId(VGMSampColl *sampcoll, std::string &id) {
     RawFile *rawfile = sampcoll->GetRawFile();
     id = rawfile->GetParRawFileFullPath();
-    if (id == L"")        //wonder if empty() is equivalent?
+    if (id == "")        //wonder if empty() is equivalent?
       id = rawfile->GetFullPath();
-    return (id != L"");
+    return (id != "");
   }
 };
 

--- a/src/main/Menu.h
+++ b/src/main/Menu.h
@@ -69,7 +69,7 @@ class Menu {
   Menu() { }
   virtual ~Menu() { }
 
-  void AddMenuItem(bool (T::*funcPtr)(void), const wchar_t *name, uint8_t flag = 0) {
+  void AddMenuItem(bool (T::*funcPtr)(void), const char* name, uint8_t flag = 0) {
     funcs.push_back(funcPtr);
     names.push_back(name);
   }
@@ -78,11 +78,11 @@ class Menu {
     return (((T *) item)->*funcs[menuItemNum])();
   }
 
-  std::vector<const wchar_t *> *GetMenuItemNames(void) {
+  std::vector<const char* > *GetMenuItemNames(void) {
     return &names;
   }
 
  protected:
-  std::vector<const wchar_t *> names;
+  std::vector<const char* > names;
   std::vector<bool (T::*)(void)> funcs;
 };

--- a/src/main/MidiFile.cpp
+++ b/src/main/MidiFile.cpp
@@ -66,7 +66,7 @@ void MidiFile::Sort(void) {
 }
 
 
-bool MidiFile::SaveMidiFile(const std::wstring &filepath) {
+bool MidiFile::SaveMidiFile(const std::string &filepath) {
   vector<uint8_t> midiBuf;
   WriteMidiToBuffer(midiBuf);
   return pRoot->UI_WriteBufferToFile(filepath, &midiBuf[0], (uint32_t) midiBuf.size());
@@ -558,28 +558,28 @@ void MidiTrack::InsertEndOfTrack(uint32_t absTime) {
   bHasEndOfTrack = true;
 }
 
-void MidiTrack::AddText(const std::wstring &wstr) {
-  aEvents.push_back(new TextEvent(this, GetDelta(), wstr));
+void MidiTrack::AddText(const std::string &str) {
+  aEvents.push_back(new TextEvent(this, GetDelta(), str));
 }
 
-void MidiTrack::InsertText(const std::wstring &wstr, uint32_t absTime) {
-  aEvents.push_back(new TextEvent(this, absTime, wstr));
+void MidiTrack::InsertText(const std::string &str, uint32_t absTime) {
+  aEvents.push_back(new TextEvent(this, absTime, str));
 }
 
-void MidiTrack::AddSeqName(const std::wstring &wstr) {
-  aEvents.push_back(new SeqNameEvent(this, GetDelta(), wstr));
+void MidiTrack::AddSeqName(const std::string &str) {
+  aEvents.push_back(new SeqNameEvent(this, GetDelta(), str));
 }
 
-void MidiTrack::InsertSeqName(const std::wstring &wstr, uint32_t absTime) {
-  aEvents.push_back(new SeqNameEvent(this, absTime, wstr));
+void MidiTrack::InsertSeqName(const std::string &str, uint32_t absTime) {
+  aEvents.push_back(new SeqNameEvent(this, absTime, str));
 }
 
-void MidiTrack::AddTrackName(const std::wstring &wstr) {
-  aEvents.push_back(new TrackNameEvent(this, GetDelta(), wstr));
+void MidiTrack::AddTrackName(const std::string &str) {
+  aEvents.push_back(new TrackNameEvent(this, GetDelta(), str));
 }
 
-void MidiTrack::InsertTrackName(const std::wstring &wstr, uint32_t absTime) {
-  aEvents.push_back(new TrackNameEvent(this, absTime, wstr));
+void MidiTrack::InsertTrackName(const std::string &str, uint32_t absTime) {
+  aEvents.push_back(new TrackNameEvent(this, absTime, str));
 }
 
 void MidiTrack::AddGMReset() {
@@ -706,8 +706,7 @@ uint32_t MidiEvent::WriteMetaEvent(vector<uint8_t> &buf,
   return AbsTime;
 }
 
-uint32_t MidiEvent::WriteMetaTextEvent(vector<uint8_t> &buf, uint32_t time, uint8_t metaType, wstring wstr) {
-  string str = wstring2string(wstr);
+uint32_t MidiEvent::WriteMetaTextEvent(vector<uint8_t> &buf, uint32_t time, uint8_t metaType, string str) {
   return WriteMetaEvent(buf, time, metaType, (uint8_t *) str.c_str(), str.length());
 }
 
@@ -716,8 +715,8 @@ uint32_t MidiEvent::WriteMetaTextEvent(vector<uint8_t> &buf, uint32_t time, uint
 //aEvents.push_back(MakeCopy());
 //}
 
-std::wstring MidiEvent::GetNoteName(int noteNumber) {
-  const wchar_t *noteNames[12] = {L"C", L"C#", L"D", L"D#", L"E", L"F", L"F#", L"G", L"G#", L"A", L"A#", L"B"};
+std::string MidiEvent::GetNoteName(int noteNumber) {
+  const char* noteNames[12] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
 
   int octave;
   int key;
@@ -731,7 +730,7 @@ std::wstring MidiEvent::GetNoteName(int noteNumber) {
   }
   octave--;
 
-  std::wstringstream name;
+  std::stringstream name;
   name << noteNames[key] << " " << octave;
   return name.str();
 }
@@ -965,8 +964,8 @@ uint32_t EndOfTrackEvent::WriteEvent(vector<uint8_t> &buf, uint32_t time) {
 //  TextEvent
 //  *********
 
-TextEvent::TextEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::wstring &wstr)
-    : MidiEvent(prntTrk, absoluteTime, 0, PRIORITY_LOWEST), text(wstr) {
+TextEvent::TextEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::string &str)
+    : MidiEvent(prntTrk, absoluteTime, 0, PRIORITY_LOWEST), text(str) {
 }
 
 uint32_t TextEvent::WriteEvent(vector<uint8_t> &buf, uint32_t time) {
@@ -977,8 +976,8 @@ uint32_t TextEvent::WriteEvent(vector<uint8_t> &buf, uint32_t time) {
 //  SeqNameEvent
 //  ************
 
-SeqNameEvent::SeqNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::wstring &wstr)
-    : MidiEvent(prntTrk, absoluteTime, 0, PRIORITY_LOWEST), text(wstr) {
+SeqNameEvent::SeqNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::string &str)
+    : MidiEvent(prntTrk, absoluteTime, 0, PRIORITY_LOWEST), text(str) {
 }
 
 uint32_t SeqNameEvent::WriteEvent(vector<uint8_t> &buf, uint32_t time) {
@@ -989,8 +988,8 @@ uint32_t SeqNameEvent::WriteEvent(vector<uint8_t> &buf, uint32_t time) {
 //  TrackNameEvent
 //  **************
 
-TrackNameEvent::TrackNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::wstring &wstr)
-    : MidiEvent(prntTrk, absoluteTime, 0, PRIORITY_LOWEST), text(wstr) {
+TrackNameEvent::TrackNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::string &str)
+    : MidiEvent(prntTrk, absoluteTime, 0, PRIORITY_LOWEST), text(str) {
 }
 
 uint32_t TrackNameEvent::WriteEvent(vector<uint8_t> &buf, uint32_t time) {

--- a/src/main/MidiFile.h
+++ b/src/main/MidiFile.h
@@ -152,12 +152,12 @@ class MidiTrack {
   void InsertTimeSig(uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter, uint32_t absTime);
   void AddEndOfTrack(void);
   void InsertEndOfTrack(uint32_t absTime);
-  void AddText(const std::wstring &wstr);
-  void InsertText(const std::wstring &wstr, uint32_t absTime);
-  void AddSeqName(const std::wstring &wstr);
-  void InsertSeqName(const std::wstring &wstr, uint32_t absTime);
-  void AddTrackName(const std::wstring &wstr);
-  void InsertTrackName(const std::wstring &wstr, uint32_t absTime);
+  void AddText(const std::string &str);
+  void InsertText(const std::string &str, uint32_t absTime);
+  void AddSeqName(const std::string &str);
+  void InsertSeqName(const std::string &str, uint32_t absTime);
+  void AddTrackName(const std::string &str);
+  void InsertTrackName(const std::string &str, uint32_t absTime);
   void AddGMReset();
   void InsertGMReset(uint32_t absTime);
   void AddGM2Reset();
@@ -214,7 +214,7 @@ class MidiFile {
   uint32_t GetPPQN();
   void WriteMidiToBuffer(std::vector<uint8_t> &buf);
   void Sort(void);
-  bool SaveMidiFile(const std::wstring &filepath);
+  bool SaveMidiFile(const std::string &filepath);
 
  protected:
   //bool bAddedTempo;
@@ -241,9 +241,9 @@ class MidiEvent {
   //virtual void PrepareWrite(void/*vector<MidiEvent*> & aEvents*/);
   virtual uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) = 0;
   uint32_t WriteMetaEvent(std::vector<uint8_t> &buf, uint32_t time, uint8_t metaType, uint8_t *data, size_t dataSize);
-  uint32_t WriteMetaTextEvent(std::vector<uint8_t> &buf, uint32_t time, uint8_t metaType, std::wstring wstr);
+  uint32_t WriteMetaTextEvent(std::vector<uint8_t> &buf, uint32_t time, uint8_t metaType, std::string str);
 
-  static std::wstring GetNoteName(int noteNumber);
+  static std::string GetNoteName(int noteNumber);
 
   bool operator<(const MidiEvent &) const;
   bool operator>(const MidiEvent &) const;
@@ -550,31 +550,31 @@ class EndOfTrackEvent
 class TextEvent
     : public MidiEvent {
  public:
-  TextEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::wstring &wstr);
+  TextEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::string &str);
   virtual MidiEventType GetEventType() { return MIDIEVENT_TEXT; }
   virtual uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time);
 
-  std::wstring text;
+  std::string text;
 };
 
 class SeqNameEvent
     : public MidiEvent {
  public:
-  SeqNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::wstring &wstr);
+  SeqNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::string &str);
   virtual MidiEventType GetEventType() { return MIDIEVENT_TEXT; }
   virtual uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time);
 
-  std::wstring text;
+  std::string text;
 };
 
 class TrackNameEvent
     : public MidiEvent {
  public:
-  TrackNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::wstring &wstr);
+  TrackNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, const std::string &str);
   virtual MidiEventType GetEventType() { return MIDIEVENT_TEXT; }
   virtual uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time);
 
-  std::wstring text;
+  std::string text;
 };
 
 // SPECIAL EVENTS THAT AFFECT OTHER MIDI EVENTS RATHER THAN DIRECTLY OUTPUT TO THE FILE

--- a/src/main/PSFFile.cpp
+++ b/src/main/PSFFile.cpp
@@ -48,7 +48,7 @@ bool PSFFile::Load(RawFile *file) {
   // Check file size.
   uint32_t fileSize = file->size();
   if (fileSize < 0x10) {
-    errorstr = L"PSF too small - likely corrupt";
+    errorstr = "PSF too small - likely corrupt";
     return false;
   }
 
@@ -56,7 +56,7 @@ bool PSFFile::Load(RawFile *file) {
   uint8_t psfSig[4];
   file->GetBytes(0, 4, psfSig);
   if (memcmp(psfSig, "PSF", 3) != 0) {
-    errorstr = L"Invalid PSF signature";
+    errorstr = "Invalid PSF signature";
     return false;
   }
 
@@ -72,14 +72,14 @@ bool PSFFile::Load(RawFile *file) {
   if ((reservedSize > fileSize) ||
       (exeSize > fileSize) ||
       ((16 + reservedSize + exeSize) > fileSize)) {
-    errorstr = L"PSF header is inconsistent";
+    errorstr = "PSF header is inconsistent";
     return false;
   }
 
   // Read compressed program section.
   uint8_t *zexebuf = new uint8_t[exeSize > 0 ? exeSize : 1];
   if (zexebuf == NULL) {
-    errorstr = L"Out of memory reading the file";
+    errorstr = "Out of memory reading the file";
     return false;
   }
   file->GetBytes(16 + reservedSize, exeSize, zexebuf);
@@ -87,7 +87,7 @@ bool PSFFile::Load(RawFile *file) {
 
   // Check program section CRC.
   if (exeCRC != crc32(crc32(0L, Z_NULL, 0), zexebuf, exeSize)) {
-    errorstr = L"CRC failure - executable data is corrupt";
+    errorstr = "CRC failure - executable data is corrupt";
     exeCompData->clear();
     return false;
   }
@@ -95,7 +95,7 @@ bool PSFFile::Load(RawFile *file) {
   // Read reserved section.
   uint8_t *reservebuf = new uint8_t[reservedSize ? reservedSize : 1];
   if (reservebuf == NULL) {
-    errorstr = L"Out of memory reading the file";
+    errorstr = "Out of memory reading the file";
     exeCompData->clear();
     return false;
   }
@@ -117,7 +117,7 @@ bool PSFFile::Load(RawFile *file) {
   // Check if tag field exists.
   char *tagSect = new char[tagSectionSize + 1];
   if (tagSect == NULL) {
-    errorstr = L"Out of memory reading the file";
+    errorstr = "Out of memory reading the file";
     exeCompData->clear();
     reservedData->clear();
     return false;
@@ -202,7 +202,7 @@ bool PSFFile::ReadExe(uint8_t *buf, size_t len, size_t stripLen) const {
   uLong destlen = (uLong) len;
   int zRet = myuncompress(buf, &destlen, exeCompData->data, (uLong) exeCompData->size, (uLong) stripLen);
   if (zRet != Z_OK) {
-    //errorstr = L"Decompression failed";
+    //errorstr = "Decompression failed";
     return false;
   }
   return true;
@@ -219,7 +219,7 @@ bool PSFFile::ReadExeDataSeg(DataSeg *&seg, size_t len, size_t stripLen) const {
   uLong destlen = (uLong) len;
   int zRet = myuncompress(buf, &destlen, exeCompData->data, (uLong) exeCompData->size, (uLong) stripLen);
   if (zRet != Z_OK) {
-    //errorstr = L"Decompression failed";
+    //errorstr = "Decompression failed";
     seg = NULL;
     delete newSeg;
     delete[] buf;
@@ -239,21 +239,21 @@ bool PSFFile::Decompress(size_t decompressed_size) {
       return true;
     }
     else {
-      errorstr = L"Decompression failed";
+      errorstr = "Decompression failed";
       return false;
     }
   }
 
   uint8_t *buf = new uint8_t[decompressed_size];
   if (buf == NULL) {
-    errorstr = L"Out of memory reading the file";
+    errorstr = "Out of memory reading the file";
     return false;
   }
 
   uLong destlen = (uLong) decompressed_size;
   int zRet = uncompress(buf, &destlen, exeCompData->data, (uLong) exeCompData->size);
   if (zRet != Z_STREAM_END) {
-    errorstr = L"Decompression failed";
+    errorstr = "Decompression failed";
     delete[] buf;
     return false;
   }
@@ -295,7 +295,7 @@ void PSFFile::Clear() {
   parent = NULL;
 }
 
-const wchar_t *PSFFile::GetError(void) const {
+const char* PSFFile::GetError(void) const {
   return errorstr;
 }
 

--- a/src/main/PSFFile.h
+++ b/src/main/PSFFile.h
@@ -21,7 +21,7 @@ class PSFFile {
   size_t GetCompressedExeSize(void) const;
   size_t GetReservedSize(void) const;
   void Clear(void);
-  const wchar_t *GetError(void) const;
+  const char* GetError(void) const;
 
  public:
   PSFFile *parent;
@@ -36,7 +36,7 @@ class PSFFile {
   DataSeg *reservedData;
   uint32_t exeCRC;
   bool decompressed;
-  wchar_t *errorstr;
+  char *errorstr;
   uint8_t *stripBuf;
   size_t stripBufSize;
 

--- a/src/main/RawFile.cpp
+++ b/src/main/RawFile.cpp
@@ -13,16 +13,16 @@ using namespace std;
 RawFile::RawFile(void)
     : propreRatio(0.5),
       processFlags(PF_USESCANNERS | PF_USELOADERS),
-      parRawFileFullPath(L""),
+      parRawFileFullPath(""),
       bCanFileRead(true),
       fileSize(0) {
   bufSize = (BUF_SIZE > fileSize) ? fileSize : BUF_SIZE;
 }
 
-RawFile::RawFile(const wstring name, uint32_t theFileSize, bool bCanRead, const VGMTag tag)
+RawFile::RawFile(const string name, uint32_t theFileSize, bool bCanRead, const VGMTag tag)
     : fileSize(theFileSize),
       fullpath(name),
-      parRawFileFullPath(L""),        //this should only be defined by VirtFile
+      parRawFileFullPath(""),        //this should only be defined by VirtFile
       propreRatio(0.5),
       bCanFileRead(bCanRead),
       tag(tag),
@@ -45,12 +45,12 @@ RawFile::~RawFile(void) {
 }
 
 // opens a file using the standard c++ file i/o routines
-bool RawFile::open(const wstring &theFileName) {
+bool RawFile::open(const string &theFileName) {
   file.open(ghc::filesystem::path(theFileName), ios::in | ios::binary);
   if (!file.is_open()) {
-    pRoot->AddLogItem(new LogItem((std::wstring(L"File ") + theFileName.c_str() + L" could not be opened"),
+    pRoot->AddLogItem(new LogItem((std::string("File ") + theFileName.c_str() + " could not be opened"),
                                   LOG_LEVEL_ERR,
-                                  L"RawFile"));
+                                  "RawFile"));
     return false;
   }
 
@@ -76,7 +76,7 @@ unsigned long RawFile::size(void) {
 }
 
 // Name says it all.
-wstring RawFile::getFileNameFromPath(const wstring &s) {
+string RawFile::getFileNameFromPath(const string &s) {
   size_t i = s.rfind('/', s.length());
   size_t j = s.rfind('\\', s.length());
   if (i == string::npos || (j != string::npos && i < j))
@@ -87,15 +87,15 @@ wstring RawFile::getFileNameFromPath(const wstring &s) {
   return s;
 }
 
-wstring RawFile::getExtFromPath(const wstring &s) {
+string RawFile::getExtFromPath(const string &s) {
   size_t i = s.rfind('.', s.length());
   if (i != string::npos) {
     return (s.substr(i + 1, s.length() - i));
   }
-  return (L"");
+  return ("");
 }
 
-wstring RawFile::removeExtFromPath(const wstring &s) {
+string RawFile::removeExtFromPath(const string &s) {
   size_t i = s.rfind('.', s.length());
   if (i != string::npos) {
     return (s.substr(0, i));
@@ -145,10 +145,10 @@ void RawFile::RemoveContainedVGMFile(VGMFile *vgmfile) {
   if (iter != containedVGMFiles.end())
     containedVGMFiles.erase(iter);
   else
-    pRoot->AddLogItem(new LogItem(std::wstring(
-        L"Error: trying to delete a vgmfile which cannot be found in containedVGMFiles."),
+    pRoot->AddLogItem(new LogItem(std::string(
+        "Error: trying to delete a vgmfile which cannot be found in containedVGMFiles."),
                                   LOG_LEVEL_DEBUG,
-                                  L"RawFile"));
+                                  "RawFile"));
 
   if (containedVGMFiles.size() == 0)
     pRoot->CloseRawFile(this);
@@ -280,7 +280,7 @@ void RawFile::UpdateBuffer(uint32_t index) {
 }
 
 bool RawFile::OnSaveAsRaw() {
-  wstring filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(filename));
+  string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(filename));
   if (filepath.length() != 0) {
     bool result;
     uint8_t *buf = new uint8_t[fileSize];        //create a buffer the size of the file
@@ -300,7 +300,7 @@ VirtFile::VirtFile()
     : RawFile() {
 }
 
-VirtFile::VirtFile(uint8_t *data, uint32_t fileSize, const wstring &name, const wchar_t *rawFileName, const VGMTag tag)
+VirtFile::VirtFile(uint8_t *data, uint32_t fileSize, const string &name, const char* rawFileName, const VGMTag tag)
     : RawFile(name, fileSize, false, tag) {
   parRawFileFullPath = rawFileName;
   buf.load(data, 0, fileSize);

--- a/src/main/RawFile.h
+++ b/src/main/RawFile.h
@@ -15,22 +15,22 @@ enum ProcessFlag {
 class RawFile {
  public:
   RawFile(void);
-  RawFile(const std::wstring name, uint32_t fileSize = 0, bool bCanRead = true, const VGMTag tag = VGMTag());
+  RawFile(const std::string name, uint32_t fileSize = 0, bool bCanRead = true, const VGMTag tag = VGMTag());
  public:
   virtual ~RawFile(void);
 
 //	void kill(void);
 
-  bool open(const std::wstring &filename);
+  bool open(const std::string &filename);
   void close();
   unsigned long size(void);
-  inline const wchar_t *GetFullPath() { return fullpath.c_str(); }
-  inline const wchar_t *GetFileName() { return filename.c_str(); }    //returns the filename with extension
-  inline const std::wstring &GetExtension() { return extension; }
-  inline const std::wstring &GetParRawFileFullPath() { return parRawFileFullPath; }
-  static std::wstring getFileNameFromPath(const std::wstring &s);
-  static std::wstring getExtFromPath(const std::wstring &s);
-  static std::wstring removeExtFromPath(const std::wstring &s);
+  inline const std::string& GetFullPath() { return fullpath; }
+  inline const std::string& GetFileName() { return filename; }    //returns the filename with extension
+  inline const std::string& GetExtension() { return extension; }
+  inline const std::string& GetParRawFileFullPath() { return parRawFileFullPath; }
+  static std::string getFileNameFromPath(const std::string& s);
+  static std::string getExtFromPath(const std::string& s);
+  static std::string removeExtFromPath(const std::string& s);
   VGMItem *GetItemFromOffset(long offset);
   VGMFile *GetVGMFileFromOffset(long offset);
 
@@ -111,10 +111,10 @@ class RawFile {
   std::filebuf *pbuf;
   bool bCanFileRead;
   unsigned long fileSize;
-  std::wstring fullpath;
-  std::wstring filename;
-  std::wstring extension;
-  std::wstring parRawFileFullPath;
+  std::string fullpath;
+  std::string filename;
+  std::string extension;
+  std::string parRawFileFullPath;
  public:
   std::list<VGMFile *> containedVGMFiles;
   VGMTag tag;
@@ -126,7 +126,7 @@ class VirtFile: public RawFile {
   VirtFile();
   VirtFile(uint8_t *data,
            uint32_t fileSize,
-           const std::wstring &name,
-           const wchar_t *parRawFileFullPath = L"",
+           const std::string &name,
+           const char* parRawFileFullPath = "",
            const VGMTag tag = VGMTag());
 };

--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -100,7 +100,7 @@ void VGMRoot::Reset(void) {
 }
 
 // opens up a file from the filesystem and scans it for known formats
-bool VGMRoot::OpenRawFile(const wstring &filename) {
+bool VGMRoot::OpenRawFile(const string &filename) {
   RawFile *newRawFile = new RawFile(filename);
   if (!newRawFile->open(filename)) {
     delete newRawFile;
@@ -116,8 +116,8 @@ bool VGMRoot::OpenRawFile(const wstring &filename) {
 // the contents of PSF2 files
 bool VGMRoot::CreateVirtFile(uint8_t *databuf,
                              uint32_t fileSize,
-                             const wstring &filename,
-                             const wstring &parRawFileFullPath,
+                             const string &filename,
+                             const string &parRawFileFullPath,
                              const VGMTag tag) {
   assert(fileSize != 0);
 
@@ -186,9 +186,9 @@ bool VGMRoot::CloseRawFile(RawFile *targFile) {
   if (iter != vRawFile.end())
     vRawFile.erase(iter);
   else
-    pRoot->AddLogItem(new LogItem(std::wstring(L"Error: trying to delete a rawfile which cannot be found in vRawFile."),
+    pRoot->AddLogItem(new LogItem(std::string("Error: trying to delete a rawfile which cannot be found in vRawFile."),
                                   LOG_LEVEL_DEBUG,
-                                  L"Root"));
+                                  "Root"));
 
   delete targFile;
   return true;
@@ -215,9 +215,9 @@ void VGMRoot::RemoveVGMFile(VGMFile *targFile, bool bRemoveFromRaw) {
   if (iter != vVGMFile.end())
     vVGMFile.erase(iter);
   else
-    pRoot->AddLogItem(new LogItem(std::wstring(L"Error: trying to delete a VGMFile which cannot be found in vVGMFile."),
+    pRoot->AddLogItem(new LogItem(std::string("Error: trying to delete a VGMFile which cannot be found in vVGMFile."),
                                   LOG_LEVEL_DEBUG,
-                                  L"Root"));
+                                  "Root"));
   if (bRemoveFromRaw)
     targFile->rawfile->RemoveContainedVGMFile(targFile);
   while (targFile->assocColls.size())
@@ -241,9 +241,9 @@ void VGMRoot::RemoveVGMColl(VGMColl *targColl) {
   if (iter != vVGMColl.end())
     vVGMColl.erase(iter);
   else
-    pRoot->AddLogItem(new LogItem(std::wstring(L"Error: trying to delete a VGMColl which cannot be found in vVGMColl."),
+    pRoot->AddLogItem(new LogItem(std::string("Error: trying to delete a VGMColl which cannot be found in vVGMColl."),
                                   LOG_LEVEL_DEBUG,
-                                  L"Root"));
+                                  "Root"));
   UI_RemoveVGMColl(targColl);
   delete targColl;
 }
@@ -272,12 +272,12 @@ void VGMRoot::UI_AddVGMFile(VGMFile *theFile) {
 
 // Given a pointer to a buffer of data, size, and a filename, this function writes the data
 // into a file on the filesystem.
-bool VGMRoot::UI_WriteBufferToFile(const wstring &filepath, uint8_t *buf, uint32_t size) {
+bool VGMRoot::UI_WriteBufferToFile(const string &filepath, uint8_t *buf, uint32_t size) {
   ofstream outfile(ghc::filesystem::path(filepath), ios::out | ios::trunc | ios::binary);
   if (!outfile.is_open()) {        //if attempt to open file failed
     pRoot->AddLogItem(new LogItem(
-      std::wstring(L"Error: could not open file " + filepath + L" for writing"),
-      LOG_LEVEL_ERR, L"Root"));
+      std::string("Error: could not open file " + filepath + " for writing"),
+      LOG_LEVEL_ERR, "Root"));
     return false;
   }
   outfile.write((const char *) buf, size);
@@ -295,7 +295,7 @@ bool VGMRoot::SaveAllAsRaw() {
       fs::path filepath = dirpath / fs::path(*file->GetName());
       uint8_t *buf = new uint8_t[file->unLength];        //create a buffer the size of the file
       file->GetBytes(file->dwOffset, file->unLength, buf);
-      result = UI_WriteBufferToFile(filepath.wstring(), buf, file->unLength);
+      result = UI_WriteBufferToFile(filepath.string(), buf, file->unLength);
       delete[] buf;
     }
     return true;
@@ -310,6 +310,6 @@ void VGMRoot::AddLogItem(LogItem *theLog) {
   UI_AddLogItem(theLog);
 }
 
-const std::wstring VGMRoot::UI_GetResourceDirPath() {
-  return std::wstring(fs::current_path().generic_wstring());
+const std::string VGMRoot::UI_GetResourceDirPath() {
+  return std::string(fs::current_path().generic_string());
 }

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -30,11 +30,11 @@ class VGMRoot {
   bool Init(void);
   void Reset(void);
   void Exit(void);
-  virtual bool OpenRawFile(const std::wstring &filename);
+  virtual bool OpenRawFile(const std::string &filename);
   bool CreateVirtFile(uint8_t *databuf,
                       uint32_t fileSize,
-                      const std::wstring &filename,
-                      const std::wstring &parRawFileFullPath = L"",
+                      const std::string &filename,
+                      const std::string &parRawFileFullPath = "",
                       const VGMTag tag = VGMTag());
   bool SetupNewRawFile(RawFile *newRawFile);
   bool CloseRawFile(RawFile *targFile);
@@ -50,7 +50,7 @@ class VGMRoot {
     vLoader.push_back(new T());
   }
 
-  virtual const std::wstring UI_GetResourceDirPath();
+  virtual const std::string UI_GetResourceDirPath();
   virtual void UI_SetRootPtr(VGMRoot **theRoot) = 0;
   virtual void UI_PreExit() { }
   virtual void UI_Exit() = 0;
@@ -74,13 +74,13 @@ class VGMRoot {
   virtual void UI_EndRemoveVGMFiles() { }
   virtual void UI_RemoveVGMColl(VGMColl *theColl) { }
   //virtual void UI_RemoveVGMFileRange(VGMFile* first, VGMFile* last) {}
-  virtual void UI_AddItem(VGMItem *item, VGMItem *parent, const std::wstring &itemName, void *UI_specific) { }
-  virtual std::wstring
-      UI_GetOpenFilePath(const std::wstring &suggestedFilename = L"", const std::wstring &extension = L"") = 0;
-  virtual std::wstring
-      UI_GetSaveFilePath(const std::wstring &suggestedFilename, const std::wstring &extension = L"") = 0;
-  virtual std::wstring UI_GetSaveDirPath(const std::wstring &suggestedDir = L"") = 0;
-  virtual bool UI_WriteBufferToFile(const std::wstring &filepath, uint8_t *buf, uint32_t size);
+  virtual void UI_AddItem(VGMItem *item, VGMItem *parent, const std::string &itemName, void *UI_specific) { }
+  virtual std::string
+      UI_GetOpenFilePath(const std::string &suggestedFilename = "", const std::string &extension = "") = 0;
+  virtual std::string
+      UI_GetSaveFilePath(const std::string &suggestedFilename, const std::string &extension = "") = 0;
+  virtual std::string UI_GetSaveDirPath(const std::string &suggestedDir = "") = 0;
+  virtual bool UI_WriteBufferToFile(const std::string &filepath, uint8_t *buf, uint32_t size);
 
 
   bool SaveAllAsRaw();

--- a/src/main/SF2File.cpp
+++ b/src/main/SF2File.cpp
@@ -450,7 +450,7 @@ std::vector<uint8_t> SF2File::SaveToMem() {
   return buf;
 }
 
-bool SF2File::SaveSF2File(const std::wstring &filepath) {
+bool SF2File::SaveSF2File(const std::string &filepath) {
   auto buf = SaveToMem();
   bool result = pRoot->UI_WriteBufferToFile(filepath, buf.data(), buf.size());
   return result;

--- a/src/main/SF2File.h
+++ b/src/main/SF2File.h
@@ -285,6 +285,6 @@ class SF2File: public RiffFile {
   ~SF2File() = default;
 
   std::vector<uint8_t> SaveToMem();
-  bool SaveSF2File(const std::wstring &filepath);
+  bool SaveSF2File(const std::string &filepath);
 
 };

--- a/src/main/SeqEvent.cpp
+++ b/src/main/SeqEvent.cpp
@@ -11,10 +11,10 @@
 SeqEvent::SeqEvent(SeqTrack *pTrack,
                    uint32_t offset,
                    uint32_t length,
-                   const std::wstring &name,
+                   const std::string &name,
                    EventColor color,
                    Icon icon,
-                   const std::wstring &desc)
+                   const std::string &desc)
     : VGMItem((VGMFile *) pTrack->parentSeq, offset, length, name, color), desc(desc), icon(icon), parentTrack(pTrack) {
 }
 
@@ -28,7 +28,7 @@ DurNoteSeqEvent::DurNoteSeqEvent(SeqTrack *pTrack,
                                  uint32_t duration,
                                  uint32_t offset,
                                  uint32_t length,
-                                 const std::wstring &name)
+                                 const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_DURNOTE), absKey(absoluteKey), vel(velocity), dur(duration) { }
 
 
@@ -41,7 +41,7 @@ NoteOnSeqEvent::NoteOnSeqEvent(SeqTrack *pTrack,
                                uint8_t velocity,
                                uint32_t offset,
                                uint32_t length,
-                               const std::wstring &name)
+                               const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_NOTEON), absKey(absoluteKey), vel(velocity) { }
 
 
@@ -54,7 +54,7 @@ NoteOffSeqEvent::NoteOffSeqEvent(SeqTrack *pTrack,
                                  uint8_t absoluteKey,
                                  uint32_t offset,
                                  uint32_t length,
-                                 const std::wstring &name)
+                                 const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_NOTEOFF), absKey(absoluteKey) { }
 
 // ************
@@ -65,7 +65,7 @@ RestSeqEvent::RestSeqEvent(SeqTrack *pTrack,
                            uint32_t duration,
                            uint32_t offset,
                            uint32_t length,
-                           const std::wstring &name)
+                           const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_REST), dur(duration) { }
 
 // *****************
@@ -76,14 +76,14 @@ SetOctaveSeqEvent::SetOctaveSeqEvent(SeqTrack *pTrack,
                                      uint8_t theOctave,
                                      uint32_t offset,
                                      uint32_t length,
-                                     const std::wstring &name)
+                                     const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_CHANGESTATE), octave(theOctave) { }
 
 // ***********
 // VolSeqEvent
 // ***********
 
-VolSeqEvent::VolSeqEvent(SeqTrack *pTrack, uint8_t volume, uint32_t offset, uint32_t length, const std::wstring &name)
+VolSeqEvent::VolSeqEvent(SeqTrack *pTrack, uint8_t volume, uint32_t offset, uint32_t length, const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_VOLUME), vol(volume) { }
 
 // ****************
@@ -95,7 +95,7 @@ VolSlideSeqEvent::VolSlideSeqEvent(SeqTrack *pTrack,
                                    uint32_t duration,
                                    uint32_t offset,
                                    uint32_t length,
-                                   const std::wstring &name)
+                                   const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_VOLUME), targVol(targetVolume), dur(duration) { }
 
 // ***********
@@ -106,7 +106,7 @@ MastVolSeqEvent::MastVolSeqEvent(SeqTrack *pTrack,
                                  uint8_t volume,
                                  uint32_t offset,
                                  uint32_t length,
-                                 const std::wstring &name)
+                                 const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_VOLUME), vol(volume) { }
 
 // ****************
@@ -118,7 +118,7 @@ MastVolSlideSeqEvent::MastVolSlideSeqEvent(SeqTrack *pTrack,
                                            uint32_t duration,
                                            uint32_t offset,
                                            uint32_t length,
-                                           const std::wstring &name)
+                                           const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_VOLUME), targVol(targetVolume), dur(duration) { }
 
 // ******************
@@ -129,7 +129,7 @@ ExpressionSeqEvent::ExpressionSeqEvent(SeqTrack *pTrack,
                                        uint8_t theLevel,
                                        uint32_t offset,
                                        uint32_t length,
-                                       const std::wstring &name)
+                                       const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_EXPRESSION), level(theLevel) { }
 
 // ***********************
@@ -141,7 +141,7 @@ ExpressionSlideSeqEvent::ExpressionSlideSeqEvent(SeqTrack *pTrack,
                                                  uint32_t duration,
                                                  uint32_t offset,
                                                  uint32_t length,
-                                                 const std::wstring &name)
+                                                 const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_EXPRESSION), targExpr(targetExpression), dur(duration) { }
 
 
@@ -150,7 +150,7 @@ ExpressionSlideSeqEvent::ExpressionSlideSeqEvent(SeqTrack *pTrack,
 // PanSeqEvent
 // ***********
 
-PanSeqEvent::PanSeqEvent(SeqTrack *pTrack, uint8_t thePan, uint32_t offset, uint32_t length, const std::wstring &name)
+PanSeqEvent::PanSeqEvent(SeqTrack *pTrack, uint8_t thePan, uint32_t offset, uint32_t length, const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_PAN), pan(thePan) { }
 
 // ****************
@@ -162,7 +162,7 @@ PanSlideSeqEvent::PanSlideSeqEvent(SeqTrack *pTrack,
                                    uint32_t duration,
                                    uint32_t offset,
                                    uint32_t length,
-                                   const std::wstring &name)
+                                   const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_PAN), targPan(targetPan), dur(duration) { }
 
 // **************
@@ -173,7 +173,7 @@ ReverbSeqEvent::ReverbSeqEvent(SeqTrack *pTrack,
                                uint8_t theReverb,
                                uint32_t offset,
                                uint32_t length,
-                               const std::wstring &name)
+                               const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_REVERB), reverb(theReverb) { }
 
 // *****************
@@ -184,7 +184,7 @@ PitchBendSeqEvent::PitchBendSeqEvent(SeqTrack *pTrack,
                                      short thePitchBend,
                                      uint32_t offset,
                                      uint32_t length,
-                                     const std::wstring &name)
+                                     const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_PITCHBEND), pitchbend(thePitchBend) { }
 
 // **********************
@@ -192,7 +192,7 @@ PitchBendSeqEvent::PitchBendSeqEvent(SeqTrack *pTrack,
 // **********************
 
 PitchBendRangeSeqEvent::PitchBendRangeSeqEvent(SeqTrack *pTrack, uint8_t theSemiTones, uint8_t theCents,
-                                               uint32_t offset, uint32_t length, const std::wstring &name)
+                                               uint32_t offset, uint32_t length, const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_PITCHBENDRANGE), semitones(theSemiTones), cents(theCents) { }
 
 // ******************
@@ -200,7 +200,7 @@ PitchBendRangeSeqEvent::PitchBendRangeSeqEvent(SeqTrack *pTrack, uint8_t theSemi
 // ******************
 
 FineTuningSeqEvent::FineTuningSeqEvent(SeqTrack *pTrack, double cents,
-                                       uint32_t offset, uint32_t length, const std::wstring &name)
+                                       uint32_t offset, uint32_t length, const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_MISC), cents(cents) { }
 
 // ****************************
@@ -208,7 +208,7 @@ FineTuningSeqEvent::FineTuningSeqEvent(SeqTrack *pTrack, double cents,
 // ****************************
 
 ModulationDepthRangeSeqEvent::ModulationDepthRangeSeqEvent(SeqTrack *pTrack, double semitones,
-                                                           uint32_t offset, uint32_t length, const std::wstring &name)
+                                                           uint32_t offset, uint32_t length, const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_MISC), semitones(semitones) { }
 
 // *****************
@@ -219,7 +219,7 @@ TransposeSeqEvent::TransposeSeqEvent(SeqTrack *pTrack,
                                      int theTranspose,
                                      uint32_t offset,
                                      uint32_t length,
-                                     const std::wstring &name)
+                                     const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_TRANSPOSE), transpose(theTranspose) { }
 
 // ******************
@@ -230,7 +230,7 @@ ModulationSeqEvent::ModulationSeqEvent(SeqTrack *pTrack,
                                        uint8_t theDepth,
                                        uint32_t offset,
                                        uint32_t length,
-                                       const std::wstring &name)
+                                       const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_MODULATION), depth(theDepth) { }
 
 // **************
@@ -241,7 +241,7 @@ BreathSeqEvent::BreathSeqEvent(SeqTrack *pTrack,
                                uint8_t theDepth,
                                uint32_t offset,
                                uint32_t length,
-                               const std::wstring &name)
+                               const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_MODULATION), depth(theDepth) { }
 
 // ***************
@@ -252,7 +252,7 @@ SustainSeqEvent::SustainSeqEvent(SeqTrack *pTrack,
                                  uint8_t theDepth,
                                  uint32_t offset,
                                  uint32_t length,
-                                 const std::wstring &name)
+                                 const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_SUSTAIN), depth(theDepth) { }
 
 // ******************
@@ -263,7 +263,7 @@ PortamentoSeqEvent::PortamentoSeqEvent(SeqTrack *pTrack,
                                        bool bPortamento,
                                        uint32_t offset,
                                        uint32_t length,
-                                       const std::wstring &name)
+                                       const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_PORTAMENTO), bOn(bPortamento) { }
 
 // **********************
@@ -274,7 +274,7 @@ PortamentoTimeSeqEvent::PortamentoTimeSeqEvent(SeqTrack *pTrack,
                                                uint8_t theTime,
                                                uint32_t offset,
                                                uint32_t length,
-                                               const std::wstring &name)
+                                               const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_PORTAMENTO), time(theTime) { }
 
 // ******************
@@ -285,7 +285,7 @@ ProgChangeSeqEvent::ProgChangeSeqEvent(SeqTrack *pTrack,
                                        uint32_t programNumber,
                                        uint32_t offset,
                                        uint32_t length,
-                                       const std::wstring &name)
+                                       const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_PROGCHANGE), progNum(programNumber) { }
 
 // *************
@@ -296,7 +296,7 @@ TempoSeqEvent::TempoSeqEvent(SeqTrack *pTrack,
                              double beatsperminute,
                              uint32_t offset,
                              uint32_t length,
-                             const std::wstring &name)
+                             const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_TEMPO), bpm(beatsperminute) { }
 
 // ******************
@@ -308,7 +308,7 @@ TempoSlideSeqEvent::TempoSlideSeqEvent(SeqTrack *pTrack,
                                        uint32_t duration,
                                        uint32_t offset,
                                        uint32_t length,
-                                       const std::wstring &name)
+                                       const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_TEMPO), targbpm(targBPM), dur(duration) { }
 
 // ***************
@@ -321,7 +321,7 @@ TimeSigSeqEvent::TimeSigSeqEvent(SeqTrack *pTrack,
                                  uint8_t theTicksPerQuarter,
                                  uint32_t offset,
                                  uint32_t length,
-                                 const std::wstring &name)
+                                 const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_TIMESIG), numer(numerator), denom(denominator),
       ticksPerQuarter(theTicksPerQuarter) { }
 

--- a/src/main/SeqEvent.h
+++ b/src/main/SeqEvent.h
@@ -4,10 +4,10 @@
 #include "MidiFile.h"
 
 #define DESCRIPTION(_str_)                                   \
-    virtual std::wstring GetDescription()                    \
+    virtual std::string GetDescription()                    \
     {                                                        \
-        std::wostringstream    desc;                         \
-        desc << name << L" -  " << _str_;                    \
+        std::ostringstream    desc;                         \
+        desc << name << " -  " << _str_;                    \
         return desc.str();                                   \
     }
 
@@ -49,13 +49,13 @@ class SeqEvent:
   SeqEvent(SeqTrack *pTrack,
            uint32_t offset = 0,
            uint32_t length = 0,
-           const std::wstring &name = L"",
+           const std::string &name = "",
            EventColor color = CLR_UNKNOWN,
            Icon icon = ICON_BINARY,
-           const std::wstring &desc = L"");
+           const std::string &desc = "");
   virtual ~SeqEvent(void) { }
-  virtual std::wstring GetDescription() {
-    return desc.empty() ? std::wstring(name) : (std::wstring(name) + L" - " + desc);
+  virtual std::string GetDescription() {
+    return desc.empty() ? std::string(name) : (std::string(name) + " - " + desc);
   }
   virtual ItemType GetType() const { return ITEMTYPE_SEQEVENT; }
   virtual EventType GetEventType() { return EVENTTYPE_UNDEFINED; }
@@ -66,7 +66,7 @@ class SeqEvent:
   SeqTrack *parentTrack;
  private:
   Icon icon;
-  std::wstring desc;
+  std::string desc;
 };
 
 
@@ -83,13 +83,13 @@ class DurNoteSeqEvent:
                   uint32_t duration,
                   uint32_t offset = 0,
                   uint32_t length = 0,
-                  const std::wstring &name = L"");
+                  const std::string &name = "");
   virtual ~DurNoteSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_DURNOTE; }
   virtual Icon GetIcon() { return ICON_NOTE; }
   DESCRIPTION(
-      L"Abs Key: " << (int) absKey << " (" << MidiEvent::GetNoteName(absKey) << ") " << L"  Velocity: " << (int) vel
-          << L"  Duration: " << dur)
+      "Abs Key: " << (int) absKey << " (" << MidiEvent::GetNoteName(absKey) << ") " << "  Velocity: " << (int) vel
+          << "  Duration: " << dur)
  public:
   uint8_t absKey;
   uint8_t vel;
@@ -108,12 +108,12 @@ class NoteOnSeqEvent:
                  uint8_t velocity,
                  uint32_t offset = 0,
                  uint32_t length = 0,
-                 const std::wstring &name = L"");
+                 const std::string &name = "");
   virtual ~NoteOnSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_NOTEON; }
   virtual Icon GetIcon() { return ICON_NOTE; }
   DESCRIPTION(
-      L"Abs Key: " << (int) absKey << " (" << MidiEvent::GetNoteName(absKey) << ") " << L"  Velocity: " << (int) vel)
+      "Abs Key: " << (int) absKey << " (" << MidiEvent::GetNoteName(absKey) << ") " << "  Velocity: " << (int) vel)
  public:
   uint8_t absKey;
   uint8_t vel;
@@ -127,11 +127,11 @@ class NoteOffSeqEvent:
     public SeqEvent {
  public:
   NoteOffSeqEvent
-      (SeqTrack *pTrack, uint8_t absoluteKey, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, uint8_t absoluteKey, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~NoteOffSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_NOTEOFF; }
   virtual Icon GetIcon() { return ICON_NOTE; }
-  DESCRIPTION(L"Abs Key: " << (int) absKey << " (" << MidiEvent::GetNoteName(absKey) << ") ")
+  DESCRIPTION("Abs Key: " << (int) absKey << " (" << MidiEvent::GetNoteName(absKey) << ") ")
  public:
   uint8_t absKey;
 };
@@ -144,11 +144,11 @@ class RestSeqEvent:
     public SeqEvent {
  public:
   RestSeqEvent
-      (SeqTrack *pTrack, uint32_t duration, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, uint32_t duration, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~RestSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_REST; }
   virtual Icon GetIcon() { return ICON_REST; }
-  DESCRIPTION(L"Duration: " << dur)
+  DESCRIPTION("Duration: " << dur)
 
  public:
   uint32_t dur;
@@ -162,9 +162,9 @@ class SetOctaveSeqEvent:
     public SeqEvent {
  public:
   SetOctaveSeqEvent
-      (SeqTrack *pTrack, uint8_t octave, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, uint8_t octave, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~SetOctaveSeqEvent(void) { }
-  DESCRIPTION(L"Octave: " << (int) octave)
+  DESCRIPTION("Octave: " << (int) octave)
  public:
   uint8_t octave;
 };
@@ -177,10 +177,10 @@ class VolSeqEvent:
     public SeqEvent {
  public:
   VolSeqEvent
-      (SeqTrack *pTrack, uint8_t volume, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, uint8_t volume, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~VolSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_VOLUME; }
-  DESCRIPTION(L"Volume: " << (int) vol)
+  DESCRIPTION("Volume: " << (int) vol)
 
  public:
   uint8_t vol;
@@ -198,10 +198,10 @@ class VolSlideSeqEvent:
                    uint32_t duration,
                    uint32_t offset = 0,
                    uint32_t length = 0,
-                   const std::wstring &name = L"");
+                   const std::string &name = "");
   virtual ~VolSlideSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_VOLUMESLIDE; }
-  DESCRIPTION(L"Target Volume: " << (int) targVol << L"  Duration: " << dur)
+  DESCRIPTION("Target Volume: " << (int) targVol << "  Duration: " << dur)
 
  public:
   uint8_t targVol;
@@ -217,9 +217,9 @@ class MastVolSeqEvent:
     public SeqEvent {
  public:
   MastVolSeqEvent
-      (SeqTrack *pTrack, uint8_t volume, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, uint8_t volume, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~MastVolSeqEvent(void) { }
-  DESCRIPTION(L"Master Volume: " << (int) vol)
+  DESCRIPTION("Master Volume: " << (int) vol)
 
  public:
   uint8_t vol;
@@ -237,9 +237,9 @@ class MastVolSlideSeqEvent:
                        uint32_t duration,
                        uint32_t offset = 0,
                        uint32_t length = 0,
-                       const std::wstring &name = L"");
+                       const std::string &name = "");
   virtual ~MastVolSlideSeqEvent(void) { }
-  DESCRIPTION(L"Target Volume: " << (int) targVol << L"  Duration: " << dur)
+  DESCRIPTION("Target Volume: " << (int) targVol << "  Duration: " << dur)
 
  public:
   uint8_t targVol;
@@ -254,10 +254,10 @@ class ExpressionSeqEvent:
     public SeqEvent {
  public:
   ExpressionSeqEvent
-      (SeqTrack *pTrack, uint8_t level, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, uint8_t level, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~ExpressionSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_EXPRESSION; }
-  DESCRIPTION(L"Expression: " << (int) level)
+  DESCRIPTION("Expression: " << (int) level)
 
  public:
   uint8_t level;
@@ -275,10 +275,10 @@ class ExpressionSlideSeqEvent:
                           uint32_t duration,
                           uint32_t offset = 0,
                           uint32_t length = 0,
-                          const std::wstring &name = L"");
+                          const std::string &name = "");
   virtual ~ExpressionSlideSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_EXPRESSIONSLIDE; }
-  DESCRIPTION(L"Target Expression: " << (int) targExpr << L"  Duration: " << dur)
+  DESCRIPTION("Target Expression: " << (int) targExpr << "  Duration: " << dur)
 
  public:
   uint8_t targExpr;
@@ -293,10 +293,10 @@ class ExpressionSlideSeqEvent:
 class PanSeqEvent:
     public SeqEvent {
  public:
-  PanSeqEvent(SeqTrack *pTrack, uint8_t pan, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+  PanSeqEvent(SeqTrack *pTrack, uint8_t pan, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~PanSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_PAN; }
-  DESCRIPTION(L"Pan: " << (int) pan)
+  DESCRIPTION("Pan: " << (int) pan)
 
  public:
   uint8_t pan;
@@ -314,9 +314,9 @@ class PanSlideSeqEvent:
                    uint32_t duration,
                    uint32_t offset = 0,
                    uint32_t length = 0,
-                   const std::wstring &name = L"");
+                   const std::string &name = "");
   virtual ~PanSlideSeqEvent(void) { }
-  DESCRIPTION(L"Target Pan: " << (int) targPan << L"  Duration: " << dur)
+  DESCRIPTION("Target Pan: " << (int) targPan << "  Duration: " << dur)
 
  public:
   uint8_t targPan;
@@ -332,10 +332,10 @@ class ReverbSeqEvent:
     public SeqEvent {
  public:
   ReverbSeqEvent
-      (SeqTrack *pTrack, uint8_t reverb, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, uint8_t reverb, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~ReverbSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_REVERB; }
-  DESCRIPTION(L"Reverb: " << (int) reverb)
+  DESCRIPTION("Reverb: " << (int) reverb)
 
  public:
   uint8_t reverb;
@@ -350,9 +350,9 @@ class PitchBendSeqEvent:
     public SeqEvent {
  public:
   PitchBendSeqEvent
-      (SeqTrack *pTrack, short thePitchBend, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, short thePitchBend, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual EventType GetEventType() { return EVENTTYPE_PITCHBEND; }
-  DESCRIPTION(L"Pitch Bend: " << pitchbend)
+  DESCRIPTION("Pitch Bend: " << pitchbend)
 
  public:
   short pitchbend;
@@ -367,9 +367,9 @@ class PitchBendRangeSeqEvent:
     public SeqEvent {
  public:
   PitchBendRangeSeqEvent(SeqTrack *pTrack, uint8_t semiTones, uint8_t cents,
-                         uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+                         uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual EventType GetEventType() { return EVENTTYPE_PITCHBENDRANGE; }
-  DESCRIPTION(L"Pitch Bend Range: " << semitones << L" semitones, " << cents << L" cents")
+  DESCRIPTION("Pitch Bend Range: " << semitones << " semitones, " << cents << " cents")
 
  public:
   uint8_t semitones;
@@ -384,9 +384,9 @@ class FineTuningSeqEvent:
     public SeqEvent {
  public:
   FineTuningSeqEvent(SeqTrack *pTrack, double cents,
-                     uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+                     uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual EventType GetEventType() { return EVENTTYPE_PITCHBENDRANGE; }
-  DESCRIPTION(L"Fine Tuning: " << cents << L" cents")
+  DESCRIPTION("Fine Tuning: " << cents << " cents")
 
  public:
   double cents;
@@ -400,9 +400,9 @@ class ModulationDepthRangeSeqEvent:
     public SeqEvent {
  public:
   ModulationDepthRangeSeqEvent(SeqTrack *pTrack, double semitones,
-                               uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+                               uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual EventType GetEventType() { return EVENTTYPE_PITCHBENDRANGE; }
-  DESCRIPTION(L"Modulation Depth Range: " << (semitones * 100.0) << L" cents")
+  DESCRIPTION("Modulation Depth Range: " << (semitones * 100.0) << " cents")
 
  public:
   double semitones;
@@ -416,9 +416,9 @@ class TransposeSeqEvent:
     public SeqEvent {
  public:
   TransposeSeqEvent
-      (SeqTrack *pTrack, int theTranspose, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, int theTranspose, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual EventType GetEventType() { return EVENTTYPE_TRANSPOSE; }
-  DESCRIPTION(L"Transpose: " << transpose)
+  DESCRIPTION("Transpose: " << transpose)
 
  public:
   int transpose;
@@ -433,10 +433,10 @@ class ModulationSeqEvent:
     public SeqEvent {
  public:
   ModulationSeqEvent
-      (SeqTrack *pTrack, uint8_t theDepth, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, uint8_t theDepth, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~ModulationSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_MODULATION; }
-  DESCRIPTION(L"Depth: " << (int) depth)
+  DESCRIPTION("Depth: " << (int) depth)
 
  public:
   uint8_t depth;
@@ -450,10 +450,10 @@ class BreathSeqEvent:
     public SeqEvent {
  public:
   BreathSeqEvent
-      (SeqTrack *pTrack, uint8_t theDepth, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, uint8_t theDepth, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~BreathSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_BREATH; }
-  DESCRIPTION(L"Breath: " << (int) depth)
+  DESCRIPTION("Breath: " << (int) depth)
 
  public:
   uint8_t depth;
@@ -467,10 +467,10 @@ class SustainSeqEvent:
     public SeqEvent {
  public:
   SustainSeqEvent
-      (SeqTrack *pTrack, uint8_t theDepth, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, uint8_t theDepth, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~SustainSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_SUSTAIN; }
-  DESCRIPTION(L"Sustain Pedal: " << (int) depth);
+  DESCRIPTION("Sustain Pedal: " << (int) depth);
 
  public:
   uint8_t depth;
@@ -484,10 +484,10 @@ class PortamentoSeqEvent:
     public SeqEvent {
  public:
   PortamentoSeqEvent
-      (SeqTrack *pTrack, bool bPortamento, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, bool bPortamento, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~PortamentoSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_PORTAMENTO; }
-  DESCRIPTION(L"Portamento: " << (bOn) ? L"On" : L"Off")
+  DESCRIPTION("Portamento: " << (bOn) ? "On" : "Off")
 
  public:
   bool bOn;
@@ -501,10 +501,10 @@ class PortamentoTimeSeqEvent:
     public SeqEvent {
  public:
   PortamentoTimeSeqEvent
-      (SeqTrack *pTrack, uint8_t time, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"");
+      (SeqTrack *pTrack, uint8_t time, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   virtual ~PortamentoTimeSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_PORTAMENTOTIME; }
-  DESCRIPTION(L"Portamento Time: " << (int) time)
+  DESCRIPTION("Portamento Time: " << (int) time)
 
  public:
   uint8_t time;
@@ -522,10 +522,10 @@ class ProgChangeSeqEvent:
                      uint32_t programNumber,
                      uint32_t offset = 0,
                      uint32_t length = 0,
-                     const std::wstring &name = L"");
+                     const std::string &name = "");
   virtual ~ProgChangeSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_PROGCHANGE; }
-  DESCRIPTION(L"Program Number: " << (int) progNum)
+  DESCRIPTION("Program Number: " << (int) progNum)
 
  public:
   uint32_t progNum;
@@ -542,11 +542,11 @@ class TempoSeqEvent:
                 double beatsperminute,
                 uint32_t offset = 0,
                 uint32_t length = 0,
-                const std::wstring &name = L"");
+                const std::string &name = "");
   virtual ~TempoSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_TEMPO; }
   virtual Icon GetIcon() { return ICON_TEMPO; }
-  DESCRIPTION(L"BPM: " << bpm)
+  DESCRIPTION("BPM: " << bpm)
 
  public:
   double bpm;
@@ -564,10 +564,10 @@ class TempoSlideSeqEvent:
                      uint32_t duration,
                      uint32_t offset = 0,
                      uint32_t length = 0,
-                     const std::wstring &name = L"");
+                     const std::string &name = "");
   virtual ~TempoSlideSeqEvent(void) { }
   virtual Icon GetIcon() { return ICON_TEMPO; }
-  DESCRIPTION(L"BPM: " << targbpm << L"  Duration: " << dur)
+  DESCRIPTION("BPM: " << targbpm << "  Duration: " << dur)
 
  public:
   double targbpm;
@@ -587,10 +587,10 @@ class TimeSigSeqEvent:
                   uint8_t theTicksPerQuarter,
                   uint32_t offset = 0,
                   uint32_t length = 0,
-                  const std::wstring &name = L"");
+                  const std::string &name = "");
   virtual ~TimeSigSeqEvent(void) { }
   virtual EventType GetEventType() { return EVENTTYPE_TIMESIG; }
-  DESCRIPTION(L"Signature: " << (int) numer << L"/" << (int) denom << L"  Ticks Per Quarter: " << (int) ticksPerQuarter)
+  DESCRIPTION("Signature: " << (int) numer << "/" << (int) denom << "  Ticks Per Quarter: " << (int) ticksPerQuarter)
 
  public:
   uint8_t numer;
@@ -611,7 +611,7 @@ class MarkerSeqEvent:
                  uint8_t databyte2,
                  uint32_t offset = 0,
                  uint32_t length = 0,
-                 const std::wstring &name = L"",
+                 const std::string &name = "",
                  EventColor color = CLR_MARKER)
       : SeqEvent(pTrack, offset, length, name, color), databyte1(databyte1), databyte2(databyte2) { }
   virtual EventType GetEventType() { return EVENTTYPE_MARKER; }
@@ -629,7 +629,7 @@ class MarkerSeqEvent:
 //	public SeqEvent
 //{
 //public:
-//	VibratoSeqEvent(SeqTrack* pTrack, uint8_t detph, uint32_t offset = 0, uint32_t length = 0, const std::wstring& name = L"") 
+//	VibratoSeqEvent(SeqTrack* pTrack, uint8_t detph, uint32_t offset = 0, uint32_t length = 0, const std::string& name = "")
 //	: SeqEvent(pTrack, offset, length, name), depth(depth)
 //	{}
 //	virtual EventType GetEventType() { return EVENTTYPE_VIBRATO; }
@@ -645,7 +645,7 @@ class MarkerSeqEvent:
 class TrackEndSeqEvent:
     public SeqEvent {
  public:
-  TrackEndSeqEvent(SeqTrack *pTrack, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"")
+  TrackEndSeqEvent(SeqTrack *pTrack, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "")
       : SeqEvent(pTrack, offset, length, name, CLR_TRACKEND) { }
   virtual EventType GetEventType() { return EVENTTYPE_TRACKEND; }
 };
@@ -657,7 +657,7 @@ class TrackEndSeqEvent:
 class LoopForeverSeqEvent:
     public SeqEvent {
  public:
-  LoopForeverSeqEvent(SeqTrack *pTrack, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"")
+  LoopForeverSeqEvent(SeqTrack *pTrack, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "")
       : SeqEvent(pTrack, offset, length, name, CLR_LOOPFOREVER) { }
   virtual EventType GetEventType() { return EVENTTYPE_LOOPFOREVER; }
 };

--- a/src/main/SeqTrack.cpp
+++ b/src/main/SeqTrack.cpp
@@ -13,7 +13,7 @@ using namespace std;
 //  ********
 
 
-SeqTrack::SeqTrack(VGMSeq *parentFile, uint32_t offset, uint32_t length, wstring name)
+SeqTrack::SeqTrack(VGMSeq *parentFile, uint32_t offset, uint32_t length, string name)
     : VGMContainerItem(parentFile, offset, length, name),
       parentSeq(parentFile),
       panVolumeCorrectionRate(1.0) {
@@ -154,8 +154,8 @@ void SeqTrack::SetChannelAndGroupFromTrkNum(int theTrackNum) {
 void SeqTrack::AddInitialMidiEvents(int trackNum) {
   if (trackNum == 0)
     pMidiTrack->AddSeqName(parentSeq->GetName()->c_str());
-  wostringstream ssTrackName;
-  ssTrackName << L"Track: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << dwStartOffset
+  ostringstream ssTrackName;
+  ssTrackName << "Track: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << dwStartOffset
       << std::endl;
   pMidiTrack->AddTrackName(ssTrackName.str().c_str());
 
@@ -295,8 +295,8 @@ void SeqTrack::AddEvent(SeqEvent *pSeqEvent) {
 
 void SeqTrack::AddGenericEvent(uint32_t offset,
                                uint32_t length,
-                               const std::wstring &sEventName,
-                               const std::wstring &sEventDesc,
+                               const std::string &sEventName,
+                               const std::string &sEventDesc,
                                EventColor color,
                                Icon icon) {
   OnEvent(offset, length);
@@ -306,9 +306,9 @@ void SeqTrack::AddGenericEvent(uint32_t offset,
   }
   else if (readMode == READMODE_CONVERT_TO_MIDI) {
     if (bWriteGenericEventAsTextEvent) {
-      wstring miditext(sEventName);
+      string miditext(sEventName);
       if (!sEventDesc.empty()) {
-        miditext += L" - ";
+        miditext += " - ";
         miditext += sEventDesc;
       }
       pMidiTrack->AddText(miditext.c_str());
@@ -319,8 +319,8 @@ void SeqTrack::AddGenericEvent(uint32_t offset,
 
 void SeqTrack::AddUnknown(uint32_t offset,
                           uint32_t length,
-                          const std::wstring &sEventName,
-                          const std::wstring &sEventDesc) {
+                          const std::string &sEventName,
+                          const std::string &sEventDesc) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true)) {
@@ -328,9 +328,9 @@ void SeqTrack::AddUnknown(uint32_t offset,
   }
   else if (readMode == READMODE_CONVERT_TO_MIDI) {
     if (bWriteGenericEventAsTextEvent) {
-      wstring miditext(sEventName);
+      string miditext(sEventName);
       if (!sEventDesc.empty()) {
-        miditext += L" - ";
+        miditext += " - ";
         miditext += sEventDesc;
       }
       pMidiTrack->AddText(miditext.c_str());
@@ -338,7 +338,7 @@ void SeqTrack::AddUnknown(uint32_t offset,
   }
 }
 
-void SeqTrack::AddSetOctave(uint32_t offset, uint32_t length, uint8_t newOctave, const std::wstring &sEventName) {
+void SeqTrack::AddSetOctave(uint32_t offset, uint32_t length, uint8_t newOctave, const std::string &sEventName) {
   OnEvent(offset, length);
 
   octave = newOctave;
@@ -346,7 +346,7 @@ void SeqTrack::AddSetOctave(uint32_t offset, uint32_t length, uint8_t newOctave,
     AddEvent(new SetOctaveSeqEvent(this, newOctave, offset, length, sEventName));
 }
 
-void SeqTrack::AddIncrementOctave(uint32_t offset, uint32_t length, const std::wstring &sEventName) {
+void SeqTrack::AddIncrementOctave(uint32_t offset, uint32_t length, const std::string &sEventName) {
   OnEvent(offset, length);
 
   octave++;
@@ -354,7 +354,7 @@ void SeqTrack::AddIncrementOctave(uint32_t offset, uint32_t length, const std::w
     AddEvent(new SeqEvent(this, offset, length, sEventName, CLR_CHANGESTATE));
 }
 
-void SeqTrack::AddDecrementOctave(uint32_t offset, uint32_t length, const std::wstring &sEventName) {
+void SeqTrack::AddDecrementOctave(uint32_t offset, uint32_t length, const std::string &sEventName) {
   OnEvent(offset, length);
 
   octave--;
@@ -362,7 +362,7 @@ void SeqTrack::AddDecrementOctave(uint32_t offset, uint32_t length, const std::w
     AddEvent(new SeqEvent(this, offset, length, sEventName, CLR_CHANGESTATE));
 }
 
-void SeqTrack::AddRest(uint32_t offset, uint32_t length, uint32_t restTime, const std::wstring &sEventName) {
+void SeqTrack::AddRest(uint32_t offset, uint32_t length, uint32_t restTime, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true)) {
@@ -374,14 +374,14 @@ void SeqTrack::AddRest(uint32_t offset, uint32_t length, uint32_t restTime, cons
   AddTime(restTime);
 }
 
-void SeqTrack::AddHold(uint32_t offset, uint32_t length, const std::wstring &sEventName) {
+void SeqTrack::AddHold(uint32_t offset, uint32_t length, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
     AddEvent(new SeqEvent(this, offset, length, sEventName, CLR_TIE));
 }
 
-void SeqTrack::AddNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t vel, const std::wstring &sEventName) {
+void SeqTrack::AddNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t vel, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -407,7 +407,7 @@ void SeqTrack::AddNoteOnNoItem(int8_t key, int8_t vel) {
 }
 
 
-void SeqTrack::AddPercNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t vel, const std::wstring &sEventName) {
+void SeqTrack::AddPercNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t vel, const std::string &sEventName) {
   uint8_t origChan = channel;
   channel = 9;
   int8_t origDrumNote = cDrumNote;
@@ -438,7 +438,7 @@ void SeqTrack::InsertNoteOn(uint32_t offset,
                             int8_t key,
                             int8_t vel,
                             uint32_t absTime,
-                            const std::wstring &sEventName) {
+                            const std::string &sEventName) {
   OnEvent(offset, length);
 
   uint8_t finalVel = vel;
@@ -455,7 +455,7 @@ void SeqTrack::InsertNoteOn(uint32_t offset,
   prevVel = vel;
 }
 
-void SeqTrack::AddNoteOff(uint32_t offset, uint32_t length, int8_t key, const std::wstring &sEventName) {
+void SeqTrack::AddNoteOff(uint32_t offset, uint32_t length, int8_t key, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -477,7 +477,7 @@ void SeqTrack::AddNoteOffNoItem(int8_t key) {
 }
 
 
-void SeqTrack::AddPercNoteOff(uint32_t offset, uint32_t length, int8_t key, const std::wstring &sEventName) {
+void SeqTrack::AddPercNoteOff(uint32_t offset, uint32_t length, int8_t key, const std::string &sEventName) {
   uint8_t origChan = channel;
   channel = 9;
   int8_t origDrumNote = cDrumNote;
@@ -507,7 +507,7 @@ void SeqTrack::InsertNoteOff(uint32_t offset,
                              uint32_t length,
                              int8_t key,
                              uint32_t absTime,
-                             const std::wstring &sEventName) {
+                             const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -526,7 +526,7 @@ void SeqTrack::AddNoteByDur(uint32_t offset,
                             int8_t key,
                             int8_t vel,
                             uint32_t dur,
-                            const std::wstring &sEventName) {
+                            const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -556,7 +556,7 @@ void SeqTrack::AddNoteByDur_Extend(uint32_t offset,
                                    int8_t key,
                                    int8_t vel,
                                    uint32_t dur,
-                                   const std::wstring &sEventName) {
+                                   const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -586,7 +586,7 @@ void SeqTrack::AddPercNoteByDur(uint32_t offset,
                                 int8_t key,
                                 int8_t vel,
                                 uint32_t dur,
-                                const std::wstring &sEventName) {
+                                const std::string &sEventName) {
   uint8_t origChan = channel;
   channel = 9;
   int8_t origDrumNote = cDrumNote;
@@ -612,7 +612,7 @@ void SeqTrack::AddPercNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur) {
   channel = origChan;
 }
 
-/*void SeqTrack::AddNoteByDur(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, uint8_t chan, const std::wstring& sEventName)
+/*void SeqTrack::AddNoteByDur(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, uint8_t chan, const std::string& sEventName)
 {
 	uint8_t origChan = channel;
 	channel = chan;
@@ -626,7 +626,7 @@ void SeqTrack::InsertNoteByDur(uint32_t offset,
                                int8_t vel,
                                uint32_t dur,
                                uint32_t absTime,
-                               const std::wstring &sEventName) {
+                               const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true)) {
@@ -669,7 +669,7 @@ void SeqTrack::LimitPrevDurNoteEnd(uint32_t absTime) {
   }
 }
 
-void SeqTrack::AddVol(uint32_t offset, uint32_t length, uint8_t newVol, const std::wstring &sEventName) {
+void SeqTrack::AddVol(uint32_t offset, uint32_t length, uint8_t newVol, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -695,7 +695,7 @@ void SeqTrack::AddVolSlide(uint32_t offset,
                            uint32_t length,
                            uint32_t dur,
                            uint8_t targVol,
-                           const std::wstring &sEventName) {
+                           const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -714,7 +714,7 @@ void SeqTrack::InsertVol(uint32_t offset,
                          uint32_t length,
                          uint8_t newVol,
                          uint32_t absTime,
-                         const std::wstring &sEventName) {
+                         const std::string &sEventName) {
   OnEvent(offset, length);
 
   double newVolPercent = newVol / 127.0;
@@ -731,7 +731,7 @@ void SeqTrack::InsertVol(uint32_t offset,
   vol = newVol;
 }
 
-void SeqTrack::AddExpression(uint32_t offset, uint32_t length, uint8_t level, const std::wstring &sEventName) {
+void SeqTrack::AddExpression(uint32_t offset, uint32_t length, uint8_t level, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -757,7 +757,7 @@ void SeqTrack::AddExpressionSlide(uint32_t offset,
                                   uint32_t length,
                                   uint32_t dur,
                                   uint8_t targExpr,
-                                  const std::wstring &sEventName) {
+                                  const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -776,7 +776,7 @@ void SeqTrack::InsertExpression(uint32_t offset,
                                 uint32_t length,
                                 uint8_t level,
                                 uint32_t absTime,
-                                const std::wstring &sEventName) {
+                                const std::string &sEventName) {
   OnEvent(offset, length);
 
   double newVolPercent = level / 127.0;
@@ -794,7 +794,7 @@ void SeqTrack::InsertExpression(uint32_t offset,
 }
 
 
-void SeqTrack::AddMasterVol(uint32_t offset, uint32_t length, uint8_t newVol, const std::wstring &sEventName) {
+void SeqTrack::AddMasterVol(uint32_t offset, uint32_t length, uint8_t newVol, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -817,7 +817,7 @@ void SeqTrack::AddMastVolSlide(uint32_t offset,
                                uint32_t length,
                                uint32_t dur,
                                uint8_t targVol,
-                               const std::wstring &sEventName) {
+                               const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -832,7 +832,7 @@ void SeqTrack::AddMastVolSlide(uint32_t offset,
                        &MidiTrack::InsertMasterVol);
 }
 
-void SeqTrack::AddPan(uint32_t offset, uint32_t length, uint8_t pan, const std::wstring &sEventName) {
+void SeqTrack::AddPan(uint32_t offset, uint32_t length, uint8_t pan, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -867,7 +867,7 @@ void SeqTrack::AddPanSlide(uint32_t offset,
                            uint32_t length,
                            uint32_t dur,
                            uint8_t targPan,
-                           const std::wstring &sEventName) {
+                           const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -881,7 +881,7 @@ void SeqTrack::InsertPan(uint32_t offset,
                          uint32_t length,
                          uint8_t pan,
                          uint32_t absTime,
-                         const std::wstring &sEventName) {
+                         const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -908,7 +908,7 @@ void SeqTrack::InsertPan(uint32_t offset,
   }
 }
 
-void SeqTrack::AddReverb(uint32_t offset, uint32_t length, uint8_t reverb, const std::wstring &sEventName) {
+void SeqTrack::AddReverb(uint32_t offset, uint32_t length, uint8_t reverb, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -933,7 +933,7 @@ void SeqTrack::InsertReverb(uint32_t offset,
                             uint32_t length,
                             uint8_t reverb,
                             uint32_t absTime,
-                            const std::wstring &sEventName) {
+                            const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -946,11 +946,11 @@ void SeqTrack::AddPitchBendMidiFormat(uint32_t offset,
                                       uint32_t length,
                                       uint8_t lo,
                                       uint8_t hi,
-                                      const std::wstring &sEventName) {
+                                      const std::string &sEventName) {
   AddPitchBend(offset, length, lo + (hi << 7) - 0x2000, sEventName);
 }
 
-void SeqTrack::AddPitchBend(uint32_t offset, uint32_t length, int16_t bend, const std::wstring &sEventName) {
+void SeqTrack::AddPitchBend(uint32_t offset, uint32_t length, int16_t bend, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -963,7 +963,7 @@ void SeqTrack::AddPitchBendRange(uint32_t offset,
                                  uint32_t length,
                                  uint8_t semitones,
                                  uint8_t cents,
-                                 const std::wstring &sEventName) {
+                                 const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -977,7 +977,7 @@ void SeqTrack::AddPitchBendRangeNoItem(uint8_t semitones, uint8_t cents) {
     pMidiTrack->AddPitchBendRange(channel, semitones, cents);
 }
 
-void SeqTrack::AddFineTuning(uint32_t offset, uint32_t length, double cents, const std::wstring &sEventName) {
+void SeqTrack::AddFineTuning(uint32_t offset, uint32_t length, double cents, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -994,7 +994,7 @@ void SeqTrack::AddFineTuningNoItem(double cents) {
 void SeqTrack::AddModulationDepthRange(uint32_t offset,
                                        uint32_t length,
                                        double semitones,
-                                       const std::wstring &sEventName) {
+                                       const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1008,7 +1008,7 @@ void SeqTrack::AddModulationDepthRangeNoItem(double semitones) {
     pMidiTrack->AddModulationDepthRange(channel, semitones);
 }
 
-void SeqTrack::AddTranspose(uint32_t offset, uint32_t length, int8_t theTranspose, const std::wstring &sEventName) {
+void SeqTrack::AddTranspose(uint32_t offset, uint32_t length, int8_t theTranspose, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1017,7 +1017,7 @@ void SeqTrack::AddTranspose(uint32_t offset, uint32_t length, int8_t theTranspos
 }
 
 
-void SeqTrack::AddModulation(uint32_t offset, uint32_t length, uint8_t depth, const std::wstring &sEventName) {
+void SeqTrack::AddModulation(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1030,7 +1030,7 @@ void SeqTrack::InsertModulation(uint32_t offset,
                                 uint32_t length,
                                 uint8_t depth,
                                 uint32_t absTime,
-                                const std::wstring &sEventName) {
+                                const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1039,7 +1039,7 @@ void SeqTrack::InsertModulation(uint32_t offset,
     pMidiTrack->InsertModulation(channel, depth, absTime);
 }
 
-void SeqTrack::AddBreath(uint32_t offset, uint32_t length, uint8_t depth, const std::wstring &sEventName) {
+void SeqTrack::AddBreath(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1052,7 +1052,7 @@ void SeqTrack::InsertBreath(uint32_t offset,
                             uint32_t length,
                             uint8_t depth,
                             uint32_t absTime,
-                            const std::wstring &sEventName) {
+                            const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1061,7 +1061,7 @@ void SeqTrack::InsertBreath(uint32_t offset,
     pMidiTrack->InsertBreath(channel, depth, absTime);
 }
 
-void SeqTrack::AddSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, const std::wstring &sEventName) {
+void SeqTrack::AddSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1074,7 +1074,7 @@ void SeqTrack::InsertSustainEvent(uint32_t offset,
                                   uint32_t length,
                                   uint8_t depth,
                                   uint32_t absTime,
-                                  const std::wstring &sEventName) {
+                                  const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1083,7 +1083,7 @@ void SeqTrack::InsertSustainEvent(uint32_t offset,
     pMidiTrack->InsertSustain(channel, depth, absTime);
 }
 
-void SeqTrack::AddPortamento(uint32_t offset, uint32_t length, bool bOn, const std::wstring &sEventName) {
+void SeqTrack::AddPortamento(uint32_t offset, uint32_t length, bool bOn, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1100,7 +1100,7 @@ void SeqTrack::InsertPortamento(uint32_t offset,
                                 uint32_t length,
                                 bool bOn,
                                 uint32_t absTime,
-                                const std::wstring &sEventName) {
+                                const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1114,7 +1114,7 @@ void SeqTrack::InsertPortamentoNoItem(bool bOn, uint32_t absTime) {
     pMidiTrack->InsertPortamento(channel, bOn, absTime);
 }
 
-void SeqTrack::AddPortamentoTime(uint32_t offset, uint32_t length, uint8_t time, const std::wstring &sEventName) {
+void SeqTrack::AddPortamentoTime(uint32_t offset, uint32_t length, uint8_t time, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1127,7 +1127,7 @@ void SeqTrack::AddPortamentoTimeNoItem(uint8_t time) {
     pMidiTrack->AddPortamentoTime(channel, time);
 }
 
-void SeqTrack::AddPortamentoTime14Bit(uint32_t offset, uint32_t length, uint16_t time, const std::wstring &sEventName) {
+void SeqTrack::AddPortamentoTime14Bit(uint32_t offset, uint32_t length, uint16_t time, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1148,7 +1148,7 @@ void SeqTrack::InsertPortamentoTime(uint32_t offset,
                                     uint32_t length,
                                     uint8_t time,
                                     uint32_t absTime,
-                                    const std::wstring &sEventName) {
+                                    const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1183,7 +1183,7 @@ void InsertExpression(uint8_t expression, uint32_t absTime);
 void AddPanEvent(uint8_t pan);
 void InsertPanEvent(uint8_t pan, uint32_t absTime);*/
 
-void SeqTrack::AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, const std::wstring &sEventName) {
+void SeqTrack::AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, const std::string &sEventName) {
   AddProgramChange(offset, length, progNum, false, sEventName);
 }
 
@@ -1191,7 +1191,7 @@ void SeqTrack::AddProgramChange(uint32_t offset,
                                 uint32_t length,
                                 uint32_t progNum,
                                 uint8_t chan,
-                                const std::wstring &sEventName) {
+                                const std::string &sEventName) {
   AddProgramChange(offset, length, progNum, false, chan, sEventName);
 }
 
@@ -1199,7 +1199,7 @@ void SeqTrack::AddProgramChange(uint32_t offset,
                                 uint32_t length,
                                 uint32_t progNum,
                                 bool requireBank,
-                                const std::wstring &sEventName) {
+                                const std::string &sEventName) {
   OnEvent(offset, length);
 
 /*	InstrAssoc* pInstrAssoc = parentSeq->GetInstrAssoc(progNum);
@@ -1231,7 +1231,7 @@ void SeqTrack::AddProgramChange(uint32_t offset,
                                 uint32_t progNum,
                                 bool requireBank,
                                 uint8_t chan,
-                                const std::wstring &sEventName) {
+                                const std::string &sEventName) {
   //if (selectMsg = NULL)
   //	selectMsg.Forma
   uint8_t origChan = channel;
@@ -1267,7 +1267,7 @@ void SeqTrack::AddBankSelectNoItem(uint8_t bank) {
   }
 }
 
-void SeqTrack::AddTempo(uint32_t offset, uint32_t length, uint32_t microsPerQuarter, const std::wstring &sEventName) {
+void SeqTrack::AddTempo(uint32_t offset, uint32_t length, uint32_t microsPerQuarter, const std::string &sEventName) {
   OnEvent(offset, length);
 
   double bpm = 60000000.0 / microsPerQuarter;
@@ -1289,11 +1289,11 @@ void SeqTrack::AddTempoSlide(uint32_t offset,
                              uint32_t length,
                              uint32_t dur,
                              uint32_t targMicrosPerQuarter,
-                             const std::wstring &sEventName) {
+                             const std::string &sEventName) {
   AddTempoBPMSlide(offset, length, dur, ((double) 60000000 / targMicrosPerQuarter), sEventName);
 }
 
-void SeqTrack::AddTempoBPM(uint32_t offset, uint32_t length, double bpm, const std::wstring &sEventName) {
+void SeqTrack::AddTempoBPM(uint32_t offset, uint32_t length, double bpm, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1314,7 +1314,7 @@ void SeqTrack::AddTempoBPMSlide(uint32_t offset,
                                 uint32_t length,
                                 uint32_t dur,
                                 double targBPM,
-                                const std::wstring &sEventName) {
+                                const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1337,7 +1337,7 @@ void SeqTrack::AddTimeSig(uint32_t offset,
                           uint8_t numer,
                           uint8_t denom,
                           uint8_t ticksPerQuarter,
-                          const std::wstring &sEventName) {
+                          const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true)) {
@@ -1359,7 +1359,7 @@ void SeqTrack::InsertTimeSig(uint32_t offset,
                              uint8_t denom,
                              uint8_t ticksPerQuarter,
                              uint32_t absTime,
-                             const std::wstring &sEventName) {
+                             const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true)) {
@@ -1371,7 +1371,7 @@ void SeqTrack::InsertTimeSig(uint32_t offset,
   }
 }
 
-bool SeqTrack::AddEndOfTrack(uint32_t offset, uint32_t length, const std::wstring &sEventName) {
+bool SeqTrack::AddEndOfTrack(uint32_t offset, uint32_t length, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1387,7 +1387,7 @@ bool SeqTrack::AddEndOfTrackNoItem() {
   return false;
 }
 
-void SeqTrack::AddGlobalTranspose(uint32_t offset, uint32_t length, int8_t semitones, const std::wstring &sEventName) {
+void SeqTrack::AddGlobalTranspose(uint32_t offset, uint32_t length, int8_t semitones, const std::string &sEventName) {
   OnEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !IsItemAtOffset(offset, false, true))
@@ -1401,7 +1401,7 @@ void SeqTrack::AddMarker(uint32_t offset,
                          const string &markername,
                          uint8_t databyte1,
                          uint8_t databyte2,
-                         const std::wstring &sEventName,
+                         const std::string &sEventName,
                          int8_t priority,
                          EventColor color) {
   OnEvent(offset, length);
@@ -1429,7 +1429,7 @@ void SeqTrack::InsertMarkerNoItem(uint32_t absTime,
 }
 
 // when in FIND_DELTA_LENGTH mode, returns true until we've hit the max number of loops defined in options
-bool SeqTrack::AddLoopForever(uint32_t offset, uint32_t length, const std::wstring &sEventName) {
+bool SeqTrack::AddLoopForever(uint32_t offset, uint32_t length, const std::string &sEventName) {
   OnEvent(offset, length);
 
   this->foreverLoops++;

--- a/src/main/SeqTrack.h
+++ b/src/main/SeqTrack.h
@@ -11,7 +11,7 @@ enum ReadMode: uint8_t;
 class SeqTrack:
     public VGMContainerItem {
  public:
-  SeqTrack(VGMSeq *parentSeqFile, uint32_t offset = 0, uint32_t length = 0, std::wstring name = L"Track");
+  SeqTrack(VGMSeq *parentSeqFile, uint32_t offset = 0, uint32_t length = 0, std::string name = "Track");
   virtual ~SeqTrack(void);
   virtual void ResetVars();
   void ResetVisitedAddresses();
@@ -45,111 +45,111 @@ class SeqTrack:
   virtual void AddEvent(SeqEvent *pSeqEvent);
   void AddControllerSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t &prevVal, uint8_t targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t));
  public:
-  void AddGenericEvent(uint32_t offset, uint32_t length, const std::wstring &sEventName, const std::wstring &sEventDesc, EventColor color, Icon icon = ICON_BINARY);
-  void AddSetOctave(uint32_t offset, uint32_t length, uint8_t newOctave, const std::wstring &sEventName = L"Set Octave");
-  void AddIncrementOctave(uint32_t offset, uint32_t length, const std::wstring &sEventName = L"Increment Octave");    // 1,Sep.2009 revise
-  void AddDecrementOctave(uint32_t offset, uint32_t length, const std::wstring &sEventName = L"Decrement Octave");    // 1,Sep.2009 revise
-  void AddRest(uint32_t offset, uint32_t length, uint32_t restTime, const std::wstring &sEventName = L"Rest");
-  void AddHold(uint32_t offset, uint32_t length, const std::wstring &sEventName = L"Hold");
-  void AddUnknown(uint32_t offset, uint32_t length, const std::wstring &sEventName = L"Unknown Event", const std::wstring &sEventDesc = L"");
+  void AddGenericEvent(uint32_t offset, uint32_t length, const std::string &sEventName, const std::string &sEventDesc, EventColor color, Icon icon = ICON_BINARY);
+  void AddSetOctave(uint32_t offset, uint32_t length, uint8_t newOctave, const std::string &sEventName = "Set Octave");
+  void AddIncrementOctave(uint32_t offset, uint32_t length, const std::string &sEventName = "Increment Octave");    // 1,Sep.2009 revise
+  void AddDecrementOctave(uint32_t offset, uint32_t length, const std::string &sEventName = "Decrement Octave");    // 1,Sep.2009 revise
+  void AddRest(uint32_t offset, uint32_t length, uint32_t restTime, const std::string &sEventName = "Rest");
+  void AddHold(uint32_t offset, uint32_t length, const std::string &sEventName = "Hold");
+  void AddUnknown(uint32_t offset, uint32_t length, const std::string &sEventName = "Unknown Event", const std::string &sEventDesc = "");
 
-  void AddNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t vel, const std::wstring &sEventName = L"Note On");
+  void AddNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t vel, const std::string &sEventName = "Note On");
   void AddNoteOnNoItem(int8_t key, int8_t vel);
-  void AddPercNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t vel, const std::wstring &sEventName = L"Percussion Note On");
+  void AddPercNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t vel, const std::string &sEventName = "Percussion Note On");
   void AddPercNoteOnNoItem(int8_t key, int8_t vel);
-  void InsertNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t absTime, const std::wstring &sEventName = L"Note On");
+  void InsertNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t absTime, const std::string &sEventName = "Note On");
 
-  void AddNoteOff(uint32_t offset, uint32_t length, int8_t key, const std::wstring &sEventName = L"Note Off");
+  void AddNoteOff(uint32_t offset, uint32_t length, int8_t key, const std::string &sEventName = "Note Off");
   void AddNoteOffNoItem(int8_t key);
-  void AddPercNoteOff(uint32_t offset, uint32_t length, int8_t key, const std::wstring &sEventName = L"Percussion Note Off");
+  void AddPercNoteOff(uint32_t offset, uint32_t length, int8_t key, const std::string &sEventName = "Percussion Note Off");
   void AddPercNoteOffNoItem(int8_t key);
-  void InsertNoteOff(uint32_t offset, uint32_t length, int8_t key, uint32_t absTime, const std::wstring &sEventName = L"Note Off");
+  void InsertNoteOff(uint32_t offset, uint32_t length, int8_t key, uint32_t absTime, const std::string &sEventName = "Note Off");
   void InsertNoteOffNoItem(int8_t key, uint32_t absTime);
 
-  void AddNoteByDur(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, const std::wstring &sEventName = L"Note with Duration");
+  void AddNoteByDur(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, const std::string &sEventName = "Note with Duration");
   void AddNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur);
-  void AddNoteByDur_Extend(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, const std::wstring &sEventName = L"Note with Duration (Extended)");
+  void AddNoteByDur_Extend(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, const std::string &sEventName = "Note with Duration (Extended)");
   void AddNoteByDurNoItem_Extend(int8_t key, int8_t vel, uint32_t dur);
-  void AddPercNoteByDur(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, const std::wstring &sEventName = L"Percussion Note with Duration");
+  void AddPercNoteByDur(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, const std::string &sEventName = "Percussion Note with Duration");
   void AddPercNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur);
-  void InsertNoteByDur(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, uint32_t absTime, const std::wstring &sEventName = L"Note On With Duration");
+  void InsertNoteByDur(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, uint32_t absTime, const std::string &sEventName = "Note On With Duration");
 
   void MakePrevDurNoteEnd();
   void MakePrevDurNoteEnd(uint32_t absTime);
   void LimitPrevDurNoteEnd();
   void LimitPrevDurNoteEnd(uint32_t absTime);
-  void AddVol(uint32_t offset, uint32_t length, uint8_t vol, const std::wstring &sEventName = L"Volume");
+  void AddVol(uint32_t offset, uint32_t length, uint8_t vol, const std::string &sEventName = "Volume");
   void AddVolNoItem(uint8_t vol);
-  void AddVolSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targVol, const std::wstring &sEventName = L"Volume Slide");
-  void InsertVol(uint32_t offset, uint32_t length, uint8_t vol, uint32_t absTime, const std::wstring &sEventName = L"Volume");
-  void AddExpression(uint32_t offset, uint32_t length, uint8_t level, const std::wstring &sEventName = L"Expression");
+  void AddVolSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targVol, const std::string &sEventName = "Volume Slide");
+  void InsertVol(uint32_t offset, uint32_t length, uint8_t vol, uint32_t absTime, const std::string &sEventName = "Volume");
+  void AddExpression(uint32_t offset, uint32_t length, uint8_t level, const std::string &sEventName = "Expression");
   void AddExpressionNoItem(uint8_t level);
-  void AddExpressionSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targExpr, const std::wstring &sEventName = L"Expression Slide");
-  void InsertExpression(uint32_t offset, uint32_t length, uint8_t level, uint32_t absTime, const std::wstring &sEventName = L"Expression");
-  void AddMasterVol(uint32_t offset, uint32_t length, uint8_t vol, const std::wstring &sEventName = L"Master Volume");
+  void AddExpressionSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targExpr, const std::string &sEventName = "Expression Slide");
+  void InsertExpression(uint32_t offset, uint32_t length, uint8_t level, uint32_t absTime, const std::string &sEventName = "Expression");
+  void AddMasterVol(uint32_t offset, uint32_t length, uint8_t vol, const std::string &sEventName = "Master Volume");
   void AddMasterVolNoItem(uint8_t newVol);
-  void AddMastVolSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targVol, const std::wstring &sEventName = L"Master Volume Slide");
+  void AddMastVolSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targVol, const std::string &sEventName = "Master Volume Slide");
 
-  void AddPan(uint32_t offset, uint32_t length, uint8_t pan, const std::wstring &sEventName = L"Pan");
+  void AddPan(uint32_t offset, uint32_t length, uint8_t pan, const std::string &sEventName = "Pan");
   void AddPanNoItem(uint8_t pan);
-  void AddPanSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targPan, const std::wstring &sEventName = L"Pan Slide");
-  void InsertPan(uint32_t offset, uint32_t length, uint8_t pan, uint32_t absTime, const std::wstring &sEventName = L"Pan");
-  void AddReverb(uint32_t offset, uint32_t length, uint8_t reverb, const std::wstring &sEventName = L"Reverb");
+  void AddPanSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targPan, const std::string &sEventName = "Pan Slide");
+  void InsertPan(uint32_t offset, uint32_t length, uint8_t pan, uint32_t absTime, const std::string &sEventName = "Pan");
+  void AddReverb(uint32_t offset, uint32_t length, uint8_t reverb, const std::string &sEventName = "Reverb");
   void AddReverbNoItem(uint8_t reverb);
   void AddMonoNoItem();
-  void InsertReverb(uint32_t offset, uint32_t length, uint8_t reverb, uint32_t absTime, const std::wstring &sEventName = L"Reverb");
-  void AddPitchBend(uint32_t offset, uint32_t length, int16_t bend, const std::wstring &sEventName = L"Pitch Bend");
-  void AddPitchBendRange(uint32_t offset, uint32_t length, uint8_t semitones, uint8_t cents = 0, const std::wstring &sEventName = L"Pitch Bend Range");
+  void InsertReverb(uint32_t offset, uint32_t length, uint8_t reverb, uint32_t absTime, const std::string &sEventName = "Reverb");
+  void AddPitchBend(uint32_t offset, uint32_t length, int16_t bend, const std::string &sEventName = "Pitch Bend");
+  void AddPitchBendRange(uint32_t offset, uint32_t length, uint8_t semitones, uint8_t cents = 0, const std::string &sEventName = "Pitch Bend Range");
   void AddPitchBendRangeNoItem(uint8_t range, uint8_t cents = 0);
-  void AddFineTuning(uint32_t offset, uint32_t length, double cents, const std::wstring &sEventName = L"Fine Tuning");
+  void AddFineTuning(uint32_t offset, uint32_t length, double cents, const std::string &sEventName = "Fine Tuning");
   void AddFineTuningNoItem(double cents);
-  void AddModulationDepthRange(uint32_t offset, uint32_t length, double semitones, const std::wstring &sEventName = L"Modulation Depth Range");
+  void AddModulationDepthRange(uint32_t offset, uint32_t length, double semitones, const std::string &sEventName = "Modulation Depth Range");
   void AddModulationDepthRangeNoItem(double semitones);
-  void AddTranspose(uint32_t offset, uint32_t length, int8_t transpose, const std::wstring &sEventName = L"Transpose");
-  void AddPitchBendMidiFormat(uint32_t offset, uint32_t length, uint8_t lo, uint8_t hi, const std::wstring &sEventName = L"Pitch Bend");
-  void AddModulation(uint32_t offset, uint32_t length, uint8_t depth, const std::wstring &sEventName = L"Modulation Depth");
-  void InsertModulation(uint32_t offset, uint32_t length, uint8_t depth, uint32_t absTime, const std::wstring &sEventName = L"Modulation Depth");
-  void AddBreath(uint32_t offset, uint32_t length, uint8_t depth, const std::wstring &sEventName = L"Breath Depth");
-  void InsertBreath(uint32_t offset, uint32_t length, uint8_t depth, uint32_t absTime, const std::wstring &sEventName = L"Breath Depth");
+  void AddTranspose(uint32_t offset, uint32_t length, int8_t transpose, const std::string &sEventName = "Transpose");
+  void AddPitchBendMidiFormat(uint32_t offset, uint32_t length, uint8_t lo, uint8_t hi, const std::string &sEventName = "Pitch Bend");
+  void AddModulation(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName = "Modulation Depth");
+  void InsertModulation(uint32_t offset, uint32_t length, uint8_t depth, uint32_t absTime, const std::string &sEventName = "Modulation Depth");
+  void AddBreath(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName = "Breath Depth");
+  void InsertBreath(uint32_t offset, uint32_t length, uint8_t depth, uint32_t absTime, const std::string &sEventName = "Breath Depth");
 
-  void AddSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, const std::wstring &sEventName = L"Sustain");
-  void InsertSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, uint32_t absTime, const std::wstring &sEventName = L"Sustain");
-  void AddPortamento(uint32_t offset, uint32_t length, bool bOn, const std::wstring &sEventName = L"Portamento");
+  void AddSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName = "Sustain");
+  void InsertSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, uint32_t absTime, const std::string &sEventName = "Sustain");
+  void AddPortamento(uint32_t offset, uint32_t length, bool bOn, const std::string &sEventName = "Portamento");
   void AddPortamentoNoItem(bool bOn);
-  void InsertPortamento(uint32_t offset, uint32_t length, bool bOn, uint32_t absTime, const std::wstring &sEventName = L"Portamento");
+  void InsertPortamento(uint32_t offset, uint32_t length, bool bOn, uint32_t absTime, const std::string &sEventName = "Portamento");
   void InsertPortamentoNoItem(bool bOn, uint32_t absTime);
-  void AddPortamentoTime(uint32_t offset, uint32_t length, uint8_t time, const std::wstring &sEventName = L"Portamento Time");
+  void AddPortamentoTime(uint32_t offset, uint32_t length, uint8_t time, const std::string &sEventName = "Portamento Time");
   void AddPortamentoTimeNoItem(uint8_t time);
-  void InsertPortamentoTime(uint32_t offset, uint32_t length, uint8_t time, uint32_t absTime, const std::wstring &sEventName = L"Portamento Time");
+  void InsertPortamentoTime(uint32_t offset, uint32_t length, uint8_t time, uint32_t absTime, const std::string &sEventName = "Portamento Time");
   void InsertPortamentoTimeNoItem(uint8_t time, uint32_t absTime);
-  void AddPortamentoTime14Bit(uint32_t offset, uint32_t length, uint16_t time, const std::wstring &sEventName = L"Portamento Time");
+  void AddPortamentoTime14Bit(uint32_t offset, uint32_t length, uint16_t time, const std::string &sEventName = "Portamento Time");
   void AddPortamentoTime14BitNoItem(uint16_t time);
   void AddPortamentoTimeModeNoItem(PortamentoTimeMode mode);
   void AddPortamentoControlNoItem(uint8_t key);
-  void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, const std::wstring &sEventName = L"Program Change");
-  void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, uint8_t chan, const std::wstring &sEventName = L"Program Change");
-  void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, bool requireBank, const std::wstring &sEventName = L"Program Change");
-  void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, bool requireBank, uint8_t chan, const std::wstring &sEventName = L"Program Change");
+  void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, const std::string &sEventName = "Program Change");
+  void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, uint8_t chan, const std::string &sEventName = "Program Change");
+  void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, bool requireBank, const std::string &sEventName = "Program Change");
+  void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, bool requireBank, uint8_t chan, const std::string &sEventName = "Program Change");
   void AddProgramChangeNoItem(uint32_t progNum, bool requireBank);
   void AddBankSelectNoItem(uint8_t bank);
-  void AddTempo(uint32_t offset, uint32_t length, uint32_t microsPerQuarter, const std::wstring &sEventName = L"Tempo");
+  void AddTempo(uint32_t offset, uint32_t length, uint32_t microsPerQuarter, const std::string &sEventName = "Tempo");
   void AddTempoNoItem(uint32_t microsPerQuarter);
-  void AddTempoSlide(uint32_t offset, uint32_t length, uint32_t dur, uint32_t targMicrosPerQuarter, const std::wstring &sEventName = L"Tempo Slide");
-  void AddTempoBPM(uint32_t offset, uint32_t length, double bpm, const std::wstring &sEventName = L"Tempo");
+  void AddTempoSlide(uint32_t offset, uint32_t length, uint32_t dur, uint32_t targMicrosPerQuarter, const std::string &sEventName = "Tempo Slide");
+  void AddTempoBPM(uint32_t offset, uint32_t length, double bpm, const std::string &sEventName = "Tempo");
   void AddTempoBPMNoItem(double bpm);
-  void AddTempoBPMSlide(uint32_t offset, uint32_t length, uint32_t dur, double targBPM, const std::wstring &sEventName = L"Tempo Slide");
-  void AddTimeSig(uint32_t offset, uint32_t length, uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter, const std::wstring &sEventName = L"Time Signature");
+  void AddTempoBPMSlide(uint32_t offset, uint32_t length, uint32_t dur, double targBPM, const std::string &sEventName = "Tempo Slide");
+  void AddTimeSig(uint32_t offset, uint32_t length, uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter, const std::string &sEventName = "Time Signature");
   void AddTimeSigNoItem(uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter);
-  void InsertTimeSig(uint32_t offset, uint32_t length, uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter, uint32_t absTime, const std::wstring &sEventName = L"Time Signature");
-  bool AddEndOfTrack(uint32_t offset, uint32_t length, const std::wstring &sEventName = L"Track End");
+  void InsertTimeSig(uint32_t offset, uint32_t length, uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter, uint32_t absTime, const std::string &sEventName = "Time Signature");
+  bool AddEndOfTrack(uint32_t offset, uint32_t length, const std::string &sEventName = "Track End");
   bool AddEndOfTrackNoItem();
 
-  void AddGlobalTranspose(uint32_t offset, uint32_t length, int8_t semitones, const std::wstring &sEventName = L"Global Transpose");
-  void AddMarker(uint32_t offset, uint32_t length, const std::string &markername, uint8_t databyte1, uint8_t databyte2, const std::wstring &sEventName, int8_t priority = 0, EventColor color = CLR_MISC);
+  void AddGlobalTranspose(uint32_t offset, uint32_t length, int8_t semitones, const std::string &sEventName = "Global Transpose");
+  void AddMarker(uint32_t offset, uint32_t length, const std::string &markername, uint8_t databyte1, uint8_t databyte2, const std::string &sEventName, int8_t priority = 0, EventColor color = CLR_MISC);
   void AddMarkerNoItem(const string &markername, uint8_t databyte1, uint8_t databyte2, int8_t priority);
   void InsertMarkerNoItem(uint32_t absTime, const string &markername, uint8_t databyte1, uint8_t databyte2, int8_t priority);
 
-  bool AddLoopForever(uint32_t offset, uint32_t length, const std::wstring &sEventName = L"Loop Forever");
+  bool AddLoopForever(uint32_t offset, uint32_t length, const std::string &sEventName = "Loop Forever");
 
  public:
   ReadMode readMode;        //state variable that determines behavior for all methods.  Are we adding UI items or converting to MIDI?

--- a/src/main/VGMColl.cpp
+++ b/src/main/VGMColl.cpp
@@ -13,7 +13,7 @@ using namespace std;
 
 DECLARE_MENU(VGMColl)
 
-VGMColl::VGMColl(wstring theName)
+VGMColl::VGMColl(string theName)
     : VGMItem(),
       name(theName),
       seq(NULL) {
@@ -33,11 +33,11 @@ void VGMColl::RemoveFileAssocs() {
     miscfiles[i]->RemoveCollAssoc(this);
 }
 
-const wstring *VGMColl::GetName(void) const {
+const string *VGMColl::GetName(void) const {
   return &name;
 }
 
-void VGMColl::SetName(const wstring *newName) {
+void VGMColl::SetName(const string *newName) {
   name = *newName;
 }
 
@@ -99,7 +99,7 @@ void VGMColl::UnpackSampColl(DLSFile &dls, VGMSampColl *sampColl, vector<VGMSamp
 
     uint16_t blockAlign = samp->bps / 8 * samp->channels;
     dls.AddWave(1, samp->channels, samp->rate, samp->rate * blockAlign, blockAlign,
-                samp->bps, bufSize, uncompSampBuf, wstring2string(samp->name));
+                samp->bps, bufSize, uncompSampBuf, samp->name);
     finalSamps.push_back(samp);
   }
 }
@@ -122,7 +122,7 @@ void VGMColl::UnpackSampColl(SynthFile &synthfile, VGMSampColl *sampColl, vector
 
     uint16_t blockAlign = samp->bps / 8 * samp->channels;
     SynthWave *wave = synthfile.AddWave(1, samp->channels, samp->rate, samp->rate * blockAlign, blockAlign,
-                                        samp->bps, bufSize, uncompSampBuf, wstring2string(samp->name));
+                                        samp->bps, bufSize, uncompSampBuf, samp->name);
     finalSamps.push_back(samp);
 
     // If we don't have any loop information, then don't create a sampInfo structure for the Wave
@@ -196,7 +196,7 @@ bool VGMColl::MainDLSCreation(DLSFile &dls) {
     for (size_t i = 0; i < nInstrs; i++) {
       VGMInstr *vgminstr = set->aInstrs[i];
       size_t nRgns = vgminstr->aRgns.size();
-      std::string name = wstring2string(vgminstr->name);
+      std::string name = vgminstr->name;
       auto bank_no = vgminstr->bank;
       /*
       * The ulBank field follows this structure:
@@ -247,8 +247,8 @@ bool VGMColl::MainDLSCreation(DLSFile &dls) {
             }
           }
           if (!bFoundIt) {
-            std::wstring message = FormatString<wstring>(L"Could not match rgn with sampOffset %X to a sample with that offset.\n  (InstrSet %d, Instr %d, Rgn %d)", rgn->sampOffset, inst, i, j);
-            pRoot->AddLogItem(new LogItem(std::wstring(message.c_str()), LOG_LEVEL_ERR, L"VGMColl"));
+            std::string message = FormatString<string>("Could not match rgn with sampOffset %X to a sample with that offset.\n  (InstrSet %d, Instr %d, Rgn %d)", rgn->sampOffset, inst, i, j);
+            pRoot->AddLogItem(new LogItem(std::string(message.c_str()), LOG_LEVEL_ERR, "VGMColl"));
             realSampNum = 0;
           }
         }
@@ -294,9 +294,9 @@ bool VGMColl::MainDLSCreation(DLSFile &dls) {
         newRgn->SetWaveLinkInfo(0, 0, 1, (uint32_t) realSampNum);
 
         if (realSampNum >= finalSamps.size()) {
-          wchar_t log[256];
-          swprintf(log, 256, L"Sample %zu does not exist.", realSampNum);
-          pRoot->AddLogItem(new LogItem(log, LOG_LEVEL_ERR, L"VGMColl"));
+          char log[256];
+          snprintf(log, 256, "Sample %zu does not exist.", realSampNum);
+          pRoot->AddLogItem(new LogItem(log, LOG_LEVEL_ERR, "VGMColl"));
           realSampNum = finalSamps.size() - 1;
         }
 
@@ -459,8 +459,8 @@ SynthFile *VGMColl::CreateSynthFile() {
             }
           }
           if (!bFoundIt) {
-            std::wstring message = FormatString<wstring>(L"Could not match rgn with sampOffset %X to a sample with that offset.\n  (InstrSet %d, Instr %d, Rgn %d)", rgn->sampOffset, inst, i, j);
-            pRoot->AddLogItem(new LogItem(std::wstring(message.c_str()), LOG_LEVEL_ERR, L"VGMColl"));
+            std::string message = FormatString<string>("Could not match rgn with sampOffset %X to a sample with that offset.\n  (InstrSet %d, Instr %d, Rgn %d)", rgn->sampOffset, inst, i, j);
+            pRoot->AddLogItem(new LogItem(std::string(message.c_str()), LOG_LEVEL_ERR, "VGMColl"));
             realSampNum = 0;
           }
         }
@@ -471,7 +471,7 @@ SynthFile *VGMColl::CreateSynthFile() {
         // Determine the position of sampColl within finalSampColls
         auto sampCollIt = std::find(finalSampColls.begin(), finalSampColls.end(), sampColl);
         if (sampCollIt == finalSampColls.end()) {
-          pRoot->AddLogItem(new LogItem(L"SampColl does not exist.", LOG_LEVEL_ERR, L"VGMColl"));
+          pRoot->AddLogItem(new LogItem("SampColl does not exist.", LOG_LEVEL_ERR, "VGMColl"));
           delete synthfile;
           PostSynthFileCreation();
           return NULL;
@@ -488,9 +488,9 @@ SynthFile *VGMColl::CreateSynthFile() {
         newRgn->SetWaveLinkInfo(0, 0, 1, (uint32_t) realSampNum);
 
         if (realSampNum >= finalSamps.size()) {
-          wchar_t log[256];
-          swprintf(log, 256, L"Sample %zu does not exist.", realSampNum);
-          pRoot->AddLogItem(new LogItem(log, LOG_LEVEL_ERR, L"VGMColl"));
+          char log[256];
+          snprintf(log, 256, "Sample %zu does not exist.", realSampNum);
+          pRoot->AddLogItem(new LogItem(log, LOG_LEVEL_ERR, "VGMColl"));
           realSampNum = finalSamps.size() - 1;
         }
 
@@ -572,43 +572,43 @@ SynthFile *VGMColl::CreateSynthFile() {
 
 
 bool VGMColl::OnSaveAllDLS() {
-  wstring dirpath = pRoot->UI_GetSaveDirPath();
+  string dirpath = pRoot->UI_GetSaveDirPath();
   if (dirpath.length() != 0) {
     DLSFile dlsfile;
-    wstring filepath = dirpath + L"\\" + ConvertToSafeFileName(this->name) + L".dls";
+    string filepath = dirpath + "\\" + ConvertToSafeFileName(this->name) + ".dls";
     if (CreateDLSFile(dlsfile)) {
       if (!dlsfile.SaveDLSFile(filepath))
-        pRoot->AddLogItem(new LogItem(std::wstring(L"Failed to save DLS file"), LOG_LEVEL_ERR, L"VGMColl"));
+        pRoot->AddLogItem(new LogItem(std::string("Failed to save DLS file"), LOG_LEVEL_ERR, "VGMColl"));
     }
     else
-      pRoot->AddLogItem(new LogItem(std::wstring(L"Failed to save DLS file"), LOG_LEVEL_ERR, L"VGMColl"));
+      pRoot->AddLogItem(new LogItem(std::string("Failed to save DLS file"), LOG_LEVEL_ERR, "VGMColl"));
 
     if (this->seq != nullptr) {
-      filepath = dirpath + L"\\" + ConvertToSafeFileName(this->name) + L".mid";
+      filepath = dirpath + "\\" + ConvertToSafeFileName(this->name) + ".mid";
       if (!this->seq->SaveAsMidi(filepath))
-        pRoot->AddLogItem(new LogItem(std::wstring(L"Failed to save MIDI file"), LOG_LEVEL_ERR, L"VGMColl"));
+        pRoot->AddLogItem(new LogItem(std::string("Failed to save MIDI file"), LOG_LEVEL_ERR, "VGMColl"));
     }
   }
   return true;
 }
 
 bool VGMColl::OnSaveAllSF2() {
-  wstring dirpath = pRoot->UI_GetSaveDirPath();
+  string dirpath = pRoot->UI_GetSaveDirPath();
   if (dirpath.length() != 0) {
-    wstring filepath = dirpath + L"\\" + ConvertToSafeFileName(this->name) + L".sf2";
+    string filepath = dirpath + "\\" + ConvertToSafeFileName(this->name) + ".sf2";
     SF2File *sf2file = CreateSF2File();
     if (sf2file != NULL) {
       if (!sf2file->SaveSF2File(filepath))
-        pRoot->AddLogItem(new LogItem(std::wstring(L"Failed to save SF2 file"), LOG_LEVEL_ERR, L"VGMColl"));
+        pRoot->AddLogItem(new LogItem(std::string("Failed to save SF2 file"), LOG_LEVEL_ERR, "VGMColl"));
       delete sf2file;
     }
     else
-      pRoot->AddLogItem(new LogItem(std::wstring(L"Failed to save SF2 file"), LOG_LEVEL_ERR, L"VGMColl"));
+      pRoot->AddLogItem(new LogItem(std::string("Failed to save SF2 file"), LOG_LEVEL_ERR, "VGMColl"));
 
     if (this->seq != nullptr) {
-      filepath = dirpath + L"\\" + ConvertToSafeFileName(this->name) + L".mid";
+      filepath = dirpath + "\\" + ConvertToSafeFileName(this->name) + ".mid";
       if (!this->seq->SaveAsMidi(filepath))
-        pRoot->AddLogItem(new LogItem(std::wstring(L"Failed to save MIDI file"), LOG_LEVEL_ERR, L"VGMColl"));
+        pRoot->AddLogItem(new LogItem(std::string("Failed to save MIDI file"), LOG_LEVEL_ERR, "VGMColl"));
     }
   }
   return true;

--- a/src/main/VGMColl.h
+++ b/src/main/VGMColl.h
@@ -15,17 +15,17 @@ class VGMColl
     : public VGMItem {
  public:
   BEGIN_MENU(VGMColl)
-      MENU_ITEM(VGMColl, OnSaveAllDLS, L"Save as MIDI and DLS.")
-      MENU_ITEM(VGMColl, OnSaveAllSF2, L"Save as MIDI and SoundFont 2.")
-      //MENU_ITEM(VGMFile, OnSaveAllAsRaw, L"Save all as original format")
+      MENU_ITEM(VGMColl, OnSaveAllDLS, "Save as MIDI and DLS.")
+      MENU_ITEM(VGMColl, OnSaveAllSF2, "Save as MIDI and SoundFont 2.")
+      //MENU_ITEM(VGMFile, OnSaveAllAsRaw, "Save all as original format")
   END_MENU()
 
-  VGMColl(std::wstring name = L"Unnamed Collection");
+  VGMColl(std::string name = "Unnamed Collection");
   virtual ~VGMColl(void);
 
   void RemoveFileAssocs();
-  const std::wstring *GetName(void) const;
-  void SetName(const std::wstring *newName);
+  const std::string *GetName(void) const;
+  void SetName(const std::string *newName);
   VGMSeq *GetSeq();
   void UseSeq(VGMSeq *theSeq);
   void AddInstrSet(VGMInstrSet *theInstrSet);
@@ -53,5 +53,5 @@ class VGMColl
   void UnpackSampColl(SynthFile &synthfile, VGMSampColl *sampColl, std::vector<VGMSamp *> &finalSamps);
 
  protected:
-  std::wstring name;
+  std::string name;
 };

--- a/src/main/VGMExport.h
+++ b/src/main/VGMExport.h
@@ -27,25 +27,25 @@ inline constexpr uint32_t operator&(VGMCollConversionTarget a, VGMCollConversion
 }
 
 template <VGMCollConversionTarget options>
-void SaveAs(VGMColl &coll, const std::wstring &dir_path) {
+void SaveAs(VGMColl &coll, const std::string &dir_path) {
   auto filename = ConvertToSafeFileName(*coll.GetName());
-  auto filepath = dir_path + L"/" + filename;
+  auto filepath = dir_path + "/" + filename;
 
   if constexpr ((options & VGMCollConversionTarget::MIDI) != 0) {
-    coll.seq->SaveAsMidi(filepath + L".mid");
+    coll.seq->SaveAsMidi(filepath + ".mid");
   }
 
   if constexpr ((options & VGMCollConversionTarget::DLS) != 0) {
     DLSFile dlsfile;
     if (coll.CreateDLSFile(dlsfile)) {
-      dlsfile.SaveDLSFile(filepath + L".dls");
+      dlsfile.SaveDLSFile(filepath + ".dls");
     }
   }
 
   if constexpr ((options & VGMCollConversionTarget::SF2) != 0) {
     SF2File *sf2file = coll.CreateSF2File();
     if (sf2file) {
-      sf2file->SaveSF2File(filepath + L".sf2");
+      sf2file->SaveSF2File(filepath + ".sf2");
     }
   }
 }

--- a/src/main/VGMFile.cpp
+++ b/src/main/VGMFile.cpp
@@ -14,7 +14,7 @@ VGMFile::VGMFile(FileType fileType,
                  RawFile *theRawFile,
                  uint32_t offset,
                  uint32_t length,
-                 wstring theName)
+                 string theName)
     : VGMContainerItem(this, offset, length),
       rawfile(theRawFile),
       bUsingRawFile(true),
@@ -44,7 +44,7 @@ bool VGMFile::OnClose() {
 }
 
 bool VGMFile::OnSaveAsRaw() {
-  wstring filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name));
+  string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name));
   if (filepath.length() != 0) {
     bool result;
     uint8_t *buf = new uint8_t[unLength];        //create a buffer the size of the file
@@ -68,9 +68,9 @@ bool VGMFile::LoadVGMFile() {
   if (fmt)
     fmt->OnNewFile(this);
 
-  pRoot->AddLogItem(new LogItem(wstring(L"Loaded \"" + name + L"\" successfully.").c_str(),
+  pRoot->AddLogItem(new LogItem(string("Loaded \"" + name + "\" successfully.").c_str(),
                                 LOG_LEVEL_INFO,
-                                L"VGMFile"));
+                                "VGMFile"));
   return val;
 }
 
@@ -83,7 +83,7 @@ const string &VGMFile::GetFormatName() {
 }
 
 
-const wstring *VGMFile::GetName(void) const {
+const string *VGMFile::GetName(void) const {
   return &name;
 }
 
@@ -149,7 +149,7 @@ uint32_t VGMFile::GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) {
 // VGMHeader
 // *********
 
-VGMHeader::VGMHeader(VGMItem *parItem, uint32_t offset, uint32_t length, const std::wstring &name)
+VGMHeader::VGMHeader(VGMItem *parItem, uint32_t offset, uint32_t length, const std::string &name)
     : VGMContainerItem(parItem->vgmfile, offset, length, name) {
 }
 
@@ -160,15 +160,15 @@ void VGMHeader::AddPointer(uint32_t offset,
                            uint32_t length,
                            uint32_t destAddress,
                            bool notNull,
-                           const std::wstring &name) {
+                           const std::string &name) {
   localitems.push_back(new VGMHeaderItem(this, VGMHeaderItem::HIT_POINTER, offset, length, name));
 }
 
-void VGMHeader::AddTempo(uint32_t offset, uint32_t length, const std::wstring &name) {
+void VGMHeader::AddTempo(uint32_t offset, uint32_t length, const std::string &name) {
   localitems.push_back(new VGMHeaderItem(this, VGMHeaderItem::HIT_TEMPO, offset, length, name));
 }
 
-void VGMHeader::AddSig(uint32_t offset, uint32_t length, const std::wstring &name) {
+void VGMHeader::AddSig(uint32_t offset, uint32_t length, const std::string &name) {
   localitems.push_back(new VGMHeaderItem(this, VGMHeaderItem::HIT_SIG, offset, length, name));
 }
 
@@ -180,7 +180,7 @@ VGMHeaderItem::VGMHeaderItem(VGMHeader *hdr,
                              HdrItemType theType,
                              uint32_t offset,
                              uint32_t length,
-                             const std::wstring &name)
+                             const std::string &name)
     : VGMItem(hdr->vgmfile, offset, length, name, CLR_HEADER), type(theType) {
 }
 

--- a/src/main/VGMFile.h
+++ b/src/main/VGMFile.h
@@ -27,9 +27,9 @@ class VGMFile:
     public VGMContainerItem {
  public:
   BEGIN_MENU(VGMFile)
-      MENU_ITEM(VGMFile, OnClose, L"Close")
-      MENU_ITEM(VGMFile, OnSaveAsRaw, L"Save as original format")
-      //MENU_ITEM(VGMFile, OnSaveAllAsRaw, L"Save all as original format")
+      MENU_ITEM(VGMFile, OnClose, "Close")
+      MENU_ITEM(VGMFile, OnSaveAsRaw, "Save as original format")
+      //MENU_ITEM(VGMFile, OnSaveAllAsRaw, "Save all as original format")
   END_MENU()
 
  public:
@@ -38,7 +38,7 @@ class VGMFile:
           RawFile *theRawFile,
           uint32_t offset,
           uint32_t length = 0,
-          std::wstring theName = L"VGM File");
+          std::string theName = "VGM File");
   virtual ~VGMFile(void);
 
   virtual ItemType GetType() const { return ITEMTYPE_VGMFILE; }
@@ -46,7 +46,7 @@ class VGMFile:
 
   virtual void AddToUI(VGMItem *parent, void *UI_specific);
 
-  const std::wstring *GetName(void) const;
+  const std::string *GetName(void) const;
 
   bool OnClose();
   bool OnSaveAsRaw();
@@ -139,7 +139,7 @@ class VGMFile:
   FileType file_type;
   const std::string &format;
   uint32_t id;
-  std::wstring name;
+  std::string name;
  public:
   RawFile *rawfile;
   std::list<VGMColl *> assocColls;
@@ -155,14 +155,14 @@ class VGMFile:
 class VGMHeader:
     public VGMContainerItem {
  public:
-  VGMHeader(VGMItem *parItem, uint32_t offset = 0, uint32_t length = 0, const std::wstring &name = L"Header");
+  VGMHeader(VGMItem *parItem, uint32_t offset = 0, uint32_t length = 0, const std::string &name = "Header");
   virtual ~VGMHeader();
 
   virtual Icon GetIcon() { return ICON_BINARY; };
 
-  void AddPointer(uint32_t offset, uint32_t length, uint32_t destAddress, bool notNull, const std::wstring &name = L"Pointer");
-  void AddTempo(uint32_t offset, uint32_t length, const std::wstring &name = L"Tempo");
-  void AddSig(uint32_t offset, uint32_t length, const std::wstring &name = L"Signature");
+  void AddPointer(uint32_t offset, uint32_t length, uint32_t destAddress, bool notNull, const std::string &name = "Pointer");
+  void AddTempo(uint32_t offset, uint32_t length, const std::string &name = "Tempo");
+  void AddSig(uint32_t offset, uint32_t length, const std::string &name = "Signature");
 
   //vector<VGMItem*> items;
 };
@@ -176,7 +176,7 @@ class VGMHeaderItem:
  public:
   enum HdrItemType { HIT_POINTER, HIT_TEMPO, HIT_SIG, HIT_GENERIC, HIT_UNKNOWN };        //HIT = Header Item Type
 
-  VGMHeaderItem(VGMHeader *hdr, HdrItemType theType, uint32_t offset, uint32_t length, const std::wstring &name);
+  VGMHeaderItem(VGMHeader *hdr, HdrItemType theType, uint32_t offset, uint32_t length, const std::string &name);
   virtual Icon GetIcon();
 
  public:

--- a/src/main/VGMInstrSet.cpp
+++ b/src/main/VGMInstrSet.cpp
@@ -17,7 +17,7 @@ VGMInstrSet::VGMInstrSet(const string &format,/*FmtID fmtID,*/
                          RawFile *file,
                          uint32_t offset,
                          uint32_t length,
-                         wstring name,
+                         string name,
                          VGMSampColl *theSampColl)
     : VGMFile(FILETYPE_INSTRSET, /*fmtID,*/format, file, offset, length, name), sampColl(theSampColl), allowEmptyInstrs(false) {
   AddContainer<VGMInstr>(aInstrs);
@@ -30,10 +30,10 @@ VGMInstrSet::~VGMInstrSet() {
 
 
 VGMInstr *VGMInstrSet::AddInstr(uint32_t offset, uint32_t length, unsigned long bank,
-                                unsigned long instrNum, const wstring &instrName) {
-  wostringstream name;
-  if (instrName == L"")
-    name << L"Instrument " << aInstrs.size();
+                                unsigned long instrNum, const string &instrName) {
+  ostringstream name;
+  if (instrName == "")
+    name << "Instrument " << aInstrs.size();
   else
     name << instrName;
 
@@ -59,7 +59,7 @@ bool VGMInstrSet::Load() {
 
   if (sampColl != NULL) {
     if (!sampColl->Load()) {
-      pRoot->AddLogItem(new LogItem(L"Failed to load VGMSampColl.", LOG_LEVEL_ERR, L"VGMInstrSet"));
+      pRoot->AddLogItem(new LogItem("Failed to load VGMSampColl.", LOG_LEVEL_ERR, "VGMInstrSet"));
     }
   }
 
@@ -89,7 +89,7 @@ bool VGMInstrSet::LoadInstrs() {
 
 
 bool VGMInstrSet::OnSaveAsDLS(void) {
-  wstring filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), L"dls");
+  string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), "dls");
   if (filepath.length() != 0) {
     return SaveAsDLS(filepath.c_str());
   }
@@ -97,7 +97,7 @@ bool VGMInstrSet::OnSaveAsDLS(void) {
 }
 
 bool VGMInstrSet::OnSaveAsSF2(void) {
-  wstring filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), L"sf2");
+  string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), "sf2");
   if (filepath.length() != 0) {
     return SaveAsSF2(filepath);
   }
@@ -105,19 +105,19 @@ bool VGMInstrSet::OnSaveAsSF2(void) {
 }
 
 
-bool VGMInstrSet::SaveAsDLS(const std::wstring &filepath) {
+bool VGMInstrSet::SaveAsDLS(const std::string &filepath) {
   DLSFile dlsfile;
   bool dlsCreationSucceeded = false;
 
   if (!assocColls.empty()) {
     dlsCreationSucceeded = assocColls.front()->CreateDLSFile(dlsfile);
   } else {
-    std::wostringstream message;
+    std::ostringstream message;
     message << name
-            << L": "
-               L"Instrument sets that are not part of a collection cannot be "
-               L"converted to DLS at the moment.";
-    pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, L"VGMInstrSet"));
+            << ": "
+               "Instrument sets that are not part of a collection cannot be "
+               "converted to DLS at the moment.";
+    pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, "VGMInstrSet"));
     return false;
   }
 
@@ -127,18 +127,18 @@ bool VGMInstrSet::SaveAsDLS(const std::wstring &filepath) {
   return false;
 }
 
-bool VGMInstrSet::SaveAsSF2(const std::wstring &filepath) {
+bool VGMInstrSet::SaveAsSF2(const std::string &filepath) {
   SF2File *sf2file = NULL;
 
   if (!assocColls.empty()) {
     sf2file = assocColls.front()->CreateSF2File();
   } else {
-    std::wostringstream message;
+    std::ostringstream message;
     message << name
-            << L": "
-               L"Instrument sets that are not part of a collection cannot be "
-               L"converted to SF2 at the moment.";
-    pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, L"VGMInstrSet"));
+            << ": "
+               "Instrument sets that are not part of a collection cannot be "
+               "converted to SF2 at the moment.";
+    pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, "VGMInstrSet"));
     return false;
   }
 
@@ -156,7 +156,7 @@ bool VGMInstrSet::SaveAsSF2(const std::wstring &filepath) {
 // ********
 
 VGMInstr::VGMInstr(VGMInstrSet *instrSet, uint32_t offset, uint32_t length, uint32_t theBank,
-                   uint32_t theInstrNum, const wstring &name, float reverb)
+                   uint32_t theInstrNum, const string &name, float reverb)
     : VGMContainerItem(instrSet, offset, length, name),
       parInstrSet(instrSet),
       bank(theBank),

--- a/src/main/VGMInstrSet.h
+++ b/src/main/VGMInstrSet.h
@@ -22,15 +22,15 @@ class VGMInstrSet:
     public VGMFile {
  public:
   BEGIN_MENU_SUB(VGMInstrSet, VGMFile)
-      MENU_ITEM(VGMInstrSet, OnSaveAsDLS, L"Convert to DLS")
-      MENU_ITEM(VGMInstrSet, OnSaveAsSF2, L"Convert to SoundFont 2")
+      MENU_ITEM(VGMInstrSet, OnSaveAsDLS, "Convert to DLS")
+      MENU_ITEM(VGMInstrSet, OnSaveAsSF2, "Convert to SoundFont 2")
   END_MENU()
 
   VGMInstrSet(const std::string &format,
               RawFile *file,
               uint32_t offset,
               uint32_t length = 0,
-              std::wstring name = L"VGMInstrSet",
+              std::string name = "VGMInstrSet",
               VGMSampColl *theSampColl = NULL);
   virtual ~VGMInstrSet(void);
 
@@ -43,15 +43,15 @@ class VGMInstrSet:
                      uint32_t length,
                      unsigned long bank,
                      unsigned long instrNum,
-                     const std::wstring &instrName = L"");
+                     const std::string &instrName = "");
 
   virtual FileType GetFileType() { return FILETYPE_INSTRSET; }
 
 
   bool OnSaveAsDLS(void);
   bool OnSaveAsSF2(void);
-  virtual bool SaveAsDLS(const std::wstring &filepath);
-  virtual bool SaveAsSF2(const std::wstring &filepath);
+  virtual bool SaveAsDLS(const std::string &filepath);
+  virtual bool SaveAsSF2(const std::string &filepath);
 
  public:
   std::vector<VGMInstr *> aInstrs;
@@ -73,7 +73,7 @@ class VGMInstr:
     public VGMContainerItem {
  public:
   VGMInstr(VGMInstrSet *parInstrSet, uint32_t offset, uint32_t length, uint32_t bank,
-           uint32_t instrNum, const std::wstring &name = L"Instrument", float reverb = defaultReverbPercent);
+           uint32_t instrNum, const std::string &name = "Instrument", float reverb = defaultReverbPercent);
   virtual ~VGMInstr(void);
 
   virtual Icon GetIcon() { return ICON_INSTR; };

--- a/src/main/VGMItem.cpp
+++ b/src/main/VGMItem.cpp
@@ -9,7 +9,7 @@ using namespace std;
 VGMItem::VGMItem() : color(CLR_UNKNOWN) {
 }
 
-VGMItem::VGMItem(VGMFile *vgmfile, uint32_t offset, uint32_t length, const wstring name, EventColor color)
+VGMItem::VGMItem(VGMFile *vgmfile, uint32_t offset, uint32_t length, const string name, EventColor color)
     : vgmfile(vgmfile), name(name), dwOffset(offset), unLength(length), color(color) {
 }
 
@@ -89,7 +89,7 @@ VGMContainerItem::VGMContainerItem() : VGMItem() {
 }
 
 VGMContainerItem::VGMContainerItem(
-    VGMFile *vgmfile, uint32_t offset, uint32_t length, const wstring name, EventColor color)
+    VGMFile *vgmfile, uint32_t offset, uint32_t length, const string name, EventColor color)
     : VGMItem(vgmfile, offset, length, name, color) {
   AddContainer(headers);
   AddContainer(localitems);
@@ -167,7 +167,7 @@ void VGMContainerItem::AddToUI(VGMItem *parent, void *UI_specific) {
   }
 }
 
-VGMHeader *VGMContainerItem::AddHeader(uint32_t offset, uint32_t length, const std::wstring &name) {
+VGMHeader *VGMContainerItem::AddHeader(uint32_t offset, uint32_t length, const std::string &name) {
   VGMHeader *header = new VGMHeader(this, offset, length, name);
   headers.push_back(header);
   return header;
@@ -177,10 +177,10 @@ void VGMContainerItem::AddItem(VGMItem *item) {
   localitems.push_back(item);
 }
 
-void VGMContainerItem::AddSimpleItem(uint32_t offset, uint32_t length, const std::wstring &name) {
+void VGMContainerItem::AddSimpleItem(uint32_t offset, uint32_t length, const std::string &name) {
   localitems.push_back(new VGMItem(this->vgmfile, offset, length, name, CLR_HEADER));
 }
 
 void VGMContainerItem::AddUnknownItem(uint32_t offset, uint32_t length) {
-  localitems.push_back(new VGMItem(this->vgmfile, offset, length, L"Unknown"));
+  localitems.push_back(new VGMItem(this->vgmfile, offset, length, "Unknown"));
 }

--- a/src/main/VGMItem.h
+++ b/src/main/VGMItem.h
@@ -71,7 +71,7 @@ public:
   VGMItem(VGMFile *vgmfile,
           uint32_t offset,
           uint32_t length = 0,
-          const std::wstring name = L"",
+          const std::string name = "",
           EventColor color = CLR_UNKNOWN);
 
   friend bool operator>(VGMItem &item1, VGMItem &item2);
@@ -86,9 +86,9 @@ public:
   virtual VGMItem *GetItemFromOffset(uint32_t offset, bool includeContainer = true, bool matchStartOffset = false);
   virtual uint32_t GuessLength() { return unLength; };
   virtual void SetGuessedLength(){};
-  virtual std::vector<const wchar_t *> *GetMenuItemNames() { return nullptr; }
+  virtual std::vector<const char* > *GetMenuItemNames() { return nullptr; }
   virtual bool CallMenuItem(VGMItem *item, int menuItemNum) { return false; }
-  virtual std::wstring GetDescription() { return name; }
+  virtual std::string GetDescription() { return name; }
   virtual ItemType GetType() const { return ITEMTYPE_UNDEFINED; }
   virtual Icon GetIcon() { return ICON_BINARY; }
   virtual void AddToUI(VGMItem *parent, void *UI_specific);
@@ -106,7 +106,7 @@ protected:
 public:
   EventColor color;
   VGMFile *vgmfile;
-  std::wstring name;
+  std::string name;
   uint32_t dwOffset;  // offset in the pDoc data buffer
   uint32_t unLength;  // num of bytes the event engulfs
 };
@@ -121,7 +121,7 @@ public:
   VGMContainerItem(VGMFile *vgmfile,
                    uint32_t offset,
                    uint32_t length = 0,
-                   const std::wstring name = L"",
+                   const std::string name = "",
                    EventColor color = CLR_HEADER);
   virtual ~VGMContainerItem();
 
@@ -131,10 +131,10 @@ public:
   void AddToUI(VGMItem *parent, void *UI_specific) override;
   bool IsContainerItem() const override { return true; }
 
-  VGMHeader *AddHeader(uint32_t offset, uint32_t length, const std::wstring &name = L"Header");
+  VGMHeader *AddHeader(uint32_t offset, uint32_t length, const std::string &name = "Header");
 
   void AddItem(VGMItem *item);
-  void AddSimpleItem(uint32_t offset, uint32_t length, const std::wstring &name);
+  void AddSimpleItem(uint32_t offset, uint32_t length, const std::string &name);
   void AddUnknownItem(uint32_t offset, uint32_t length);
 
   template <class T>

--- a/src/main/VGMMiscFile.cpp
+++ b/src/main/VGMMiscFile.cpp
@@ -8,7 +8,7 @@ using namespace std;
 // VGMMiscFile
 // ***********
 
-VGMMiscFile::VGMMiscFile(const string &format, RawFile *file, uint32_t offset, uint32_t length, wstring name)
+VGMMiscFile::VGMMiscFile(const string &format, RawFile *file, uint32_t offset, uint32_t length, string name)
     : VGMFile(FILETYPE_MISC, format, file, offset, length, name) {
 
 }

--- a/src/main/VGMMiscFile.h
+++ b/src/main/VGMMiscFile.h
@@ -16,7 +16,7 @@ class VGMMiscFile:
               RawFile *file,
               uint32_t offset,
               uint32_t length = 0,
-              std::wstring name = L"VGMMiscFile");
+              std::string name = "VGMMiscFile");
 
   virtual FileType GetFileType() { return FILETYPE_MISC; }
 

--- a/src/main/VGMMultiSectionSeq.cpp
+++ b/src/main/VGMMultiSectionSeq.cpp
@@ -8,7 +8,7 @@ VGMMultiSectionSeq::VGMMultiSectionSeq(const std::string &format,
                                        RawFile *file,
                                        uint32_t offset,
                                        uint32_t length,
-                                       std::wstring name)
+                                       std::string name)
     : VGMSeq(format, file, offset, length, name),
       dwStartOffset(offset) {
   AddContainer<VGMSeqSection>(aSections);

--- a/src/main/VGMMultiSectionSeq.h
+++ b/src/main/VGMMultiSectionSeq.h
@@ -10,7 +10,7 @@ class VGMMultiSectionSeq:
                      RawFile *file,
                      uint32_t offset,
                      uint32_t length = 0,
-                     std::wstring name = L"VGM Sequence");
+                     std::string name = "VGM Sequence");
   virtual ~VGMMultiSectionSeq();
 
   virtual void ResetVars();

--- a/src/main/VGMRgn.cpp
+++ b/src/main/VGMRgn.cpp
@@ -6,7 +6,7 @@
 // VGMRgn
 // ******
 
-VGMRgn::VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length, const std::wstring &name)
+VGMRgn::VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length, const std::string &name)
     : VGMContainerItem(instr->parInstrSet, offset, length, name),
       parInstr(instr),
       keyLow(0),
@@ -31,7 +31,7 @@ VGMRgn::VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length, const std::wst
 }
 
 VGMRgn::VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length, uint8_t theKeyLow, uint8_t theKeyHigh,
-               uint8_t theVelLow, uint8_t theVelHigh, int theSampNum, const std::wstring &name)
+               uint8_t theVelLow, uint8_t theVelHigh, int theSampNum, const std::string &name)
     : VGMContainerItem(instr->parInstrSet, offset, length, name),
       parInstr(instr),
       keyLow(theKeyLow),
@@ -105,18 +105,18 @@ void VGMRgn::SetADSR(long attackTime, uint16_t atkTransform, long decayTime, lon
   release_time = releaseTime;
 }
 
-void VGMRgn::AddGeneralItem(uint32_t offset, uint32_t length, const std::wstring &name) {
+void VGMRgn::AddGeneralItem(uint32_t offset, uint32_t length, const std::string &name) {
   items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_GENERIC, offset, length, name));
 }
 
 void VGMRgn::AddUnknown(uint32_t offset, uint32_t length) {
-  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_UNKNOWN, offset, length, L"Unknown"));
+  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_UNKNOWN, offset, length, "Unknown"));
 }
 
 //assumes pan is given as 0-127 value, converts it to our double -1.0 to 1.0 format
 void VGMRgn::AddPan(uint8_t p, uint32_t offset, uint32_t length) {
   SetPan(p);
-  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_PAN, offset, length, L"Pan"));
+  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_PAN, offset, length, "Pan"));
 }
 
 void VGMRgn::SetVolume(double vol) {
@@ -125,42 +125,42 @@ void VGMRgn::SetVolume(double vol) {
 
 void VGMRgn::AddVolume(double vol, uint32_t offset, uint32_t length) {
   volume = vol;
-  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_VOL, offset, length, L"Volume"));
+  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_VOL, offset, length, "Volume"));
 }
 
 void VGMRgn::AddUnityKey(uint8_t uk, uint32_t offset, uint32_t length) {
   this->unityKey = uk;
-  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_UNITYKEY, offset, length, L"Unity Key"));
+  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_UNITYKEY, offset, length, "Unity Key"));
 }
 
 void VGMRgn::AddFineTune(int16_t relativePitchCents, uint32_t offset, uint32_t length) {
   this->fineTune = relativePitchCents;
-  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_FINETUNE, offset, length, L"Fine Tune"));
+  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_FINETUNE, offset, length, "Fine Tune"));
 }
 
 void VGMRgn::AddKeyLow(uint8_t kl, uint32_t offset, uint32_t length) {
   keyLow = kl;
-  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_KEYLOW, offset, length, L"Note Range: Low Key"));
+  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_KEYLOW, offset, length, "Note Range: Low Key"));
 }
 
 void VGMRgn::AddKeyHigh(uint8_t kh, uint32_t offset, uint32_t length) {
   keyHigh = kh;
-  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_KEYHIGH, offset, length, L"Note Range: High Key"));
+  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_KEYHIGH, offset, length, "Note Range: High Key"));
 }
 
 void VGMRgn::AddVelLow(uint8_t vl, uint32_t offset, uint32_t length) {
   velLow = vl;
-  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_VELLOW, offset, length, L"Vel Range: Low"));
+  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_VELLOW, offset, length, "Vel Range: Low"));
 }
 
 void VGMRgn::AddVelHigh(uint8_t vh, uint32_t offset, uint32_t length) {
   velHigh = vh;
-  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_VELHIGH, offset, length, L"Vel Range: High"));
+  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_VELHIGH, offset, length, "Vel Range: High"));
 }
 
 void VGMRgn::AddSampNum(int sn, uint32_t offset, uint32_t length) {
   sampNum = sn;
-  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_SAMPNUM, offset, length, L"Sample Number"));
+  items.push_back(new VGMRgnItem(this, VGMRgnItem::RIT_SAMPNUM, offset, length, "Sample Number"));
 }
 
 
@@ -168,7 +168,7 @@ void VGMRgn::AddSampNum(int sn, uint32_t offset, uint32_t length) {
 // VGMRgnItem
 // **********
 
-VGMRgnItem::VGMRgnItem(VGMRgn *rgn, RgnItemType theType, uint32_t offset, uint32_t length, const std::wstring &name)
+VGMRgnItem::VGMRgnItem(VGMRgn *rgn, RgnItemType theType, uint32_t offset, uint32_t length, const std::string &name)
     : VGMItem(rgn->vgmfile, offset, length, name), type(theType) {
 }
 

--- a/src/main/VGMRgn.h
+++ b/src/main/VGMRgn.h
@@ -14,9 +14,9 @@ class VGMSampColl;
 class VGMRgn:
     public VGMContainerItem {
  public:
-  VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length = 0, const std::wstring &name = L"Region");
+  VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length = 0, const std::string &name = "Region");
   VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length, uint8_t keyLow, uint8_t keyHigh, uint8_t velLow,
-         uint8_t velHigh, int sampNum, const std::wstring &name = L"Region");
+         uint8_t velHigh, int sampNum, const std::string &name = "Region");
   ~VGMRgn(void);
 
   virtual bool LoadRgn() { return true; }
@@ -30,7 +30,7 @@ class VGMRgn:
   void SetADSR(long attack_time, uint16_t atk_transform, long decay_time, long sustain_lev,
                uint16_t rls_transform, long release_time);
 
-  void AddGeneralItem(uint32_t offset, uint32_t length, const std::wstring &name);
+  void AddGeneralItem(uint32_t offset, uint32_t length, const std::string &name);
   void AddUnknown(uint32_t offset, uint32_t length);
   void SetFineTune(int16_t relativePitchCents) { fineTune = relativePitchCents; }
   void SetPan(uint8_t pan);
@@ -115,7 +115,7 @@ class VGMRgnItem:
     RIT_SAMPNUM
   };        //HIT = Header Item Type
 
-  VGMRgnItem(VGMRgn *rgn, RgnItemType theType, uint32_t offset, uint32_t length, const std::wstring &name);
+  VGMRgnItem(VGMRgn *rgn, RgnItemType theType, uint32_t offset, uint32_t length, const std::string &name);
   virtual Icon GetIcon();
 
  public:

--- a/src/main/VGMSamp.cpp
+++ b/src/main/VGMSamp.cpp
@@ -17,7 +17,7 @@ DECLARE_MENU(VGMSamp)
 
 VGMSamp::VGMSamp(VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t dataOffset,
                  uint32_t dataLen, uint8_t nChannels, uint16_t theBPS, uint32_t theRate,
-                 wstring theName)
+                 string theName)
     : VGMItem(sampColl->vgmfile, offset, length, theName), dataOff(dataOffset), dataLength(dataLen),
       bps(theBPS), rate(theRate), channels(nChannels), parSampColl(sampColl) {
 }
@@ -44,13 +44,13 @@ void VGMSamp::ConvertToStdWave(uint8_t *buf) {
 }
 
 bool VGMSamp::OnSaveAsWav() {
-  wstring filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), L"wav");
+  string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), "wav");
   if (filepath.empty())
     return SaveAsWav(filepath);
   return false;
 }
 
-bool VGMSamp::SaveAsWav(const std::wstring &filepath) {
+bool VGMSamp::SaveAsWav(const std::string &filepath) {
   uint32_t bufSize;
   if (this->ulUncompressedSize)
     bufSize = this->ulUncompressedSize;

--- a/src/main/VGMSamp.h
+++ b/src/main/VGMSamp.h
@@ -16,12 +16,12 @@ enum WAVE_TYPE { WT_UNDEFINED, WT_PCM8, WT_PCM16 };
 class VGMSamp : public VGMItem {
 public:
   BEGIN_MENU(VGMSamp)
-  MENU_ITEM(VGMSamp, OnSaveAsWav, L"Convert to WAV file")
+  MENU_ITEM(VGMSamp, OnSaveAsWav, "Convert to WAV file")
   END_MENU()
 
   VGMSamp(VGMSampColl *sampColl, uint32_t offset = 0, uint32_t length = 0, uint32_t dataOffset = 0,
           uint32_t dataLength = 0, uint8_t channels = 1, uint16_t bps = 16, uint32_t rate = 0,
-          std::wstring name = L"Sample");
+          std::string name = "Sample");
   virtual ~VGMSamp() = default;
 
   virtual Icon GetIcon() { return ICON_SAMP; };
@@ -45,7 +45,7 @@ public:
   inline void SetLoopLengthMeasure(LoopMeasure measure) { loop.loopLengthMeasure = measure; }
 
   bool OnSaveAsWav();
-  bool SaveAsWav(const std::wstring &filepath);
+  bool SaveAsWav(const std::string &filepath);
 
 public:
   WAVE_TYPE waveType = WT_UNDEFINED;

--- a/src/main/VGMSampColl.cpp
+++ b/src/main/VGMSampColl.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 DECLARE_MENU(VGMSampColl)
 
-VGMSampColl::VGMSampColl(const string &format, RawFile *rawfile, uint32_t offset, uint32_t length, wstring theName)
+VGMSampColl::VGMSampColl(const string &format, RawFile *rawfile, uint32_t offset, uint32_t length, string theName)
     : VGMFile(FILETYPE_SAMPCOLL, format, rawfile, offset, length, theName),
       parInstrSet(NULL),
       bLoadOnInstrSetMatch(false),
@@ -22,7 +22,7 @@ VGMSampColl::VGMSampColl(const string &format, RawFile *rawfile, uint32_t offset
 }
 
 VGMSampColl::VGMSampColl(const string &format, RawFile *rawfile, VGMInstrSet *instrset,
-                         uint32_t offset, uint32_t length, wstring theName)
+                         uint32_t offset, uint32_t length, string theName)
     : VGMFile(FILETYPE_SAMPCOLL, format, rawfile, offset, length, theName),
       parInstrSet(instrset),
       bLoadOnInstrSetMatch(false),
@@ -85,7 +85,7 @@ bool VGMSampColl::GetSampleInfo() {
 }
 
 VGMSamp *VGMSampColl::AddSamp(uint32_t offset, uint32_t length, uint32_t dataOffset, uint32_t dataLength,
-                              uint8_t nChannels, uint16_t bps, uint32_t theRate, wstring name) {
+                              uint8_t nChannels, uint16_t bps, uint32_t theRate, string name) {
   VGMSamp *newSamp = new VGMSamp(this, offset, length, dataOffset, dataLength, nChannels,
                                  bps, theRate, name);
   samples.push_back(newSamp);
@@ -93,10 +93,10 @@ VGMSamp *VGMSampColl::AddSamp(uint32_t offset, uint32_t length, uint32_t dataOff
 }
 
 bool VGMSampColl::OnSaveAllAsWav() {
-  wstring dirpath = pRoot->UI_GetSaveDirPath();
+  string dirpath = pRoot->UI_GetSaveDirPath();
   if (dirpath.length() != 0) {
     for (uint32_t i = 0; i < samples.size(); i++) {
-      wstring filepath = dirpath + L"/" + ConvertToSafeFileName(samples[i]->name) + L".wav";
+      string filepath = dirpath + "/" + ConvertToSafeFileName(samples[i]->name) + ".wav";
       samples[i]->SaveAsWav(filepath);
     }
     return true;

--- a/src/main/VGMSampColl.h
+++ b/src/main/VGMSampColl.h
@@ -12,13 +12,13 @@ class VGMSampColl:
     public VGMFile {
  public:
   BEGIN_MENU_SUB(VGMSampColl, VGMFile)
-      MENU_ITEM(VGMSampColl, OnSaveAllAsWav, L"Save all as WAV")
+      MENU_ITEM(VGMSampColl, OnSaveAllAsWav, "Save all as WAV")
   END_MENU()
 
   VGMSampColl(const std::string &format, RawFile *rawfile, uint32_t offset, uint32_t length = 0,
-              std::wstring theName = L"VGMSampColl");
+              std::string theName = "VGMSampColl");
   VGMSampColl(const std::string &format, RawFile *rawfile, VGMInstrSet *instrset,
-              uint32_t offset, uint32_t length = 0, std::wstring theName = L"VGMSampColl");
+              uint32_t offset, uint32_t length = 0, std::string theName = "VGMSampColl");
   virtual ~VGMSampColl(void);
   void UseInstrSet(VGMInstrSet *instrset) { parInstrSet = instrset; }
 
@@ -28,7 +28,7 @@ class VGMSampColl:
 
   VGMSamp *AddSamp(uint32_t offset, uint32_t length, uint32_t dataOffset, uint32_t dataLength,
                    uint8_t nChannels = 1, uint16_t bps = 16, uint32_t theRate = 0,
-                   std::wstring name = L"Sample");
+                   std::string name = "Sample");
   bool OnSaveAllAsWav();
 
  protected:

--- a/src/main/VGMSeq.cpp
+++ b/src/main/VGMSeq.cpp
@@ -12,7 +12,7 @@ DECLARE_MENU(VGMSeq)
 
 using namespace std;
 
-VGMSeq::VGMSeq(const string &format, RawFile *file, uint32_t offset, uint32_t length, wstring name)
+VGMSeq::VGMSeq(const string &format, RawFile *file, uint32_t offset, uint32_t length, string name)
     : VGMFile(FILETYPE_SEQ, format, file, offset, length, name),
       midi(NULL),
       bMonophonicTracks(false),
@@ -183,8 +183,8 @@ void VGMSeq::LoadTracksMain(long stopTime) {
       // check time limit
       if (time >= stopTime) {
         if (readMode == READMODE_ADD_TO_UI) {
-          wstring itemName = *this->GetName() + L" - Abort loading tracks by time limit.";
-          pRoot->AddLogItem(new LogItem(itemName.c_str(), LOG_LEVEL_WARN, L"VGMSeq"));
+          string itemName = *this->GetName() + " - Abort loading tracks by time limit.";
+          pRoot->AddLogItem(new LogItem(itemName.c_str(), LOG_LEVEL_WARN, "VGMSeq"));
         }
 
         InactivateAllTracks();
@@ -323,14 +323,14 @@ void VGMSeq::AddInstrumentRef(uint32_t progNum) {
 }
 
 bool VGMSeq::OnSaveAsMidi(void) {
-  wstring filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), L"mid");
+  string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), "mid");
   if (filepath.length() != 0)
     return SaveAsMidi(filepath);
   return false;
 }
 
 
-bool VGMSeq::SaveAsMidi(const std::wstring &filepath) {
+bool VGMSeq::SaveAsMidi(const std::string &filepath) {
   MidiFile *midi = this->ConvertToMidi();
   if (!midi)
     return false;

--- a/src/main/VGMSeq.h
+++ b/src/main/VGMSeq.h
@@ -29,14 +29,14 @@ enum class PortamentoTimeMode : uint8_t {
 class VGMSeq: public VGMFile {
  public:
   BEGIN_MENU_SUB(VGMSeq, VGMFile)
-      MENU_ITEM(VGMSeq, OnSaveAsMidi, L"Save as MIDI")
+      MENU_ITEM(VGMSeq, OnSaveAsMidi, "Save as MIDI")
   END_MENU()
 
   VGMSeq(const std::string &format,
          RawFile *file,
          uint32_t offset,
          uint32_t length = 0,
-         std::wstring name = L"VGM Sequence");
+         std::string name = "VGM Sequence");
   virtual ~VGMSeq(void);
 
   virtual Icon GetIcon() { return ICON_SEQ; }
@@ -91,7 +91,7 @@ class VGMSeq: public VGMFile {
   }
 
   bool OnSaveAsMidi(void);
-  virtual bool SaveAsMidi(const std::wstring &filepath);
+  virtual bool SaveAsMidi(const std::string &filepath);
 
   virtual bool HasActiveTracks();
   virtual void InactivateAllTracks();

--- a/src/main/VGMSeqNoTrks.cpp
+++ b/src/main/VGMSeqNoTrks.cpp
@@ -5,7 +5,7 @@
 
 using namespace std;
 
-VGMSeqNoTrks::VGMSeqNoTrks(const string &format, RawFile *file, uint32_t offset, wstring name)
+VGMSeqNoTrks::VGMSeqNoTrks(const string &format, RawFile *file, uint32_t offset, string name)
     : VGMSeq(format, file, offset, 0, name),
       SeqTrack(this) {
   ResetVars();

--- a/src/main/VGMSeqNoTrks.h
+++ b/src/main/VGMSeqNoTrks.h
@@ -6,7 +6,7 @@ class VGMSeqNoTrks:
     public VGMSeq,
     public SeqTrack {
  public:
-  VGMSeqNoTrks(const std::string &format, RawFile *file, uint32_t offset, std::wstring name = L"VGM Sequence");
+  VGMSeqNoTrks(const std::string &format, RawFile *file, uint32_t offset, std::string name = "VGM Sequence");
  public:
   virtual ~VGMSeqNoTrks(void);
 
@@ -24,7 +24,7 @@ class VGMSeqNoTrks:
   inline uint32_t GetWordBE(uint32_t offset) { return VGMSeq::GetWordBE(offset); }
   inline uint32_t &offset(void) { return VGMSeq::dwOffset; }
   inline uint32_t &length(void) { return VGMSeq::unLength; }
-  inline std::wstring &name(void) { return VGMSeq::name; }
+  inline std::string &name(void) { return VGMSeq::name; }
 
   inline uint32_t &eventsOffset() { return dwEventsOffset; }
 

--- a/src/main/VGMSeqSection.cpp
+++ b/src/main/VGMSeqSection.cpp
@@ -6,7 +6,7 @@
 VGMSeqSection::VGMSeqSection(VGMMultiSectionSeq *parentFile,
                              uint32_t theOffset,
                              uint32_t theLength,
-                             const std::wstring theName,
+                             const std::string theName,
                              EventColor color)
     : VGMContainerItem(parentFile, theOffset, theLength, theName, color),
       parentSeq(parentFile) {

--- a/src/main/VGMSeqSection.h
+++ b/src/main/VGMSeqSection.h
@@ -14,7 +14,7 @@ class VGMSeqSection
   VGMSeqSection(VGMMultiSectionSeq *parentFile,
                 uint32_t theOffset,
                 uint32_t theLength = 0,
-                const std::wstring theName = L"Section",
+                const std::string theName = "Section",
                 EventColor color = CLR_HEADER);
   virtual ~VGMSeqSection(void);
 

--- a/src/main/VGMTag.cpp
+++ b/src/main/VGMTag.cpp
@@ -11,7 +11,7 @@ VGMTag::VGMTag(void) :
     length(0.0) {
 }
 
-VGMTag::VGMTag(const std::wstring &_title, const std::wstring &_artist, const std::wstring &_album) :
+VGMTag::VGMTag(const std::string &_title, const std::string &_artist, const std::string &_album) :
     title(_title),
     album(_album),
     artist(_artist),

--- a/src/main/VGMTag.h
+++ b/src/main/VGMTag.h
@@ -3,7 +3,7 @@
 class VGMTag {
  public:
   VGMTag(void);
-  VGMTag(const std::wstring &_title, const std::wstring &_artist = L"", const std::wstring &_album = L"");
+  VGMTag(const std::string &_title, const std::string &_artist = "", const std::string &_album = "");
   virtual ~VGMTag(void);
 
   bool HasTitle(void);
@@ -14,11 +14,11 @@ class VGMTag {
   bool HasLength(void);
 
  public:
-  std::wstring title;
-  std::wstring artist;
-  std::wstring album;
-  std::wstring comment;
-  std::map<std::wstring, std::vector<uint8_t> > binaries;
+  std::string title;
+  std::string artist;
+  std::string album;
+  std::string comment;
+  std::map<std::string, std::vector<uint8_t> > binaries;
 
   /** Track number */
   int track_number;

--- a/src/main/common.cpp
+++ b/src/main/common.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 #include "common.h"
 
-std::wstring StringToUpper(std::wstring myString) {
+std::string StringToUpper(std::string myString) {
   const size_t length = myString.length();
   for (size_t i = 0; i != length; ++i) {
     myString[i] = toupper(myString[i]);
@@ -9,7 +9,7 @@ std::wstring StringToUpper(std::wstring myString) {
   return myString;
 }
 
-std::wstring StringToLower(std::wstring myString) {
+std::string StringToLower(std::string myString) {
   const size_t length = myString.length();
   for (size_t i = 0; i != length; ++i) {
     myString[i] = tolower(myString[i]);
@@ -24,55 +24,56 @@ uint32_t StringToHex(const std::string &str) {
   return value;
 }
 
-std::wstring ConvertToSafeFileName(const std::wstring &str) {
-  std::wstring filename;
+std::string ConvertToSafeFileName(const std::string &str) {
+  std::string filename;
   filename.reserve(str.length());
 
-  const wchar_t *forbiddenChars = L"\\/:,;*?\"<>|";
+  const char* forbiddenChars = "\\/:,;*?\"<>|";
   size_t pos_begin = 0;
   size_t pos_end;
-  while ((pos_end = str.find_first_of(forbiddenChars, pos_begin)) != std::wstring::npos) {
+  while ((pos_end = str.find_first_of(forbiddenChars, pos_begin)) != std::string::npos) {
     filename += str.substr(pos_begin, pos_end - pos_begin);
     if (filename[filename.length() - 1] != L' ') {
-      filename += L" ";
+      filename += " ";
     }
     pos_begin = pos_end + 1;
   }
   filename += str.substr(pos_begin);
 
   // right trim
-  filename.erase(filename.find_last_not_of(L" \n\r\t") + 1);
+  filename.erase(filename.find_last_not_of(" \n\r\t") + 1);
 
   return filename;
 }
 
-wchar_t *GetFileWithBase(const wchar_t *f, const wchar_t *newfile) {
-  static wchar_t *ret;
-  wchar_t *tp1;
+char* GetFileWithBase(const char* f, const char* newfile) {
+  static char* ret;
+  char *tp1;
 
 #if PSS_STYLE == 1
-  tp1=((wchar_t *)wcsrchr (f,'/'));
+  tp1 = ((char*)strrchr(f, '/'));
 #else
-  tp1 = ((wchar_t *) std::wcsrchr(f, '\\'));
+  tp1 = ((char*)strrchr(f, '\\'));
 #if PSS_STYLE != 3
   {
-    wchar_t *tp3;
+    char *tp3;
 
-    tp3 = ((wchar_t *) std::wcsrchr(f, '/'));
-    if (tp1 < tp3) tp1 = tp3;
+    tp3 = ((char*)strrchr(f, '/'));
+    if (tp1 < tp3) {
+      tp1 = tp3;
+    }
   }
 #endif
 #endif
   if (!tp1) {
-    ret = (wchar_t *) malloc(wcslen(newfile) + 1);
-    wcscpy(ret, newfile);
+    ret = (char*)malloc(strlen(newfile) + 1);  // +1 for the null terminator
+    strcpy(ret, newfile);
+  } else {
+    ret = (char*)malloc((tp1 - f + 2 + strlen(newfile)) * sizeof(char));  // 1 for the null terminator, 1 for the '/'.
+    memcpy(ret, f, (tp1 - f) * sizeof(char));
+    ret[tp1 - f] = '/';
+    ret[tp1 - f + 1] = '\0';
+    strcat(ret, newfile);
   }
-  else {
-    ret = (wchar_t *) malloc((tp1 - f + 2 + wcslen(newfile)) * sizeof(wchar_t));    // 1(NULL), 1(/).
-    memcpy(ret, f, (tp1 - f) * sizeof(wchar_t));
-    ret[tp1 - f] = L'/';
-    ret[tp1 - f + 1] = 0;
-    wcscat(ret, newfile);
-  }
-  return (ret);
+  return ret;
 }

--- a/src/main/common.h
+++ b/src/main/common.h
@@ -14,8 +14,8 @@
     struct _##type;    \
     typedef _##type type
 
-std::wstring StringToUpper(std::wstring myString);
-std::wstring StringToLower(std::wstring myString);
+std::string StringToUpper(std::string myString);
+std::string StringToLower(std::string myString);
 
 /**
 Converts a std::string to any class with a proper overload of the >> opertor
@@ -32,37 +32,7 @@ void FromString(const std::string &temp, T *out) {
 
 uint32_t StringToHex(const std::string &str);
 
-std::wstring ConvertToSafeFileName(const std::wstring &str);
-
-inline std::string wstring2string(const std::wstring &wstr) {
-  char *mbs = new char[wstr.length() * MB_CUR_MAX + 1];
-  wcstombs(mbs, wstr.c_str(), wstr.length() * MB_CUR_MAX + 1);
-  std::string str(mbs);
-  delete[] mbs;
-  return str;
-}
-
-inline std::wstring string2wstring(std::string &str) {
-  wchar_t *wcs = new wchar_t[str.length() + 1];
-  mbstowcs(wcs, str.c_str(), str.length() + 1);
-  std::wstring wstr(wcs);
-  delete[] wcs;
-  return wstr;
-}
-
-//std::string WstringToString(std::wstring& wstr)
-//{
-//	std::stringstream stream;
-//	stream << wstr;
-//	return stream.str();
-//}
-//
-//std::wstring StringToWstring(std::string& str)
-//{
-//	std::wostringstream stream;
-//	stream << str;
-//	return stream.str();
-//}
+std::string ConvertToSafeFileName(const std::string &str);
 
 inline int CountBytesOfVal(uint8_t *buf, uint32_t numBytes, uint8_t val) {
   int count = 0;
@@ -119,7 +89,7 @@ struct SizeOffsetPair {
   }
 };
 
-wchar_t *GetFileWithBase(const wchar_t *f, const wchar_t *newfile);
+char* GetFileWithBase(const char* f, const char* newfile);
 
 
 #endif // !defined(COMMON_H)

--- a/src/main/formats/AkaoFormat.cpp
+++ b/src/main/formats/AkaoFormat.cpp
@@ -22,16 +22,16 @@ bool AkaoColl::LoadMain() {
 
       if (!((rgn->artNum - sampcoll->starting_art_id) >= 0 &&
           rgn->artNum - sampcoll->starting_art_id < 200)) {
-        pRoot->AddLogItem(new LogItem(std::wstring(L"Articulation reference does not exist in the samp collection"),
+        pRoot->AddLogItem(new LogItem(std::string("Articulation reference does not exist in the samp collection"),
                                       LOG_LEVEL_ERR,
-                                      L"AkaoColl"));
+                                      "AkaoColl"));
         art = &sampcoll->akArts.front();
       }
 
       if (rgn->artNum - sampcoll->starting_art_id >= sampcoll->akArts.size()) {
-        pRoot->AddLogItem(new LogItem(std::wstring(L"Referencing an articulation that was not loaded"),
+        pRoot->AddLogItem(new LogItem(std::string("Referencing an articulation that was not loaded"),
                                       LOG_LEVEL_ERR,
-                                      L"AkaoColl"));
+                                      "AkaoColl"));
         art = &sampcoll->akArts.back();
       }
       else

--- a/src/main/formats/AkaoFormat.h
+++ b/src/main/formats/AkaoFormat.h
@@ -13,7 +13,7 @@ class AkaoInstrSet;
 class AkaoColl final :
     public VGMColl {
  public:
-  explicit AkaoColl(std::wstring name = L"Unnamed Collection") : VGMColl(name), origInstrSet(nullptr), numAddedInstrs(0) {}
+  explicit AkaoColl(std::string name = "Unnamed Collection") : VGMColl(name), origInstrSet(nullptr), numAddedInstrs(0) {}
 
   bool LoadMain() override;
   void PreSynthFileCreation() override;

--- a/src/main/formats/AkaoInstr.cpp
+++ b/src/main/formats/AkaoInstr.cpp
@@ -15,7 +15,7 @@ AkaoInstrSet::AkaoInstrSet(RawFile *file,
                            uint32_t instrOff,
                            uint32_t dkitOff,
                            uint32_t theID,
-                           std::wstring name)
+                           std::string name)
     : VGMInstrSet(AkaoFormat::name, file, 0, length, std::move(name)), version_(version) {
   allowEmptyInstrs = true;
   id = theID;
@@ -32,7 +32,7 @@ AkaoInstrSet::AkaoInstrSet(RawFile *file,
 
 AkaoInstrSet::AkaoInstrSet(RawFile *file, uint32_t end_boundary_offset,
   AkaoPs1Version version, std::set<uint32_t> custom_instrument_addresses,
-  std::set<uint32_t> drum_instrument_addresses, std::wstring name)
+  std::set<uint32_t> drum_instrument_addresses, std::string name)
   : VGMInstrSet(AkaoFormat::name, file, 0, 0, std::move(name)), bMelInstrs(false), bDrumKit(false),
   instrSetOff(0), drumkitOff(0), end_boundary_offset(end_boundary_offset), version_(version)
 {
@@ -58,7 +58,7 @@ AkaoInstrSet::AkaoInstrSet(RawFile *file, uint32_t end_boundary_offset,
 }
 
 AkaoInstrSet::AkaoInstrSet(RawFile *file, uint32_t offset,
-  uint32_t end_boundary_offset, AkaoPs1Version version, wstring name)
+  uint32_t end_boundary_offset, AkaoPs1Version version, string name)
     : VGMInstrSet(AkaoFormat::name, file, offset, 0, std::move(name)), bMelInstrs(false),
       bDrumKit(false), instrSetOff(0), drumkitOff(0), end_boundary_offset(end_boundary_offset),
       version_(version)
@@ -68,11 +68,11 @@ AkaoInstrSet::AkaoInstrSet(RawFile *file, uint32_t offset,
 
 bool AkaoInstrSet::GetInstrPointers() {
   if (bMelInstrs) {
-    VGMHeader *SSEQHdr = AddHeader(instrSetOff, 0x10, L"Instr Ptr Table");
+    VGMHeader *SSEQHdr = AddHeader(instrSetOff, 0x10, "Instr Ptr Table");
     int i = 0;
     //-1 aka 0xFFFF if signed or 0 and past the first pointer value
     for (int j = instrSetOff; (GetShort(j) != static_cast<uint16_t>(-1)) && ((GetShort(j) != 0) || i == 0) && i < 16; j += 2) {
-      SSEQHdr->AddSimpleItem(j, 2, L"Instr Pointer");
+      SSEQHdr->AddSimpleItem(j, 2, "Instr Pointer");
       aInstrs.push_back(new AkaoInstr(this, instrSetOff + 0x20 + GetShort(j), 0, 1, i++));
     }
   }
@@ -101,7 +101,7 @@ bool AkaoInstrSet::GetInstrPointers() {
 // *********
 
 AkaoInstr::AkaoInstr(AkaoInstrSet *instrSet, uint32_t offset, uint32_t length, uint32_t theBank,
-                     uint32_t theInstrNum, std::wstring name)
+                     uint32_t theInstrNum, std::string name)
     : VGMInstr(instrSet, offset, length, theBank, theInstrNum, std::move(name)), bDrumKit(false) {
 }
 
@@ -109,13 +109,13 @@ bool AkaoInstr::LoadInstr() {
   for (int k = 0; dwOffset + k * 8 < GetRawFile()->size(); k++) {
     if (version() < AkaoPs1Version::VERSION_3_0) {
       if (GetByte(dwOffset + k * 8) >= 0x80) {
-        AddSimpleItem(dwOffset + k * 8, 8, L"Region Terminator");
+        AddSimpleItem(dwOffset + k * 8, 8, "Region Terminator");
         break;
       }
     }
     else {
       if (GetByte(dwOffset + k * 8 + 5) == 0) {
-        AddSimpleItem(dwOffset + k * 8, 8, L"Region Terminator");
+        AddSimpleItem(dwOffset + k * 8, 8, "Region Terminator");
         break;
       }
     }
@@ -130,7 +130,7 @@ bool AkaoInstr::LoadInstr() {
   SetGuessedLength();
 
   if (aRgns.empty())
-    pRoot->AddLogItem(new LogItem(L"Instrument has no regions.", LOG_LEVEL_WARN, L"AkaoInstr"));
+    pRoot->AddLogItem(new LogItem("Instrument has no regions.", LOG_LEVEL_WARN, "AkaoInstr"));
 
   return true;
 }
@@ -141,7 +141,7 @@ bool AkaoInstr::LoadInstr() {
 
 AkaoDrumKit::AkaoDrumKit(AkaoInstrSet *instrSet, uint32_t offset, uint32_t length, uint32_t theBank,
                          uint32_t theInstrNum)
-    : AkaoInstr(instrSet, offset, length, theBank, theInstrNum, L"Drum Kit") {
+    : AkaoInstr(instrSet, offset, length, theBank, theInstrNum, "Drum Kit") {
   bDrumKit = true;
 }
 
@@ -170,18 +170,18 @@ bool AkaoDrumKit::LoadInstr() {
       const uint8_t raw_volume = GetByte(rgn_offset + 6);
       const double volume = raw_volume == 0 ? 1.0 : raw_volume / 128.0;
       rgn->SetVolume(volume);
-      rgn->AddGeneralItem(rgn_offset, 1, L"Associated Articulation ID");
-      rgn->AddGeneralItem(rgn_offset + 1, 1, L"Relative Unity Key");
+      rgn->AddGeneralItem(rgn_offset, 1, "Associated Articulation ID");
+      rgn->AddGeneralItem(rgn_offset + 1, 1, "Relative Unity Key");
       // TODO: set ADSR to the region
-      rgn->AddGeneralItem(rgn_offset + 2, 1, L"ADSR Attack Rate");
-      rgn->AddGeneralItem(rgn_offset + 3, 1, L"ADSR Sustain Rate");
-      rgn->AddGeneralItem(rgn_offset + 4, 1, L"ADSR Sustain Mode");
-      rgn->AddGeneralItem(rgn_offset + 5, 1, L"ADSR Release Rate");
-      rgn->AddGeneralItem(rgn_offset + 6, 1, L"Attenuation");
+      rgn->AddGeneralItem(rgn_offset + 2, 1, "ADSR Attack Rate");
+      rgn->AddGeneralItem(rgn_offset + 3, 1, "ADSR Sustain Rate");
+      rgn->AddGeneralItem(rgn_offset + 4, 1, "ADSR Sustain Mode");
+      rgn->AddGeneralItem(rgn_offset + 5, 1, "ADSR Release Rate");
+      rgn->AddGeneralItem(rgn_offset + 6, 1, "Attenuation");
       const uint8_t raw_pan_reverb = GetByte(rgn_offset + 7);
       const uint8_t pan = raw_pan_reverb & 0x7f;
       const bool reverb = (raw_pan_reverb & 0x80) != 0;
-      rgn->AddGeneralItem(rgn_offset + 7, 1, L"Pan & Reverb On/Off");
+      rgn->AddGeneralItem(rgn_offset + 7, 1, "Pan & Reverb On/Off");
       rgn->SetPan(pan);
       // TODO: set reverb on/off to the region
     }
@@ -206,15 +206,15 @@ bool AkaoDrumKit::LoadInstr() {
       rgn->drumRelUnityKey = GetByte(rgn_offset + 1);
       const uint16_t raw_volume = GetWord(rgn_offset + 2);
       rgn->SetVolume(raw_volume / static_cast<double>(127 * 128));
-      rgn->AddGeneralItem(rgn_offset, 1, L"Associated Articulation ID");
-      rgn->AddGeneralItem(rgn_offset + 1, 1, L"Relative Unity Key");
-      rgn->AddGeneralItem(rgn_offset + 2, 2, L"Attenuation");
+      rgn->AddGeneralItem(rgn_offset, 1, "Associated Articulation ID");
+      rgn->AddGeneralItem(rgn_offset + 1, 1, "Relative Unity Key");
+      rgn->AddGeneralItem(rgn_offset + 2, 2, "Attenuation");
       const uint8_t pan = GetByte(rgn_offset + 4);
       rgn->AddPan(pan, rgn_offset + 4, 1);
 
       // TODO: set reverb on/off to the region
       if (version() >= AkaoPs1Version::VERSION_2) {
-        rgn->AddGeneralItem(rgn_offset + 5, 1, L"Reverb On/Off");
+        rgn->AddGeneralItem(rgn_offset + 5, 1, "Reverb On/Off");
       }
     }
   }
@@ -224,7 +224,7 @@ bool AkaoDrumKit::LoadInstr() {
   SetGuessedLength();
 
   if (aRgns.empty())
-    pRoot->AddLogItem(new LogItem(L"Instrument has no regions.", LOG_LEVEL_WARN, L"AkaoInstr"));
+    pRoot->AddLogItem(new LogItem("Instrument has no regions.", LOG_LEVEL_WARN, "AkaoInstr"));
 
   return true;
 }
@@ -234,25 +234,25 @@ bool AkaoDrumKit::LoadInstr() {
 // AkaoRgn
 // *******
 AkaoRgn::AkaoRgn(VGMInstr *instr, uint32_t offset, uint32_t length, uint8_t keyLow, uint8_t keyHigh,
-                 uint8_t artIDNum, std::wstring name)
+                 uint8_t artIDNum, std::string name)
     : VGMRgn(instr, offset, length, keyLow, keyHigh, 0, 0x7F, 0, name), artNum(artIDNum),
       adsr1(0), adsr2(0), drumRelUnityKey(0) {
 }
 
-AkaoRgn::AkaoRgn(VGMInstr *instr, uint32_t offset, uint32_t length, std::wstring name)
+AkaoRgn::AkaoRgn(VGMInstr *instr, uint32_t offset, uint32_t length, std::string name)
     : VGMRgn(instr, offset, length, name), artNum(0), adsr1(0), adsr2(0), drumRelUnityKey(0) {
 }
 
 bool AkaoRgn::LoadRgn() {
-  AddGeneralItem(dwOffset + 0, 1, L"Associated Articulation ID");
+  AddGeneralItem(dwOffset + 0, 1, "Associated Articulation ID");
   artNum = GetByte(dwOffset + 0); //- first_sample_id;
   AddKeyLow(GetByte(dwOffset + 1), dwOffset + 1);
   AddKeyHigh(GetByte(dwOffset + 2), dwOffset + 2);
   // TODO: ADSR conversion?
-  AddGeneralItem(dwOffset + 3, 1, L"ADSR Attack Rate");
-  AddGeneralItem(dwOffset + 4, 1, L"ADSR Sustain Rate");
-  AddGeneralItem(dwOffset + 5, 1, L"ADSR Sustain Mode");
-  AddGeneralItem(dwOffset + 6, 1, L"ADSR Release Rate");
+  AddGeneralItem(dwOffset + 3, 1, "ADSR Attack Rate");
+  AddGeneralItem(dwOffset + 4, 1, "ADSR Sustain Rate");
+  AddGeneralItem(dwOffset + 5, 1, "ADSR Sustain Mode");
+  AddGeneralItem(dwOffset + 6, 1, "ADSR Release Rate");
   const uint8_t raw_volume = GetByte(dwOffset + 7);
   const double volume = raw_volume == 0 ? 1.0 : raw_volume / 128.0;
   AddVolume(volume, dwOffset + 7, 1);
@@ -264,13 +264,13 @@ bool AkaoRgn::LoadRgn() {
 // AkaoSampColl
 // ************
 
-AkaoSampColl::AkaoSampColl(RawFile *file, uint32_t offset, AkaoPs1Version version, std::wstring name)
+AkaoSampColl::AkaoSampColl(RawFile *file, uint32_t offset, AkaoPs1Version version, std::string name)
     : VGMSampColl(AkaoFormat::name, file, offset, 0, std::move(name)), starting_art_id(0), sample_set_id(0),
       version_(version), sample_section_size(0), nNumArts(0), arts_offset(0),
       sample_section_offset(0) {
 }
 
-AkaoSampColl::AkaoSampColl(RawFile *file, AkaoInstrDatLocation file_location, std::wstring name)
+AkaoSampColl::AkaoSampColl(RawFile *file, AkaoInstrDatLocation file_location, std::string name)
     : VGMSampColl(AkaoFormat::name, file, 0, 0, std::move(name)), starting_art_id(0), sample_set_id(0),
       version_(AkaoPs1Version::VERSION_1_0), sample_section_size(0), nNumArts(0), arts_offset(0),
       sample_section_offset(0), file_location(file_location)
@@ -339,11 +339,11 @@ bool AkaoSampColl::GetHeaderInfo() {
   if (version() >= AkaoPs1Version::VERSION_3_0) {
     VGMHeader *hdr = AddHeader(dwOffset, 0x40);
     hdr->AddSig(dwOffset, 4);
-    hdr->AddSimpleItem(dwOffset + 4, 2, L"ID");
-    hdr->AddSimpleItem(dwOffset + 0x10, 4, L"SPU Destination Address");
-    hdr->AddSimpleItem(dwOffset + 0x14, 4, L"Sample Section Size");
-    hdr->AddSimpleItem(dwOffset + 0x18, 4, L"Starting Articulation ID");
-    hdr->AddSimpleItem(dwOffset + 0x1C, 4, L"Number of Articulations");
+    hdr->AddSimpleItem(dwOffset + 4, 2, "ID");
+    hdr->AddSimpleItem(dwOffset + 0x10, 4, "SPU Destination Address");
+    hdr->AddSimpleItem(dwOffset + 0x14, 4, "Sample Section Size");
+    hdr->AddSimpleItem(dwOffset + 0x18, 4, "Starting Articulation ID");
+    hdr->AddSimpleItem(dwOffset + 0x1C, 4, "Number of Articulations");
 
     id = GetShort(0x4 + dwOffset);
     sample_section_size = GetWord(0x14 + dwOffset);
@@ -354,11 +354,11 @@ bool AkaoSampColl::GetHeaderInfo() {
   else if (version() >= AkaoPs1Version::VERSION_1_1) {
     VGMHeader *hdr = AddHeader(dwOffset, 0x40);
     hdr->AddSig(dwOffset, 4);
-    hdr->AddSimpleItem(dwOffset + 0x10, 4, L"SPU Destination Address");
-    hdr->AddSimpleItem(dwOffset + 0x14, 4, L"Sample Section Size");
-    hdr->AddSimpleItem(dwOffset + 0x18, 4, L"Starting Articulation ID");
+    hdr->AddSimpleItem(dwOffset + 0x10, 4, "SPU Destination Address");
+    hdr->AddSimpleItem(dwOffset + 0x14, 4, "Sample Section Size");
+    hdr->AddSimpleItem(dwOffset + 0x18, 4, "Starting Articulation ID");
     if (version() >= AkaoPs1Version::VERSION_1_2)
-      hdr->AddSimpleItem(dwOffset + 0x1C, 4, L"Ending Articulation ID");
+      hdr->AddSimpleItem(dwOffset + 0x1C, 4, "Ending Articulation ID");
 
     sample_section_size = GetWord(0x14 + dwOffset);
     starting_art_id = GetWord(0x18 + dwOffset);
@@ -376,8 +376,8 @@ bool AkaoSampColl::GetHeaderInfo() {
   else if (version() == AkaoPs1Version::VERSION_1_0) {
     VGMHeader *hdr = AddHeader(file_location.instrAllOffset, 0x10);
     hdr->AddSig(dwOffset, 4);
-    hdr->AddSimpleItem(file_location.instrAllOffset, 4, L"SPU Destination Address");
-    hdr->AddSimpleItem(file_location.instrAllOffset + 4, 4, L"Sample Section Size");
+    hdr->AddSimpleItem(file_location.instrAllOffset, 4, "SPU Destination Address");
+    hdr->AddSimpleItem(file_location.instrAllOffset + 4, 4, "Sample Section Size");
 
     sample_section_offset = file_location.instrAllOffset + 0x10;
     sample_section_size = GetWord(file_location.instrAllOffset + 4);
@@ -405,13 +405,13 @@ bool AkaoSampColl::GetSampleInfo() {
 
     if (version() >= AkaoPs1Version::VERSION_3_1) {
       const uint32_t art_offset = arts_offset + i * 0x10;
-      VGMHeader *ArtHdr = AddHeader(art_offset, 16, L"Articulation");
-      ArtHdr->AddSimpleItem(art_offset, 4, L"Sample Offset");
-      ArtHdr->AddSimpleItem(art_offset + 4, 4, L"Loop Point");
-      ArtHdr->AddSimpleItem(art_offset + 8, 2, L"Fine Tune");
-      ArtHdr->AddSimpleItem(art_offset + 10, 2, L"Unity Key");
-      ArtHdr->AddSimpleItem(art_offset + 12, 2, L"ADSR1");
-      ArtHdr->AddSimpleItem(art_offset + 14, 2, L"ADSR2");
+      VGMHeader *ArtHdr = AddHeader(art_offset, 16, "Articulation");
+      ArtHdr->AddSimpleItem(art_offset, 4, "Sample Offset");
+      ArtHdr->AddSimpleItem(art_offset + 4, 4, "Loop Point");
+      ArtHdr->AddSimpleItem(art_offset + 8, 2, "Fine Tune");
+      ArtHdr->AddSimpleItem(art_offset + 10, 2, "Unity Key");
+      ArtHdr->AddSimpleItem(art_offset + 12, 2, "ADSR1");
+      ArtHdr->AddSimpleItem(art_offset + 14, 2, "ADSR2");
 
       const int16_t raw_fine_tune = GetShort(art_offset + 8);
       const double freq_multiplier = (raw_fine_tune >= 0)
@@ -431,29 +431,29 @@ bool AkaoSampColl::GetSampleInfo() {
     }
     else if (version() == AkaoPs1Version::VERSION_3_0) {
       const uint32_t art_offset = arts_offset + i * 0x40;
-      VGMHeader *ArtHdr = AddHeader(art_offset, 0x40, L"Articulation");
-      ArtHdr->AddSimpleItem(art_offset, 4, L"Sample Offset");
-      ArtHdr->AddSimpleItem(art_offset + 4, 4, L"Loop Point");
-      ArtHdr->AddSimpleItem(art_offset + 8, 4, L"Base Pitch (C)");
-      ArtHdr->AddSimpleItem(art_offset + 0x0C, 4, L"Base Pitch (C#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x10, 4, L"Base Pitch (D)");
-      ArtHdr->AddSimpleItem(art_offset + 0x14, 4, L"Base Pitch (D#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x18, 4, L"Base Pitch (E)");
-      ArtHdr->AddSimpleItem(art_offset + 0x1C, 4, L"Base Pitch (F)");
-      ArtHdr->AddSimpleItem(art_offset + 0x20, 4, L"Base Pitch (F#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x24, 4, L"Base Pitch (G)");
-      ArtHdr->AddSimpleItem(art_offset + 0x28, 4, L"Base Pitch (G#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x2C, 4, L"Base Pitch (A)");
-      ArtHdr->AddSimpleItem(art_offset + 0x30, 4, L"Base Pitch (A#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x34, 4, L"Base Pitch (B)");
-      ArtHdr->AddSimpleItem(art_offset + 0x38, 1, L"ADSR Attack Rate");
-      ArtHdr->AddSimpleItem(art_offset + 0x39, 1, L"ADSR Decay Rate");
-      ArtHdr->AddSimpleItem(art_offset + 0x3A, 1, L"ADSR Sustain Level");
-      ArtHdr->AddSimpleItem(art_offset + 0x3B, 1, L"ADSR Sustain Rate");
-      ArtHdr->AddSimpleItem(art_offset + 0x3C, 1, L"ADSR Release Rate");
-      ArtHdr->AddSimpleItem(art_offset + 0x3D, 1, L"ADSR Attack Mode");
-      ArtHdr->AddSimpleItem(art_offset + 0x3E, 1, L"ADSR Sustain Mode");
-      ArtHdr->AddSimpleItem(art_offset + 0x3F, 1, L"ADSR Release Mode");
+      VGMHeader *ArtHdr = AddHeader(art_offset, 0x40, "Articulation");
+      ArtHdr->AddSimpleItem(art_offset, 4, "Sample Offset");
+      ArtHdr->AddSimpleItem(art_offset + 4, 4, "Loop Point");
+      ArtHdr->AddSimpleItem(art_offset + 8, 4, "Base Pitch (C)");
+      ArtHdr->AddSimpleItem(art_offset + 0x0C, 4, "Base Pitch (C#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x10, 4, "Base Pitch (D)");
+      ArtHdr->AddSimpleItem(art_offset + 0x14, 4, "Base Pitch (D#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x18, 4, "Base Pitch (E)");
+      ArtHdr->AddSimpleItem(art_offset + 0x1C, 4, "Base Pitch (F)");
+      ArtHdr->AddSimpleItem(art_offset + 0x20, 4, "Base Pitch (F#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x24, 4, "Base Pitch (G)");
+      ArtHdr->AddSimpleItem(art_offset + 0x28, 4, "Base Pitch (G#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x2C, 4, "Base Pitch (A)");
+      ArtHdr->AddSimpleItem(art_offset + 0x30, 4, "Base Pitch (A#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x34, 4, "Base Pitch (B)");
+      ArtHdr->AddSimpleItem(art_offset + 0x38, 1, "ADSR Attack Rate");
+      ArtHdr->AddSimpleItem(art_offset + 0x39, 1, "ADSR Decay Rate");
+      ArtHdr->AddSimpleItem(art_offset + 0x3A, 1, "ADSR Sustain Level");
+      ArtHdr->AddSimpleItem(art_offset + 0x3B, 1, "ADSR Sustain Rate");
+      ArtHdr->AddSimpleItem(art_offset + 0x3C, 1, "ADSR Release Rate");
+      ArtHdr->AddSimpleItem(art_offset + 0x3D, 1, "ADSR Attack Mode");
+      ArtHdr->AddSimpleItem(art_offset + 0x3E, 1, "ADSR Sustain Mode");
+      ArtHdr->AddSimpleItem(art_offset + 0x3F, 1, "ADSR Release Mode");
 
       const uint8_t ar = GetByte(art_offset + 0x38);
       const uint8_t dr = GetByte(art_offset + 0x39);
@@ -482,29 +482,29 @@ bool AkaoSampColl::GetSampleInfo() {
       const uint32_t spu_dest_address = GetWord(dwOffset + 0x10);
 
       const uint32_t art_offset = arts_offset + i * 0x40;
-      VGMHeader *ArtHdr = AddHeader(art_offset, 0x40, L"Articulation");
-      ArtHdr->AddSimpleItem(art_offset, 4, L"Sample Offset");
-      ArtHdr->AddSimpleItem(art_offset + 4, 4, L"Loop Point");
-      ArtHdr->AddSimpleItem(art_offset + 8, 1, L"ADSR Attack Rate");
-      ArtHdr->AddSimpleItem(art_offset + 9, 1, L"ADSR Decay Rate");
-      ArtHdr->AddSimpleItem(art_offset + 0x0A, 1, L"ADSR Sustain Level");
-      ArtHdr->AddSimpleItem(art_offset + 0x0B, 1, L"ADSR Sustain Rate");
-      ArtHdr->AddSimpleItem(art_offset + 0x0C, 1, L"ADSR Release Rate");
-      ArtHdr->AddSimpleItem(art_offset + 0x0D, 1, L"ADSR Attack Mode");
-      ArtHdr->AddSimpleItem(art_offset + 0x0E, 1, L"ADSR Sustain Mode");
-      ArtHdr->AddSimpleItem(art_offset + 0x0F, 1, L"ADSR Release Mode");
-      ArtHdr->AddSimpleItem(art_offset + 0x10, 4, L"Base Pitch (C)");
-      ArtHdr->AddSimpleItem(art_offset + 0x14, 4, L"Base Pitch (C#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x18, 4, L"Base Pitch (D)");
-      ArtHdr->AddSimpleItem(art_offset + 0x1C, 4, L"Base Pitch (D#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x20, 4, L"Base Pitch (E)");
-      ArtHdr->AddSimpleItem(art_offset + 0x24, 4, L"Base Pitch (F)");
-      ArtHdr->AddSimpleItem(art_offset + 0x28, 4, L"Base Pitch (F#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x2C, 4, L"Base Pitch (G)");
-      ArtHdr->AddSimpleItem(art_offset + 0x30, 4, L"Base Pitch (G#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x34, 4, L"Base Pitch (A)");
-      ArtHdr->AddSimpleItem(art_offset + 0x38, 4, L"Base Pitch (A#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x3C, 4, L"Base Pitch (B)");
+      VGMHeader *ArtHdr = AddHeader(art_offset, 0x40, "Articulation");
+      ArtHdr->AddSimpleItem(art_offset, 4, "Sample Offset");
+      ArtHdr->AddSimpleItem(art_offset + 4, 4, "Loop Point");
+      ArtHdr->AddSimpleItem(art_offset + 8, 1, "ADSR Attack Rate");
+      ArtHdr->AddSimpleItem(art_offset + 9, 1, "ADSR Decay Rate");
+      ArtHdr->AddSimpleItem(art_offset + 0x0A, 1, "ADSR Sustain Level");
+      ArtHdr->AddSimpleItem(art_offset + 0x0B, 1, "ADSR Sustain Rate");
+      ArtHdr->AddSimpleItem(art_offset + 0x0C, 1, "ADSR Release Rate");
+      ArtHdr->AddSimpleItem(art_offset + 0x0D, 1, "ADSR Attack Mode");
+      ArtHdr->AddSimpleItem(art_offset + 0x0E, 1, "ADSR Sustain Mode");
+      ArtHdr->AddSimpleItem(art_offset + 0x0F, 1, "ADSR Release Mode");
+      ArtHdr->AddSimpleItem(art_offset + 0x10, 4, "Base Pitch (C)");
+      ArtHdr->AddSimpleItem(art_offset + 0x14, 4, "Base Pitch (C#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x18, 4, "Base Pitch (D)");
+      ArtHdr->AddSimpleItem(art_offset + 0x1C, 4, "Base Pitch (D#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x20, 4, "Base Pitch (E)");
+      ArtHdr->AddSimpleItem(art_offset + 0x24, 4, "Base Pitch (F)");
+      ArtHdr->AddSimpleItem(art_offset + 0x28, 4, "Base Pitch (F#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x2C, 4, "Base Pitch (G)");
+      ArtHdr->AddSimpleItem(art_offset + 0x30, 4, "Base Pitch (G#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x34, 4, "Base Pitch (A)");
+      ArtHdr->AddSimpleItem(art_offset + 0x38, 4, "Base Pitch (A#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x3C, 4, "Base Pitch (B)");
 
       const uint32_t sample_start_address = GetWord(art_offset);
       const uint32_t loop_start_address = GetWord(art_offset + 4);
@@ -538,29 +538,29 @@ bool AkaoSampColl::GetSampleInfo() {
       const uint32_t spu_dest_address = GetWord(file_location.instrAllOffset);
 
       const uint32_t art_offset = file_location.instrDatOffset + i * 0x40;
-      VGMHeader *ArtHdr = AddHeader(art_offset, 0x40, L"Articulation");
-      ArtHdr->AddSimpleItem(art_offset, 4, L"Sample Offset");
-      ArtHdr->AddSimpleItem(art_offset + 4, 4, L"Loop Point");
-      ArtHdr->AddSimpleItem(art_offset + 8, 1, L"ADSR Attack Rate");
-      ArtHdr->AddSimpleItem(art_offset + 9, 1, L"ADSR Decay Rate");
-      ArtHdr->AddSimpleItem(art_offset + 0x0A, 1, L"ADSR Sustain Level");
-      ArtHdr->AddSimpleItem(art_offset + 0x0B, 1, L"ADSR Sustain Rate");
-      ArtHdr->AddSimpleItem(art_offset + 0x0C, 1, L"ADSR Release Rate");
-      ArtHdr->AddSimpleItem(art_offset + 0x0D, 1, L"ADSR Attack Mode");
-      ArtHdr->AddSimpleItem(art_offset + 0x0E, 1, L"ADSR Sustain Mode");
-      ArtHdr->AddSimpleItem(art_offset + 0x0F, 1, L"ADSR Release Mode");
-      ArtHdr->AddSimpleItem(art_offset + 0x10, 4, L"Base Pitch (C)");
-      ArtHdr->AddSimpleItem(art_offset + 0x14, 4, L"Base Pitch (C#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x18, 4, L"Base Pitch (D)");
-      ArtHdr->AddSimpleItem(art_offset + 0x1C, 4, L"Base Pitch (D#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x20, 4, L"Base Pitch (E)");
-      ArtHdr->AddSimpleItem(art_offset + 0x24, 4, L"Base Pitch (F)");
-      ArtHdr->AddSimpleItem(art_offset + 0x28, 4, L"Base Pitch (F#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x2C, 4, L"Base Pitch (G)");
-      ArtHdr->AddSimpleItem(art_offset + 0x30, 4, L"Base Pitch (G#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x34, 4, L"Base Pitch (A)");
-      ArtHdr->AddSimpleItem(art_offset + 0x38, 4, L"Base Pitch (A#)");
-      ArtHdr->AddSimpleItem(art_offset + 0x3C, 4, L"Base Pitch (B)");
+      VGMHeader *ArtHdr = AddHeader(art_offset, 0x40, "Articulation");
+      ArtHdr->AddSimpleItem(art_offset, 4, "Sample Offset");
+      ArtHdr->AddSimpleItem(art_offset + 4, 4, "Loop Point");
+      ArtHdr->AddSimpleItem(art_offset + 8, 1, "ADSR Attack Rate");
+      ArtHdr->AddSimpleItem(art_offset + 9, 1, "ADSR Decay Rate");
+      ArtHdr->AddSimpleItem(art_offset + 0x0A, 1, "ADSR Sustain Level");
+      ArtHdr->AddSimpleItem(art_offset + 0x0B, 1, "ADSR Sustain Rate");
+      ArtHdr->AddSimpleItem(art_offset + 0x0C, 1, "ADSR Release Rate");
+      ArtHdr->AddSimpleItem(art_offset + 0x0D, 1, "ADSR Attack Mode");
+      ArtHdr->AddSimpleItem(art_offset + 0x0E, 1, "ADSR Sustain Mode");
+      ArtHdr->AddSimpleItem(art_offset + 0x0F, 1, "ADSR Release Mode");
+      ArtHdr->AddSimpleItem(art_offset + 0x10, 4, "Base Pitch (C)");
+      ArtHdr->AddSimpleItem(art_offset + 0x14, 4, "Base Pitch (C#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x18, 4, "Base Pitch (D)");
+      ArtHdr->AddSimpleItem(art_offset + 0x1C, 4, "Base Pitch (D#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x20, 4, "Base Pitch (E)");
+      ArtHdr->AddSimpleItem(art_offset + 0x24, 4, "Base Pitch (F)");
+      ArtHdr->AddSimpleItem(art_offset + 0x28, 4, "Base Pitch (F#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x2C, 4, "Base Pitch (G)");
+      ArtHdr->AddSimpleItem(art_offset + 0x30, 4, "Base Pitch (G#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x34, 4, "Base Pitch (A)");
+      ArtHdr->AddSimpleItem(art_offset + 0x38, 4, "Base Pitch (A#)");
+      ArtHdr->AddSimpleItem(art_offset + 0x3C, 4, "Base Pitch (B)");
 
       const uint32_t sample_start_address = GetWord(art_offset);
       const uint32_t loop_start_address = GetWord(art_offset + 4);
@@ -627,18 +627,18 @@ bool AkaoSampColl::GetSampleInfo() {
   }
 
   for (const auto & sample_offset : sample_offsets) {
-    wostringstream name;
-    name << L"Sample " << samples.size();
+    ostringstream name;
+    name << "Sample " << samples.size();
 
     bool loop;
     const uint32_t offset = sample_section_offset + sample_offset;
     if (offset >= sample_section_offset + sample_section_size) {
       // Out of bounds
-      wostringstream message;
-      message << L"The sample offset of AkaoRgn exceeds the sample section size."
-        << L" Offset: 0x" << std::hex << std::uppercase << sample_offset
-        << L" (0x" << std::hex << std::uppercase << offset << L")";
-      pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, L"AkaoSampColl"));
+      ostringstream message;
+      message << "The sample offset of AkaoRgn exceeds the sample section size."
+        << " Offset: 0x" << std::hex << std::uppercase << sample_offset
+        << " (0x" << std::hex << std::uppercase << offset << ")";
+      pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, "AkaoSampColl"));
       continue;
     }
 

--- a/src/main/formats/AkaoInstr.h
+++ b/src/main/formats/AkaoInstr.h
@@ -29,9 +29,9 @@ class AkaoInstrSet final : public VGMInstrSet {
                uint32_t instrOff,
                uint32_t dkitOff,
                uint32_t id,
-               std::wstring name = L"Akao Instrument Bank");
-  AkaoInstrSet(RawFile *file, uint32_t end_boundary_offset, AkaoPs1Version version, std::set<uint32_t> custom_instrument_addresses, std::set<uint32_t> drum_instrument_addresses, std::wstring name = L"Akao Instrument Bank");
-  AkaoInstrSet(RawFile *file, uint32_t offset, uint32_t end_boundary_offset, AkaoPs1Version version, std::wstring name = L"Akao Instrument Bank (Dummy)");
+               std::string name = "Akao Instrument Bank");
+  AkaoInstrSet(RawFile *file, uint32_t end_boundary_offset, AkaoPs1Version version, std::set<uint32_t> custom_instrument_addresses, std::set<uint32_t> drum_instrument_addresses, std::string name = "Akao Instrument Bank");
+  AkaoInstrSet(RawFile *file, uint32_t offset, uint32_t end_boundary_offset, AkaoPs1Version version, std::string name = "Akao Instrument Bank (Dummy)");
   bool GetInstrPointers() override;
 
   [[nodiscard]] AkaoPs1Version version() const noexcept { return version_; }
@@ -59,7 +59,7 @@ class AkaoInstr: public VGMInstr {
             uint32_t length,
             uint32_t bank,
             uint32_t instrNum,
-            std::wstring name = L"Instrument");
+            std::string name = "Instrument");
   bool LoadInstr() override;
 
   [[nodiscard]] AkaoInstrSet * instrSet() const noexcept { return reinterpret_cast<AkaoInstrSet*>(this->parInstrSet); }
@@ -88,9 +88,9 @@ class AkaoDrumKit final : public AkaoInstr {
 class AkaoRgn final :
     public VGMRgn {
  public:
-  AkaoRgn(VGMInstr *instr, uint32_t offset, uint32_t length = 0, std::wstring name = L"Region");
+  AkaoRgn(VGMInstr *instr, uint32_t offset, uint32_t length = 0, std::string name = "Region");
   AkaoRgn(VGMInstr *instr, uint32_t offset, uint32_t length, uint8_t keyLow, uint8_t keyHigh,
-          uint8_t artIDNum, std::wstring name = L"Region");
+          uint8_t artIDNum, std::string name = "Region");
 
   bool LoadRgn() override;
 
@@ -122,8 +122,8 @@ struct AkaoArt {
 class AkaoSampColl final :
     public VGMSampColl {
  public:
-   AkaoSampColl(RawFile *file, uint32_t offset, AkaoPs1Version version, std::wstring name = L"Akao Sample Collection");
-   AkaoSampColl(RawFile *file, AkaoInstrDatLocation file_location, std::wstring name = L"Akao Sample Collection");
+   AkaoSampColl(RawFile *file, uint32_t offset, AkaoPs1Version version, std::string name = "Akao Sample Collection");
+   AkaoSampColl(RawFile *file, AkaoInstrDatLocation file_location, std::string name = "Akao Sample Collection");
 
   bool GetHeaderInfo() override;
   bool GetSampleInfo() override;

--- a/src/main/formats/AkaoScanner.cpp
+++ b/src/main/formats/AkaoScanner.cpp
@@ -75,23 +75,23 @@ void AkaoScanner::Scan(RawFile *file, void *info) {
 }
 
 AkaoPs1Version AkaoScanner::DetermineVersionFromTag(RawFile *file) noexcept {
-  const std::wstring & album = file->tag.album;
-  if (album == L"Final Fantasy 7" || album == L"Final Fantasy VII")
+  const std::string & album = file->tag.album;
+  if (album == "Final Fantasy 7" || album == "Final Fantasy VII")
     return AkaoPs1Version::VERSION_1_0;
-  else if (album == L"SaGa Frontier")
+  else if (album == "SaGa Frontier")
     return AkaoPs1Version::VERSION_1_1;
-  else if (album == L"Front Mission 2" || album == L"Chocobo's Mysterious Dungeon")
+  else if (album == "Front Mission 2" || album == "Chocobo's Mysterious Dungeon")
     return AkaoPs1Version::VERSION_1_2;
-  else if (album == L"Parasite Eve")
+  else if (album == "Parasite Eve")
     return AkaoPs1Version::VERSION_2;
-  else if (album == L"Another Mind")
+  else if (album == "Another Mind")
     return AkaoPs1Version::VERSION_3_0;
-  else if (album == L"Chocobo Dungeon 2" || album == L"Final Fantasy 8" || album == L"Final Fantasy VIII"
-    || album == L"Chocobo Racing" || album == L"SaGa Frontier 2" || album == L"Racing Lagoon")
+  else if (album == "Chocobo Dungeon 2" || album == "Final Fantasy 8" || album == "Final Fantasy VIII"
+    || album == "Chocobo Racing" || album == "SaGa Frontier 2" || album == "Racing Lagoon")
     return AkaoPs1Version::VERSION_3_1;
-  else if (album == L"Legend of Mana" || album == L"Front Mission 3" || album == L"Chrono Cross"
-    || album == L"Vagrant Story" || album == L"Final Fantasy 9" || album == L"Final Fantasy IX"
-    || album == L"Final Fantasy Origins - FF2")
+  else if (album == "Legend of Mana" || album == "Front Mission 3" || album == "Chrono Cross"
+    || album == "Vagrant Story" || album == "Final Fantasy 9" || album == "Final Fantasy IX"
+    || album == "Final Fantasy Origins - FF2")
     return AkaoPs1Version::VERSION_3_2;
   return AkaoPs1Version::UNKNOWN;
 }

--- a/src/main/formats/AkaoSeq.cpp
+++ b/src/main/formats/AkaoSeq.cpp
@@ -21,7 +21,7 @@ void AkaoSeq::ResetVars() {
   VGMSeq::ResetVars();
 
   condition = 0;
-  if (rawfile->tag.album == L"Final Fantasy 9" && rawfile->tag.title == L"Final Battle")
+  if (rawfile->tag.album == "Final Fantasy 9" && rawfile->tag.title == "Final Battle")
     condition = 2;
 }
 
@@ -74,13 +74,13 @@ bool AkaoSeq::GetHeaderInfo() {
   if (version() >= AkaoPs1Version::VERSION_3_0) {
     VGMHeader *hdr = AddHeader(dwOffset, 0x40);
     hdr->AddSig(dwOffset, 4);
-    hdr->AddSimpleItem(dwOffset + 0x4, 2, L"ID");
-    hdr->AddSimpleItem(dwOffset + 0x6, 2, L"Size");
-    hdr->AddSimpleItem(dwOffset + 0x8, 2, L"Reverb Type");
-    hdr->AddSimpleItem(dwOffset + 0x14, 2, L"Associated Sample Set ID");
-    hdr->AddSimpleItem(dwOffset + 0x20, 4, L"Number of Tracks (# of true bits)");
-    hdr->AddSimpleItem(dwOffset + 0x30, 4, L"Instrument Data Pointer");
-    hdr->AddSimpleItem(dwOffset + 0x34, 4, L"Drumkit Data Pointer");
+    hdr->AddSimpleItem(dwOffset + 0x4, 2, "ID");
+    hdr->AddSimpleItem(dwOffset + 0x6, 2, "Size");
+    hdr->AddSimpleItem(dwOffset + 0x8, 2, "Reverb Type");
+    hdr->AddSimpleItem(dwOffset + 0x14, 2, "Associated Sample Set ID");
+    hdr->AddSimpleItem(dwOffset + 0x20, 4, "Number of Tracks (# of true bits)");
+    hdr->AddSimpleItem(dwOffset + 0x30, 4, "Instrument Data Pointer");
+    hdr->AddSimpleItem(dwOffset + 0x34, 4, "Drumkit Data Pointer");
 
     unLength = GetShort(dwOffset + 6);
     id = GetShort(dwOffset + 0x14);
@@ -89,10 +89,10 @@ bool AkaoSeq::GetHeaderInfo() {
   else if (version() == AkaoPs1Version::VERSION_2) {
     VGMHeader *hdr = AddHeader(dwOffset, 0x20);
     hdr->AddSig(dwOffset, 4);
-    hdr->AddSimpleItem(dwOffset + 0x4, 2, L"ID");
-    hdr->AddSimpleItem(dwOffset + 0x6, 2, L"Size (Excluding first 16 bytes)");
-    hdr->AddSimpleItem(dwOffset + 0x8, 2, L"Reverb Type");
-    hdr->AddSimpleItem(dwOffset + 0x10, 4, L"Number of Tracks (# of true bits)");
+    hdr->AddSimpleItem(dwOffset + 0x4, 2, "ID");
+    hdr->AddSimpleItem(dwOffset + 0x6, 2, "Size (Excluding first 16 bytes)");
+    hdr->AddSimpleItem(dwOffset + 0x8, 2, "Reverb Type");
+    hdr->AddSimpleItem(dwOffset + 0x10, 4, "Number of Tracks (# of true bits)");
 
     unLength = 0x10 + GetShort(dwOffset + 6);
     track_header_offset = 0x20;
@@ -100,13 +100,13 @@ bool AkaoSeq::GetHeaderInfo() {
   else if (version() < AkaoPs1Version::VERSION_2) {
     VGMHeader *hdr = AddHeader(dwOffset, 0x14);
     hdr->AddSig(dwOffset, 4);
-    hdr->AddSimpleItem(dwOffset + 0x4, 2, L"ID");
-    hdr->AddSimpleItem(dwOffset + 0x6, 2, L"Size (Excluding first 16 bytes)");
-    hdr->AddSimpleItem(dwOffset + 0x8, 2, L"Reverb Type");
-    std::wostringstream timestamp_text;
-    timestamp_text << L"Timestamp (" << ReadTimestampAsText() << L")";
+    hdr->AddSimpleItem(dwOffset + 0x4, 2, "ID");
+    hdr->AddSimpleItem(dwOffset + 0x6, 2, "Size (Excluding first 16 bytes)");
+    hdr->AddSimpleItem(dwOffset + 0x8, 2, "Reverb Type");
+    std::ostringstream timestamp_text;
+    timestamp_text << "Timestamp (" << ReadTimestampAsText() << ")";
     hdr->AddSimpleItem(dwOffset + 0xA, 6, timestamp_text.str());
-    hdr->AddSimpleItem(dwOffset + 0x10, 4, L"Number of Tracks (# of true bits)");
+    hdr->AddSimpleItem(dwOffset + 0x10, 4, "Number of Tracks (# of true bits)");
 
     unLength = 0x10 + GetShort(dwOffset + 6);
     track_header_offset = 0x14;
@@ -115,7 +115,7 @@ bool AkaoSeq::GetHeaderInfo() {
     return false;
   }
 
-  name = L"Akao Seq";
+  name = "Akao Seq";
 
   SetPPQN(0x30);
   seq_id = GetShort(dwOffset + 4);
@@ -136,8 +136,8 @@ bool AkaoSeq::GetHeaderInfo() {
 
   VGMHeader *track_pointer_header = AddHeader(dwOffset + track_header_offset, nNumTracks * 2);
   for (unsigned int i = 0; i < nNumTracks; i++) {
-    std::wstringstream name;
-    name << L"Offset: Track " << (i + 1);
+    std::stringstream name;
+    name << "Offset: Track " << (i + 1);
     track_pointer_header->AddSimpleItem(dwOffset + track_header_offset + (i * 2), 2, name.str());
   }
 
@@ -177,7 +177,7 @@ bool AkaoSeq::GetTrackPointers() {
   return true;
 }
 
-std::wstring AkaoSeq::ReadTimestampAsText() {
+std::string AkaoSeq::ReadTimestampAsText() {
   const uint8_t year_bcd = GetByte(dwOffset + 0xA);
   const uint8_t month_bcd = GetByte(dwOffset + 0xB);
   const uint8_t day_bcd = GetByte(dwOffset + 0xC);
@@ -188,13 +188,13 @@ std::wstring AkaoSeq::ReadTimestampAsText() {
   // Should we solve the year 2000 problem?
   const unsigned int year_bcd_full = 0x1900 + year_bcd;
 
-  std::wostringstream text;
-  text << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << year_bcd_full << L"-"
-    << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << month_bcd << L"-"
-    << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << day_bcd << L"T"
-    << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << hour_bcd << L":"
-    << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << minute_bcd << L":"
-    << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << second_bcd;
+  std::ostringstream text;
+  text << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << year_bcd_full << "-"
+    << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << month_bcd << "-"
+    << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << day_bcd << "T"
+    << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << hour_bcd << ":"
+    << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << minute_bcd << ":"
+    << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << second_bcd;
   return text.str();
 }
 
@@ -218,7 +218,7 @@ AkaoInstrSet* AkaoSeq::NewInstrSet() const {
       length = unLength - (drum_set_offset() - dwOffset);
 
     return length != 0
-      ? new AkaoInstrSet(rawfile, length, version(), instrument_set_offset(), drum_set_offset(), id, L"Akao Instr Set")
+      ? new AkaoInstrSet(rawfile, length, version(), instrument_set_offset(), drum_set_offset(), id, "Akao Instr Set")
       : new AkaoInstrSet(rawfile, dwOffset, dwOffset + unLength, version());
   } else {
     return new AkaoInstrSet(rawfile, dwOffset + unLength, version(), custom_instrument_addresses, drum_instrument_addresses);
@@ -546,10 +546,10 @@ bool AkaoTrack::ReadEvent() {
   const uint32_t beginOffset = curOffset;
   const uint8_t status_byte = GetByte(curOffset++);
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
-  std::wstringstream opcode_strm;
-  opcode_strm << L"0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << status_byte;
+  std::stringstream opcode_strm;
+  opcode_strm << "0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << status_byte;
 
   const bool op_note_with_length = (version >= AkaoPs1Version::VERSION_3_0)
     && (status_byte >= 0xF0) && (status_byte <= 0xFD);
@@ -602,8 +602,8 @@ bool AkaoTrack::ReadEvent() {
     {
       MakePrevDurNoteEnd(GetTime() + dur);
       AddTime(delta_time);
-      desc << L"Length: " << delta_time << L"  Duration: " << dur;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str(), CLR_TIE);
+      desc << "Length: " << delta_time << "  Duration: " << dur;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str(), CLR_TIE);
     }
     else // rest
     {
@@ -611,7 +611,7 @@ bool AkaoTrack::ReadEvent() {
     }
   }
   else if ((status_byte >= 0x9A) && (status_byte <= 0x9F)) {
-    AddUnknown(beginOffset, curOffset - beginOffset, L"Undefined");
+    AddUnknown(beginOffset, curOffset - beginOffset, "Undefined");
     return false; // they should not be used
   }
   else {
@@ -624,7 +624,7 @@ bool AkaoTrack::ReadEvent() {
       if (event_iterator != parentSeq->sub_event_map.end())
         event = event_iterator->second;
 
-      opcode_strm << L" 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << op;
+      opcode_strm << " 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << op;
     }
     else if ((version == AkaoPs1Version::VERSION_1_2 || version == AkaoPs1Version::VERSION_2) && status_byte == 0xFC)
     {
@@ -633,7 +633,7 @@ bool AkaoTrack::ReadEvent() {
       if (event_iterator != parentSeq->sub_event_map.end())
         event = event_iterator->second;
 
-      opcode_strm << L" 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << op;
+      opcode_strm << " 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << op;
     }
     else
     {
@@ -642,7 +642,7 @@ bool AkaoTrack::ReadEvent() {
         event = event_iterator->second;
     }
 
-    const std::wstring opcode_str = opcode_strm.str();
+    const std::string opcode_str = opcode_strm.str();
 
     switch (event) {
     case EVENT_END:
@@ -662,8 +662,8 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t delta_time = GetByte(curOffset++);
       last_delta_time = one_time_delta_time = delta_time;
       use_one_time_delta_time = true;
-      desc << L"Length: " << delta_time;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Next Note Length", desc.str(), CLR_CHANGESTATE);
+      desc << "Length: " << delta_time;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Next Note Length", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
@@ -685,8 +685,8 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_length = GetByte(curOffset++);
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const int8_t semitones = GetByte(curOffset++);
-      desc << L"Length: " << length << L"  Key: " << semitones << L" semitones";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pitch Slide", desc.str(), CLR_PITCHBEND, ICON_CONTROL);
+      desc << "Length: " << length << "  Key: " << semitones << " semitones";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc.str(), CLR_PITCHBEND, ICON_CONTROL);
       break;
     }
 
@@ -726,8 +726,8 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_length = GetByte(curOffset++);
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t expression = GetByte(curOffset++);
-      desc << L"Target Expression: " << expression << L"  Duration: " << length;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Expression Slide Per Note", desc.str(), CLR_VOLUME, ICON_CONTROL);
+      desc << "Target Expression: " << expression << "  Duration: " << length;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Expression Slide Per Note", desc.str(), CLR_VOLUME, ICON_CONTROL);
       break;
     }
 
@@ -754,62 +754,62 @@ bool AkaoTrack::ReadEvent() {
       {
         const uint8_t clock = raw_clock & 0x3f;
         const int8_t signed_clock = ((clock & 0x20) != 0) ? (0x20 - (clock & 0x1f)) : clock;
-        desc << L"Clock: " << signed_clock << " (Relative)";
+        desc << "Clock: " << signed_clock << " (Relative)";
       }
       else
       {
         const uint8_t clock = raw_clock & 0x3f;
-        desc << L"Clock: " << clock;
+        desc << "Clock: " << clock;
       }
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Noise Clock", desc.str(), CLR_CHANGESTATE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Noise Clock", desc.str(), CLR_CHANGESTATE, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR_ATTACK_RATE: {
       const uint8_t ar = GetByte(curOffset++); // 0-127
-      desc << L"AR: " << ar;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR Attack Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "AR: " << ar;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Attack Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR_DECAY_RATE: {
       const uint8_t dr = GetByte(curOffset++); // 0-15
-      desc << L"DR: " << dr;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR Decay Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "DR: " << dr;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Decay Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR_SUSTAIN_LEVEL: {
       const uint8_t sl = GetByte(curOffset++); // 0-15
-      desc << L"SL: " << sl;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR Sustain Level", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "SL: " << sl;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Sustain Level", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR_DECAY_RATE_AND_SUSTAIN_LEVEL: {
       const uint8_t dr = GetByte(curOffset++); // 0-15
       const uint8_t sl = GetByte(curOffset++); // 0-15
-      desc << L"DR: " << dr << L"  SL: " << sl;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR Decay Rate & Sustain Level", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "DR: " << dr << "  SL: " << sl;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Decay Rate & Sustain Level", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR_SUSTAIN_RATE: {
       const uint8_t sr = GetByte(curOffset++); // 0-127
-      desc << L"SR: " << sr;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR Sustain Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "SR: " << sr;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Sustain Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR_RELEASE_RATE: {
       const uint8_t rr = GetByte(curOffset++); // 0-127
-      desc << L"RR: " << rr;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR Release Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "RR: " << rr;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Release Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_RESET_ADSR:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reset ADSR", L"", CLR_ADSR);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Reset ADSR", "", CLR_ADSR);
       break;
 
     case EVENT_VIBRATO: {
@@ -817,8 +817,8 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_rate = GetByte(curOffset++);
       const uint16_t rate = raw_rate == 0 ? 256 : raw_rate;
       const uint8_t type = GetByte(curOffset++); // 0-15
-      desc << L"Delay: " << delay << L"  Rate: " << rate << L"  LFO Type: " << type;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato", desc.str(), CLR_LFO, ICON_CONTROL);
+      desc << "Delay: " << delay << "  Rate: " << rate << "  LFO Type: " << type;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc.str(), CLR_LFO, ICON_CONTROL);
       break;
     }
 
@@ -826,25 +826,25 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_depth = GetByte(curOffset++);
       const uint8_t depth = raw_depth & 0x7f;
       const uint8_t depth_type = (raw_depth & 0x80) >> 7;
-      desc << L"Depth: " << depth;
+      desc << "Depth: " << depth;
       if (depth_type == 0) {
-        desc << L" (15/256 scale, approx 50 cents at maximum)";
+        desc << " (15/256 scale, approx 50 cents at maximum)";
       }
       else {
-        desc << L" (1/1 scale, approx 700 cents at maximum)";
+        desc << " (1/1 scale, approx 700 cents at maximum)";
       }
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato Depth", desc.str(), CLR_LFO);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Depth", desc.str(), CLR_LFO);
       break;
     }
 
     case EVENT_VIBRATO_OFF:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato Off", L"", CLR_LFO);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Off", "", CLR_LFO);
       break;
 
     case EVENT_ADSR_ATTACK_MODE: {
       const uint8_t ar_mode = GetByte(curOffset++);
-      desc << L"Mode: " << ar_mode;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR Attack Rate Mode", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "Mode: " << ar_mode;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Attack Rate Mode", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -853,26 +853,26 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_rate = GetByte(curOffset++);
       const uint16_t rate = raw_rate == 0 ? 256 : raw_rate;
       const uint8_t type = GetByte(curOffset++); // 0-15
-      desc << L"Delay: " << delay << L"  Rate: " << rate << L"  LFO Type: " << type;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tremolo", desc.str(), CLR_LFO, ICON_CONTROL);
+      desc << "Delay: " << delay << "  Rate: " << rate << "  LFO Type: " << type;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo", desc.str(), CLR_LFO, ICON_CONTROL);
       break;
     }
 
     case EVENT_TREMOLO_DEPTH: {
       const uint8_t depth = GetByte(curOffset++);
-      desc << L"Depth: " << depth;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tremolo Depth", desc.str(), CLR_LFO);
+      desc << "Depth: " << depth;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth", desc.str(), CLR_LFO);
       break;
     }
 
     case EVENT_TREMOLO_OFF:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tremolo Off", L"", CLR_LFO);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Off", "", CLR_LFO);
       break;
 
     case EVENT_ADSR_SUSTAIN_MODE: {
       const uint8_t sr_mode = GetByte(curOffset++);
-      desc << L"Mode: " << sr_mode;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR Sustain Rate Mode", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "Mode: " << sr_mode;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Sustain Rate Mode", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -880,26 +880,26 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_rate = GetByte(curOffset++);
       const uint16_t rate = raw_rate == 0 ? 256 : raw_rate;
       const uint8_t type = GetByte(curOffset++); // 0-15
-      desc << L"Rate: " << rate << L"  LFO Type: " << type;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan LFO", desc.str(), CLR_LFO, ICON_CONTROL);
+      desc << "Rate: " << rate << "  LFO Type: " << type;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO", desc.str(), CLR_LFO, ICON_CONTROL);
       break;
     }
 
     case EVENT_PAN_LFO_DEPTH: {
       const uint8_t depth = GetByte(curOffset++);
-      desc << L"Depth: " << depth;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan LFO Depth", desc.str(), CLR_LFO);
+      desc << "Depth: " << depth;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Depth", desc.str(), CLR_LFO);
       break;
     }
 
     case EVENT_PAN_LFO_OFF:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan LFO Off", L"", CLR_LFO);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Off", "", CLR_LFO);
       break;
 
     case EVENT_ADSR_RELEASE_MODE: {
       const uint8_t rr_mode = GetByte(curOffset++);
-      desc << L"Mode: " << rr_mode;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR Release Rate Mode", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "Mode: " << rr_mode;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Release Rate Mode", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -911,38 +911,38 @@ bool AkaoTrack::ReadEvent() {
 
     case EVENT_TRANSPOSE_REL: {
       const int8_t key = GetByte(curOffset++);
-      AddTranspose(beginOffset, curOffset - beginOffset, transpose + key, L"Transpose (Relative)");
+      AddTranspose(beginOffset, curOffset - beginOffset, transpose + key, "Transpose (Relative)");
       break;
     }
 
     case EVENT_REVERB_ON:
       // TODO: reverb control
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reverb On", L"", CLR_REVERB);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Reverb On", "", CLR_REVERB);
       break;
 
     case EVENT_REVERB_OFF:
       // TODO: reverb control
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reverb Off", L"", CLR_REVERB);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Off", "", CLR_REVERB);
       break;
 
     case EVENT_NOISE_ON:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Noise On", L"", CLR_PROGCHANGE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Noise On", "", CLR_PROGCHANGE, ICON_CONTROL);
       break;
 
     case EVENT_NOISE_OFF:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Noise Off", L"", CLR_PROGCHANGE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Noise Off", "", CLR_PROGCHANGE, ICON_CONTROL);
       break;
 
     case EVENT_PITCH_MOD_ON:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"FM (Pitch LFO) On", L"", CLR_PROGCHANGE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) On", "", CLR_PROGCHANGE, ICON_CONTROL);
       break;
 
     case EVENT_PITCH_MOD_OFF:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"FM (Pitch LFO) Off", L"", CLR_PROGCHANGE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) Off", "", CLR_PROGCHANGE, ICON_CONTROL);
       break;
 
     case EVENT_LOOP_START:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Repeat Start", L"", CLR_LOOP, ICON_STARTREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Start", "", CLR_LOOP, ICON_STARTREP);
 
       loop_layer = (loop_layer + 1) & 3;
       loop_begin_loc[loop_layer] = curOffset;
@@ -953,8 +953,8 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_count = GetByte(curOffset++);
       const uint16_t count = raw_count == 0 ? 256 : raw_count;
 
-      desc << L"Count: " << count;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Repeat Until", desc.str(), CLR_LOOP, ICON_ENDREP);
+      desc << "Count: " << count;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Until", desc.str(), CLR_LOOP, ICON_ENDREP);
 
       loop_counter[loop_layer]++;
       if (loop_counter[loop_layer] == count)
@@ -969,7 +969,7 @@ bool AkaoTrack::ReadEvent() {
     }
 
     case EVENT_LOOP_AGAIN: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Repeat Again", L"", CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Again", "", CLR_LOOP, ICON_ENDREP);
 
       loop_counter[loop_layer]++;
       curOffset = loop_begin_loc[loop_layer];
@@ -978,16 +978,16 @@ bool AkaoTrack::ReadEvent() {
 
     case EVENT_RESET_VOICE_EFFECTS:
       // Reset noise, FM modulation, reverb, etc.
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reset Voice Effects", L"", CLR_CHANGESTATE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Reset Voice Effects", "", CLR_CHANGESTATE, ICON_CONTROL);
       break;
 
     case EVENT_SLUR_ON:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Slur On (No Key Off, No Retrigger)", L"", CLR_CHANGESTATE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Slur On (No Key Off, No Retrigger)", "", CLR_CHANGESTATE, ICON_CONTROL);
       slur = true;
       break;
 
     case EVENT_SLUR_OFF:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Slur Off", L"", CLR_CHANGESTATE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Slur Off", "", CLR_CHANGESTATE, ICON_CONTROL);
       slur = false;
       break;
 
@@ -995,7 +995,7 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_delay = GetByte(curOffset++);
       const uint16_t delay = raw_delay == 0 ? 1 : raw_delay + 1;
       desc << "Delay: " << delay;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Noise On & Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Noise On & Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
       break;
     }
 
@@ -1003,17 +1003,17 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_delay = GetByte(curOffset++);
       const uint16_t delay = raw_delay == 0 ? 1 : raw_delay + 1;
       desc << "Delay: " << delay;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Noise On/Off Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Noise On/Off Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
       break;
     }
 
     case EVENT_LEGATO_ON:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Legato On (No Key Off)", L"", CLR_CHANGESTATE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Legato On (No Key Off)", "", CLR_CHANGESTATE, ICON_CONTROL);
       legato = true;
       break;
 
     case EVENT_LEGATO_OFF:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Legato Off", L"", CLR_CHANGESTATE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Legato Off", "", CLR_CHANGESTATE, ICON_CONTROL);
       legato = false;
       break;
 
@@ -1021,7 +1021,7 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_delay = GetByte(curOffset++);
       const uint16_t delay = raw_delay == 0 ? 1 : raw_delay + 1;
       desc << "Delay: " << delay;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"FM (Pitch LFO) On & Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) On & Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
       break;
     }
 
@@ -1029,24 +1029,24 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_delay = GetByte(curOffset++);
       const uint16_t delay = raw_delay == 0 ? 1 : raw_delay + 1;
       desc << "Delay: " << delay;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"FM (Pitch LFO) On/Off Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) On/Off Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
       break;
     }
 
     case EVENT_PITCH_SIDE_CHAIN_ON:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pitch Side Chain On", L"", CLR_MISC);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Side Chain On", "", CLR_MISC);
       break;
 
     case EVENT_PITCH_SIDE_CHAIN_OFF:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pitch Side Chain Off", L"", CLR_MISC);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Side Chain Off", "", CLR_MISC);
       break;
 
     case EVENT_PITCH_TO_VOLUME_SIDE_CHAIN_ON:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pitch-Volume Side Chain On", L"", CLR_MISC);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pitch-Volume Side Chain On", "", CLR_MISC);
       break;
 
     case EVENT_PITCH_TO_VOLUME_SIDE_CHAIN_OFF:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pitch-Volume Side Chain Off", L"", CLR_MISC);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pitch-Volume Side Chain Off", "", CLR_MISC);
       break;
 
     case EVENT_TUNING_ABS:
@@ -1057,8 +1057,8 @@ bool AkaoTrack::ReadEvent() {
       const int div = tuning >= 0 ? 128 : 256;
       const double scale = tuning / static_cast<double>(div);
       const double cents = (scale / log(2.0)) * 1200.0;
-      desc << L"Tuning: " << cents << L" cents (" << tuning << L"/" << div << L")";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tuning", desc.str(), CLR_MISC, ICON_CONTROL);
+      desc << "Tuning: " << cents << " cents (" << tuning << "/" << div << ")";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tuning", desc.str(), CLR_MISC, ICON_CONTROL);
       AddFineTuningNoItem(cents);
       break;
     }
@@ -1070,8 +1070,8 @@ bool AkaoTrack::ReadEvent() {
       const int div = tuning >= 0 ? 128 : 256;
       const double scale = tuning / static_cast<double>(div);
       const double cents = (scale / log(2.0)) * 1200.0;
-      desc << L"Amount: " << relative_tuning <<  L"  Tuning: " << cents << L" cents (" << tuning << L"/" << div << L")";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tuning (Relative)", desc.str(), CLR_MISC, ICON_CONTROL);
+      desc << "Amount: " << relative_tuning <<  "  Tuning: " << cents << " cents (" << tuning << "/" << div << ")";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tuning (Relative)", desc.str(), CLR_MISC, ICON_CONTROL);
       AddFineTuningNoItem(cents);
       break;
     }
@@ -1079,15 +1079,15 @@ bool AkaoTrack::ReadEvent() {
     case EVENT_PORTAMENTO_ON: {
       const uint8_t raw_speed = GetByte(curOffset++);
       const uint16_t speed = raw_speed == 0 ? 256 : raw_speed;
-      desc << L"Time: " << speed << " tick(s)";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Portamento", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      desc << "Time: " << speed << " tick(s)";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Portamento", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
       //AddPortamentoTimeNoItem(speed);
       AddPortamentoNoItem(true);
       break;
     }
 
     case EVENT_PORTAMENTO_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Portamento Off", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Off", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
       //AddPortamentoTimeNoItem(0);
       AddPortamentoNoItem(false);
       break;
@@ -1097,8 +1097,8 @@ bool AkaoTrack::ReadEvent() {
       const int8_t relative_length = GetByte(curOffset++);
       const int16_t length = std::min(std::max(last_delta_time + relative_length, 1), 255);
       delta_time_overwrite = length;
-      desc << L"Duration (Relative Amount): " << relative_length;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Fixed Note Length", desc.str(), CLR_MISC, ICON_CONTROL);
+      desc << "Duration (Relative Amount): " << relative_length;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Fixed Note Length", desc.str(), CLR_MISC, ICON_CONTROL);
       break;
     }
 
@@ -1108,14 +1108,14 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_depth = GetByte(curOffset++);
       const uint8_t depth = raw_depth & 0x7f;
       const uint8_t depth_type = (raw_depth & 0x80) >> 7;
-      desc << L"Duration: " << length << L"  Target Depth: " << depth;
+      desc << "Duration: " << length << "  Target Depth: " << depth;
       if (depth_type == 0) {
-        desc << L" (15/256 scale, approx 50 cents at maximum)";
+        desc << " (15/256 scale, approx 50 cents at maximum)";
       }
       else {
-        desc << L" (1/1 scale, approx 700 cents at maximum)";
+        desc << " (1/1 scale, approx 700 cents at maximum)";
       }
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato Depth Slide", desc.str(), CLR_LFO, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Depth Slide", desc.str(), CLR_LFO, ICON_CONTROL);
       break;
     }
 
@@ -1123,8 +1123,8 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_length = GetByte(curOffset++);
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t depth = GetByte(curOffset++);
-      desc << L"Duration: " << length << L"  Target Depth: " << depth;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tremolo Depth Slide", desc.str(), CLR_LFO, ICON_CONTROL);
+      desc << "Duration: " << length << "  Target Depth: " << depth;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth Slide", desc.str(), CLR_LFO, ICON_CONTROL);
       break;
     }
 
@@ -1132,8 +1132,8 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_length = GetByte(curOffset++);
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t depth = GetByte(curOffset++);
-      desc << L"Duration: " << length << L"  Target Depth: " << depth;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan LFO Depth Slide", desc.str(), CLR_LFO);
+      desc << "Duration: " << length << "  Target Depth: " << depth;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Depth Slide", desc.str(), CLR_LFO);
       break;
     }
 
@@ -1141,8 +1141,8 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_length = GetByte(curOffset++);
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t rate = GetByte(curOffset++);
-      desc << L"Duration: " << length << L"  Target Rate: " << rate;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato Rate Slide", desc.str(), CLR_LFO, ICON_CONTROL);
+      desc << "Duration: " << length << "  Target Rate: " << rate;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Rate Slide", desc.str(), CLR_LFO, ICON_CONTROL);
       break;
     }
 
@@ -1150,8 +1150,8 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_length = GetByte(curOffset++);
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t rate = GetByte(curOffset++);
-      desc << L"Duration: " << length << L"  Target Rate: " << rate;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tremolo Rate Slide", desc.str(), CLR_LFO, ICON_CONTROL);
+      desc << "Duration: " << length << "  Target Rate: " << rate;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Rate Slide", desc.str(), CLR_LFO, ICON_CONTROL);
       break;
     }
 
@@ -1159,33 +1159,33 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t raw_length = GetByte(curOffset++);
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t rate = GetByte(curOffset++);
-      desc << L"Duration: " << length << L"  Target Rate: " << rate;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan LFO Rate Slide", desc.str(), CLR_LFO, ICON_CONTROL);
+      desc << "Duration: " << length << "  Target Rate: " << rate;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Rate Slide", desc.str(), CLR_LFO, ICON_CONTROL);
       break;
     }
 
     case EVENT_E0: {
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       break;
     }
 
     case EVENT_E1: {
       curOffset++;
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       break;
     }
 
     case EVENT_E2: {
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       break;
     }
 
@@ -1213,8 +1213,8 @@ bool AkaoTrack::ReadEvent() {
       const int16_t depth = GetShort(curOffset);
       curOffset += 2;
 
-      desc << L"Depth: " << depth;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reverb Depth", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Depth: " << depth;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -1224,8 +1224,8 @@ bool AkaoTrack::ReadEvent() {
       const int16_t depth = GetShort(curOffset);
       curOffset += 2;
 
-      desc << L"Duration: " << length << L"  Target Depth: " << depth;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reverb Depth Slide", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Duration: " << length << "  Target Depth: " << depth;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth Slide", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -1234,8 +1234,8 @@ bool AkaoTrack::ReadEvent() {
       curOffset += 2;
       const uint32_t drum_instrset_offset = curOffset + relative_drum_offset;
 
-      desc << L"Offset: 0x" << std::hex << std::setfill(L'0') << std::uppercase << drum_instrset_offset;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Drum Kit On", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      desc << "Offset: 0x" << std::hex << std::setfill('0') << std::uppercase << drum_instrset_offset;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Drum Kit On", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
 
       if (readMode == READMODE_ADD_TO_UI) {
         parentSeq->drum_instrument_addresses.insert(drum_instrset_offset);
@@ -1254,7 +1254,7 @@ bool AkaoTrack::ReadEvent() {
     }
 
     case EVENT_DRUM_ON_V2: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Drum Kit On", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Drum Kit On", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
       AddBankSelectNoItem(127);
       AddProgramChangeNoItem(127, false);
       drum = true;
@@ -1264,7 +1264,7 @@ bool AkaoTrack::ReadEvent() {
 
     case EVENT_DRUM_OFF:
       // TODO: restore program change for regular instrument
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Drum Kit Off", L"", CLR_PROGCHANGE, ICON_PROGCHANGE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Drum Kit Off", "", CLR_PROGCHANGE, ICON_PROGCHANGE);
       drum = false;
       break;
 
@@ -1274,14 +1274,14 @@ bool AkaoTrack::ReadEvent() {
       curOffset += 2;
       const uint32_t length = curOffset - beginOffset;
 
-      desc << L"Destination: 0x" << std::hex << std::setfill(L'0') << std::uppercase << dest;
+      desc << "Destination: 0x" << std::hex << std::setfill('0') << std::uppercase << dest;
       curOffset = dest;
 
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(beginOffset, length, L"Jump", desc.str(), CLR_LOOPFOREVER);
+        AddGenericEvent(beginOffset, length, "Jump", desc.str(), CLR_LOOPFOREVER);
       }
       else {
-        if (!AddLoopForever(beginOffset, length, L"Jump"))
+        if (!AddLoopForever(beginOffset, length, "Jump"))
           return AnyUnvisitedJumpDestinations();
       }
       break;
@@ -1294,7 +1294,7 @@ bool AkaoTrack::ReadEvent() {
       curOffset += 2;
       const uint32_t length = curOffset - beginOffset;
 
-      desc << L"Conditional Value" << target_value << L"  Destination: 0x" << std::hex << std::setfill(L'0') << std::uppercase << dest;
+      desc << "Conditional Value" << target_value << "  Destination: 0x" << std::hex << std::setfill('0') << std::uppercase << dest;
 
       if (readMode == READMODE_ADD_TO_UI) {
         // This event performs conditional jump if certain CPU variable matches to the condValue.
@@ -1314,7 +1314,7 @@ bool AkaoTrack::ReadEvent() {
           curOffset = dest;
       }
 
-      AddGenericEvent(beginOffset, length, L"CPU-Conditional Jump", desc.str(), CLR_LOOP);
+      AddGenericEvent(beginOffset, length, "CPU-Conditional Jump", desc.str(), CLR_LOOP);
       break;
     }
 
@@ -1326,8 +1326,8 @@ bool AkaoTrack::ReadEvent() {
       curOffset += 2;
       const uint32_t length = curOffset - beginOffset;
 
-      desc << L"Count: " << count << L"  Destination: 0x" << std::hex << std::setfill(L'0') << std::uppercase << dest;
-      AddGenericEvent(beginOffset, length, L"Repeat Branch", desc.str(), CLR_MISC);
+      desc << "Count: " << count << "  Destination: 0x" << std::hex << std::setfill('0') << std::uppercase << dest;
+      AddGenericEvent(beginOffset, length, "Repeat Branch", desc.str(), CLR_MISC);
 
       if (loop_counter[loop_layer] + 1 == count)
         curOffset = dest;
@@ -1343,8 +1343,8 @@ bool AkaoTrack::ReadEvent() {
       curOffset += 2;
       const uint32_t length = curOffset - beginOffset;
 
-      desc << L"Count: " << count << L"  Destination: 0x" << std::hex << std::setfill(L'0') << std::uppercase << dest;
-      AddGenericEvent(beginOffset, length, L"Repeat Break", desc.str(), CLR_MISC);
+      desc << "Count: " << count << "  Destination: 0x" << std::hex << std::setfill('0') << std::uppercase << dest;
+      AddGenericEvent(beginOffset, length, "Repeat Break", desc.str(), CLR_MISC);
 
       if (loop_counter[loop_layer] + 1 == count)
         curOffset = dest;
@@ -1357,23 +1357,23 @@ bool AkaoTrack::ReadEvent() {
       parentSeq->bUsesIndividualArts = true;
       const uint8_t artNum = GetByte(curOffset++);
       AddBankSelectNoItem(0);
-      AddProgramChange(beginOffset, curOffset - beginOffset, artNum, false, L"Program Change w/o Attack Sample");
+      AddProgramChange(beginOffset, curOffset - beginOffset, artNum, false, "Program Change w/o Attack Sample");
       break;
     }
 
     case EVENT_F3_FF7: {
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       break;
     }
 
     case EVENT_F3_SAGAFRO: {
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       break;
     }
 
@@ -1382,15 +1382,15 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t artNum = GetByte(curOffset++);
       const uint8_t artNum2 = GetByte(curOffset++);
 
-      desc << L"Program Number for Primary Voice: " << artNum << L"  Program Number for Secondary Voice: " << artNum2;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Overlay Voice On (With Program Change)", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      desc << "Program Number for Primary Voice: " << artNum << "  Program Number for Secondary Voice: " << artNum2;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Voice On (With Program Change)", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
       AddBankSelectNoItem(0);
       AddProgramChangeNoItem(artNum, false);
       break;
     }
 
     case EVENT_OVERLAY_VOICE_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Overlay Voice Off", L"", CLR_MISC, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Voice Off", "", CLR_MISC, ICON_CONTROL);
       break;
     }
 
@@ -1398,8 +1398,8 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t balance = GetByte(curOffset++);
       const int primary_percent = (127 - balance) * 100 / 256;
       const int secondary_percent = balance * 100 / 256;
-      desc << L"Balance: " << balance << L" (Primary Voice Volume " << primary_percent << "%, Secondary Voice Volume " << secondary_percent << L"%)";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Overlay Volume Balance", desc.str(), CLR_VOLUME, ICON_CONTROL);
+      desc << "Balance: " << balance << " (Primary Voice Volume " << primary_percent << "%, Secondary Voice Volume " << secondary_percent << "%)";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Volume Balance", desc.str(), CLR_VOLUME, ICON_CONTROL);
       break;
     }
 
@@ -1409,72 +1409,72 @@ bool AkaoTrack::ReadEvent() {
       const uint8_t balance = GetByte(curOffset++);
       const int primary_percent = (127 - balance) * 100 / 256;
       const int secondary_percent = balance * 100 / 256;
-      desc << L"Duration: " << length << L"  Target Balance: " << balance << L" (Primary Voice Volume " << primary_percent << "%, Secondary Voice Volume " << secondary_percent << L"%)";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Overlay Volume Balance Fade", desc.str(), CLR_VOLUME, ICON_CONTROL);
+      desc << "Duration: " << length << "  Target Balance: " << balance << " (Primary Voice Volume " << primary_percent << "%, Secondary Voice Volume " << secondary_percent << "%)";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Volume Balance Fade", desc.str(), CLR_VOLUME, ICON_CONTROL);
       break;
     }
 
     case EVENT_ALTERNATE_VOICE_ON: {
       const uint8_t rr = GetByte(curOffset++); // 0-127
-      desc << L"Release Rate: " << rr;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Alternate Voice On", desc.str(), CLR_MISC);
+      desc << "Release Rate: " << rr;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Alternate Voice On", desc.str(), CLR_MISC);
       break;
     }
 
     case EVENT_ALTERNATE_VOICE_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Alternate Voice Off", L"", CLR_MISC);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Alternate Voice Off", "", CLR_MISC);
       break;
     }
 
     case EVENT_FC_0C: {
       curOffset += 2;
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       break;
     }
 
     case EVENT_FC_0D: {
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       break;
     }
 
     case EVENT_FC_0E: {
       curOffset++;
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       break;
     }
 
     case EVENT_FC_0F: {
       curOffset += 2;
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       break;
     }
 
     case EVENT_FC_10: {
       curOffset++;
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       break;
     }
 
     case EVENT_FC_11: {
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       break;
     }
 
@@ -1484,8 +1484,8 @@ bool AkaoTrack::ReadEvent() {
       curOffset += 2;
       const uint32_t length = curOffset - beginOffset;
 
-      desc << L"Destination: 0x" << std::hex << std::setfill(L'0') << std::uppercase << dest;
-      AddGenericEvent(beginOffset, length, L"Play Pattern", desc.str(), CLR_MISC);
+      desc << "Destination: 0x" << std::hex << std::setfill('0') << std::uppercase << dest;
+      AddGenericEvent(beginOffset, length, "Play Pattern", desc.str(), CLR_MISC);
 
       pattern_return_offset = curOffset;
       curOffset = dest;
@@ -1493,22 +1493,22 @@ bool AkaoTrack::ReadEvent() {
     }
 
     case EVENT_END_PATTERN: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"End Pattern", L"", CLR_MISC);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "End Pattern", "", CLR_MISC);
       curOffset = pattern_return_offset;
       break;
     }
 
     case EVENT_ALLOC_RESERVED_VOICES: {
       const uint8_t count = GetByte(curOffset++);
-      desc << L"Number of Voices: " << count;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Allocate Reserved Voices", desc.str(), CLR_MISC);
+      desc << "Number of Voices: " << count;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Allocate Reserved Voices", desc.str(), CLR_MISC);
       break;
     }
 
     case EVENT_FREE_RESERVED_VOICES: {
       const uint8_t count = 0;
-      desc << L"Number of Voices: " << count;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Free Reserved Voices", desc.str(), CLR_MISC);
+      desc << "Number of Voices: " << count;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Free Reserved Voices", desc.str(), CLR_MISC);
       break;
     }
 
@@ -1520,7 +1520,7 @@ bool AkaoTrack::ReadEvent() {
         const uint8_t denom = static_cast<uint8_t>((parentSeq->ppqn * 4) / ticksPerBeat); // or should it always be 4? no idea
         AddTimeSig(beginOffset, curOffset - beginOffset, beatsPerMeasure, denom, ticksPerBeat);
       } else {
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Time Signature", L"", CLR_TIMESIG, ICON_TIMESIG);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Time Signature", "", CLR_TIMESIG, ICON_TIMESIG);
       }
       break;
     }
@@ -1528,8 +1528,8 @@ bool AkaoTrack::ReadEvent() {
     case EVENT_MEASURE: {
       const uint16_t measure = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Measure: " << measure;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Marker (Measure Number)", desc.str(), CLR_MISC);
+      desc << "Measure: " << measure;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Marker (Measure Number)", desc.str(), CLR_MISC);
       // TODO: write midi marker event
       break;
     }
@@ -1538,10 +1538,10 @@ bool AkaoTrack::ReadEvent() {
       // Chrono Cross - 114 Shadow Forest
       // Chrono Cross - 119 Hydra Marshes
       // Chrono Cross - 302 Chronopolis
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_WARN, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_WARN, "AkaoSeq"));
       break;
     }
 
@@ -1550,8 +1550,8 @@ bool AkaoTrack::ReadEvent() {
       curOffset += 2;
       const uint32_t key_split_regions_offset = curOffset + relative_key_split_regions_offset;
 
-      desc << L"Offset: 0x" << std::hex << std::setfill(L'0') << std::uppercase << key_split_regions_offset;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Program Change (Key-Split Instrument)", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      desc << "Offset: 0x" << std::hex << std::setfill('0') << std::uppercase << key_split_regions_offset;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Program Change (Key-Split Instrument)", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
 
       if (readMode == READMODE_ADD_TO_UI) {
         parentSeq->custom_instrument_addresses.insert(key_split_regions_offset);
@@ -1569,32 +1569,32 @@ bool AkaoTrack::ReadEvent() {
     case EVENT_PROGCHANGE_KEY_SPLIT_V2: {
       const uint8_t progNum = GetByte(curOffset++);
       AddBankSelectNoItem(1);
-      AddProgramChange(beginOffset, curOffset - beginOffset, progNum, false, L"Program Change (Key-Split Instrument)");
+      AddProgramChange(beginOffset, curOffset - beginOffset, progNum, false, "Program Change (Key-Split Instrument)");
       break;
     }
 
     case EVENT_FE_1C: {
       curOffset++;
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_WARN, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_WARN, "AkaoSeq"));
       break;
     }
 
     case EVENT_USE_RESERVED_VOICES:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Use Reserved Voices", L"", CLR_MISC);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Use Reserved Voices", "", CLR_MISC);
       break;
 
     case EVENT_USE_NO_RESERVED_VOICES:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Use No Reserved Voices", L"", CLR_MISC);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Use No Reserved Voices", "", CLR_MISC);
       break;
 
     default:
-      desc << L"Filename: " << parentSeq->rawfile->GetFileName() << L" Event: " << opcode_str
-        << " Address: 0x" << std::hex << std::setfill(L'0') << std::uppercase << beginOffset;
+      desc << "Filename: " << parentSeq->rawfile->GetFileName() << " Event: " << opcode_str
+        << " Address: 0x" << std::hex << std::setfill('0') << std::uppercase << beginOffset;
       AddUnknown(beginOffset, curOffset - beginOffset);
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, L"AkaoSeq"));
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()), LOG_LEVEL_ERR, "AkaoSeq"));
       return false;
     }
   }

--- a/src/main/formats/AkaoSeq.h
+++ b/src/main/formats/AkaoSeq.h
@@ -145,7 +145,7 @@ class AkaoSeq final :
 
   [[nodiscard]] AkaoPs1Version version() const noexcept { return version_; }
 
-  [[nodiscard]] std::wstring ReadTimestampAsText();
+  [[nodiscard]] std::string ReadTimestampAsText();
   [[nodiscard]] double GetTempoInBPM(uint16_t tempo) const;
 
   [[nodiscard]] AkaoInstrSet* NewInstrSet() const;

--- a/src/main/formats/AkaoSnesInstr.cpp
+++ b/src/main/formats/AkaoSnesInstr.cpp
@@ -12,7 +12,7 @@ AkaoSnesInstrSet::AkaoSnesInstrSet(RawFile *file,
                                    uint16_t addrTuningTable,
                                    uint16_t addrADSRTable,
                                    uint16_t addrDrumKitTable,
-                                   const std::wstring &name) :
+                                   const std::string &name) :
     VGMInstrSet(AkaoSnesFormat::name, file, addrTuningTable, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrTuningTable(addrTuningTable),
@@ -77,8 +77,8 @@ bool AkaoSnesInstrSet::GetInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << srcn;
+    std::ostringstream instrName;
+    instrName << "Instrument " << srcn;
     AkaoSnesInstr *newInstr = new AkaoSnesInstr(this, version, srcn, spcDirAddr, addrTuningTable, addrADSRTable, instrName.str());
     aInstrs.push_back(newInstr);
   }
@@ -88,7 +88,7 @@ bool AkaoSnesInstrSet::GetInstrPointers() {
 
   if (addrDrumKitTable) {
     // One percussion instrument covers all percussion sounds
-    AkaoSnesDrumKit *newDrumKitInstr = new AkaoSnesDrumKit(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrTuningTable, addrADSRTable, addrDrumKitTable, L"Drum Kit");
+    AkaoSnesDrumKit *newDrumKitInstr = new AkaoSnesDrumKit(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrTuningTable, addrADSRTable, addrDrumKitTable, "Drum Kit");
     aInstrs.push_back(newDrumKitInstr);
   }
 
@@ -112,7 +112,7 @@ AkaoSnesInstr::AkaoSnesInstr(VGMInstrSet *instrSet,
                              uint32_t spcDirAddr,
                              uint16_t addrTuningTable,
                              uint16_t addrADSRTable,
-                             const std::wstring &name) :
+                             const std::string &name) :
     VGMInstr(instrSet, addrTuningTable, 0, 0, srcn, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrTuningTable(addrTuningTable),
@@ -153,7 +153,7 @@ AkaoSnesDrumKit::AkaoSnesDrumKit(VGMInstrSet *instrSet,
                                  uint16_t addrTuningTable,
                                  uint16_t addrADSRTable,
                                  uint16_t addrDrumKitTable,
-                                 const std::wstring &name) :
+                                 const std::string &name) :
   VGMInstr(instrSet, addrTuningTable, 0, programNum >> 7, programNum & 0x7F, name), version(ver),
   spcDirAddr(spcDirAddr),
   addrTuningTable(addrTuningTable),
@@ -241,8 +241,8 @@ bool AkaoSnesRgn::InitializeRegion(uint8_t srcn,
     adsr1 = GetByte(addrADSRTable + srcn * 2);
     adsr2 = GetByte(addrADSRTable + srcn * 2 + 1);
 
-    AddSimpleItem(addrADSRTable + srcn * 2, 1, L"ADSR1");
-    AddSimpleItem(addrADSRTable + srcn * 2 + 1, 1, L"ADSR2");
+    AddSimpleItem(addrADSRTable + srcn * 2, 1, "ADSR1");
+    AddSimpleItem(addrADSRTable + srcn * 2 + 1, 1, "ADSR2");
   }
 
   uint8_t tuning1;
@@ -251,13 +251,13 @@ bool AkaoSnesRgn::InitializeRegion(uint8_t srcn,
     tuning1 = GetByte(addrTuningTable + srcn);
     tuning2 = 0;
 
-    AddSimpleItem(addrTuningTable + srcn, 1, L"Tuning");
+    AddSimpleItem(addrTuningTable + srcn, 1, "Tuning");
   }
   else {
     tuning1 = GetByte(addrTuningTable + srcn * 2);
     tuning2 = GetByte(addrTuningTable + srcn * 2 + 1);
 
-    AddSimpleItem(addrTuningTable + srcn * 2, 2, L"Tuning");
+    AddSimpleItem(addrTuningTable + srcn * 2, 2, "Tuning");
   }
 
   double pitch_scale;
@@ -315,9 +315,9 @@ bool AkaoSnesDrumKitRgn::InitializePercussionRegion(uint8_t percussionIndex,
                                                        uint16_t addrADSRTable,
                                                        uint16_t addrDrumKitTable)
 {
-  wostringstream newName;
+  ostringstream newName;
   
-  newName << L"Drum " << percussionIndex;
+  newName << "Drum " << percussionIndex;
   name = newName.str();
 
   uint32_t srcnOffset = addrDrumKitTable + percussionIndex * 3;
@@ -336,7 +336,7 @@ bool AkaoSnesDrumKitRgn::InitializePercussionRegion(uint8_t percussionIndex,
   unityKey = (unityKey + KEY_BIAS) - GetByte(keyOffset) + percussionIndex;
   
   AddSampNum(sampNum, srcnOffset);
-  AddSimpleItem(keyOffset, 1, L"Key");
+  AddSimpleItem(keyOffset, 1, "Key");
 
   uint8_t panValue = GetByte(panOffset);
   if (panValue < 0x80) {

--- a/src/main/formats/AkaoSnesInstr.h
+++ b/src/main/formats/AkaoSnesInstr.h
@@ -19,7 +19,7 @@ class AkaoSnesInstrSet:
                    uint16_t addrTuningTable,
                    uint16_t addrADSRTable,
                    uint16_t addrDrumKitTable,
-                   const std::wstring &name = L"AkaoSnesInstrSet");
+                   const std::string &name = "AkaoSnesInstrSet");
   virtual ~AkaoSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -48,7 +48,7 @@ class AkaoSnesInstr
                 uint32_t spcDirAddr,
                 uint16_t addrTuningTable,
                 uint16_t addrADSRTable,
-                const std::wstring &name = L"AkaoSnesInstr");
+                const std::string &name = "AkaoSnesInstr");
   virtual ~AkaoSnesInstr(void);
 
   virtual bool LoadInstr();
@@ -75,7 +75,7 @@ public:
                   uint16_t addrTuningTable,
                   uint16_t addrADSRTable,
                   uint16_t addrDrumKitTable,
-                  const std::wstring &name = L"AkaoSnesDrumKit");
+                  const std::string &name = "AkaoSnesDrumKit");
   virtual ~AkaoSnesDrumKit(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/AkaoSnesScanner.cpp
+++ b/src/main/formats/AkaoSnesScanner.cpp
@@ -328,7 +328,7 @@ void AkaoSnesScanner::Scan(RawFile *file, void *info) {
 void AkaoSnesScanner::SearchForAkaoSnesFromARAM(RawFile *file) {
   AkaoSnesVersion version = AKAOSNES_NONE;
   AkaoSnesMinorVersion minorVersion = AKAOSNES_NOMINORVERSION;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   // search for note length table
   uint32_t ofsReadNoteLength;

--- a/src/main/formats/AkaoSnesScanner.h
+++ b/src/main/formats/AkaoSnesScanner.h
@@ -8,7 +8,7 @@ class AkaoSnesScanner:
     public VGMScanner {
  public:
   AkaoSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~AkaoSnesScanner(void) {
   }

--- a/src/main/formats/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnesSeq.cpp
@@ -16,7 +16,7 @@ AkaoSnesSeq::AkaoSnesSeq(RawFile *file,
                          AkaoSnesMinorVersion minorVer,
                          uint32_t seqdataOffset,
                          uint32_t addrAPURelocBase,
-                         std::wstring newName)
+                         std::string newName)
     : VGMSeq(AkaoSnesFormat::name, file, seqdataOffset, 0, newName),
       version(ver),
       minorVersion(minorVer),
@@ -54,21 +54,21 @@ bool AkaoSnesSeq::GetHeaderInfo(void) {
   else {
     // Later versions are relocatable
     if (version == AKAOSNES_V3) {
-      header->AddSimpleItem(curOffset, 2, L"ROM Address Base");
+      header->AddSimpleItem(curOffset, 2, "ROM Address Base");
       addrROMRelocBase = GetShort(curOffset);
       if (minorVersion != AKAOSNES_V3_FFMQ) {
         curOffset += 2;
       }
 
-      header->AddSimpleItem(curOffset + MAX_TRACKS * 2, 2, L"End Address");
+      header->AddSimpleItem(curOffset + MAX_TRACKS * 2, 2, "End Address");
       addrSequenceEnd = GetShortAddress(curOffset + MAX_TRACKS * 2);
     }
     else if (version == AKAOSNES_V4) {
-      header->AddSimpleItem(curOffset, 2, L"ROM Address Base");
+      header->AddSimpleItem(curOffset, 2, "ROM Address Base");
       addrROMRelocBase = GetShort(curOffset);
       curOffset += 2;
 
-      header->AddSimpleItem(curOffset, 2, L"End Address");
+      header->AddSimpleItem(curOffset, 2, "End Address");
       addrSequenceEnd = GetShortAddress(curOffset);
       curOffset += 2;
     }
@@ -83,12 +83,12 @@ bool AkaoSnesSeq::GetHeaderInfo(void) {
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t addrTrackStart = GetShortAddress(curOffset);
     if (addrTrackStart != addrSequenceEnd) {
-      std::wstringstream trackName;
-      trackName << L"Track Pointer " << (trackIndex + 1);
+      std::stringstream trackName;
+      trackName << "Track Pointer " << (trackIndex + 1);
       header->AddSimpleItem(curOffset, 2, trackName.str().c_str());
     }
     else {
-      header->AddSimpleItem(curOffset, 2, L"NULL");
+      header->AddSimpleItem(curOffset, 2, "NULL");
     }
     curOffset += 2;
   }
@@ -594,7 +594,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   AkaoSnesSeqEventType eventType = (AkaoSnesSeqEventType) 0;
   std::map<uint8_t, AkaoSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -604,27 +604,27 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -632,12 +632,12 @@ bool AkaoSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -646,13 +646,13 @@ bool AkaoSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -676,7 +676,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
         uint8_t note = octave * 12 + noteIndex;
 
         if (percussion) {
-          AddNoteByDur(beginOffset, curOffset - beginOffset, noteIndex + AkaoSnesDrumKitRgn::KEY_BIAS - transpose, vel, dur, L"Percussion Note with Duration");
+          AddNoteByDur(beginOffset, curOffset - beginOffset, noteIndex + AkaoSnesDrumKitRgn::KEY_BIAS - transpose, vel, dur, "Percussion Note with Duration");
         }
         else {
           AddNoteByDur(beginOffset, curOffset - beginOffset, note, vel, dur);
@@ -686,7 +686,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
       }
       else if (noteIndex == parentSeq->STATUS_NOTEINDEX_TIE) {
         MakePrevDurNoteEnd(GetTime() + dur);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
         AddTime(len);
       }
       else {
@@ -697,13 +697,13 @@ bool AkaoSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_NOP: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
       break;
     }
 
     case EVENT_NOP1: {
       curOffset++;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
       break;
     }
 
@@ -727,10 +727,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
       uint8_t vol = GetByte(curOffset++);
 
       if (fadeLength != 0) {
-        desc << L"Fade Length: " << (int) fadeLength << L"  Volume: " << (int) vol;
+        desc << "Fade Length: " << (int) fadeLength << "  Volume: " << (int) vol;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Volume Fade",
+                        "Volume Fade",
                         desc.str().c_str(),
                         CLR_VOLUME,
                         ICON_CONTROL);
@@ -766,8 +766,8 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
       // TODO: apply volume scale
       if (fadeLength != 0) {
-        desc << L"Fade Length: " << (int) fadeLength << L"  Pan: " << (int) pan;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan Fade", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
+        desc << "Fade Length: " << (int) fadeLength << "  Pan: " << (int) pan;
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
       }
       else {
         AddPan(beginOffset, curOffset - beginOffset, midiPan);
@@ -784,20 +784,20 @@ bool AkaoSnesTrack::ReadEvent(void) {
         pitchSlideDelay = GetByte(curOffset++);
         pitchSlideLength = GetByte(curOffset++);
         pitchSlideSemitones = GetByte(curOffset++);
-        desc << L"Delay: " << (int) pitchSlideDelay << L"  Length: " << (int) pitchSlideLength << L"  Key: "
-            << (int) pitchSlideSemitones << L" semitones";
+        desc << "Delay: " << (int) pitchSlideDelay << "  Length: " << (int) pitchSlideLength << "  Key: "
+            << (int) pitchSlideSemitones << " semitones";
       }
       else { // AKAOSNES_V2
         pitchSlideSemitones = GetByte(curOffset++);
         pitchSlideDelay = GetByte(curOffset++);
         pitchSlideLength = GetByte(curOffset++);
-        desc << L"Key: " << (int) pitchSlideSemitones << L" semitones  Delay: " << (int) pitchSlideDelay
-            << L"  Length: " << (int) pitchSlideLength;
+        desc << "Key: " << (int) pitchSlideSemitones << " semitones  Delay: " << (int) pitchSlideDelay
+            << "  Length: " << (int) pitchSlideLength;
       }
 
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Slide On",
+                      "Pitch Slide On",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -807,7 +807,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_PITCH_SLIDE_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Slide Off",
+                      "Pitch Slide Off",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -817,10 +817,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_PITCH_SLIDE: {
       uint8_t pitchSlideLength = GetByte(curOffset++);
       int8_t pitchSlideSemitones = GetByte(curOffset++);
-      desc << L"Length: " << (int) pitchSlideLength << L"  Key: " << (int) pitchSlideSemitones << L" semitones";
+      desc << "Length: " << (int) pitchSlideLength << "  Key: " << (int) pitchSlideSemitones << " semitones";
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Slide",
+                      "Pitch Slide",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -831,10 +831,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
       uint8_t lfoDelay = GetByte(curOffset++);
       uint8_t lfoRate = GetByte(curOffset++);
       uint8_t lfoDepth = GetByte(curOffset++);
-      desc << L"Delay: " << (int) lfoDelay << L"  Rate: " << (int) lfoRate << L"  Depth: " << (int) lfoDepth;
+      desc << "Delay: " << (int) lfoDelay << "  Rate: " << (int) lfoRate << "  Depth: " << (int) lfoDepth;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato",
+                      "Vibrato",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -844,7 +844,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_VIBRATO_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato Off",
+                      "Vibrato Off",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -855,10 +855,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
       uint8_t lfoDelay = GetByte(curOffset++);
       uint8_t lfoRate = GetByte(curOffset++);
       uint8_t lfoDepth = GetByte(curOffset++);
-      desc << L"Delay: " << (int) lfoDelay << L"  Rate: " << (int) lfoRate << L"  Depth: " << (int) lfoDepth;
+      desc << "Delay: " << (int) lfoDelay << "  Rate: " << (int) lfoRate << "  Depth: " << (int) lfoDepth;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Tremolo",
+                      "Tremolo",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -868,7 +868,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_TREMOLO_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Tremolo Off",
+                      "Tremolo Off",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -878,10 +878,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_PAN_LFO_ON: {
       uint8_t lfoDepth = GetByte(curOffset++);
       uint8_t lfoRate = GetByte(curOffset++);
-      desc << L"Depth: " << (int) lfoDepth << L"  Rate: " << (int) lfoRate;
+      desc << "Depth: " << (int) lfoDepth << "  Rate: " << (int) lfoRate;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pan LFO",
+                      "Pan LFO",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -892,10 +892,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
       uint8_t lfoDelay = GetByte(curOffset++);
       uint8_t lfoRate = GetByte(curOffset++);
       uint8_t lfoDepth = GetByte(curOffset++);
-      desc << L"Delay: " << (int) lfoDelay << L"  Rate: " << (int) lfoRate << L"  Depth: " << (int) lfoDepth;
+      desc << "Delay: " << (int) lfoDelay << "  Rate: " << (int) lfoRate << "  Depth: " << (int) lfoDepth;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pan LFO",
+                      "Pan LFO",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -905,7 +905,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_PAN_LFO_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pan LFO Off",
+                      "Pan LFO Off",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -914,10 +914,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_NOISE_FREQ: {
       uint8_t newNCK = GetByte(curOffset++) & 0x1f;
-      desc << L"Noise Frequency (NCK): " << (int) newNCK;
+      desc << "Noise Frequency (NCK): " << (int) newNCK;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Noise Frequency",
+                      "Noise Frequency",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -927,7 +927,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_NOISE_ON: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Noise On",
+                      "Noise On",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -937,7 +937,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_NOISE_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Noise Off",
+                      "Noise Off",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -947,7 +947,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_PITCHMOD_ON: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Modulation On",
+                      "Pitch Modulation On",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -957,7 +957,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_PITCHMOD_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Modulation Off",
+                      "Pitch Modulation Off",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -965,12 +965,12 @@ bool AkaoSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_ECHO_ON: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo On", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -998,7 +998,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_TRANSPOSE_REL: {
       int8_t newTranspose = GetByte(curOffset++);
-      AddTranspose(beginOffset, curOffset - beginOffset, transpose + newTranspose, L"Transpose (Relative)");
+      AddTranspose(beginOffset, curOffset - beginOffset, transpose + newTranspose, "Transpose (Relative)");
       break;
     }
 
@@ -1027,10 +1027,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_VOLUME_ENVELOPE: {
       uint8_t envelopeIndex = GetByte(curOffset++);
-      desc << L"Envelope: " << (int) envelopeIndex;
+      desc << "Envelope: " << (int) envelopeIndex;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Volume Envelope",
+                      "Volume Envelope",
                       desc.str().c_str(),
                       CLR_VOLUME,
                       ICON_CONTROL);
@@ -1039,10 +1039,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_GAIN_RELEASE: {
       uint8_t gain = GetByte(curOffset++) & 0x1f;
-      desc << L"GAIN: " << (int) gain;
+      desc << "GAIN: " << (int) gain;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Release Rate (GAIN)",
+                      "Release Rate (GAIN)",
                       desc.str().c_str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -1055,10 +1055,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
         rate = 100;
       }
 
-      desc << L"Note Length: " << (int) rate << " %";
+      desc << "Note Length: " << (int) rate << " %";
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Duration Rate",
+                      "Duration Rate",
                       desc.str().c_str(),
                       CLR_DURNOTE,
                       ICON_CONTROL);
@@ -1067,10 +1067,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_ADSR_AR: {
       uint8_t newAR = GetByte(curOffset++) & 15;
-      desc << L"AR: " << (int) newAR;
+      desc << "AR: " << (int) newAR;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"ADSR Attack Rate",
+                      "ADSR Attack Rate",
                       desc.str().c_str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -1079,10 +1079,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_ADSR_DR: {
       uint8_t newDR = GetByte(curOffset++) & 7;
-      desc << L"DR: " << (int) newDR;
+      desc << "DR: " << (int) newDR;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"ADSR Decay Rate",
+                      "ADSR Decay Rate",
                       desc.str().c_str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -1091,10 +1091,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_ADSR_SL: {
       uint8_t newSL = GetByte(curOffset++) & 7;
-      desc << L"SL: " << (int) newSL;
+      desc << "SL: " << (int) newSL;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"ADSR Sustain Level",
+                      "ADSR Sustain Level",
                       desc.str().c_str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -1103,10 +1103,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_ADSR_SR: {
       uint8_t newSR = GetByte(curOffset++) & 15;
-      desc << L"SR: " << (int) newSR;
+      desc << "SR: " << (int) newSR;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"ADSR Sustain Rate",
+                      "ADSR Sustain Rate",
                       desc.str().c_str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -1116,7 +1116,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_ADSR_DEFAULT: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Default ADSR",
+                      "Default ADSR",
                       desc.str().c_str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -1129,8 +1129,8 @@ bool AkaoSnesTrack::ReadEvent(void) {
         count++;
       }
 
-      desc << L"Loop Count: " << (int) count;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      desc << "Loop Count: " << (int) count;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
 
       loopStart[loopLevel] = curOffset;
       if (parentSeq->version == AKAOSNES_V4) {
@@ -1156,7 +1156,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
         curOffset = loopStart[prevLoopLevel];
       }
       else {
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
         if (loopDecCount[prevLoopLevel] - 1 == 0) {
           // repeat end
@@ -1184,7 +1184,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_SLUR_ON: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Slur On (No Key Off/On)",
+                      "Slur On (No Key Off/On)",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -1195,7 +1195,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_SLUR_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Slur Off",
+                      "Slur Off",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -1206,7 +1206,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_LEGATO_ON: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Legato On (No Key Off)",
+                      "Legato On (No Key Off)",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -1217,7 +1217,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_LEGATO_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Legato Off",
+                      "Legato Off",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -1228,16 +1228,16 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_ONETIME_DURATION: {
       uint8_t dur = GetByte(curOffset++);
       onetimeDuration = dur;
-      desc << L"Duration: " << (int) dur;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Duration (One-Time)", desc.str().c_str(), CLR_DURNOTE);
+      desc << "Duration: " << (int) dur;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Duration (One-Time)", desc.str().c_str(), CLR_DURNOTE);
       break;
     }
 
     case EVENT_JUMP_TO_SFX_LO: {
       // TODO: EVENT_JUMP_TO_SFX_LO
       uint8_t sfxIndex = GetByte(curOffset++);
-      desc << L"SFX: " << (int) sfxIndex;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Jump to SFX (LOWORD)", desc.str().c_str());
+      desc << "SFX: " << (int) sfxIndex;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Jump to SFX (LOWORD)", desc.str().c_str());
       bContinue = false;
       break;
     }
@@ -1245,8 +1245,8 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_JUMP_TO_SFX_HI: {
       // TODO: EVENT_JUMP_TO_SFX_HI
       uint8_t sfxIndex = GetByte(curOffset++);
-      desc << L"SFX: " << (int) sfxIndex;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Jump to SFX (HIWORD)", desc.str().c_str());
+      desc << "SFX: " << (int) sfxIndex;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Jump to SFX (HIWORD)", desc.str().c_str());
       bContinue = false;
       break;
     }
@@ -1254,8 +1254,8 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_PLAY_SFX: {
       // TODO: EVENT_PLAY_SFX
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Play SFX", desc.str().c_str());
+      desc << "Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Play SFX", desc.str().c_str());
       break;
     }
 
@@ -1290,8 +1290,8 @@ bool AkaoSnesTrack::ReadEvent(void) {
       }
 
       if (fadeLength != 0) {
-        desc << L"Fade Length: " << (int) fadeLength << L"  BPM: " << parentSeq->GetTempoInBPM(newTempo);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tempo Fade", desc.str().c_str(), CLR_TEMPO, ICON_TEMPO);
+        desc << "Fade Length: " << (int) fadeLength << "  BPM: " << parentSeq->GetTempoInBPM(newTempo);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Tempo Fade", desc.str().c_str(), CLR_TEMPO, ICON_TEMPO);
       }
       else {
         AddTempoBPM(beginOffset, curOffset - beginOffset, parentSeq->GetTempoInBPM(newTempo));
@@ -1301,10 +1301,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_ECHO_VOLUME: {
       uint8_t vol = GetByte(curOffset++);
-      desc << L"Volume: " << (int) vol;
+      desc << "Volume: " << (int) vol;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Volume",
+                      "Echo Volume",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -1315,10 +1315,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
       uint16_t fadeLength = GetByte(curOffset++);
       int8_t vol = GetByte(curOffset++);
 
-      desc << L"Fade Length: " << (int) fadeLength << L"  Volume: " << (int) vol;
+      desc << "Fade Length: " << (int) fadeLength << "  Volume: " << (int) vol;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Volume Fade",
+                      "Echo Volume Fade",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -1328,10 +1328,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_ECHO_FEEDBACK_FIR: {
       int8_t feedback = GetByte(curOffset++);
       uint8_t filterIndex = GetByte(curOffset++);
-      desc << L"Feedback: " << (int) feedback << L"  FIR: " << (int) filterIndex;
+      desc << "Feedback: " << (int) feedback << "  FIR: " << (int) filterIndex;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Feedback & FIR",
+                      "Echo Feedback & FIR",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -1349,11 +1349,11 @@ bool AkaoSnesTrack::ReadEvent(void) {
       uint16_t dest = GetShortAddress(curOffset);
       curOffset += 2;
 
-      desc << L"Count: " << (int) count << L"  Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+      desc << "Count: " << (int) count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Loop Break / Jump to Volta",
+                      "Loop Break / Jump to Volta",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_ENDREP);
@@ -1394,26 +1394,26 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_GOTO: {
       uint16_t dest = GetShortAddress(curOffset);
       curOffset += 2;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       uint32_t length = curOffset - beginOffset;
 
       curOffset = dest;
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
       }
       else {
-        bContinue = AddLoopForever(beginOffset, length, L"Jump");
+        bContinue = AddLoopForever(beginOffset, length, "Jump");
       }
       break;
     }
 
     case EVENT_INC_CPU_SHARED_COUNTER: {
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Increment CPU-Shared Counter", desc.str().c_str());
+      AddUnknown(beginOffset, curOffset - beginOffset, "Increment CPU-Shared Counter", desc.str().c_str());
       break;
     }
 
     case EVENT_ZERO_CPU_SHARED_COUNTER: {
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Zero CPU-Shared Counter", desc.str().c_str());
+      AddUnknown(beginOffset, curOffset - beginOffset, "Zero CPU-Shared Counter", desc.str().c_str());
       break;
     }
 
@@ -1421,10 +1421,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
       uint16_t fadeLength = GetByte(curOffset++);
       uint8_t feedback = GetByte(curOffset++);
 
-      desc << L"Fade Length: " << (int) fadeLength << L"  Feedback: " << (int) feedback;
+      desc << "Fade Length: " << (int) fadeLength << "  Feedback: " << (int) feedback;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Feedback Fade",
+                      "Echo Feedback Fade",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -1435,10 +1435,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
       uint16_t fadeLength = GetByte(curOffset++);
       uint8_t filterIndex = GetByte(curOffset++);
 
-      desc << L"Fade Length: " << (int) fadeLength << L"  FIR: " << (int) vol;
+      desc << "Fade Length: " << (int) fadeLength << "  FIR: " << (int) vol;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo FIR Fade",
+                      "Echo FIR Fade",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -1447,10 +1447,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_ECHO_FEEDBACK: {
       uint8_t feedback = GetByte(curOffset++);
-      desc << L"Feedback: " << (int) feedback;
+      desc << "Feedback: " << (int) feedback;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Feedback",
+                      "Echo Feedback",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -1459,24 +1459,24 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_ECHO_FIR: {
       uint8_t filterIndex = GetByte(curOffset++);
-      desc << L"FIR: " << (int) vol;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo FIR", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      desc << "FIR: " << (int) vol;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_CPU_CONTROLED_SET_VALUE: {
       uint8_t value = GetByte(curOffset++);
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Set Value for CPU-Controled Jump", desc.str().c_str());
+      AddUnknown(beginOffset, curOffset - beginOffset, "Set Value for CPU-Controled Jump", desc.str().c_str());
       break;
     }
 
     case EVENT_CPU_CONTROLED_JUMP: {
       uint16_t dest = GetShortAddress(curOffset);
       curOffset += 2;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase
            << (int)dest;
 
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"CPU-Controled Jump", desc.str(),
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "CPU-Controled Jump", desc.str(),
                       CLR_LOOP);
 
       if (jumpActivatedByMainCpu) {
@@ -1494,16 +1494,16 @@ bool AkaoSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++) & 15;
       uint16_t dest = GetShortAddress(curOffset);
       curOffset += 2;
-      desc << L"Arg1: " << (int)arg1 << L"  Destination: $" << std::hex << std::setfill(L'0')
+      desc << "Arg1: " << (int)arg1 << "  Destination: $" << std::hex << std::setfill('0')
            << std::setw(4) << std::uppercase << (int)dest;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"CPU-Controled Jump", desc.str().c_str());
+      AddUnknown(beginOffset, curOffset - beginOffset, "CPU-Controled Jump", desc.str().c_str());
       break;
     }
 
     case EVENT_PERC_ON: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Percussion On",
+                      "Percussion On",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -1515,7 +1515,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_PERC_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Percussion Off",
+                      "Percussion Off",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -1529,7 +1529,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
       // apparently, it is caused by wrong destination address of conditional branch
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Ignore Master Volume (Broken)",
+                      "Ignore Master Volume (Broken)",
                       desc.str().c_str(),
                       CLR_VOLUME,
                       ICON_CONTROL);
@@ -1539,7 +1539,7 @@ bool AkaoSnesTrack::ReadEvent(void) {
     case EVENT_IGNORE_MASTER_VOLUME: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Ignore Master Volume",
+                      "Ignore Master Volume",
                       desc.str().c_str(),
                       CLR_VOLUME,
                       ICON_CONTROL);
@@ -1548,10 +1548,10 @@ bool AkaoSnesTrack::ReadEvent(void) {
 
     case EVENT_IGNORE_MASTER_VOLUME_BY_PROGNUM: {
       ignoreMasterVolumeProgNum = GetByte(curOffset++);
-      desc << L"Program Number: " << (int) ignoreMasterVolumeProgNum;
+      desc << "Program Number: " << (int) ignoreMasterVolumeProgNum;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Ignore Master Volume By Program Number",
+                      "Ignore Master Volume By Program Number",
                       desc.str().c_str(),
                       CLR_VOLUME,
                       ICON_CONTROL);
@@ -1565,17 +1565,17 @@ bool AkaoSnesTrack::ReadEvent(void) {
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"AkaoSnesSeq"));
+                                    "AkaoSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnesSeq.h
@@ -96,7 +96,7 @@ class AkaoSnesSeq
               AkaoSnesMinorVersion minorVer,
               uint32_t seqdataOffset,
               uint32_t addrAPURelocBase,
-              std::wstring newName = L"Square AKAO SNES Seq");
+              std::string newName = "Square AKAO SNES Seq");
   virtual ~AkaoSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/CPSInstr.cpp
+++ b/src/main/formats/CPSInstr.cpp
@@ -12,7 +12,7 @@ using namespace std;
 // ****************
 
 
-CPSArticTable::CPSArticTable(RawFile *file, std::wstring &name, uint32_t offset, uint32_t length)
+CPSArticTable::CPSArticTable(RawFile *file, std::string &name, uint32_t offset, uint32_t length)
     : VGMMiscFile(CPSFormat::name, file, offset, length, name) {
 }
 
@@ -32,15 +32,15 @@ bool CPSArticTable::LoadMain() {
       continue;
 
 
-    wostringstream name;
-    name << L"Articulation " << i;
+    ostringstream name;
+    name << "Articulation " << i;
     VGMContainerItem *containerItem = new VGMContainerItem(this, off, sizeof(qs_artic_info), name.str());
-    containerItem->AddSimpleItem(off, 1, L"Attack Rate");
-    containerItem->AddSimpleItem(off + 1, 1, L"Decay Rate");
-    containerItem->AddSimpleItem(off + 2, 1, L"Sustain Level");
-    containerItem->AddSimpleItem(off + 3, 1, L"Sustain Rate");
-    containerItem->AddSimpleItem(off + 4, 1, L"Release Rate");
-    containerItem->AddSimpleItem(off + 5, 3, L"Unknown");
+    containerItem->AddSimpleItem(off, 1, "Attack Rate");
+    containerItem->AddSimpleItem(off + 1, 1, "Decay Rate");
+    containerItem->AddSimpleItem(off + 2, 1, "Sustain Level");
+    containerItem->AddSimpleItem(off + 3, 1, "Sustain Rate");
+    containerItem->AddSimpleItem(off + 4, 1, "Release Rate");
+    containerItem->AddSimpleItem(off + 5, 3, "Unknown");
     this->AddItem(containerItem);
   }
   //unLength = off - dwOffset;
@@ -57,7 +57,7 @@ bool CPSArticTable::LoadMain() {
 // ******************
 
 CPSSampleInfoTable::CPSSampleInfoTable(RawFile *file,
-                                       wstring &name,
+                                       string &name,
                                        uint32_t offset,
                                        uint32_t length)
     : VGMMiscFile(CPSFormat::name, file, offset, length, name) {
@@ -71,7 +71,7 @@ CPSSampleInfoTable::~CPSSampleInfoTable(void) {
 
 
 CPS2SampleInfoTable::CPS2SampleInfoTable(RawFile *file,
-                                         wstring &name,
+                                         string &name,
                                          uint32_t offset,
                                          uint32_t length)
     : CPSSampleInfoTable(file, name, offset, length) {
@@ -87,15 +87,15 @@ bool CPS2SampleInfoTable::LoadMain() {
     test1 = GetWord(off + 8);
     test2 = GetWord(off + 12);
 
-    wostringstream name;
-    name << L"Sample Info " << i;
+    ostringstream name;
+    name << "Sample Info " << i;
 
     VGMContainerItem *containerItem = new VGMContainerItem(this, off, sizeof(qs_samp_info_cps2), name.str());
-    containerItem->AddSimpleItem(off + 0, 1, L"Bank");
-    containerItem->AddSimpleItem(off + 1, 2, L"Offset");
-    containerItem->AddSimpleItem(off + 3, 2, L"Loop Offset");
-    containerItem->AddSimpleItem(off + 5, 2, L"End Offset");
-    containerItem->AddSimpleItem(off + 7, 1, L"Unity Key");
+    containerItem->AddSimpleItem(off + 0, 1, "Bank");
+    containerItem->AddSimpleItem(off + 1, 2, "Offset");
+    containerItem->AddSimpleItem(off + 3, 2, "Loop Offset");
+    containerItem->AddSimpleItem(off + 5, 2, "End Offset");
+    containerItem->AddSimpleItem(off + 7, 1, "Unity Key");
     this->AddItem(containerItem);
   }
   unLength = off - 8 - dwOffset;
@@ -132,7 +132,7 @@ bool CPS2SampleInfoTable::LoadMain() {
 
 
 CPS3SampleInfoTable::CPS3SampleInfoTable(RawFile *file,
-                                         wstring &name,
+                                         string &name,
                                          uint32_t offset,
                                          uint32_t length)
     : CPSSampleInfoTable(file, name, offset, length) {
@@ -152,14 +152,14 @@ bool CPS3SampleInfoTable::LoadMain() {
   int i=0;
   for (uint32_t off = dwOffset; off < dwOffset + unLength; off += 16) {
 
-    wostringstream name;
-    name << L"Sample Info " << i;
+    ostringstream name;
+    name << "Sample Info " << i;
 
     VGMContainerItem *containerItem = new VGMContainerItem(this, off, 16, name.str());
-    containerItem->AddSimpleItem(off + 0, 4, L"Offset");
-    containerItem->AddSimpleItem(off + 4, 4, L"Loop Offset");
-    containerItem->AddSimpleItem(off + 8, 4, L"End Offset");
-    containerItem->AddSimpleItem(off + 12, 4, L"Unity Key");
+    containerItem->AddSimpleItem(off + 0, 4, "Offset");
+    containerItem->AddSimpleItem(off + 4, 4, "Loop Offset");
+    containerItem->AddSimpleItem(off + 8, 4, "End Offset");
+    containerItem->AddSimpleItem(off + 12, 4, "Unity Key");
     this->AddItem(containerItem);
 
     sample_info& info = infos[i];
@@ -183,7 +183,7 @@ CPSInstrSet::CPSInstrSet(RawFile *file,
                          int numInstrBanks,
                          CPSSampleInfoTable *theSampInfoTable,
                          CPSArticTable *theArticTable,
-                         wstring &name)
+                         string &name)
     : VGMInstrSet(CPSFormat::name, file, offset, 0, name),
       fmt_version(version),
       num_instr_banks(numInstrBanks),
@@ -211,9 +211,9 @@ bool CPSInstrSet::GetInstrPointers() {
 
     for (uint32_t bank = 0; bank < num_instr_banks; bank++)
       for (uint32_t i = 0; i < 256; i++) {
-        std::wostringstream ss;
-        ss << L"Instrument " << bank * 256 << i;
-        wstring name = ss.str();
+        std::ostringstream ss;
+        ss << "Instrument " << bank * 256 << i;
+        string name = ss.str();
         aInstrs.push_back(new CPSInstr(this,
                                        dwOffset + i * 8 + (bank * 256 * 8),
                                        8,
@@ -247,8 +247,8 @@ bool CPSInstrSet::GetInstrPointers() {
         uint8_t bank = i;
         uint32_t bankOff = instr_table_ptrs[bank] - 0x6000000;
 
-        std::wostringstream pointersStream;
-        pointersStream << L"Bank " << bank << " Instrument Pointers";
+        std::ostringstream pointersStream;
+        pointersStream << "Bank " << bank << " Instrument Pointers";
         auto instrPointersItem = new VGMContainerItem(this->vgmfile, bankOff, 128*2, pointersStream.str(), CLR_HEADER);
 
         // For each bank, iterate over all instr ptrs and create instruments
@@ -258,13 +258,13 @@ bool CPSInstrSet::GetInstrPointers() {
           if (instrPtrOffset == 0) {
             continue;
           }
-          std::wostringstream pointerStream;
-          pointerStream << L"Instrument Pointer " << j;
+          std::ostringstream pointerStream;
+          pointerStream << "Instrument Pointer " << j;
           instrPointersItem->AddSimpleItem(bankOff + (j*2), 2, pointerStream.str());
 
-          std::wostringstream ss;
-          ss << L"Instrument " << j << " bank " << bank;
-          wstring name = ss.str();
+          std::ostringstream ss;
+          ss << "Instrument " << j << " bank " << bank;
+          string name = ss.str();
           aInstrs.push_back(new CPSInstr(this, instrPtr, 0, bank*2, j, name));
         }
         this->AddItem(instrPointersItem);
@@ -284,9 +284,9 @@ bool CPSInstrSet::GetInstrPointers() {
         if (GetShort(j) == 0 && GetByte(j + 2) == 0 && i != 0)
           break;
 
-        std::wostringstream ss;
-        ss << L"Instrument " << totalInstrs << k;
-        wstring name = ss.str();
+        std::ostringstream ss;
+        ss << "Instrument " << totalInstrs << k;
+        string name = ss.str();
         aInstrs.push_back(new CPSInstr(this, j, instr_info_length, (i * 2) + (k / 128), (k % 128), name));
       }
       totalInstrs += k;
@@ -305,7 +305,7 @@ CPSInstr::CPSInstr(VGMInstrSet *instrSet,
                    uint32_t length,
                    uint32_t theBank,
                    uint32_t theInstrNum,
-                   wstring &name)
+                   string &name)
     : VGMInstr(instrSet, offset, length, theBank, theInstrNum, name) {
 }
 
@@ -319,14 +319,14 @@ bool CPSInstr::LoadInstr() {
   if (formatVersion < VER_103) {
     VGMRgn* rgn = new VGMRgn(this, dwOffset, unLength);
     rgns.push_back(rgn);
-    rgn->AddSimpleItem(this->dwOffset,     1, L"Sample Info Index");
-    rgn->AddSimpleItem(this->dwOffset + 1, 1, L"Unknown / Ignored");
-    rgn->AddSimpleItem(this->dwOffset + 2, 1, L"Attack Rate");
-    rgn->AddSimpleItem(this->dwOffset + 3, 1, L"Decay Rate");
-    rgn->AddSimpleItem(this->dwOffset + 4, 1, L"Sustain Level");
-    rgn->AddSimpleItem(this->dwOffset + 5, 1, L"Sustain Rate");
-    rgn->AddSimpleItem(this->dwOffset + 6, 1, L"Release Rate");
-    rgn->AddSimpleItem(this->dwOffset + 7, 1, L"Unknown");
+    rgn->AddSimpleItem(this->dwOffset,     1, "Sample Info Index");
+    rgn->AddSimpleItem(this->dwOffset + 1, 1, "Unknown / Ignored");
+    rgn->AddSimpleItem(this->dwOffset + 2, 1, "Attack Rate");
+    rgn->AddSimpleItem(this->dwOffset + 3, 1, "Decay Rate");
+    rgn->AddSimpleItem(this->dwOffset + 4, 1, "Sustain Level");
+    rgn->AddSimpleItem(this->dwOffset + 5, 1, "Sustain Rate");
+    rgn->AddSimpleItem(this->dwOffset + 6, 1, "Release Rate");
+    rgn->AddSimpleItem(this->dwOffset + 7, 1, "Unknown");
 
     qs_prog_info_ver_101 progInfo;
     GetBytes(dwOffset, sizeof(qs_prog_info_ver_101), &progInfo);
@@ -345,11 +345,11 @@ bool CPSInstr::LoadInstr() {
 
     rgn->AddSampNum(progInfo.sample_index, this->dwOffset, 2);
     rgn->AddFineTune( (int16_t)((progInfo.fine_tune / 256.0) * 100), this->dwOffset + 2, 1);
-    rgn->AddSimpleItem(this->dwOffset + 3, 1, L"Attack Rate");
-    rgn->AddSimpleItem(this->dwOffset + 4, 1, L"Decay Rate");
-    rgn->AddSimpleItem(this->dwOffset + 5, 1, L"Sustain Level");
-    rgn->AddSimpleItem(this->dwOffset + 6, 1, L"Sustain Rate");
-    rgn->AddSimpleItem(this->dwOffset + 7, 1, L"Release Rate");
+    rgn->AddSimpleItem(this->dwOffset + 3, 1, "Attack Rate");
+    rgn->AddSimpleItem(this->dwOffset + 4, 1, "Decay Rate");
+    rgn->AddSimpleItem(this->dwOffset + 5, 1, "Sustain Level");
+    rgn->AddSimpleItem(this->dwOffset + 6, 1, "Sustain Rate");
+    rgn->AddSimpleItem(this->dwOffset + 7, 1, "Release Rate");
 
     this->attack_rate = progInfo.attack_rate;
     this->decay_rate = progInfo.decay_rate;
@@ -373,11 +373,11 @@ bool CPSInstr::LoadInstr() {
       rgn->keyLow = prevKeyHigh + (uint8_t)1;
       prevKeyHigh = progInfo.key_high;
       rgn->AddSampNum(progInfo.sample_index, off+5, 1);
-      rgn->AddSimpleItem(off + 7, 1, L"Attack Rate");
-      rgn->AddSimpleItem(off + 8, 1, L"Decay Rate");
-      rgn->AddSimpleItem(off + 9, 1, L"Sustain Level");
-      rgn->AddSimpleItem(off + 10, 1, L"Sustain Rate");
-      rgn->AddSimpleItem(off + 11, 1, L"Release Rate");
+      rgn->AddSimpleItem(off + 7, 1, "Attack Rate");
+      rgn->AddSimpleItem(off + 8, 1, "Decay Rate");
+      rgn->AddSimpleItem(off + 9, 1, "Sustain Level");
+      rgn->AddSimpleItem(off + 10, 1, "Sustain Rate");
+      rgn->AddSimpleItem(off + 11, 1, "Release Rate");
 
 
       this->attack_rate = progInfo.attack_rate;
@@ -389,14 +389,14 @@ bool CPSInstr::LoadInstr() {
     unLength = off - dwOffset;
   }
   else {
-    VGMRgn* rgn = new VGMRgn(this, dwOffset, unLength, L"Region");
+    VGMRgn* rgn = new VGMRgn(this, dwOffset, unLength, "Region");
     rgns.push_back(rgn);
     qs_prog_info_ver_130 progInfo;
     GetBytes(dwOffset, sizeof(qs_prog_info_ver_130), &progInfo);
 
-    rgn->AddSimpleItem(this->dwOffset,     2, L"Sample Info Index");
-    rgn->AddSimpleItem(this->dwOffset + 2, 1, L"Unknown");
-    rgn->AddSimpleItem(this->dwOffset + 3, 1, L"Articulation Index");
+    rgn->AddSimpleItem(this->dwOffset,     2, "Sample Info Index");
+    rgn->AddSimpleItem(this->dwOffset + 2, 1, "Unknown");
+    rgn->AddSimpleItem(this->dwOffset + 3, 1, "Articulation Index");
 
     CPSArticTable *articTable = ((CPSInstrSet *) this->parInstrSet)->articTable;
     qs_artic_info *artic = &articTable->artics[progInfo.artic_index];
@@ -489,7 +489,7 @@ CPSSampColl::CPSSampColl(RawFile *file,
                          CPSSampleInfoTable *sampinfotable,
                          uint32_t offset,
                          uint32_t length,
-                         wstring name)
+                         string name)
     : VGMSampColl(CPSFormat::name, file, offset, length, name),
       instrset(theinstrset),
       sampInfoTable(sampinfotable) {
@@ -508,8 +508,8 @@ bool CPSSampColl::GetSampleInfo() {
   uint32_t baseOffset;
 
   for (uint32_t i = 0; i < numSamples; i++) {
-    wostringstream name;
-    name << L"Sample " << i;
+    ostringstream name;
+    name << "Sample " << i;
 
     sample_info& sampInfo = sampInfoTable->infos[i];
     // Base address correction for Strider2, which maps qsound start address to 200000h.

--- a/src/main/formats/CPSInstr.h
+++ b/src/main/formats/CPSInstr.h
@@ -159,7 +159,7 @@ const uint16_t decay_rate_table[64] = {
 class CPSArticTable
     : public VGMMiscFile {
 public:
-  CPSArticTable(RawFile *file, std::wstring &name, uint32_t offset, uint32_t length);
+  CPSArticTable(RawFile *file, std::string &name, uint32_t offset, uint32_t length);
   virtual ~CPSArticTable(void);
 
   virtual bool LoadMain();
@@ -175,7 +175,7 @@ public:
 class CPSSampleInfoTable
     : public VGMMiscFile {
 public:
-  CPSSampleInfoTable(RawFile *file, std::wstring &name, uint32_t offset, uint32_t length = 0);
+  CPSSampleInfoTable(RawFile *file, std::string &name, uint32_t offset, uint32_t length = 0);
   ~CPSSampleInfoTable(void);
 
 public:
@@ -187,7 +187,7 @@ public:
 class CPS2SampleInfoTable
     : public CPSSampleInfoTable {
 public:
-  CPS2SampleInfoTable(RawFile *file, std::wstring &name, uint32_t offset, uint32_t length = 0);
+  CPS2SampleInfoTable(RawFile *file, std::string &name, uint32_t offset, uint32_t length = 0);
 
   virtual bool LoadMain();
 };
@@ -195,7 +195,7 @@ public:
 class CPS3SampleInfoTable
     : public CPSSampleInfoTable {
 public:
-  CPS3SampleInfoTable(RawFile *file, std::wstring &name, uint32_t offset, uint32_t length = 0);
+  CPS3SampleInfoTable(RawFile *file, std::string &name, uint32_t offset, uint32_t length = 0);
 
   virtual bool LoadMain();
 };
@@ -213,7 +213,7 @@ public:
               int numInstrBanks,
               CPSSampleInfoTable *sampInfoTable,
               CPSArticTable *articTable,
-              std::wstring &name);
+              std::string &name);
   virtual ~CPSInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -239,7 +239,7 @@ public:
            uint32_t length,
            uint32_t theBank,
            uint32_t theInstrNum,
-           std::wstring &name);
+           std::string &name);
   virtual ~CPSInstr(void);
   virtual bool LoadInstr();
 protected:
@@ -265,7 +265,7 @@ class CPSSampColl
     : public VGMSampColl {
 public:
   CPSSampColl(RawFile *file, CPSInstrSet *instrset, CPSSampleInfoTable *sampinfotable, uint32_t offset,
-              uint32_t length = 0, std::wstring name = std::wstring(L"QSound Sample Collection"));
+              uint32_t length = 0, std::string name = std::string("QSound Sample Collection"));
   virtual bool GetHeaderInfo();
   virtual bool GetSampleInfo();
 

--- a/src/main/formats/CPSScanner.cpp
+++ b/src/main/formats/CPSScanner.cpp
@@ -11,8 +11,8 @@ void CPSScanner::Scan(RawFile *file, void *info) {
   CPSFormatVer fmt_ver = GetVersionEnum(gameentry->fmt_version_str);
 
   if (fmt_ver == VER_UNDEFINED) {
-    wstring alert = L"XML entry uses an undefined QSound version: " + string2wstring(gameentry->fmt_version_str);
-    pRoot->AddLogItem(new LogItem(alert, LOG_LEVEL_ERR, L"CPSScanner"));
+    string alert = "XML entry uses an undefined QSound version: " + gameentry->fmt_version_str;
+    pRoot->AddLogItem(new LogItem(alert, LOG_LEVEL_ERR, "CPSScanner"));
     return;
   }
 
@@ -89,26 +89,26 @@ void CPSScanner::Scan(RawFile *file, void *info) {
   CPSSampleInfoTable *sampInfoTable = 0;
   CPSArticTable *articTable = 0;
 
-  wstring artic_table_name;
-  wstring instrset_name;
-  wstring samp_info_table_name;
-  wstring sampcoll_name;
-  wstring seq_table_name;
+  string artic_table_name;
+  string instrset_name;
+  string samp_info_table_name;
+  string sampcoll_name;
+  string seq_table_name;
 
-  wostringstream name;
-  name << gameentry->name.c_str() << L" articulation table";
+  ostringstream name;
+  name << gameentry->name.c_str() << " articulation table";
   artic_table_name = name.str();
-  name.str(L"");
-  name << gameentry->name.c_str() << L" instrument set";
+  name.str("");
+  name << gameentry->name.c_str() << " instrument set";
   instrset_name = name.str();
-  name.str(L"");
-  name << gameentry->name.c_str() << L" sample collection";
+  name.str("");
+  name << gameentry->name.c_str() << " sample collection";
   sampcoll_name = name.str();
-  name.str(L"");
-  name << gameentry->name.c_str() << L" sample info table";
+  name.str("");
+  name << gameentry->name.c_str() << " sample info table";
   samp_info_table_name = name.str();
-  name.str(L"");
-  name << gameentry->name.c_str() << L" sequence pointer table";
+  name.str("");
+  name << gameentry->name.c_str() << " sequence pointer table";
   seq_table_name = name.str();
 
 
@@ -189,14 +189,14 @@ void CPSScanner::Scan(RawFile *file, void *info) {
       seqPointer = programFile->GetWordBE(seq_table_offset + k) & 0x0FFFFF;
     }
 
-    seqTable->AddSimpleItem(seq_table_offset + k, 4, L"Sequence Pointer");
+    seqTable->AddSimpleItem(seq_table_offset + k, 4, "Sequence Pointer");
 
-    name.str(L"");
-    name << gameentry->name.c_str() << L" song " << k / 4;
+    name.str("");
+    name << gameentry->name.c_str() << " song " << k / 4;
     VGMColl *coll = new VGMColl(name.str());
-    name.str(L"");
-    name << gameentry->name.c_str() << L" seq " << k / 4;
-    wstring seqName = name.str();
+    name.str("");
+    name << gameentry->name.c_str() << " seq " << k / 4;
+    string seqName = name.str();
     CPSSeq *newSeq = new CPSSeq(programFile, seqPointer, fmt_ver, seqName);
     if (newSeq->LoadVGMFile()) {
       coll->UseSeq(newSeq);
@@ -232,18 +232,18 @@ void CPSScanner::LoadCPS1(MAMEGame *gameentry) {
     return;
 
   if (fmt_ver == VER_UNDEFINED) {
-    wstring alert = L"XML entry uses an undefined QSound version: " + string2wstring(gameentry->fmt_version_str);
-    pRoot->AddLogItem(new LogItem(alert, LOG_LEVEL_ERR, L"CPSScanner"));
+    string alert = "XML entry uses an undefined QSound version: " + gameentry->fmt_version_str;
+    pRoot->AddLogItem(new LogItem(alert, LOG_LEVEL_ERR, "CPSScanner"));
     return;
   }
 
   RawFile *programFile = seqRomGroupEntry->file;
 
-  wstring seq_table_name;
-  wostringstream name;
+  string seq_table_name;
+  ostringstream name;
 
-  name.str(L"");
-  name << gameentry->name.c_str() << L" sequence pointer table";
+  name.str("");
+  name << gameentry->name.c_str() << " sequence pointer table";
   seq_table_name = name.str();
 
   uint8_t ptrsStart;
@@ -287,11 +287,11 @@ void CPSScanner::LoadCPS1(MAMEGame *gameentry) {
       continue;
     }
 
-    seqTable->AddSimpleItem(seq_table_offset + k, ptrSize, L"Sequence Pointer");
+    seqTable->AddSimpleItem(seq_table_offset + k, ptrSize, "Sequence Pointer");
 
-    name.str(L"");
-    name << gameentry->name.c_str() << L" seq " << (k-ptrsStart) / ptrSize;
-    wstring seqName = name.str();
+    name.str("");
+    name << gameentry->name.c_str() << " seq " << (k-ptrsStart) / ptrSize;
+    string seqName = name.str();
     CPSSeq *newSeq = new CPSSeq(programFile, seqPointer, fmt_ver, seqName);
     //    printf("LOADING SEQ at %X\n", seqPointer);
     if (!newSeq->LoadVGMFile()) {

--- a/src/main/formats/CPSSeq.cpp
+++ b/src/main/formats/CPSSeq.cpp
@@ -13,7 +13,7 @@ DECLARE_FORMAT(CPS);
 // CPSSeq
 // ******
 
-CPSSeq::CPSSeq(RawFile *file, uint32_t offset, CPSFormatVer fmtVersion, wstring &name)
+CPSSeq::CPSSeq(RawFile *file, uint32_t offset, CPSFormatVer fmtVersion, string &name)
     : VGMSeq(CPSFormat::name, file, offset, 0, name),
       fmt_version(fmtVersion) {
   HasMonophonicTracks();
@@ -44,15 +44,15 @@ bool CPSSeq::GetTrackPointers(void) {
   if ((GetByte(dwOffset) & 0x80) > 0)
     return false;
 
-  this->AddHeader(dwOffset, 1, L"Sequence Flags");
-  VGMHeader *header = this->AddHeader(dwOffset + 1, GetShortBE(dwOffset + 1) - 1, L"Track Pointers");
+  this->AddHeader(dwOffset, 1, "Sequence Flags");
+  VGMHeader *header = this->AddHeader(dwOffset + 1, GetShortBE(dwOffset + 1) - 1, "Track Pointers");
 
   const int maxTracks = fmt_version <= VER_CPS1_502 ? 12 : 16;
 
   for (int i = 0; i < maxTracks; i++) {
     uint32_t offset = GetShortBE(dwOffset + 1 + i * 2);
     if (offset == 0) {
-      header->AddSimpleItem(dwOffset + 1 + (i * 2), 2, L"No Track");
+      header->AddSimpleItem(dwOffset + 1 + (i * 2), 2, "No Track");
       continue;
     }
     //if (GetShortBE(offset+dwOffset) == 0xE017)	//Rest, EndTrack (used by empty tracks)
@@ -78,7 +78,7 @@ bool CPSSeq::GetTrackPointers(void) {
         newTrack = new CPSTrackV1(this, offset + dwOffset);
     }
     aTracks.push_back(newTrack);
-    header->AddSimpleItem(dwOffset + 1 + (i * 2), 2, L"Track Pointer");
+    header->AddSimpleItem(dwOffset + 1 + (i * 2), 2, "Track Pointer");
   }
   if (aTracks.size() == 0)
     return false;

--- a/src/main/formats/CPSSeq.h
+++ b/src/main/formats/CPSSeq.h
@@ -82,7 +82,7 @@ static const uint16_t lfo_rate_table[128] = {
 class CPSSeq:
     public VGMSeq {
 public:
-  CPSSeq(RawFile *file, uint32_t offset, CPSFormatVer fmt_version, std::wstring &name);
+  CPSSeq(RawFile *file, uint32_t offset, CPSFormatVer fmt_version, std::string &name);
   virtual ~CPSSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/CPSTrackV1.cpp
+++ b/src/main/formats/CPSTrackV1.cpp
@@ -80,16 +80,16 @@ bool CPSTrackV1::ReadEvent(void) {
       // Tie note
       if ((noteState & 0x40) > 0) {
         if (!bPrevNoteTie) {
-          AddNoteOn(beginOffset, curOffset - beginOffset, key, 127, L"Note On (tied / with portamento)");
+          AddNoteOn(beginOffset, curOffset - beginOffset, key, 127, "Note On (tied / with portamento)");
           AddPortamentoNoItem(true);
         }
         else if (key != prevTieNote) {
           CalculateAndAddPortamentoTimeNoItem(key - prevTieNote);
-          AddNoteOn(beginOffset, curOffset - beginOffset, key, 127, L"Note On (tied)");
+          AddNoteOn(beginOffset, curOffset - beginOffset, key, 127, "Note On (tied)");
           AddNoteOffNoItem(prevTieNote);
         }
         else
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", L"", CLR_NOTEON);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", "", CLR_NOTEON);
         bPrevNoteTie = true;
         prevTieNote = key;
       }
@@ -104,7 +104,7 @@ bool CPSTrackV1::ReadEvent(void) {
           else {
             AddTime(absDur);
             delta -= absDur;
-            AddNoteOff(beginOffset, curOffset - beginOffset, prevTieNote, L"Note Off (tied)");
+            AddNoteOff(beginOffset, curOffset - beginOffset, prevTieNote, "Note Off (tied)");
             AddPortamentoNoItem(false);
           }
         }
@@ -115,7 +115,7 @@ bool CPSTrackV1::ReadEvent(void) {
       }
     }
     else {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Rest", L"", CLR_REST);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Rest", "", CLR_REST);
     }
     AddTime(delta);
   }
@@ -126,39 +126,39 @@ bool CPSTrackV1::ReadEvent(void) {
         noteState ^= 0x20;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Note State xor 0x20 (change duration table)",
-                        L"",
+                        "Note State xor 0x20 (change duration table)",
+                        "",
                         CLR_CHANGESTATE);
         break;
       case 0x01 :
         noteState ^= 0x40;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Note State xor 0x40 (Toggle tie)",
-                        L"",
+                        "Note State xor 0x40 (Toggle tie)",
+                        "",
                         CLR_CHANGESTATE);
         break;
       case 0x02 :
         noteState |= (1 << 4);
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Note State |= 0x10 (change duration table)",
-                        L"",
+                        "Note State |= 0x10 (change duration table)",
+                        "",
                         CLR_CHANGESTATE);
         break;
       case 0x03 :
         noteState ^= 8;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Note State xor 8 (change octave)",
-                        L"",
+                        "Note State xor 8 (change octave)",
+                        "",
                         CLR_CHANGESTATE);
         break;
 
       case 0x04 :
         noteState &= 0x97;
         noteState |= GetByte(curOffset++);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Change Note State (& 0x97)", L"", CLR_CHANGESTATE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Change Note State (& 0x97)", "", CLR_CHANGESTATE);
         break;
 
       case 0x05 : {
@@ -197,7 +197,7 @@ bool CPSTrackV1::ReadEvent(void) {
 
       case 0x06 :
         dur = GetByte(curOffset++);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Set Duration", L"", CLR_CHANGESTATE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Set Duration", "", CLR_CHANGESTATE);
         break;
 
       case 0x07 :
@@ -221,7 +221,7 @@ bool CPSTrackV1::ReadEvent(void) {
       case 0x09 :
         noteState &= 0xF8;
         noteState |= GetByte(curOffset++);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Set Octave", L"", CLR_CHANGESTATE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Set Octave", "", CLR_CHANGESTATE);
         break;
 
       // Global Transpose
@@ -247,7 +247,7 @@ bool CPSTrackV1::ReadEvent(void) {
                   string("pitchbend"),
                   pitchbend,
                   0,
-                  L"Pitch Bend",
+                  "Pitch Bend",
                   PRIORITY_MIDDLE,
                   CLR_PITCHBEND);
         //AddPitchBend(beginOffset, curOffset-beginOffset, (cents / 200) * 8192);
@@ -269,7 +269,7 @@ bool CPSTrackV1::ReadEvent(void) {
         } else {
           portamentoCentsPerSec = 0;
         }
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Portamento Time", L"", CLR_PORTAMENTOTIME);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Time", "", CLR_PORTAMENTOTIME);
         break;
       }
 
@@ -332,7 +332,7 @@ bool CPSTrackV1::ReadEvent(void) {
           }
         }
 
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop", L"", CLR_LOOP);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", CLR_LOOP);
 
         if (loop[loopNum] == 0) {
           bInLoop = false;
@@ -368,7 +368,7 @@ bool CPSTrackV1::ReadEvent(void) {
           {
             uint16_t jump = GetShortBE(curOffset);
             curOffset += 2;
-            AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Break", L"", CLR_LOOP);
+            AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", "", CLR_LOOP);
 
 //            printf("%X LOOP BREAK JUMPING TO %X\n", curOffset, jump);
             if (((CPSSeq *) parentSeq)->fmt_version <= VER_CPS1_425) {
@@ -417,12 +417,12 @@ bool CPSTrackV1::ReadEvent(void) {
 
       case 0x19 :
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Reg9 Event (unknown to MAME)");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Reg9 Event (unknown to MAME)");
         break;
 
       case 0x1A : {
         vol = GetByte(curOffset++);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Master Volume", L"", CLR_UNKNOWN);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Master Volume", "", CLR_UNKNOWN);
         //this->AddMasterVol(beginOffset, curOffset-beginOffset, vol);
         break;
       }
@@ -437,7 +437,7 @@ bool CPSTrackV1::ReadEvent(void) {
                     string("vibrato"),
                     vibratoDepth,
                     0,
-                    L"Vibrato",
+                    "Vibrato",
                     PRIORITY_HIGH,
                     CLR_PITCHBEND);
         }
@@ -454,7 +454,7 @@ bool CPSTrackV1::ReadEvent(void) {
                         string("vibrato"),
                         data,
                         0,
-                        L"Vibrato",
+                        "Vibrato",
                         PRIORITY_HIGH,
                         CLR_PITCHBEND);
               break;
@@ -466,7 +466,7 @@ bool CPSTrackV1::ReadEvent(void) {
                         string("tremelo"),
                         data,
                         0,
-                        L"Tremelo",
+                        "Tremelo",
                         PRIORITY_MIDDLE,
                         CLR_EXPRESSION);
               break;
@@ -478,7 +478,7 @@ bool CPSTrackV1::ReadEvent(void) {
                         string("lfo"),
                         data,
                         0,
-                        L"LFO Rate",
+                        "LFO Rate",
                         PRIORITY_MIDDLE,
                         CLR_LFO);
               break;
@@ -490,7 +490,7 @@ bool CPSTrackV1::ReadEvent(void) {
                         string("resetlfo"),
                         data,
                         0,
-                        L"LFO Reset",
+                        "LFO Reset",
                         PRIORITY_MIDDLE,
                         CLR_LFO);
               break;
@@ -507,7 +507,7 @@ bool CPSTrackV1::ReadEvent(void) {
                     string("tremelo"),
                     tremeloDepth,
                     0,
-                    L"Tremelo",
+                    "Tremelo",
                     PRIORITY_MIDDLE,
                     CLR_EXPRESSION);
         }
@@ -528,11 +528,11 @@ bool CPSTrackV1::ReadEvent(void) {
                     string("lfo"),
                     rate,
                     0,
-                    L"LFO Rate",
+                    "LFO Rate",
                     PRIORITY_MIDDLE,
                     CLR_LFO);
         else
-          AddUnknown(beginOffset, curOffset - beginOffset, L"NOP");
+          AddUnknown(beginOffset, curOffset - beginOffset, "NOP");
         break;
       }
 
@@ -545,11 +545,11 @@ bool CPSTrackV1::ReadEvent(void) {
                     string("resetlfo"),
                     data,
                     0,
-                    L"LFO Reset",
+                    "LFO Reset",
                     PRIORITY_MIDDLE,
                     CLR_LFO);
         else
-          AddUnknown(beginOffset, curOffset - beginOffset, L"NOP");
+          AddUnknown(beginOffset, curOffset - beginOffset, "NOP");
       }
       break;
       case 0x1F : {
@@ -561,7 +561,7 @@ bool CPSTrackV1::ReadEvent(void) {
         else {
           bank = value;
           AddBankSelectNoItem(bank * 2);
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Bank Change", L"", CLR_PROGCHANGE);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Bank Change", "", CLR_PROGCHANGE);
         }
 
         break;
@@ -588,7 +588,7 @@ bool CPSTrackV1::ReadEvent(void) {
         break;
 
       default :
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"UNKNOWN", L"", CLR_UNRECOGNIZED);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", CLR_UNRECOGNIZED);
     }
   }
   return true;

--- a/src/main/formats/CPSTrackV2.cpp
+++ b/src/main/formats/CPSTrackV2.cpp
@@ -77,7 +77,7 @@ bool CPSTrackV2::ReadEvent(void) {
 
     case C2_SETBANK:
       AddBankSelectNoItem(GetByte(curOffset++) * 2);
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Bank Change", L"", CLR_PROGCHANGE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Bank Change", "", CLR_PROGCHANGE);
       break;
 
     case C3_PITCHBEND: {
@@ -88,7 +88,7 @@ bool CPSTrackV2::ReadEvent(void) {
 //                string("pitchbend"),
 //                pitchbend,
 //                0,
-//                L"Pitch Bend",
+//                "Pitch Bend",
 //                PRIORITY_MIDDLE,
 //                CLR_PITCHBEND);
       break;
@@ -107,7 +107,7 @@ bool CPSTrackV2::ReadEvent(void) {
                 string("vibrato"),
                 vibratoDepth,
                 0,
-                L"Vibrato",
+                "Vibrato",
                 PRIORITY_HIGH,
                 CLR_PITCHBEND);
       break;
@@ -166,22 +166,22 @@ bool CPSTrackV2::ReadEvent(void) {
 
     case D0_LOOP_1_START:
       loopOffset[0] = curOffset;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop 1 Start", L"", CLR_LOOP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop 1 Start", "", CLR_LOOP);
       break;
 
     case D1_LOOP_2_START:
       loopOffset[1] = curOffset;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop 2 Start", L"", CLR_LOOP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop 2 Start", "", CLR_LOOP);
       break;
 
     case D2_LOOP_3_START:
       loopOffset[2] = curOffset;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop 3 Start", L"", CLR_LOOP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop 3 Start", "", CLR_LOOP);
       break;
 
     case D3_LOOP_4_START:
       loopOffset[3] = curOffset;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop 4 Start", L"", CLR_LOOP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop 4 Start", "", CLR_LOOP);
       break;
 
     case D4_LOOP_1: loopNum = 0; goto handleLoop;
@@ -203,7 +203,7 @@ bool CPSTrackV2::ReadEvent(void) {
         curOffset = loopOffset[loopNum];
       }
       else {
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop", L"", CLR_LOOP);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", CLR_LOOP);
         loopCounter[loopNum] = loopCount; //start loop
         curOffset = loopOffset[loopNum];
       }
@@ -218,7 +218,7 @@ bool CPSTrackV2::ReadEvent(void) {
       if (loopCounter[loopNum] - 1 == 0) {
         loopCounter[loopNum] = 0;
         uint16_t jump = GetShortBE(curOffset);
-        AddGenericEvent(beginOffset, (curOffset+2) - beginOffset, L"Loop Break", L"", CLR_LOOP);
+        AddGenericEvent(beginOffset, (curOffset+2) - beginOffset, "Loop Break", "", CLR_LOOP);
         curOffset += jump + 2;
       }
       else {
@@ -233,7 +233,7 @@ bool CPSTrackV2::ReadEvent(void) {
 
     case DD_TRANSPOSE:
       transpose += (int8_t)GetByte(curOffset++);
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Transpose", L"", CLR_CHANGESTATE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Transpose", "", CLR_CHANGESTATE);
       break;
 
     case EVENT_DE:
@@ -254,7 +254,7 @@ bool CPSTrackV2::ReadEvent(void) {
 //                string("resetlfo"),
 //                data,
 //                0,
-//                L"LFO Reset",
+//                "LFO Reset",
 //                PRIORITY_MIDDLE,
 //                CLR_LFO);
       break;
@@ -267,7 +267,7 @@ bool CPSTrackV2::ReadEvent(void) {
 //                string("lfo"),
 //                rate,
 //                0,
-//                L"LFO Rate",
+//                "LFO Rate",
 //                PRIORITY_MIDDLE,
 //                CLR_LFO);
       break;
@@ -280,7 +280,7 @@ bool CPSTrackV2::ReadEvent(void) {
 //                string("tremelo"),
 //                tremeloDepth,
 //                0,
-//                L"Tremelo",
+//                "Tremelo",
 //                PRIORITY_MIDDLE,
 //                CLR_EXPRESSION);
       break;
@@ -323,7 +323,7 @@ bool CPSTrackV2::ReadEvent(void) {
       return false;
 
     default :
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"UNKNOWN", L"", CLR_UNRECOGNIZED);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", CLR_UNRECOGNIZED);
       break;
   }
 

--- a/src/main/formats/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnesInstr.cpp
@@ -8,7 +8,7 @@
 // CapcomSnesInstrSet
 // ****************
 
-CapcomSnesInstrSet::CapcomSnesInstrSet(RawFile *file, uint32_t offset, uint32_t spcDirAddr, const std::wstring &name) :
+CapcomSnesInstrSet::CapcomSnesInstrSet(RawFile *file, uint32_t offset, uint32_t spcDirAddr, const std::string &name) :
     VGMInstrSet(CapcomSnesFormat::name, file, offset, 0, name),
     spcDirAddr(spcDirAddr) {
 }
@@ -54,8 +54,8 @@ bool CapcomSnesInstrSet::GetInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << instr;
+    std::ostringstream instrName;
+    instrName << "Instrument " << instr;
     CapcomSnesInstr
         *newInstr = new CapcomSnesInstr(this, addrInstrHeader, instr >> 7, instr & 0x7f, spcDirAddr, instrName.str());
     aInstrs.push_back(newInstr);
@@ -83,7 +83,7 @@ CapcomSnesInstr::CapcomSnesInstr(VGMInstrSet *instrSet,
                                  uint32_t theBank,
                                  uint32_t theInstrNum,
                                  uint32_t spcDirAddr,
-                                 const std::wstring &name) :
+                                 const std::string &name) :
     VGMInstr(instrSet, offset, 6, theBank, theInstrNum, name),
     spcDirAddr(spcDirAddr) {
 }
@@ -164,9 +164,9 @@ CapcomSnesRgn::CapcomSnesRgn(CapcomSnesInstr *instr, uint32_t offset) :
   }
 
   AddSampNum(srcn, offset, 1);
-  AddSimpleItem(offset + 1, 1, L"ADSR1");
-  AddSimpleItem(offset + 2, 1, L"ADSR2");
-  AddSimpleItem(offset + 3, 1, L"GAIN");
+  AddSimpleItem(offset + 1, 1, "ADSR1");
+  AddSimpleItem(offset + 2, 1, "ADSR2");
+  AddSimpleItem(offset + 3, 1, "GAIN");
   AddUnityKey(96 - (int) (coarse_tuning), offset + 4, 1);
   AddFineTune((int16_t) (fine_tuning * 100.0), offset + 5, 1);
   SNESConvADSR<VGMRgn>(this, adsr1, adsr2, gain);

--- a/src/main/formats/CapcomSnesInstr.h
+++ b/src/main/formats/CapcomSnesInstr.h
@@ -11,7 +11,7 @@ class CapcomSnesInstrSet:
     public VGMInstrSet {
  public:
   CapcomSnesInstrSet
-      (RawFile *file, uint32_t offset, uint32_t spcDirAddr, const std::wstring &name = L"CapcomSnesInstrSet");
+      (RawFile *file, uint32_t offset, uint32_t spcDirAddr, const std::string &name = "CapcomSnesInstrSet");
   virtual ~CapcomSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -34,7 +34,7 @@ class CapcomSnesInstr
                   uint32_t theBank,
                   uint32_t theInstrNum,
                   uint32_t spcDirAddr,
-                  const std::wstring &name = L"CapcomSnesInstr");
+                  const std::string &name = "CapcomSnesInstr");
   virtual ~CapcomSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/CapcomSnesScanner.cpp
+++ b/src/main/formats/CapcomSnesScanner.cpp
@@ -115,8 +115,8 @@ void CapcomSnesScanner::SearchForCapcomSnesFromARAM(RawFile *file) {
   uint32_t addrBGMHeader;
   uint32_t addrInstrTable;
 
-  wstring basefilename = RawFile::removeExtFromPath(file->GetFileName());
-  wstring name = file->tag.HasTitle() ? file->tag.title : basefilename;
+  string basefilename = RawFile::removeExtFromPath(file->GetFileName());
+  string name = file->tag.HasTitle() ? file->tag.title : basefilename;
 
   // find a song list
   hasSongList = file->SearchBytePattern(ptnReadSongList, ofsReadSongListASM);

--- a/src/main/formats/CapcomSnesScanner.h
+++ b/src/main/formats/CapcomSnesScanner.h
@@ -8,7 +8,7 @@ class CapcomSnesScanner:
     public VGMScanner {
  public:
   CapcomSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~CapcomSnesScanner(void) {
   }

--- a/src/main/formats/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnesSeq.cpp
@@ -31,7 +31,7 @@ CapcomSnesSeq::CapcomSnesSeq(RawFile *file,
                              CapcomSnesVersion ver,
                              uint32_t seqdataOffset,
                              bool priorityInHeader,
-                             wstring newName)
+                             string newName)
     : VGMSeq(CapcomSnesFormat::name, file, seqdataOffset), version(ver), priorityInHeader(priorityInHeader) {
   name = newName;
 
@@ -59,17 +59,17 @@ void CapcomSnesSeq::ResetVars(void) {
 bool CapcomSnesSeq::GetHeaderInfo(void) {
   SetPPQN(SEQ_PPQN);
 
-  VGMHeader *seqHeader = AddHeader(dwOffset, (priorityInHeader ? 1 : 0) + MAX_TRACKS * 2, L"Sequence Header");
+  VGMHeader *seqHeader = AddHeader(dwOffset, (priorityInHeader ? 1 : 0) + MAX_TRACKS * 2, "Sequence Header");
   uint32_t curHeaderOffset = dwOffset;
 
   if (priorityInHeader) {
-    seqHeader->AddSimpleItem(curHeaderOffset, 1, L"Priority");
+    seqHeader->AddSimpleItem(curHeaderOffset, 1, "Priority");
     curHeaderOffset++;
   }
 
   for (int i = 0; i < MAX_TRACKS; i++) {
     uint16_t trkOff = GetShortBE(curHeaderOffset);
-    seqHeader->AddPointer(curHeaderOffset, 2, trkOff, true, L"Track Pointer");
+    seqHeader->AddPointer(curHeaderOffset, 2, trkOff, true, "Track Pointer");
     curHeaderOffset += 2;
   }
 
@@ -243,7 +243,7 @@ bool CapcomSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  wstringstream desc;
+  stringstream desc;
 
   if (statusByte >= 0x20) {
     uint8_t keyIndex = statusByte & 0x1f;
@@ -261,7 +261,7 @@ bool CapcomSnesTrack::ReadEvent(void) {
       else {
         // error: note length is not a byte value.
         len = 0;
-        pRoot->AddLogItem(new LogItem(L"Note length overflow\n", LOG_LEVEL_WARN, L"CapcomSnesSeq"));
+        pRoot->AddLogItem(new LogItem("Note length overflow\n", LOG_LEVEL_WARN, "CapcomSnesSeq"));
       }
       setNoteDotted(false);
     }
@@ -302,7 +302,7 @@ bool CapcomSnesTrack::ReadEvent(void) {
         AddTime(dur);
         MakePrevDurNoteEnd();
         AddTime(len - dur);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
       }
       else {
         AddNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur);
@@ -321,27 +321,27 @@ bool CapcomSnesTrack::ReadEvent(void) {
 
     switch (eventType) {
       case EVENT_UNKNOWN0:
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
         break;
 
       case EVENT_UNKNOWN1: {
         uint8_t arg1 = GetByte(curOffset++);
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-            << std::dec << std::setfill(L' ') << std::setw(0)
-            << L"  Arg1: " << (int) arg1;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+            << std::dec << std::setfill(' ') << std::setw(0)
+            << "  Arg1: " << (int) arg1;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
         break;
       }
 
       case EVENT_UNKNOWN2: {
         uint8_t arg1 = GetByte(curOffset++);
         uint8_t arg2 = GetByte(curOffset++);
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-            << std::dec << std::setfill(L' ') << std::setw(0)
-            << L"  Arg1: " << (int) arg1
-            << L"  Arg2: " << (int) arg2;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+            << std::dec << std::setfill(' ') << std::setw(0)
+            << "  Arg1: " << (int) arg1
+            << "  Arg2: " << (int) arg2;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
         break;
       }
 
@@ -349,12 +349,12 @@ bool CapcomSnesTrack::ReadEvent(void) {
         uint8_t arg1 = GetByte(curOffset++);
         uint8_t arg2 = GetByte(curOffset++);
         uint8_t arg3 = GetByte(curOffset++);
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-            << std::dec << std::setfill(L' ') << std::setw(0)
-            << L"  Arg1: " << (int) arg1
-            << L"  Arg2: " << (int) arg2
-            << L"  Arg3: " << (int) arg3;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+            << std::dec << std::setfill(' ') << std::setw(0)
+            << "  Arg1: " << (int) arg1
+            << "  Arg2: " << (int) arg2
+            << "  Arg3: " << (int) arg3;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
         break;
       }
 
@@ -363,45 +363,45 @@ bool CapcomSnesTrack::ReadEvent(void) {
         uint8_t arg2 = GetByte(curOffset++);
         uint8_t arg3 = GetByte(curOffset++);
         uint8_t arg4 = GetByte(curOffset++);
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-            << std::dec << std::setfill(L' ') << std::setw(0)
-            << L"  Arg1: " << (int) arg1
-            << L"  Arg2: " << (int) arg2
-            << L"  Arg3: " << (int) arg3
-            << L"  Arg4: " << (int) arg4;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+            << std::dec << std::setfill(' ') << std::setw(0)
+            << "  Arg1: " << (int) arg1
+            << "  Arg2: " << (int) arg2
+            << "  Arg3: " << (int) arg3
+            << "  Arg4: " << (int) arg4;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
         break;
       }
 
       case EVENT_TOGGLE_TRIPLET:
         setNoteTriplet(!isNoteTriplet());
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Toggle Triplet", L"", CLR_DURNOTE, ICON_CONTROL);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Toggle Triplet", "", CLR_DURNOTE, ICON_CONTROL);
         break;
 
       case EVENT_TOGGLE_SLUR:
         setNoteSlurred(!isNoteSlurred());
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Toggle Slur/Tie", L"", CLR_DURNOTE, ICON_CONTROL);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Toggle Slur/Tie", "", CLR_DURNOTE, ICON_CONTROL);
         break;
 
       case EVENT_DOTTED_NOTE_ON:
         setNoteDotted(true);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Dotted Note On", L"", CLR_DURNOTE, ICON_CONTROL);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Dotted Note On", "", CLR_DURNOTE, ICON_CONTROL);
         break;
 
       case EVENT_TOGGLE_OCTAVE_UP:
         setNoteOctaveUp(!isNoteOctaveUp());
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Toggle 2-Octave Up", L"", CLR_DURNOTE, ICON_CONTROL);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Toggle 2-Octave Up", "", CLR_DURNOTE, ICON_CONTROL);
         break;
 
       case EVENT_NOTE_ATTRIBUTES: {
         uint8_t attributes = GetByte(curOffset++);
         noteAttributes &= ~(CAPCOM_SNES_MASK_NOTE_OCTAVE_UP | CAPCOM_SNES_MASK_NOTE_TRIPLET | CAPCOM_SNES_MASK_NOTE_SLURRED);
         noteAttributes |= attributes;
-        desc << L"Triplet: " << (isNoteTriplet() ? L"On" : L"Off") << L"  " << L"Slur: "
-            << (isNoteSlurred() ? L"On" : L"Off") << L"  " << L"2-Octave Up: " << (isNoteOctaveUp() ? L"On" : L"Off");
+        desc << "Triplet: " << (isNoteTriplet() ? "On" : "Off") << "  " << "Slur: "
+            << (isNoteSlurred() ? "On" : "Off") << "  " << "2-Octave Up: " << (isNoteOctaveUp() ? "On" : "Off");
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Note Attributes",
+                        "Note Attributes",
                         desc.str().c_str(),
                         CLR_DURNOTE,
                         ICON_CONTROL);
@@ -419,10 +419,10 @@ bool CapcomSnesTrack::ReadEvent(void) {
       case EVENT_DURATION: {
         uint8_t newDurationRate = GetByte(curOffset++);
         durationRate = newDurationRate;
-        desc << L"Duration: " << (int) newDurationRate << L"/256";
+        desc << "Duration: " << (int) newDurationRate << "/256";
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Duration",
+                        "Duration",
                         desc.str().c_str(),
                         CLR_DURNOTE,
                         ICON_CONTROL);
@@ -457,9 +457,9 @@ bool CapcomSnesTrack::ReadEvent(void) {
 
       case EVENT_OCTAVE: {
         uint8_t newOctave = GetByte(curOffset++);
-        desc << L"Octave: " << (int) newOctave;
+        desc << "Octave: " << (int) newOctave;
         setNoteOctave(newOctave);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Octave", desc.str().c_str(), CLR_DURNOTE, ICON_CONTROL);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Octave", desc.str().c_str(), CLR_DURNOTE, ICON_CONTROL);
         break;
       }
 
@@ -485,10 +485,10 @@ bool CapcomSnesTrack::ReadEvent(void) {
       case EVENT_PORTAMENTO_TIME: {
         // TODO: calculate portamento time in milliseconds
         uint8_t newPortamentoTime = GetByte(curOffset++);
-        desc << L"Time: " << (int) newPortamentoTime;
+        desc << "Time: " << (int) newPortamentoTime;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Portamento Time",
+                        "Portamento Time",
                         desc.str().c_str(),
                         CLR_PORTAMENTOTIME,
                         ICON_CONTROL);
@@ -506,15 +506,15 @@ bool CapcomSnesTrack::ReadEvent(void) {
         curOffset += 2;
 
         uint8_t repeatSlot;
-        wchar_t *repeatEventName;
+        char* repeatEventName;
         switch (eventType) {
-			case EVENT_REPEAT_UNTIL_1: repeatSlot = 0; repeatEventName = L"Repeat Until #1"; break;
-			case EVENT_REPEAT_UNTIL_2: repeatSlot = 1; repeatEventName = L"Repeat Until #2"; break;
-			case EVENT_REPEAT_UNTIL_3: repeatSlot = 2; repeatEventName = L"Repeat Until #3"; break;
-			case EVENT_REPEAT_UNTIL_4: repeatSlot = 3; repeatEventName = L"Repeat Until #4"; break;
+			case EVENT_REPEAT_UNTIL_1: repeatSlot = 0; repeatEventName = "Repeat Until #1"; break;
+			case EVENT_REPEAT_UNTIL_2: repeatSlot = 1; repeatEventName = "Repeat Until #2"; break;
+			case EVENT_REPEAT_UNTIL_3: repeatSlot = 2; repeatEventName = "Repeat Until #3"; break;
+			case EVENT_REPEAT_UNTIL_4: repeatSlot = 3; repeatEventName = "Repeat Until #4"; break;
         }
 
-        desc << L"Times: " << (int) times << L"  Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+        desc << "Times: " << (int) times << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
             << std::uppercase << (int) dest;
         if (times == 0 && repeatCount[repeatSlot] == 0) {
           // infinite loop
@@ -559,17 +559,17 @@ bool CapcomSnesTrack::ReadEvent(void) {
         curOffset += 2;
 
         uint8_t repeatSlot;
-        wchar_t *repeatEventName;
+        char* repeatEventName;
         switch (eventType) {
-			case EVENT_REPEAT_BREAK_1: repeatSlot = 0; repeatEventName = L"Repeat Break #1"; break;
-			case EVENT_REPEAT_BREAK_2: repeatSlot = 1; repeatEventName = L"Repeat Break #2"; break;
-			case EVENT_REPEAT_BREAK_3: repeatSlot = 2; repeatEventName = L"Repeat Break #3"; break;
-			case EVENT_REPEAT_BREAK_4: repeatSlot = 3; repeatEventName = L"Repeat Break #4"; break;
+			case EVENT_REPEAT_BREAK_1: repeatSlot = 0; repeatEventName = "Repeat Break #1"; break;
+			case EVENT_REPEAT_BREAK_2: repeatSlot = 1; repeatEventName = "Repeat Break #2"; break;
+			case EVENT_REPEAT_BREAK_3: repeatSlot = 2; repeatEventName = "Repeat Break #3"; break;
+			case EVENT_REPEAT_BREAK_4: repeatSlot = 3; repeatEventName = "Repeat Break #4"; break;
         }
 
-        desc << L"Note: { " << L"Triplet: " << (isNoteTriplet() ? L"On" : L"Off") << L"  " << L"Slur: "
-            << (isNoteSlurred() ? L"On" : L"Off") << L"  " << L"2-Octave Up: " << (isNoteOctaveUp() ? L"On" : L"Off")
-            << L" }  " << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase
+        desc << "Note: { " << "Triplet: " << (isNoteTriplet() ? "On" : "Off") << "  " << "Slur: "
+            << (isNoteSlurred() ? "On" : "Off") << "  " << "2-Octave Up: " << (isNoteOctaveUp() ? "On" : "Off")
+            << " }  " << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase
             << (int) dest;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
@@ -591,14 +591,14 @@ bool CapcomSnesTrack::ReadEvent(void) {
       case EVENT_GOTO: {
         uint16_t dest = GetShortBE(curOffset);
         curOffset += 2;
-        desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+        desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
         uint32_t length = curOffset - beginOffset;
 
         if (!IsOffsetUsed(dest)) {
-          AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+          AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
         }
         else {
-          bContinue = AddLoopForever(beginOffset, length, L"Jump");
+          bContinue = AddLoopForever(beginOffset, length, "Jump");
 
           if (readMode == READMODE_ADD_TO_UI) {
             if (GetByte(curOffset) == 0x17) {
@@ -660,18 +660,18 @@ bool CapcomSnesTrack::ReadEvent(void) {
       case EVENT_LFO: {
         uint8_t lfoType = GetByte(curOffset++);
         uint8_t lfoAmount = GetByte(curOffset++);
-        desc << L"Type: " << (int) lfoType << L"  Amount: " << (int) lfoAmount;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"LFO Param", desc.str().c_str(), CLR_LFO, ICON_CONTROL);
+        desc << "Type: " << (int) lfoType << "  Amount: " << (int) lfoAmount;
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "LFO Param", desc.str().c_str(), CLR_LFO, ICON_CONTROL);
         break;
       }
 
       case EVENT_ECHO_PARAM: {
         uint8_t echoArg1 = GetByte(curOffset++);
         uint8_t echoPreset = GetByte(curOffset++);
-        desc << L"Arg1: " << (int) echoArg1 << L"  Preset: " << (int) echoPreset;
+        desc << "Arg1: " << (int) echoArg1 << "  Preset: " << (int) echoPreset;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Echo Param",
+                        "Echo Param",
                         desc.str().c_str(),
                         CLR_REVERB,
                         ICON_CONTROL);
@@ -681,20 +681,20 @@ bool CapcomSnesTrack::ReadEvent(void) {
       case EVENT_ECHO_ONOFF: {
         bool echoOn = (GetByte(curOffset++) & 1) != 0;
         if (echoOn) {
-          AddReverb(beginOffset, curOffset - beginOffset, parentSeq->midiReverb, L"Echo On");
+          AddReverb(beginOffset, curOffset - beginOffset, parentSeq->midiReverb, "Echo On");
         }
         else {
-          AddReverb(beginOffset, curOffset - beginOffset, 0, L"Echo Off");
+          AddReverb(beginOffset, curOffset - beginOffset, 0, "Echo Off");
         }
         break;
       }
 
       case EVENT_RELEASE_RATE: {
         uint8_t gain = GetByte(curOffset++) | 0xa0;
-        desc << L"GAIN: $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) gain;
+        desc << "GAIN: $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) gain;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Release Rate",
+                        "Release Rate",
                         desc.str().c_str(),
                         CLR_SUSTAIN,
                         ICON_CONTROL);
@@ -702,18 +702,18 @@ bool CapcomSnesTrack::ReadEvent(void) {
       }
 
       default:
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-        pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+        pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                       LOG_LEVEL_ERR,
-                                      L"CapcomSnesSeq"));
+                                      "CapcomSnesSeq"));
         bContinue = false;
         break;
     }
   }
 
-  //wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //LogDebug(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/CapcomSnesSeq.h
+++ b/src/main/formats/CapcomSnesSeq.h
@@ -59,7 +59,7 @@ class CapcomSnesSeq
                 CapcomSnesVersion ver,
                 uint32_t seqdata_offset,
                 bool priorityInHeader,
-                std::wstring newName = L"Capcom SNES Seq");
+                std::string newName = "Capcom SNES Seq");
   virtual ~CapcomSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/ChunSnesInstr.cpp
+++ b/src/main/formats/ChunSnesInstr.cpp
@@ -12,7 +12,7 @@ ChunSnesInstrSet::ChunSnesInstrSet(RawFile *file,
                                    uint16_t addrSampNumTable,
                                    uint16_t addrSampleTable,
                                    uint32_t spcDirAddr,
-                                   const std::wstring &name) :
+                                   const std::string &name) :
     VGMInstrSet(ChunSnesFormat::name, file, addrInstrSet, 0, name), version(ver),
     addrSampNumTable(addrSampNumTable),
     addrSampleTable(addrSampleTable),
@@ -29,7 +29,7 @@ bool ChunSnesInstrSet::GetHeaderInfo() {
   }
 
   unsigned int nNumInstrs = GetByte(curOffset);
-  AddSimpleItem(curOffset, 1, L"Number of Instruments");
+  AddSimpleItem(curOffset, 1, "Number of Instruments");
   curOffset++;
 
   if (version != CHUNSNES_SUMMER) { // CHUNSNES_WINTER
@@ -57,8 +57,8 @@ bool ChunSnesInstrSet::GetInstrPointers() {
   }
 
   for (unsigned int instrNum = 0; instrNum < nNumInstrs; instrNum++) {
-    std::wstringstream instrName;
-    instrName << L"Instrument " << (instrNum + 1);
+    std::stringstream instrName;
+    instrName << "Instrument " << (instrNum + 1);
     AddSimpleItem(curOffset, 1, instrName.str().c_str());
 
     uint8_t globalInstrNum = GetByte(curOffset);
@@ -109,7 +109,7 @@ ChunSnesInstr::ChunSnesInstr(VGMInstrSet *instrSet,
                              uint16_t addrInstr,
                              uint16_t addrSampleTable,
                              uint32_t spcDirAddr,
-                             const std::wstring &name) :
+                             const std::string &name) :
     VGMInstr(instrSet, addrInstr, 0, 0, theInstrNum, name), version(ver),
     addrSampleTable(addrSampleTable),
     spcDirAddr(spcDirAddr) {
@@ -120,7 +120,7 @@ ChunSnesInstr::~ChunSnesInstr() {
 
 bool ChunSnesInstr::LoadInstr() {
   uint8_t srcn = GetByte(dwOffset);
-  AddSimpleItem(dwOffset, 1, L"Sample Number");
+  AddSimpleItem(dwOffset, 1, "Sample Number");
   if (srcn == 0xff) {
     return false;
   }
@@ -153,10 +153,10 @@ ChunSnesRgn::ChunSnesRgn(ChunSnesInstr *instr, ChunSnesVersion ver, uint8_t srcn
     VGMRgn(instr, addrRgn, 8),
     version(ver) {
   AddUnknown(dwOffset, 2);
-  AddSimpleItem(dwOffset + 2, 1, L"ADSR(1)");
-  AddSimpleItem(dwOffset + 3, 1, L"ADSR(2)");
-  AddSimpleItem(dwOffset + 4, 1, L"GAIN");
-  AddSimpleItem(dwOffset + 5, 2, L"Tuning");
+  AddSimpleItem(dwOffset + 2, 1, "ADSR(1)");
+  AddSimpleItem(dwOffset + 3, 1, "ADSR(2)");
+  AddSimpleItem(dwOffset + 4, 1, "GAIN");
+  AddSimpleItem(dwOffset + 5, 2, "Tuning");
   AddUnknown(dwOffset + 7, 1);
 
   const uint8_t adsr1 = GetByte(dwOffset + 2);

--- a/src/main/formats/ChunSnesInstr.h
+++ b/src/main/formats/ChunSnesInstr.h
@@ -17,7 +17,7 @@ class ChunSnesInstrSet:
                    uint16_t addrSampNumTable,
                    uint16_t addrSampleTable,
                    uint32_t spcDirAddr,
-                   const std::wstring &name = L"ChunSnesInstrSet");
+                   const std::string &name = "ChunSnesInstrSet");
   virtual ~ChunSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -45,7 +45,7 @@ class ChunSnesInstr
                 uint16_t addrInstr,
                 uint16_t addrSampleTable,
                 uint32_t spcDirAddr,
-                const std::wstring &name = L"ChunSnesInstr");
+                const std::string &name = "ChunSnesInstr");
   virtual ~ChunSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/ChunSnesScanner.cpp
+++ b/src/main/formats/ChunSnesScanner.cpp
@@ -397,7 +397,7 @@ void ChunSnesScanner::Scan(RawFile *file, void *info) {
 void ChunSnesScanner::SearchForChunSnesFromARAM(RawFile *file) {
   ChunSnesVersion version = CHUNSNES_NONE;
   ChunSnesMinorVersion minorVersion = CHUNSNES_NOMINORVERSION;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   // search song list and detect engine version
   uint32_t ofsLoadSeq;

--- a/src/main/formats/ChunSnesScanner.h
+++ b/src/main/formats/ChunSnesScanner.h
@@ -8,7 +8,7 @@ class ChunSnesScanner:
     public VGMScanner {
  public:
   ChunSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~ChunSnesScanner(void) {
   }

--- a/src/main/formats/ChunSnesSeq.cpp
+++ b/src/main/formats/ChunSnesSeq.cpp
@@ -15,7 +15,7 @@ ChunSnesSeq::ChunSnesSeq(RawFile *file,
                          ChunSnesVersion ver,
                          ChunSnesMinorVersion minorVer,
                          uint32_t seqdataOffset,
-                         std::wstring newName)
+                         std::string newName)
     : VGMSeq(ChunSnesFormat::name, file, seqdataOffset, 0, newName),
       version(ver),
       minorVersion(minorVer),
@@ -52,7 +52,7 @@ bool ChunSnesSeq::GetHeaderInfo(void) {
   initialTempo = GetByte(curOffset++);
   AlwaysWriteInitialTempo(GetTempoInBPM(initialTempo));
 
-  header->AddSimpleItem(curOffset, 1, L"Number of Tracks");
+  header->AddSimpleItem(curOffset, 1, "Number of Tracks");
   nNumTracks = GetByte(curOffset++);
   if (nNumTracks == 0 || nNumTracks > MAX_TRACKS) {
     return false;
@@ -69,8 +69,8 @@ bool ChunSnesSeq::GetHeaderInfo(void) {
       addrTrackStart = dwOffset + ofsTrackStart;
     }
 
-    std::wstringstream trackName;
-    trackName << L"Track Pointer " << (trackIndex + 1);
+    std::stringstream trackName;
+    trackName << "Track Pointer " << (trackIndex + 1);
     header->AddSimpleItem(curOffset, 2, trackName.str());
 
     ChunSnesTrack *track = new ChunSnesTrack(this, addrTrackStart);
@@ -239,7 +239,7 @@ bool ChunSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   ChunSnesSeqEventType eventType = (ChunSnesSeqEventType) 0;
   std::map<uint8_t, ChunSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -249,27 +249,27 @@ bool ChunSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -277,12 +277,12 @@ bool ChunSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -291,18 +291,18 @@ bool ChunSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_NOP: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP", desc.str(), CLR_MISC, ICON_BINARY);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str(), CLR_MISC, ICON_BINARY);
       break;
     }
 
@@ -346,7 +346,7 @@ bool ChunSnesTrack::ReadEvent(void) {
       }
       else if (tie) {
         // update note duration without changing note pitch
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str(), CLR_TIE, ICON_NOTE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str(), CLR_TIE, ICON_NOTE);
         MakePrevDurNoteEnd(GetTime() + dur);
         AddTime(noteLength);
       }
@@ -354,8 +354,8 @@ bool ChunSnesTrack::ReadEvent(void) {
         if (prevNoteSlurred && key == prevNoteKey) {
           // slurred note with same key works as tie
           MakePrevDurNoteEnd(GetTime() + dur);
-          desc << L"Abs Key: " << key << " (" << MidiEvent::GetNoteName(key) << ") " << L"  Duration: " << dur;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Note with Duration", desc.str(), CLR_TIE, ICON_NOTE);
+          desc << "Abs Key: " << key << " (" << MidiEvent::GetNoteName(key) << ") " << "  Duration: " << dur;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Note with Duration", desc.str(), CLR_TIE, ICON_NOTE);
         }
         else {
           AddNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur);
@@ -378,15 +378,15 @@ bool ChunSnesTrack::ReadEvent(void) {
       uint8_t durIndex = statusByte - 0xa0;
       noteDurationRate = NOTE_DUR_TABLE[durIndex];
       if (noteDurationRate == 0) {
-        desc << L"Duration Rate: Slur (Full)";
+        desc << "Duration Rate: Slur (Full)";
       }
       else if (noteDurationRate == 254) {
-        desc << L"Duration Rate: Full - 1";
+        desc << "Duration Rate: Full - 1";
       }
       else {
-        desc << L"Duration Rate: " << ((int) noteDurationRate + 1) << L"/256";
+        desc << "Duration Rate: " << ((int) noteDurationRate + 1) << "/256";
       }
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Duration Rate from Table", desc.str(), CLR_DURNOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate from Table", desc.str(), CLR_DURNOTE);
       break;
     }
 
@@ -394,8 +394,8 @@ bool ChunSnesTrack::ReadEvent(void) {
       int16_t destOffset = GetShort(curOffset);
       curOffset += 2;
       uint16_t dest = curOffset + destOffset;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Break (Alt)", desc.str(), CLR_LOOP, ICON_ENDREP);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break (Alt)", desc.str(), CLR_LOOP, ICON_ENDREP);
 
       if (loopCountAlt != 0) {
         curOffset = dest;
@@ -408,8 +408,8 @@ bool ChunSnesTrack::ReadEvent(void) {
       int16_t destOffset = GetShort(curOffset);
       curOffset += 2;
       uint16_t dest = curOffset + destOffset;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Again (Alt)", desc.str(), CLR_LOOP, ICON_ENDREP);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again (Alt)", desc.str(), CLR_LOOP, ICON_ENDREP);
 
       if (loopCountAlt == 0) {
         loopCountAlt = 2;
@@ -425,8 +425,8 @@ bool ChunSnesTrack::ReadEvent(void) {
 
     case EVENT_ADSR_RELEASE_SR: {
       uint8_t release_sr = GetByte(curOffset++) & 31;
-      desc << L"SR (Release): " << (int) release_sr;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR Release Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "SR (Release): " << (int) release_sr;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Release Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -440,9 +440,9 @@ bool ChunSnesTrack::ReadEvent(void) {
       uint8_t sl = (adsr2 & 0xe0) >> 5;
       uint8_t sr = adsr2 & 0x1f;
 
-      desc << L"AR: " << (int) ar << L"  DR: " << (int) dr << L"  SL: " << (int) sl << L"  SR: " << (int) sr
-          << L"  SR (Release): " << (int) release_sr;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR & Release Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "AR: " << (int) ar << "  DR: " << (int) dr << "  SL: " << (int) sl << "  SR: " << (int) sr
+          << "  SR (Release): " << (int) release_sr;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR & Release Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -450,9 +450,9 @@ bool ChunSnesTrack::ReadEvent(void) {
       uint8_t param = GetByte(curOffset++);
       bool invertLeft = (param & 1) != 0;
       bool invertRight = (param & 2) != 0;
-      desc << L"Invert Left: " << (invertLeft ? L"On" : L"Off") << L"  Invert Right: "
-          << (invertRight ? L"On" : L"Off");
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Surround", desc.str(), CLR_PAN, ICON_CONTROL);
+      desc << "Invert Left: " << (invertLeft ? "On" : "Off") << "  Invert Right: "
+          << (invertRight ? "On" : "Off");
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Surround", desc.str(), CLR_PAN, ICON_CONTROL);
       break;
     }
 
@@ -461,8 +461,8 @@ bool ChunSnesTrack::ReadEvent(void) {
       curOffset += 2;
       uint8_t condValue = GetByte(curOffset++);
       uint16_t dest = curOffset + destOffset;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Conditional Jump", desc.str(), CLR_MISC);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump", desc.str(), CLR_MISC);
 
       if ((parentSeq->conditionVar & 0x7f) == condValue) {
         // repeat again
@@ -478,36 +478,36 @@ bool ChunSnesTrack::ReadEvent(void) {
 
     case EVENT_INC_COUNTER: {
       // increment a counter value, which will be sent to main CPU
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Increment Counter", desc.str(), CLR_MISC);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Increment Counter", desc.str(), CLR_MISC);
       break;
     }
 
     case EVENT_PITCH_ENVELOPE: {
       uint8_t envelopeIndex = GetByte(curOffset++);
       if (envelopeIndex == 0xff) {
-        desc << L"Envelope: Off";
+        desc << "Envelope: Off";
       }
       else {
-        desc << L"Envelope: " << envelopeIndex;
+        desc << "Envelope: " << envelopeIndex;
       }
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pitch Envelope", desc.str(), CLR_LFO, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope", desc.str(), CLR_LFO, ICON_CONTROL);
       break;
     }
 
     case EVENT_NOISE_ON: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Noise On", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Noise On", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
       break;
     }
 
     case EVENT_NOISE_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Noise Off", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Noise Off", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
       break;
     }
 
     case EVENT_MASTER_VOLUME_FADE: {
       uint8_t mastVol = GetByte(curOffset++);
       uint8_t fadeLength = GetByte(curOffset++);
-      desc << L"Master Volume: " << (int) mastVol << L"  Fade Length: " << (int) fadeLength;
+      desc << "Master Volume: " << (int) mastVol << "  Fade Length: " << (int) fadeLength;
 
       uint8_t midiMastVol = min(mastVol, (uint8_t) 0x7f);
       AddMastVolSlide(beginOffset, curOffset - beginOffset, fadeLength, midiMastVol);
@@ -517,7 +517,7 @@ bool ChunSnesTrack::ReadEvent(void) {
     case EVENT_EXPRESSION_FADE: {
       uint8_t vol = GetByte(curOffset++);
       uint8_t fadeLength = GetByte(curOffset++);
-      desc << L"Expression: " << (int) vol << L"  Fade Length: " << (int) fadeLength;
+      desc << "Expression: " << (int) vol << "  Fade Length: " << (int) fadeLength;
 
       AddExpressionSlide(beginOffset, curOffset - beginOffset, fadeLength, vol >> 1);
       break;
@@ -526,15 +526,15 @@ bool ChunSnesTrack::ReadEvent(void) {
     case EVENT_FULL_VOLUME_FADE: {
       // fade channel volume to zero or full, do not know where it is used
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Arg1: " << arg1;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Fade", desc.str(), CLR_VOLUME, ICON_CONTROL);
+      desc << "Arg1: " << arg1;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Fade", desc.str(), CLR_VOLUME, ICON_CONTROL);
       break;
     }
 
     case EVENT_PAN_FADE: {
       int8_t pan = GetByte(curOffset++);
       uint8_t fadeLength = GetByte(curOffset++);
-      desc << L"Pan: " << (int) pan << L"  Fade Length: " << (int) fadeLength;
+      desc << "Pan: " << (int) pan << "  Fade Length: " << (int) fadeLength;
 
       // TODO: slide in real curve, apply volume scale
       double volumeScale;
@@ -555,15 +555,15 @@ bool ChunSnesTrack::ReadEvent(void) {
       int16_t destOffset = GetShort(curOffset);
       curOffset += 2;
       uint16_t dest = curOffset + destOffset;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       uint32_t length = curOffset - beginOffset;
 
       curOffset = dest;
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(beginOffset, length, L"Jump", desc.str(), CLR_LOOPFOREVER);
+        AddGenericEvent(beginOffset, length, "Jump", desc.str(), CLR_LOOPFOREVER);
       }
       else {
-        bContinue = AddLoopForever(beginOffset, length, L"Jump");
+        bContinue = AddLoopForever(beginOffset, length, "Jump");
       }
       break;
     }
@@ -583,15 +583,15 @@ bool ChunSnesTrack::ReadEvent(void) {
     case EVENT_DURATION_RATE: {
       noteDurationRate = GetByte(curOffset++);
       if (noteDurationRate == 0) {
-        desc << L"Duration Rate: Tie/Slur";
+        desc << "Duration Rate: Tie/Slur";
       }
       else if (noteDurationRate == 254) {
-        desc << L"Duration Rate: Full - 1";
+        desc << "Duration Rate: Full - 1";
       }
       else {
-        desc << L"Duration Rate: " << ((int) noteDurationRate + 1) << L"/256";
+        desc << "Duration Rate: " << ((int) noteDurationRate + 1) << "/256";
       }
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Duration Rate", desc.str(), CLR_DURNOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str(), CLR_DURNOTE);
       break;
     }
 
@@ -620,8 +620,8 @@ bool ChunSnesTrack::ReadEvent(void) {
       uint8_t sl = (adsr2 & 0xe0) >> 5;
       uint8_t sr = adsr2 & 0x1f;
 
-      desc << L"AR: " << (int) ar << L"  DR: " << (int) dr << L"  SL: " << (int) sl << L"  SR: " << (int) sr;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "AR: " << (int) ar << "  DR: " << (int) dr << "  SL: " << (int) sl << "  SR: " << (int) sr;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -637,13 +637,13 @@ bool ChunSnesTrack::ReadEvent(void) {
       // refresh duration info promptly
       SyncNoteLengthWithPriorTrack();
 
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Sync Note Length On", desc.str(), CLR_DURNOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Sync Note Length On", desc.str(), CLR_DURNOTE);
       break;
     }
 
     case EVENT_SYNC_NOTE_LEN_OFF: {
       syncNoteLen = false;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Sync Note Length Off", desc.str(), CLR_DURNOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Sync Note Length Off", desc.str(), CLR_DURNOTE);
       break;
     }
 
@@ -651,8 +651,8 @@ bool ChunSnesTrack::ReadEvent(void) {
       int16_t destOffset = GetShort(curOffset);
       curOffset += 2;
       uint16_t dest = curOffset + destOffset;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Again", desc.str(), CLR_LOOP, ICON_ENDREP);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again", desc.str(), CLR_LOOP, ICON_ENDREP);
 
       if (loopCount == 0) {
         loopCount = 2;
@@ -671,9 +671,9 @@ bool ChunSnesTrack::ReadEvent(void) {
       int16_t destOffset = GetShort(curOffset);
       curOffset += 2;
       uint16_t dest = curOffset + destOffset;
-      desc << L"Times: " << (int) times << L"  Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+      desc << "Times: " << (int) times << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Until", desc.str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Until", desc.str(), CLR_LOOP, ICON_ENDREP);
 
       if (loopCount == 0) {
         loopCount = times;
@@ -697,8 +697,8 @@ bool ChunSnesTrack::ReadEvent(void) {
       int16_t destOffset = GetShort(curOffset);
       curOffset += 2;
       uint16_t dest = curOffset + destOffset;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pattern Play", desc.str(), CLR_LOOP, ICON_STARTREP);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pattern Play", desc.str(), CLR_LOOP, ICON_STARTREP);
 
       if (subNestLevel >= CHUNSNES_SUBLEVEL_MAX) {
         // stack overflow
@@ -714,7 +714,7 @@ bool ChunSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_RET: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pattern End", desc.str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pattern End", desc.str(), CLR_LOOP, ICON_ENDREP);
 
       if (subNestLevel > 0) {
         curOffset = subReturnAddr[subNestLevel - 1];
@@ -733,19 +733,19 @@ bool ChunSnesTrack::ReadEvent(void) {
     case EVENT_PITCH_SLIDE: {
       int8_t semitones = GetByte(curOffset++);
       uint8_t length = GetByte(curOffset++);
-      desc << L"Key: " << (semitones > 0 ? L"+" : L"") << (int) semitones << L" semitones" << L"  Length: "
+      desc << "Key: " << (semitones > 0 ? "+" : "") << (int) semitones << " semitones" << "  Length: "
           << (int) length;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pitch Slide", desc.str(), CLR_PITCHBEND, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc.str(), CLR_PITCHBEND, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_ON: {
-      AddReverb(beginOffset, curOffset - beginOffset, 40, L"Echo On");
+      AddReverb(beginOffset, curOffset - beginOffset, 40, "Echo On");
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      AddReverb(beginOffset, curOffset - beginOffset, 0, L"Echo Off");
+      AddReverb(beginOffset, curOffset - beginOffset, 0, "Echo Off");
       break;
     }
 
@@ -763,14 +763,14 @@ bool ChunSnesTrack::ReadEvent(void) {
       // here we dispatch only a part of them
       switch (presetType) {
         case PRESET_CONDITION:
-          desc << L"Value: " << presetIndex;
+          desc << "Value: " << presetIndex;
           parentSeq->conditionVar = presetIndex; // luckily those preset starts from preset 0 :)
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Set Condition Value", desc.str(), CLR_CHANGESTATE);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Set Condition Value", desc.str(), CLR_CHANGESTATE);
           break;
 
         default:
-          desc << L"Preset: " << presetIndex;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Load Preset", desc.str(), CLR_MISC);
+          desc << "Preset: " << presetIndex;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Load Preset", desc.str(), CLR_MISC);
           break;
       }
 
@@ -780,7 +780,7 @@ bool ChunSnesTrack::ReadEvent(void) {
     case EVENT_END: {
       if (subNestLevel > 0) {
         // return from subroutine (normally not used)
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"End of Track", desc.str(), CLR_TRACKEND, ICON_TRACKEND);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "End of Track", desc.str(), CLR_TRACKEND, ICON_TRACKEND);
         curOffset = subReturnAddr[subNestLevel - 1];
         subNestLevel--;
       }
@@ -793,17 +793,17 @@ bool ChunSnesTrack::ReadEvent(void) {
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"ChunSnesSeq"));
+                                    "ChunSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //std::wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //std::ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/ChunSnesSeq.h
+++ b/src/main/formats/ChunSnesSeq.h
@@ -64,7 +64,7 @@ class ChunSnesSeq
               ChunSnesVersion ver,
               ChunSnesMinorVersion minorVer,
               uint32_t seqdataOffset,
-              std::wstring newName = L"Chun SNES Seq");
+              std::string newName = "Chun SNES Seq");
   virtual ~ChunSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/CompileSnesInstr.cpp
+++ b/src/main/formats/CompileSnesInstr.cpp
@@ -11,7 +11,7 @@ CompileSnesInstrSet::CompileSnesInstrSet(RawFile *file,
                                          uint16_t addrTuningTable,
                                          uint16_t addrPitchTablePtrs,
                                          uint32_t spcDirAddr,
-                                         const std::wstring &name)
+                                         const std::string &name)
     : VGMInstrSet(CompileSnesFormat::name, file, addrTuningTable, 0, name), version(ver),
       addrTuningTable(addrTuningTable),
       addrPitchTablePtrs(addrPitchTablePtrs),
@@ -53,8 +53,8 @@ bool CompileSnesInstrSet::GetInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << srcn;
+    std::ostringstream instrName;
+    instrName << "Instrument " << srcn;
     CompileSnesInstr *newInstr =
         new CompileSnesInstr(this, version, ofsInstrEntry, addrPitchTablePtrs, srcn, spcDirAddr, instrName.str());
     aInstrs.push_back(newInstr);
@@ -83,7 +83,7 @@ CompileSnesInstr::CompileSnesInstr(VGMInstrSet *instrSet,
                                    uint16_t addrPitchTablePtrs,
                                    uint8_t srcn,
                                    uint32_t spcDirAddr,
-                                   const std::wstring &name)
+                                   const std::string &name)
     : VGMInstr(instrSet, addrTuningTableItem, CompileSnesInstr::ExpectedSize(ver), 0, srcn, name), version(ver),
       addrPitchTablePtrs(addrPitchTablePtrs),
       spcDirAddr(spcDirAddr) {
@@ -157,7 +157,7 @@ CompileSnesRgn::CompileSnesRgn(CompileSnesInstr *instr,
   }
   else {
     uint8_t pitchTableIndex = GetByte(addrTuningTableItem + 1);
-    AddSimpleItem(dwOffset + 1, 1, L"Pitch Table Index");
+    AddSimpleItem(dwOffset + 1, 1, "Pitch Table Index");
 
     if (pitchTableIndex == 0) {
       pitchTable.assign(std::begin(REGULAR_PITCH_TABLE), std::end(REGULAR_PITCH_TABLE));

--- a/src/main/formats/CompileSnesInstr.h
+++ b/src/main/formats/CompileSnesInstr.h
@@ -16,7 +16,7 @@ class CompileSnesInstrSet:
                       uint16_t addrTuningTable,
                       uint16_t addrPitchTablePtrs,
                       uint32_t spcDirAddr,
-                      const std::wstring &name = L"CompileSnesInstrSet");
+                      const std::string &name = "CompileSnesInstrSet");
   virtual ~CompileSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -44,7 +44,7 @@ class CompileSnesInstr
                    uint16_t addrPitchTablePtrs,
                    uint8_t srcn,
                    uint32_t spcDirAddr,
-                   const std::wstring &name = L"CompileSnesInstr");
+                   const std::string &name = "CompileSnesInstr");
   virtual ~CompileSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/CompileSnesScanner.cpp
+++ b/src/main/formats/CompileSnesScanner.cpp
@@ -44,8 +44,8 @@ void CompileSnesScanner::Scan(RawFile *file, void *info) {
 void CompileSnesScanner::SearchForCompileSnesFromARAM(RawFile *file) {
   CompileSnesVersion version = COMPILESNES_NONE;
 
-  std::wstring basefilename = RawFile::removeExtFromPath(file->GetFileName());
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : basefilename;
+  std::string basefilename = RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : basefilename;
 
   // scan for table pointer initialize code
   uint32_t ofsSetSongListAddress;

--- a/src/main/formats/CompileSnesScanner.h
+++ b/src/main/formats/CompileSnesScanner.h
@@ -8,7 +8,7 @@ class CompileSnesScanner:
     public VGMScanner {
  public:
   CompileSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~CompileSnesScanner(void) {
   }

--- a/src/main/formats/CompileSnesSeq.cpp
+++ b/src/main/formats/CompileSnesSeq.cpp
@@ -19,7 +19,7 @@ const uint8_t CompileSnesSeq::noteDurTable[] = {
     0x18, 0x20, 0x30, 0x09, 0x12, 0x1e, 0x24, 0x2a,
 };
 
-CompileSnesSeq::CompileSnesSeq(RawFile *file, CompileSnesVersion ver, uint32_t seqdataOffset, std::wstring newName)
+CompileSnesSeq::CompileSnesSeq(RawFile *file, CompileSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(CompileSnesFormat::name, file, seqdataOffset), version(ver),
       STATUS_PERCUSSION_NOTE_MIN(0xc0),
       STATUS_PERCUSSION_NOTE_MAX(0xdd),
@@ -46,7 +46,7 @@ bool CompileSnesSeq::GetHeaderInfo(void) {
 
   VGMHeader *header = AddHeader(dwOffset, 0);
 
-  header->AddSimpleItem(dwOffset, 1, L"Number of Tracks");
+  header->AddSimpleItem(dwOffset, 1, "Number of Tracks");
   nNumTracks = GetByte(dwOffset);
   if (nNumTracks == 0 || nNumTracks > 8) {
     return false;
@@ -54,23 +54,23 @@ bool CompileSnesSeq::GetHeaderInfo(void) {
 
   uint32_t curOffset = dwOffset + 1;
   for (uint8_t trackIndex = 0; trackIndex < nNumTracks; trackIndex++) {
-    std::wstringstream trackName;
-    trackName << L"Track " << (trackIndex + 1);
+    std::stringstream trackName;
+    trackName << "Track " << (trackIndex + 1);
 
     VGMHeader *trackHeader = header->AddHeader(curOffset, 14, trackName.str().c_str());
-    trackHeader->AddSimpleItem(curOffset, 1, L"Channel");
-    trackHeader->AddSimpleItem(curOffset + 1, 1, L"Flags");
-    trackHeader->AddSimpleItem(curOffset + 2, 1, L"Volume");
-    trackHeader->AddSimpleItem(curOffset + 3, 1, L"Volume Envelope");
-    trackHeader->AddSimpleItem(curOffset + 4, 1, L"Vibrato");
-    trackHeader->AddSimpleItem(curOffset + 5, 1, L"Transpose");
+    trackHeader->AddSimpleItem(curOffset, 1, "Channel");
+    trackHeader->AddSimpleItem(curOffset + 1, 1, "Flags");
+    trackHeader->AddSimpleItem(curOffset + 2, 1, "Volume");
+    trackHeader->AddSimpleItem(curOffset + 3, 1, "Volume Envelope");
+    trackHeader->AddSimpleItem(curOffset + 4, 1, "Vibrato");
+    trackHeader->AddSimpleItem(curOffset + 5, 1, "Transpose");
     trackHeader->AddTempo(curOffset + 6, 1);
-    trackHeader->AddSimpleItem(curOffset + 7, 1, L"Branch ID (Channel #)");
-    trackHeader->AddSimpleItem(curOffset + 8, 2, L"Score Pointer");
-    trackHeader->AddSimpleItem(curOffset + 10, 1, L"SRCN");
-    trackHeader->AddSimpleItem(curOffset + 11, 1, L"ADSR");
-    trackHeader->AddSimpleItem(curOffset + 12, 1, L"Pan");
-    trackHeader->AddSimpleItem(curOffset + 13, 1, L"Reserved");
+    trackHeader->AddSimpleItem(curOffset + 7, 1, "Branch ID (Channel #)");
+    trackHeader->AddSimpleItem(curOffset + 8, 2, "Score Pointer");
+    trackHeader->AddSimpleItem(curOffset + 10, 1, "SRCN");
+    trackHeader->AddSimpleItem(curOffset + 11, 1, "ADSR");
+    trackHeader->AddSimpleItem(curOffset + 12, 1, "Pan");
+    trackHeader->AddSimpleItem(curOffset + 13, 1, "Reserved");
     curOffset += 14;
   }
 
@@ -229,7 +229,7 @@ bool CompileSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   CompileSnesSeqEventType eventType = (CompileSnesSeqEventType) 0;
   std::map<uint8_t, CompileSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -239,27 +239,27 @@ bool CompileSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -267,12 +267,12 @@ bool CompileSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -281,13 +281,13 @@ bool CompileSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -297,29 +297,29 @@ bool CompileSnesTrack::ReadEvent(void) {
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
       uint8_t arg5 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4
-          << L"  Arg5: " << (int) arg5;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4
+          << "  Arg5: " << (int) arg5;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_GOTO: {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       uint32_t length = curOffset - beginOffset;
 
       curOffset = dest;
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
       }
       else {
-        bContinue = AddLoopForever(beginOffset, length, L"Jump");
+        bContinue = AddLoopForever(beginOffset, length, "Jump");
       }
       break;
     }
@@ -329,9 +329,9 @@ bool CompileSnesTrack::ReadEvent(void) {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
 
-      desc << L"Nest Level: " << (int) repeatNest << L"  Destination: $" << std::hex << std::setfill(L'0')
+      desc << "Nest Level: " << (int) repeatNest << "  Destination: $" << std::hex << std::setfill('0')
           << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Repeat End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Repeat End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       repeatCount[repeatNest]--;
       if (repeatCount[repeatNest] != 0) {
@@ -348,10 +348,10 @@ bool CompileSnesTrack::ReadEvent(void) {
 
     case EVENT_VIBRATO: {
       uint8_t envelopeIndex = GetByte(curOffset++);
-      desc << L"Envelope Index: " << (int) envelopeIndex;
+      desc << "Envelope Index: " << (int) envelopeIndex;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato",
+                      "Vibrato",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -360,10 +360,10 @@ bool CompileSnesTrack::ReadEvent(void) {
 
     case EVENT_PORTAMENTO_TIME: {
       uint8_t rate = GetByte(curOffset++);
-      desc << L"Rate: " << (int) rate;
+      desc << "Rate: " << (int) rate;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Portamento Time",
+                      "Portamento Time",
                       desc.str().c_str(),
                       CLR_PORTAMENTOTIME,
                       ICON_CONTROL);
@@ -380,10 +380,10 @@ bool CompileSnesTrack::ReadEvent(void) {
 
     case EVENT_VOLUME_ENVELOPE: {
       uint8_t envelopeIndex = GetByte(curOffset++);
-      desc << L"Envelope Index: " << (int) envelopeIndex;
+      desc << "Envelope Index: " << (int) envelopeIndex;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Volume Envelope",
+                      "Volume Envelope",
                       desc.str().c_str(),
                       CLR_VOLUME,
                       ICON_CONTROL);
@@ -393,7 +393,7 @@ bool CompileSnesTrack::ReadEvent(void) {
     case EVENT_TRANSPOSE: {
       int8_t delta = (int8_t) GetByte(curOffset++);
       spcTranspose += delta;
-      AddTranspose(beginOffset, curOffset - beginOffset, spcTranspose, L"Transpose (Relative)");
+      AddTranspose(beginOffset, curOffset - beginOffset, spcTranspose, "Transpose (Relative)");
       break;
     }
 
@@ -401,7 +401,7 @@ bool CompileSnesTrack::ReadEvent(void) {
       int8_t delta = (int8_t) GetByte(curOffset++);
       spcVolume += delta;
       uint8_t midiVolume = Convert7bitPercentVolValToStdMidiVal(spcVolume / 2);
-      AddVol(beginOffset, curOffset - beginOffset, midiVolume, L"Volume (Relative)");
+      AddVol(beginOffset, curOffset - beginOffset, midiVolume, "Volume (Relative)");
       break;
     }
 
@@ -412,7 +412,7 @@ bool CompileSnesTrack::ReadEvent(void) {
       bool hasDuration = ReadDurationBytes(curOffset, duration);
       if (hasDuration) {
         spcNoteDuration = duration;
-        desc << L"Duration: " << (int) duration;
+        desc << "Duration: " << (int) duration;
       }
 
       if (rest) {
@@ -421,7 +421,7 @@ bool CompileSnesTrack::ReadEvent(void) {
       else {
         uint8_t noteNumber = statusByte - 1;
         AddNoteByDur(beginOffset, curOffset - beginOffset, noteNumber, 100, spcNoteDuration,
-                     hasDuration ? L"Note with Duration" : L"Note");
+                     hasDuration ? "Note with Duration" : "Note");
         AddTime(spcNoteDuration);
       }
       break;
@@ -432,8 +432,8 @@ bool CompileSnesTrack::ReadEvent(void) {
       uint8_t times = GetByte(curOffset++);
       int actualTimes = (times == 0) ? 256 : times;
 
-      desc << L"Nest Level: " << (int) repeatNest << L"  Times: " << actualTimes;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Count", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      desc << "Nest Level: " << (int) repeatNest << "  Times: " << actualTimes;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Count", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
 
       repeatCount[repeatNest] = times;
       break;
@@ -444,7 +444,7 @@ bool CompileSnesTrack::ReadEvent(void) {
       spcFlags = flags;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Flags",
+                      "Flags",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -468,10 +468,10 @@ bool CompileSnesTrack::ReadEvent(void) {
         curOffset += 2;
       }
 
-      desc << L"Pitch Register Delta: " << (int) newTuning;
+      desc << "Pitch Register Delta: " << (int) newTuning;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Tuning",
+                      "Tuning",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -481,11 +481,11 @@ bool CompileSnesTrack::ReadEvent(void) {
     case EVENT_CALL: {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
 
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pattern Play",
+                      "Pattern Play",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -498,7 +498,7 @@ bool CompileSnesTrack::ReadEvent(void) {
     case EVENT_RET: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"End Pattern",
+                      "End Pattern",
                       desc.str().c_str(),
                       CLR_TRACKEND,
                       ICON_ENDREP);
@@ -514,8 +514,8 @@ bool CompileSnesTrack::ReadEvent(void) {
 
     case EVENT_ADSR: {
       uint8_t envelopeIndex = GetByte(curOffset++);
-      desc << L"Envelope Index: " << (int) envelopeIndex;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR", desc.str().c_str(), CLR_VOLUME, ICON_CONTROL);
+      desc << "Envelope Index: " << (int) envelopeIndex;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str().c_str(), CLR_VOLUME, ICON_CONTROL);
       break;
     }
 
@@ -523,7 +523,7 @@ bool CompileSnesTrack::ReadEvent(void) {
       spcFlags |= COMPILESNES_FLAGS_PORTAMENTO;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Portamento On",
+                      "Portamento On",
                       desc.str().c_str(),
                       CLR_PORTAMENTO,
                       ICON_CONTROL);
@@ -534,7 +534,7 @@ bool CompileSnesTrack::ReadEvent(void) {
       spcFlags &= ~COMPILESNES_FLAGS_PORTAMENTO;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Portamento Off",
+                      "Portamento Off",
                       desc.str().c_str(),
                       CLR_PORTAMENTO,
                       ICON_CONTROL);
@@ -543,10 +543,10 @@ bool CompileSnesTrack::ReadEvent(void) {
 
     case EVENT_PANPOT_ENVELOPE: {
       uint8_t envelopeIndex = GetByte(curOffset++);
-      desc << L"Envelope Index: " << (int) envelopeIndex;
+      desc << "Envelope Index: " << (int) envelopeIndex;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Panpot Envelope",
+                      "Panpot Envelope",
                       desc.str().c_str(),
                       CLR_PAN,
                       ICON_CONTROL);
@@ -569,9 +569,9 @@ bool CompileSnesTrack::ReadEvent(void) {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
 
-      desc << L"Nest Level: " << (int) repeatNest << L"  Destination: $" << std::hex << std::setfill(L'0')
+      desc << "Nest Level: " << (int) repeatNest << "  Destination: $" << std::hex << std::setfill('0')
           << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Repeat Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       repeatCount[repeatNest]--;
       if (repeatCount[repeatNest] == 0) {
@@ -588,10 +588,10 @@ bool CompileSnesTrack::ReadEvent(void) {
       }
       spcNoteDuration = duration;
 
-      desc << L"Duration: " << (int) duration;
+      desc << "Duration: " << (int) duration;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Duration (Direct)",
+                      "Duration (Direct)",
                       desc.str().c_str(),
                       CLR_DURNOTE,
                       ICON_CONTROL);
@@ -606,8 +606,8 @@ bool CompileSnesTrack::ReadEvent(void) {
       }
       spcNoteDuration = duration;
 
-      desc << L"Duration: " << (int) duration;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Duration", desc.str().c_str(), CLR_DURNOTE, ICON_CONTROL);
+      desc << "Duration: " << (int) duration;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Duration", desc.str().c_str(), CLR_DURNOTE, ICON_CONTROL);
       break;
     }
 
@@ -616,28 +616,28 @@ bool CompileSnesTrack::ReadEvent(void) {
       bool hasDuration = ReadDurationBytes(curOffset, duration);
       if (hasDuration) {
         spcNoteDuration = duration;
-        desc << L"Duration: " << (int) duration;
+        desc << "Duration: " << (int) duration;
       }
 
       uint8_t percNoteNumber = statusByte - parentSeq->STATUS_PERCUSSION_NOTE_MIN;
       AddPercNoteByDur(beginOffset, curOffset - beginOffset, percNoteNumber, 100, spcNoteDuration,
-                       hasDuration ? L"Percussion Note with Duration" : L"Percussion Note");
+                       hasDuration ? "Percussion Note with Duration" : "Percussion Note");
       AddTime(spcNoteDuration);
       break;
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"CompileSnesSeq"));
+                                    "CompileSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/CompileSnesSeq.h
+++ b/src/main/formats/CompileSnesSeq.h
@@ -44,7 +44,7 @@ class CompileSnesSeq
     : public VGMSeq {
  public:
   CompileSnesSeq
-      (RawFile *file, CompileSnesVersion ver, uint32_t seqdataOffset, std::wstring newName = L"Compile SNES Seq");
+      (RawFile *file, CompileSnesVersion ver, uint32_t seqdataOffset, std::string newName = "Compile SNES Seq");
   virtual ~CompileSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/FFTInstr.cpp
+++ b/src/main/formats/FFTInstr.cpp
@@ -43,21 +43,21 @@ bool WdsInstrSet::GetHeaderInfo() {
     version = VERSION_WDS;
 
   //バイナリエディタ表示用
-  wostringstream theName;
-  theName << L"wds " << id;
+  ostringstream theName;
+  theName << "wds " << id;
   name = theName.str();
 
   //ヘッダーobjectの生成
   VGMHeader *wdsHeader = AddHeader(dwOffset, sizeof(WdsHdr));
   wdsHeader->AddSig(dwOffset, sizeof(long));
   wdsHeader->AddUnknownItem(dwOffset + 0x04, sizeof(long));
-  wdsHeader->AddSimpleItem(dwOffset + 0x08, sizeof(long), L"Header size? (0)");
+  wdsHeader->AddSimpleItem(dwOffset + 0x08, sizeof(long), "Header size? (0)");
   wdsHeader->AddUnknownItem(dwOffset + 0x0C, sizeof(long));
-  wdsHeader->AddSimpleItem(dwOffset + 0x10, sizeof(long), L"Header size? (1)");
-  wdsHeader->AddSimpleItem(dwOffset + 0x14, sizeof(long), L"AD-PCM body(.VB) size");
-  wdsHeader->AddSimpleItem(dwOffset + 0x18, sizeof(long), L"Header size? (2)");
-  wdsHeader->AddSimpleItem(dwOffset + 0x1C, sizeof(long), L"Number of Instruments");
-  wdsHeader->AddSimpleItem(dwOffset + 0x20, sizeof(long), L"Bank number");
+  wdsHeader->AddSimpleItem(dwOffset + 0x10, sizeof(long), "Header size? (1)");
+  wdsHeader->AddSimpleItem(dwOffset + 0x14, sizeof(long), "AD-PCM body(.VB) size");
+  wdsHeader->AddSimpleItem(dwOffset + 0x18, sizeof(long), "Header size? (2)");
+  wdsHeader->AddSimpleItem(dwOffset + 0x1C, sizeof(long), "Number of Instruments");
+  wdsHeader->AddSimpleItem(dwOffset + 0x20, sizeof(long), "Bank number");
   wdsHeader->AddUnknownItem(dwOffset + 0x24, sizeof(long));
   wdsHeader->AddUnknownItem(dwOffset + 0x28, sizeof(long));
   wdsHeader->AddUnknownItem(dwOffset + 0x2C, sizeof(long));
@@ -131,9 +131,9 @@ bool WdsInstr::LoadInstr() {
   // see the declaration of iFineTune for info on where to find the actual code and table for this in FFT
   rgn->fineTune = (short) ((double) rgndata.iFineTune * (100.0 / 256.0));
 
-  rgn->AddGeneralItem(dwOffset + 0x00, sizeof(uint32_t), L"Sample Offset");
-  rgn->AddGeneralItem(dwOffset + 0x04, sizeof(uint16_t), L"Loop Offset");
-  rgn->AddGeneralItem(dwOffset + 0x06, sizeof(uint16_t), L"Pitch Fine Tune");
+  rgn->AddGeneralItem(dwOffset + 0x00, sizeof(uint32_t), "Sample Offset");
+  rgn->AddGeneralItem(dwOffset + 0x04, sizeof(uint16_t), "Loop Offset");
+  rgn->AddGeneralItem(dwOffset + 0x06, sizeof(uint16_t), "Pitch Fine Tune");
 
   if (parInstrSet->version == WdsInstrSet::VERSION_WDS) {
     uint32_t adsr_rate = GetWord(dwOffset + 0x08);
@@ -150,12 +150,12 @@ bool WdsInstr::LoadInstr() {
     uint8_t Sm = (adsr_mode >> 4) & 0x07;
     uint8_t Rm = (adsr_mode >> 8) & 0x07;
 
-    rgn->AddGeneralItem(dwOffset + 0x08, sizeof(uint8_t), L"ADSR Attack Rate");
-    rgn->AddGeneralItem(dwOffset + 0x09, sizeof(uint8_t), L"ADSR Decay Rate & Sustain Level");
-    rgn->AddGeneralItem(dwOffset + 0x0a, sizeof(uint8_t), L"ADSR Sustain Rate");
-    rgn->AddGeneralItem(dwOffset + 0x0b, sizeof(uint8_t), L"ADSR Release Rate");
-    rgn->AddGeneralItem(dwOffset + 0x0c, sizeof(uint8_t), L"ADSR Attack Mode & Sustain Mode / Direction");
-    rgn->AddGeneralItem(dwOffset + 0x0d, sizeof(uint8_t), L"ADSR Release Mode");
+    rgn->AddGeneralItem(dwOffset + 0x08, sizeof(uint8_t), "ADSR Attack Rate");
+    rgn->AddGeneralItem(dwOffset + 0x09, sizeof(uint8_t), "ADSR Decay Rate & Sustain Level");
+    rgn->AddGeneralItem(dwOffset + 0x0a, sizeof(uint8_t), "ADSR Sustain Rate");
+    rgn->AddGeneralItem(dwOffset + 0x0b, sizeof(uint8_t), "ADSR Release Rate");
+    rgn->AddGeneralItem(dwOffset + 0x0c, sizeof(uint8_t), "ADSR Attack Mode & Sustain Mode / Direction");
+    rgn->AddGeneralItem(dwOffset + 0x0d, sizeof(uint8_t), "ADSR Release Mode");
     rgn->AddUnknown(dwOffset + 0x0e, sizeof(uint8_t));
     rgn->AddUnknown(dwOffset + 0x0f, sizeof(uint8_t));
 
@@ -166,12 +166,12 @@ bool WdsInstr::LoadInstr() {
     PSXConvADSR(rgn, rgndata.Am > 1, rgndata.Ar, rgndata.Dr, rgndata.Sl, 1, 1, rgndata.Sr, 1, rgndata.Rr, false);
     aRgns.push_back(rgn);
 
-    rgn->AddGeneralItem(dwOffset + 0x08, sizeof(uint8_t), L"Attack Rate");
-    rgn->AddGeneralItem(dwOffset + 0x09, sizeof(uint8_t), L"Decay Rate");
-    rgn->AddGeneralItem(dwOffset + 0x0A, sizeof(uint8_t), L"Sustain Rate");
-    rgn->AddGeneralItem(dwOffset + 0x0B, sizeof(uint8_t), L"Release Rate");
-    rgn->AddGeneralItem(dwOffset + 0x0C, sizeof(uint8_t), L"Sustain Level");
-    rgn->AddGeneralItem(dwOffset + 0x0D, sizeof(uint8_t), L"Attack Rate Mode?");
+    rgn->AddGeneralItem(dwOffset + 0x08, sizeof(uint8_t), "Attack Rate");
+    rgn->AddGeneralItem(dwOffset + 0x09, sizeof(uint8_t), "Decay Rate");
+    rgn->AddGeneralItem(dwOffset + 0x0A, sizeof(uint8_t), "Sustain Rate");
+    rgn->AddGeneralItem(dwOffset + 0x0B, sizeof(uint8_t), "Release Rate");
+    rgn->AddGeneralItem(dwOffset + 0x0C, sizeof(uint8_t), "Sustain Level");
+    rgn->AddGeneralItem(dwOffset + 0x0D, sizeof(uint8_t), "Attack Rate Mode?");
     rgn->AddUnknown(dwOffset + 0x0E, sizeof(uint8_t));
     rgn->AddUnknown(dwOffset + 0x0F, sizeof(uint8_t));
   }

--- a/src/main/formats/FFTSeq.cpp
+++ b/src/main/formats/FFTSeq.cpp
@@ -39,25 +39,25 @@ bool FFTSeq::GetHeaderInfo(void) {
   int titleLength = ptPercussionTbl - ptSongTitle;
   char *songtitle = new char[titleLength];
   GetBytes(dwOffset + ptSongTitle, titleLength, songtitle);
-  this->name = std::wstring(songtitle, songtitle + titleLength);
+  this->name = std::string(songtitle, songtitle + titleLength);
   delete[] songtitle;
 
   VGMHeader *hdr = AddHeader(dwOffset, 0x22);
   hdr->AddSig(dwOffset, 4);
-  hdr->AddSimpleItem(dwOffset + 0x08, 2, L"Size");
-  hdr->AddSimpleItem(dwOffset + 0x14, 1, L"Track count");
-  hdr->AddSimpleItem(dwOffset + 0x15, 1, L"Drum instrument count");
-  hdr->AddSimpleItem(dwOffset + 0x16, 1, L"Associated Sample Set ID");
-  hdr->AddSimpleItem(dwOffset + 0x1E, 2, L"Song title Pointer");
-  hdr->AddSimpleItem(dwOffset + 0x20, 2, L"Drumkit Data Pointer");
+  hdr->AddSimpleItem(dwOffset + 0x08, 2, "Size");
+  hdr->AddSimpleItem(dwOffset + 0x14, 1, "Track count");
+  hdr->AddSimpleItem(dwOffset + 0x15, 1, "Drum instrument count");
+  hdr->AddSimpleItem(dwOffset + 0x16, 1, "Associated Sample Set ID");
+  hdr->AddSimpleItem(dwOffset + 0x1E, 2, "Song title Pointer");
+  hdr->AddSimpleItem(dwOffset + 0x20, 2, "Drumkit Data Pointer");
 
-  VGMHeader *trackPtrs = AddHeader(dwOffset + 0x22, nNumTracks * 2, L"Track Pointers");
+  VGMHeader *trackPtrs = AddHeader(dwOffset + 0x22, nNumTracks * 2, "Track Pointers");
   for (unsigned int i = 0; i < nNumTracks; i++)
-    trackPtrs->AddSimpleItem(dwOffset + 0x22 + i * 2, 2, L"Track Pointer");
-  VGMHeader *titleHdr = AddHeader(dwOffset + ptSongTitle, titleLength, L"Song Name");
+    trackPtrs->AddSimpleItem(dwOffset + 0x22 + i * 2, 2, "Track Pointer");
+  VGMHeader *titleHdr = AddHeader(dwOffset + ptSongTitle, titleLength, "Song Name");
 
 //	if(cNumPercussion!=0){										//これ、やっぱ、いらない。
-//		hdr->AddSimpleItem(dwOffset+ptPercussionTbl, cNumPercussion*5, L"Drumkit Struct");
+//		hdr->AddSimpleItem(dwOffset+ptPercussionTbl, cNumPercussion*5, "Drumkit Struct");
 //	}
 //-----------------------------------------------------------
 
@@ -71,7 +71,7 @@ bool FFTSeq::GetHeaderInfo(void) {
 //	}
 
 
-//	hdr->AddSimpleItem(dwOffset + ptMusicTile, i, L"Music title");		//やっぱ書かないでいいや。
+//	hdr->AddSimpleItem(dwOffset + ptMusicTile, i, "Music title");		//やっぱ書かないでいいや。
 
 
   return true;
@@ -156,7 +156,7 @@ bool FFTTrack::ReadEvent(void) {
         //hold (Tie)
       case 0x81:
         AddTime(GetByte(curOffset++));
-        AddHold(beginOffset, curOffset - beginOffset, L"Tie");
+        AddHold(beginOffset, curOffset - beginOffset, "Tie");
         break;
 
         //--------
@@ -176,7 +176,7 @@ bool FFTTrack::ReadEvent(void) {
       case 0x91:
         infiniteLoopPt = curOffset;
         infiniteLoopOctave = octave;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Track Repeat Point", L"", CLR_LOOP);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Track Repeat Point", "", CLR_LOOP);
         //AddEventItem(_T("Repeat"), ICON_STARTREP, beginOffset, curOffset-beginOffset, BG_CLR_WHEAT);
         break;
 
@@ -219,14 +219,14 @@ bool FFTTrack::ReadEvent(void) {
         loop_counter[loop_layer] = 0;
         loop_repeats[loop_layer] = loopCount - 1;
         loop_octave[loop_layer] = octave;            //1,Sep.2009 revise
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Repeat Begin", L"", CLR_LOOP);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Begin", "", CLR_LOOP);
         //AddEventItem("Loop Begin", ICON_STARTREP, beginOffset, curOffset-beginOffset, BG_CLR_WHEAT);
         break;
       }
 
         //Repeat End
       case 0x99:
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Repeat End", L"", CLR_LOOP);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Repeat End", "", CLR_LOOP);
         //AddEventItem("Loop End", ICON_ENDREP, beginOffset, curOffset-beginOffset, BG_CLR_WHEAT);
 
         // hitting loop end for first time
@@ -256,7 +256,7 @@ bool FFTTrack::ReadEvent(void) {
 
         //Repeat break on last repeat
       case 0x9A:
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Repeat Break", L"", CLR_LOOP);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Break", "", CLR_LOOP);
         //AddEventItem("Loop Break", ICON_ENDREP, beginOffset, curOffset-beginOffset, BG_CLR_WHEAT);
 
         // if this is the last run of the loop, we break
@@ -284,7 +284,7 @@ bool FFTTrack::ReadEvent(void) {
       case 0xA2: {
         uint8_t cTempoSlideTimes = GetByte(curOffset++);        //slide times [ticks]
         uint8_t cTempoSlideTarget = (GetByte(curOffset++) * 256) / 218;        //Target Panpot
-        AddTempoBPM(beginOffset, curOffset - beginOffset, cTempoSlideTarget, L"Tempo slide");
+        AddTempoBPM(beginOffset, curOffset - beginOffset, cTempoSlideTarget, "Tempo slide");
         break;
       }
 
@@ -315,22 +315,22 @@ bool FFTTrack::ReadEvent(void) {
 
         //Percussion On
       case 0xAE :
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Percussion On", L"", CLR_CHANGESTATE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Percussion On", "", CLR_CHANGESTATE);
         break;
 
         //Percussion Off
       case 0xAF:
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Percussion Off", L"", CLR_CHANGESTATE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Percussion Off", "", CLR_CHANGESTATE);
         break;
 
         //Slur On
       case 0xB0:
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Slur On", L"", CLR_PORTAMENTO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Slur On", "", CLR_PORTAMENTO);
         break;
 
         //Slur Off
       case 0xB1:
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Slur Off", L"", CLR_PORTAMENTO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Slur Off", "", CLR_PORTAMENTO);
         break;
 
         //unknown
@@ -348,12 +348,12 @@ bool FFTTrack::ReadEvent(void) {
 
         //Reverb On
       case 0xBA :
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reverb On", L"", CLR_REVERB);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Reverb On", "", CLR_REVERB);
         break;
 
         //Reverb Off
       case 0xBB :
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reverb Off", L"", CLR_REVERB);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Off", "", CLR_REVERB);
         break;
 
         //--------
@@ -361,22 +361,22 @@ bool FFTTrack::ReadEvent(void) {
 
         //ADSR Reset
       case 0xC0:
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR: Reset", L"", CLR_ADSR);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Reset", "", CLR_ADSR);
         break;
 
       case 0xC2:
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR: Attack Rate?", L"", CLR_ADSR);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Attack Rate?", "", CLR_ADSR);
         break;
 
       case 0xC4:
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR: Sustain Rate?", L"", CLR_ADSR);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Sustain Rate?", "", CLR_ADSR);
         break;
 
       case 0xC5:
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR: Release Rate?", L"", CLR_ADSR);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Release Rate?", "", CLR_ADSR);
         break;
 
       case 0xC6:
@@ -397,12 +397,12 @@ bool FFTTrack::ReadEvent(void) {
 
       case 0xC9:
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR: Decay Rate?", L"", CLR_ADSR);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Decay Rate?", "", CLR_ADSR);
         break;
 
       case 0xCA:
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR: Sustain Level?", L"", CLR_ADSR);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Sustain Level?", "", CLR_ADSR);
         break;
 
         //--------
@@ -423,27 +423,27 @@ bool FFTTrack::ReadEvent(void) {
         // unknown
       case 0xD2:
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pitch Bend?", L"", CLR_PITCHBEND);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Bend?", "", CLR_PITCHBEND);
         break;
 
         //Portamento (Pitch bend slide)
       case 0xD4: {
         uint8_t cPitchSlideTimes = GetByte(curOffset++);        //slide times [ticks]
         uint8_t cPitchSlideDepth = GetByte(curOffset++);        //Target Panpot
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Portamento", L"", CLR_PORTAMENTO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Portamento", "", CLR_PORTAMENTO);
         break;
       }
 
         // unknown
       case 0xD6:
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Detune?", L"", CLR_PITCHBEND);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Detune?", "", CLR_PITCHBEND);
         break;
 
         // LFO Depth
       case 0xD7: {
         uint8_t cPitchLFO_Depth = GetByte(curOffset++);        //slide times [ticks]
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"LFO Depth (Pitch bend)", L"", CLR_LFO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "LFO Depth (Pitch bend)", "", CLR_LFO);
         break;
       }
 
@@ -452,7 +452,7 @@ bool FFTTrack::ReadEvent(void) {
         uint8_t cPitchLFO_Decay2 = GetByte(curOffset++);
         uint8_t cPitchLFO_Cycle = GetByte(curOffset++);
         uint8_t cPitchLFO_Decay1 = GetByte(curOffset++);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"LFO Length (Pitch bend)", L"", CLR_LFO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "LFO Length (Pitch bend)", "", CLR_LFO);
         break;
       }
 
@@ -461,7 +461,7 @@ bool FFTTrack::ReadEvent(void) {
         curOffset++;
         curOffset++;
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"LFO ? (Pitch bend)", L"", CLR_LFO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "LFO ? (Pitch bend)", "", CLR_LFO);
         break;
 
         // unknown
@@ -494,7 +494,7 @@ bool FFTTrack::ReadEvent(void) {
         // LFO Depth
       case 0xE3: {
         uint8_t cVolLFO_Depth = GetByte(curOffset++);        //
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"LFO Depth (Volume)", L"", CLR_LFO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "LFO Depth (Volume)", "", CLR_LFO);
         break;
       }
 
@@ -503,7 +503,7 @@ bool FFTTrack::ReadEvent(void) {
         uint8_t cVolLFO_Decay2 = GetByte(curOffset++);
         uint8_t cVolLFO_Cycle = GetByte(curOffset++);
         uint8_t cVolLFO_Decay1 = GetByte(curOffset++);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"LFO Length (Volume)", L"", CLR_LFO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "LFO Length (Volume)", "", CLR_LFO);
         break;
       }
 
@@ -512,7 +512,7 @@ bool FFTTrack::ReadEvent(void) {
         curOffset++;
         curOffset++;
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"LFO ? (Volume)", L"", CLR_LFO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "LFO ? (Volume)", "", CLR_LFO);
         break;
 
         // unknown
@@ -545,7 +545,7 @@ bool FFTTrack::ReadEvent(void) {
         // LFO Depth
       case 0xEB: {
         uint8_t cPanLFO_Depth = GetByte(curOffset++);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"LFO Depth (Panpot)", L"", CLR_LFO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "LFO Depth (Panpot)", "", CLR_LFO);
         break;
       }
 
@@ -554,7 +554,7 @@ bool FFTTrack::ReadEvent(void) {
         uint8_t cPanLFO_Decay2 = GetByte(curOffset++);
         uint8_t cPanLFO_Cycle = GetByte(curOffset++);
         uint8_t cPanLFO_Decay1 = GetByte(curOffset++);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"LFO Length (Panpot)", L"", CLR_LFO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "LFO Length (Panpot)", "", CLR_LFO);
         break;
       }
 
@@ -563,7 +563,7 @@ bool FFTTrack::ReadEvent(void) {
         curOffset++;
         curOffset++;
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"LFO ? (Panpot)", L"", CLR_LFO);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "LFO ? (Panpot)", "", CLR_LFO);
         break;
 
         // unknown
@@ -611,7 +611,7 @@ bool FFTTrack::ReadEvent(void) {
         // Program(WDS) bank select
       case 0xFE:
         uint8_t cProgBankNum = GetByte(curOffset++);        //Bank Number [ticks]
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Program bank select", L"", CLR_PROGCHANGE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Program bank select", "", CLR_PROGCHANGE);
         break;
 
     }

--- a/src/main/formats/FalcomSnesInstr.cpp
+++ b/src/main/formats/FalcomSnesInstr.cpp
@@ -12,7 +12,7 @@ FalcomSnesInstrSet::FalcomSnesInstrSet(RawFile *file,
                                        uint32_t addrSampToInstrTable,
                                        uint32_t spcDirAddr,
                                        const std::map<uint8_t, uint16_t> &instrADSRHints,
-                                       const std::wstring &name) :
+                                       const std::string &name) :
     VGMInstrSet(FalcomSnesFormat::name, file, offset, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrSampToInstrTable(addrSampToInstrTable),
@@ -74,8 +74,8 @@ bool FalcomSnesInstrSet::GetInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << instr;
+    std::ostringstream instrName;
+    instrName << "Instrument " << instr;
     FalcomSnesInstr *newInstr =
         new FalcomSnesInstr(this, version, addrInstrHeader, instr >> 7, instr & 0x7f, srcn, spcDirAddr, instrName.str());
     aInstrs.push_back(newInstr);
@@ -105,7 +105,7 @@ FalcomSnesInstr::FalcomSnesInstr(VGMInstrSet *instrSet,
                                  uint32_t theInstrNum,
                                  uint8_t srcn,
                                  uint32_t spcDirAddr,
-                                 const std::wstring &name) :
+                                 const std::string &name) :
     VGMInstr(instrSet, offset, 5, theBank, theInstrNum, name), version(ver),
     srcn(srcn),
     spcDirAddr(spcDirAddr) {
@@ -169,8 +169,8 @@ FalcomSnesRgn::FalcomSnesRgn(FalcomSnesInstr *instr,
   }
 
   sampNum = srcn;
-  AddSimpleItem(offset, 1, L"ADSR1");
-  AddSimpleItem(offset + 1, 1, L"ADSR2");
+  AddSimpleItem(offset, 1, "ADSR1");
+  AddSimpleItem(offset + 1, 1, "ADSR2");
   AddUnityKey(96 - (int) (coarse_tuning), offset + 3, 1);
   AddFineTune((int16_t) (fine_tuning * 100.0), offset + 4, 1);
   SNESConvADSR<VGMRgn>(this, adsr1, adsr2, 0);

--- a/src/main/formats/FalcomSnesInstr.h
+++ b/src/main/formats/FalcomSnesInstr.h
@@ -24,7 +24,7 @@ class FalcomSnesInstrSet:
                      uint32_t addrSampToInstrTable,
                      uint32_t spcDirAddr,
                      const std::map<uint8_t, uint16_t> &instrADSRHints,
-                     const std::wstring &name = L"FalcomSnesInstrSet");
+                     const std::string &name = "FalcomSnesInstrSet");
   virtual ~FalcomSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -53,7 +53,7 @@ class FalcomSnesInstr
                   uint32_t theInstrNum,
                   uint8_t srcn,
                   uint32_t spcDirAddr,
-                  const std::wstring &name = L"FalcomSnesInstr");
+                  const std::string &name = "FalcomSnesInstr");
   virtual ~FalcomSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/FalcomSnesScanner.cpp
+++ b/src/main/formats/FalcomSnesScanner.cpp
@@ -82,7 +82,7 @@ void FalcomSnesScanner::Scan(RawFile *file, void *info) {
 
 void FalcomSnesScanner::SearchForFalcomSnesFromARAM(RawFile *file) {
   FalcomSnesVersion version = FALCOMSNES_NONE;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   uint32_t ofsLoadSeq;
   uint16_t addrSeqHeader;

--- a/src/main/formats/FalcomSnesScanner.h
+++ b/src/main/formats/FalcomSnesScanner.h
@@ -6,7 +6,7 @@ class FalcomSnesScanner:
     public VGMScanner {
  public:
   FalcomSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~FalcomSnesScanner(void) {
   }

--- a/src/main/formats/FalcomSnesSeq.cpp
+++ b/src/main/formats/FalcomSnesSeq.cpp
@@ -34,7 +34,7 @@ const uint8_t FalcomSnesSeq::VOLUME_TABLE[129] = {
 FalcomSnesSeq::FalcomSnesSeq(RawFile *file,
                                      FalcomSnesVersion ver,
                                      uint32_t seqdataOffset,
-                                     std::wstring newName)
+                                     std::string newName)
     : VGMSeq(FalcomSnesFormat::name, file, seqdataOffset, 0, newName), version(ver) {
   bLoadTickByTick = true;
   bAllowDiscontinuousTrackData = true;
@@ -69,17 +69,17 @@ bool FalcomSnesSeq::GetHeaderInfo(void) {
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t ofsTrackStart = GetShort(curOffset);
     if (ofsTrackStart != 0) {
-      std::wstringstream trackName;
-      trackName << L"Track Pointer " << (trackIndex + 1);
+      std::stringstream trackName;
+      trackName << "Track Pointer " << (trackIndex + 1);
       header->AddSimpleItem(curOffset, 2, trackName.str());
     }
     else {
-      header->AddSimpleItem(curOffset, 2, L"NULL");
+      header->AddSimpleItem(curOffset, 2, "NULL");
     }
     curOffset += 2;
   }
 
-  header->AddSimpleItem(dwOffset + 0x18, 7, L"Duration Table");
+  header->AddSimpleItem(dwOffset + 0x18, 7, "Duration Table");
   for (uint8_t offset = 0; offset < 7; offset++) {
     NoteDurTable.push_back(GetByte(dwOffset + 0x18 + offset));
   }
@@ -214,7 +214,7 @@ bool FalcomSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   FalcomSnesSeqEventType eventType = (FalcomSnesSeqEventType) 0;
   std::map<uint8_t, FalcomSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -224,27 +224,27 @@ bool FalcomSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -252,12 +252,12 @@ bool FalcomSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -266,22 +266,22 @@ bool FalcomSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_NOP1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP.1", desc.str(), CLR_MISC, ICON_BINARY);
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP.1", desc.str(), CLR_MISC, ICON_BINARY);
       break;
     }
 
@@ -289,12 +289,12 @@ bool FalcomSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"NOP.3", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "NOP.3", desc.str());
       break;
     }
 
@@ -335,7 +335,7 @@ bool FalcomSnesTrack::ReadEvent(void) {
         if (prevNoteSlurred && key == prevNoteKey) {
           // tie
           MakePrevDurNoteEnd(GetTime() + dur);
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
         }
         else {
           // note
@@ -374,25 +374,25 @@ bool FalcomSnesTrack::ReadEvent(void) {
       uint8_t vibratoDepth = GetByte(curOffset++);
       uint8_t vibratoRate = GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) vibratoDelay
-           << L"  Depth: " << (int) vibratoDepth
-           << L"  Rate: " << (int) vibratoRate;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato", desc.str().c_str(), CLR_MODULATION, ICON_CONTROL);
+      desc << "Delay: " << (int) vibratoDelay
+           << "  Depth: " << (int) vibratoDepth
+           << "  Rate: " << (int) vibratoRate;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc.str().c_str(), CLR_MODULATION, ICON_CONTROL);
       break;
     }
 
     case EVENT_VIBRATO_ON_OFF: {
       bool vibratoOn = GetByte(curOffset++) != 0;
 
-      desc << L"Vibrato: " << (vibratoOn ? "On" : "Off");
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato On/Off", desc.str().c_str(), CLR_MODULATION, ICON_CONTROL);
+      desc << "Vibrato: " << (vibratoOn ? "On" : "Off");
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato On/Off", desc.str().c_str(), CLR_MODULATION, ICON_CONTROL);
       break;
     }
 
     case EVENT_QUANTIZE: {
       uint8_t newQuantize = GetByte(curOffset++);
-      desc << L"Duration Rate: 1.0 - " << newQuantize << "/256";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Duration Rate", desc.str().c_str(), CLR_DURNOTE);
+      desc << "Duration Rate: 1.0 - " << newQuantize << "/256";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str().c_str(), CLR_DURNOTE);
       spcNoteQuantize = newQuantize;
       break;
     }
@@ -412,8 +412,8 @@ bool FalcomSnesTrack::ReadEvent(void) {
       uint8_t amounts[] = { 8, 1, 2, 4 };
       uint8_t amount = amounts[statusByte - 0xdf];
 
-      desc << L"Decrease Volume by : " << amount;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, desc.str(), L"", CLR_VOLUME, ICON_CONTROL);
+      desc << "Decrease Volume by : " << amount;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, desc.str(), "", CLR_VOLUME, ICON_CONTROL);
 
       // add MIDI events only if updated
       uint8_t newVolume = (uint8_t)max((int8_t)spcVolume - amount, 0);
@@ -428,8 +428,8 @@ bool FalcomSnesTrack::ReadEvent(void) {
       uint8_t amounts[] = { 8, 1, 2, 4 };
       uint8_t amount = amounts[statusByte - 0xe3];
 
-      desc << L"Increase Volume by : " << amount;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, desc.str(), L"", CLR_VOLUME, ICON_CONTROL);
+      desc << "Increase Volume by : " << amount;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, desc.str(), "", CLR_VOLUME, ICON_CONTROL);
 
       // add MIDI events only if updated
       uint8_t newVolume = (uint8_t)min(spcVolume + amount, 0x7f);
@@ -454,8 +454,8 @@ bool FalcomSnesTrack::ReadEvent(void) {
     case EVENT_PAN_DEC: {
       uint8_t amount = 8;
 
-      desc << L"Decrease Pan by : " << amount;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, desc.str(), L"", CLR_PAN, ICON_CONTROL);
+      desc << "Decrease Pan by : " << amount;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, desc.str(), "", CLR_PAN, ICON_CONTROL);
 
       // add MIDI events only if updated
       uint8_t newPan = (uint8_t)max((int8_t)spcPan - amount, 0);
@@ -473,8 +473,8 @@ bool FalcomSnesTrack::ReadEvent(void) {
     case EVENT_PAN_INC: {
       uint8_t amount = 8;
 
-      desc << L"Increase Pan by : " << amount;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, desc.str(), L"", CLR_PAN, ICON_CONTROL);
+      desc << "Increase Pan by : " << amount;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, desc.str(), "", CLR_PAN, ICON_CONTROL);
 
       // add MIDI events only if updated
       uint8_t newPan = (uint8_t)min(spcPan + amount, 0x7f);
@@ -494,25 +494,25 @@ bool FalcomSnesTrack::ReadEvent(void) {
       uint8_t lfoDepth = GetByte(curOffset++);
       uint8_t lfoRate = GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) lfoDelay
-           << L"  Depth: " << (int) lfoDepth
-           << L"  Rate: " << (int) lfoRate;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan LFO", desc.str().c_str(), CLR_MODULATION, ICON_CONTROL);
+      desc << "Delay: " << (int) lfoDelay
+           << "  Depth: " << (int) lfoDepth
+           << "  Rate: " << (int) lfoRate;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO", desc.str().c_str(), CLR_MODULATION, ICON_CONTROL);
       break;
     }
 
     case EVENT_PAN_LFO_ON_OFF: {
       bool lfoOn = GetByte(curOffset++) != 0;
 
-      desc << L"Pan LFO: " << (lfoOn ? "On" : "Off");
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan LFO On/Off", desc.str().c_str(), CLR_MODULATION, ICON_CONTROL);
+      desc << "Pan LFO: " << (lfoOn ? "On" : "Off");
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO On/Off", desc.str().c_str(), CLR_MODULATION, ICON_CONTROL);
       break;
     }
 
     case EVENT_TUNING: {
       int8_t newTuning = GetByte(curOffset++);
-      desc << L"Hearz: " << (newTuning >= 0 ? L"+" : L"") << newTuning << L" Hz";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Fine Tuning", desc.str(), CLR_TRANSPOSE, ICON_CONTROL);
+      desc << "Hearz: " << (newTuning >= 0 ? "+" : "") << newTuning << " Hz";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc.str(), CLR_TRANSPOSE, ICON_CONTROL);
 
       // TODO: more accurate fine tuning
       AddFineTuningNoItem(newTuning / 128.0 * 64.0);
@@ -522,9 +522,9 @@ bool FalcomSnesTrack::ReadEvent(void) {
 
     case EVENT_LOOP_START: {
       uint8_t count = GetByte(curOffset++);
-      desc << L"Loop Count: " << (int) count;
+      desc << "Loop Count: " << (int) count;
       uint16_t repeatCountAddr = curOffset++;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
 
       // save the repeat count
       parentSeq->repeatCountMap[repeatCountAddr] = count;
@@ -537,9 +537,9 @@ bool FalcomSnesTrack::ReadEvent(void) {
       uint16_t dest = curOffset + destOffset;
       int16_t repeatCountOffset = GetShort(dest - 2);
       uint16_t repeatCountAddr = dest + repeatCountOffset;
-      desc << "Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest <<
-              "Loop Count Address: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) repeatCountAddr;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest <<
+              "Loop Count Address: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) repeatCountAddr;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       if (parentSeq->repeatCountMap.count(repeatCountAddr) == 0) {
         bContinue = false;
@@ -558,8 +558,8 @@ bool FalcomSnesTrack::ReadEvent(void) {
       curOffset += 2;
       uint16_t repeatCountAddr = curOffset + destOffset;
       uint16_t dest = repeatCountAddr + 1;
-      desc << "Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       if (parentSeq->repeatCountMap.count(repeatCountAddr) == 0) {
         bContinue = false;
@@ -580,18 +580,18 @@ bool FalcomSnesTrack::ReadEvent(void) {
       uint8_t pitchEnvelopeDepth = GetByte(curOffset++);
       uint8_t pitchEnvelopeRate = GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) pitchEnvelopeDelay
-           << L"  Depth: " << (int) pitchEnvelopeDepth
-           << L"  Rate: " << (int) pitchEnvelopeRate;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pitch Envelope", desc.str().c_str(), CLR_PITCHBEND, ICON_CONTROL);
+      desc << "Delay: " << (int) pitchEnvelopeDelay
+           << "  Depth: " << (int) pitchEnvelopeDepth
+           << "  Rate: " << (int) pitchEnvelopeRate;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope", desc.str().c_str(), CLR_PITCHBEND, ICON_CONTROL);
       break;
     }
 
     case EVENT_PITCH_ENVELOPE_ON_OFF: {
       bool pitchEnvelopeOn = GetByte(curOffset++) != 0;
 
-      desc << L"Pitch Envelope: " << (pitchEnvelopeOn ? "On" : "Off");
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pitch Envelope On/Off", desc.str().c_str(), CLR_PITCHBEND, ICON_CONTROL);
+      desc << "Pitch Envelope: " << (pitchEnvelopeOn ? "On" : "Off");
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope On/Off", desc.str().c_str(), CLR_PITCHBEND, ICON_CONTROL);
       break;
     }
 
@@ -599,9 +599,9 @@ bool FalcomSnesTrack::ReadEvent(void) {
       uint8_t adsr1 = GetByte(curOffset++);
       uint8_t adsr2 = GetByte(curOffset++);
 	  spcADSR = adsr1 | (adsr2 << 8);
-      desc << L"ADSR(1): $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << adsr1 <<
-          L"  ADSR(2): $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << adsr2;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "ADSR(1): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << adsr1 <<
+          "  ADSR(2): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << adsr2;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -609,29 +609,29 @@ bool FalcomSnesTrack::ReadEvent(void) {
       // Note: This command doesn't work properly on Ys V
       uint8_t newGAIN = GetByte(curOffset++);
 
-      desc << L"GAIN: $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) newGAIN << L")";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"GAIN", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+      desc << "GAIN: $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) newGAIN << ")";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "GAIN", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_NOISE_FREQ: {
       uint8_t newNCK = GetByte(curOffset++) & 0x1f;
-      desc << L"Noise Frequency (NCK): " << (int) newNCK;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Noise Frequency", desc.str().c_str(), CLR_CHANGESTATE, ICON_CONTROL);
+      desc << "Noise Frequency (NCK): " << (int) newNCK;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Noise Frequency", desc.str().c_str(), CLR_CHANGESTATE, ICON_CONTROL);
       break;
     }
 
     case EVENT_PITCHMOD: {
       bool echoOn = (GetByte(curOffset++) != 0);
-      desc << L"Pitch Modulation: " << (echoOn ? L"On" : L"Off");
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Pitch Modulation: " << (echoOn ? "On" : "Off");
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO: {
       bool echoOn = (GetByte(curOffset++) != 0);
-      desc << L"Echo Write: " << (echoOn ? L"On" : L"Off");
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Echo Write: " << (echoOn ? "On" : "Off");
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str(), CLR_REVERB, ICON_CONTROL);
       AddReverbNoItem(echoOn ? 40 : 0);
       break;
     }
@@ -641,8 +641,8 @@ bool FalcomSnesTrack::ReadEvent(void) {
       uint8_t spcEFB = GetByte(curOffset++);
       uint8_t spcFIR = GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) spcEDL << L"  Feedback: " << (int) spcEFB << L"  FIR: " << (int) spcFIR;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Param", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Delay: " << (int) spcEDL << "  Feedback: " << (int) spcEFB << "  FIR: " << (int) spcFIR;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
 
       // enable echo for the channel
       AddReverbNoItem(40);
@@ -652,24 +652,24 @@ bool FalcomSnesTrack::ReadEvent(void) {
     case EVENT_ECHO_VOLUME_ON_OFF: {
       bool echoVolumeOn = GetByte(curOffset++) != 0;
 
-      desc << L"Echo Volume: " << (echoVolumeOn ? "On" : "Off");
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Volume On/Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Echo Volume: " << (echoVolumeOn ? "On" : "Off");
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume On/Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_VOLUME: {
       int8_t echoVolumeLeft = GetByte(curOffset++);
       int8_t echoVolumeRight = GetByte(curOffset++);
-      desc << L"Echo Volume Left: " << echoVolumeLeft << L"  Echo Volume Right: " << echoVolumeRight;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Volume", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Echo Volume Left: " << echoVolumeLeft << "  Echo Volume Right: " << echoVolumeRight;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_FIR_OVERWRITE: {
       uint8_t presetNo = GetByte(curOffset++);
       curOffset += 8; // FIR C0-C7
-	  desc << L"Preset: #" << presetNo;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo FIR Overwrite", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+	  desc << "Preset: #" << presetNo;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR Overwrite", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -683,32 +683,32 @@ bool FalcomSnesTrack::ReadEvent(void) {
       }
       else {
         uint16_t dest = curOffset + destOffset;
-        desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+        desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
         uint32_t length = curOffset - beginOffset;
 
         curOffset = dest;
         if (!IsOffsetUsed(dest)) {
-          AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+          AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
         }
         else {
-          bContinue = AddLoopForever(beginOffset, length, L"Jump");
+          bContinue = AddLoopForever(beginOffset, length, "Jump");
         }
       }
       break;
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"FalcomSnesSeq"));
+                                    "FalcomSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //std::wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //std::ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/FalcomSnesSeq.h
+++ b/src/main/formats/FalcomSnesSeq.h
@@ -52,7 +52,7 @@ class FalcomSnesSeq
   FalcomSnesSeq(RawFile *file,
                     FalcomSnesVersion ver,
                     uint32_t seqdata_offset,
-                    std::wstring newName = L"Falcom SNES Seq");
+                    std::string newName = "Falcom SNES Seq");
   virtual ~FalcomSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/GraphResSnesInstr.cpp
+++ b/src/main/formats/GraphResSnesInstr.cpp
@@ -10,7 +10,7 @@ GraphResSnesInstrSet::GraphResSnesInstrSet(RawFile *file,
                                            GraphResSnesVersion ver,
                                            uint32_t spcDirAddr,
                                            const std::map<uint8_t, uint16_t> &instrADSRHints,
-                                           const std::wstring &name) :
+                                           const std::string &name) :
     VGMInstrSet(GraphResSnesFormat::name, file, spcDirAddr, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     instrADSRHints(instrADSRHints) {
@@ -57,8 +57,8 @@ bool GraphResSnesInstrSet::GetInstrPointers() {
       adsr = instrADSRHints[srcn];
     }
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << srcn;
+    std::ostringstream instrName;
+    instrName << "Instrument " << srcn;
     GraphResSnesInstr *newInstr = new GraphResSnesInstr(this, version, srcn, spcDirAddr, adsr, instrName.str());
     aInstrs.push_back(newInstr);
   }
@@ -86,7 +86,7 @@ GraphResSnesInstr::GraphResSnesInstr(VGMInstrSet *instrSet,
                                      uint8_t srcn,
                                      uint32_t spcDirAddr,
                                      uint16_t adsr,
-                                     const std::wstring &name) :
+                                     const std::string &name) :
     VGMInstr(instrSet, spcDirAddr + srcn * 4, 4, 0, srcn, name), version(ver),
     spcDirAddr(spcDirAddr),
     adsr(adsr) {
@@ -126,8 +126,8 @@ GraphResSnesRgn::GraphResSnesRgn(GraphResSnesInstr *instr,
   uint8_t adsr2 = adsr & 0xff;
 
   uint32_t offDirEnt = spcDirAddr + srcn * 4;
-  AddSimpleItem(offDirEnt, 2, L"SA");
-  AddSimpleItem(offDirEnt + 2, 2, L"LSA");
+  AddSimpleItem(offDirEnt, 2, "SA");
+  AddSimpleItem(offDirEnt + 2, 2, "LSA");
 
   sampNum = srcn;
   unityKey = 57; // o4a = $1000

--- a/src/main/formats/GraphResSnesInstr.h
+++ b/src/main/formats/GraphResSnesInstr.h
@@ -15,7 +15,7 @@ class GraphResSnesInstrSet:
                        GraphResSnesVersion ver,
                        uint32_t spcDirAddr,
                        const std::map<uint8_t, uint16_t> &instrADSRHints = std::map<uint8_t, uint16_t>(),
-                       const std::wstring &name = L"GraphResSnesInstrSet");
+                       const std::string &name = "GraphResSnesInstrSet");
   virtual ~GraphResSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -41,7 +41,7 @@ class GraphResSnesInstr
                     uint8_t srcn,
                     uint32_t spcDirAddr,
                     uint16_t adsr = 0x8fe0,
-                    const std::wstring &name = L"GraphResSnesInstr");
+                    const std::string &name = "GraphResSnesInstr");
   virtual ~GraphResSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/GraphResSnesScanner.cpp
+++ b/src/main/formats/GraphResSnesScanner.cpp
@@ -63,7 +63,7 @@ void GraphResSnesScanner::Scan(RawFile *file, void *info) {
 
 void GraphResSnesScanner::SearchForGraphResSnesFromARAM(RawFile *file) {
   GraphResSnesVersion version = GRAPHRESSNES_NONE;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   // search song header
   uint32_t ofsLoadSeq;

--- a/src/main/formats/GraphResSnesScanner.h
+++ b/src/main/formats/GraphResSnesScanner.h
@@ -6,7 +6,7 @@ class GraphResSnesScanner:
     public VGMScanner {
  public:
   GraphResSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~GraphResSnesScanner(void) {
   }

--- a/src/main/formats/GraphResSnesSeq.cpp
+++ b/src/main/formats/GraphResSnesSeq.cpp
@@ -12,7 +12,7 @@ DECLARE_FORMAT(GraphResSnes);
 #define MAX_TRACKS  8
 #define SEQ_PPQN    48
 
-GraphResSnesSeq::GraphResSnesSeq(RawFile *file, GraphResSnesVersion ver, uint32_t seqdataOffset, std::wstring newName)
+GraphResSnesSeq::GraphResSnesSeq(RawFile *file, GraphResSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(GraphResSnesFormat::name, file, seqdataOffset, 0, newName), version(ver) {
   bLoadTickByTick = true;
   bAllowDiscontinuousTrackData = true;
@@ -43,15 +43,15 @@ bool GraphResSnesSeq::GetHeaderInfo(void) {
 
   uint32_t curOffset = dwOffset;
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
-    std::wstringstream trackName;
-    trackName << L"Track Pointer " << (trackIndex + 1);
+    std::stringstream trackName;
+    trackName << "Track Pointer " << (trackIndex + 1);
 
     bool trackUsed = (GetByte(curOffset) != 0);
     if (trackUsed) {
-      header->AddSimpleItem(curOffset, 1, L"Enable Track");
+      header->AddSimpleItem(curOffset, 1, "Enable Track");
     }
     else {
-      header->AddSimpleItem(curOffset, 1, L"Disable Track");
+      header->AddSimpleItem(curOffset, 1, "Disable Track");
     }
     header->AddSimpleItem(curOffset + 1, 2, trackName.str());
     curOffset += 3;
@@ -170,7 +170,7 @@ bool GraphResSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   GraphResSnesSeqEventType eventType = (GraphResSnesSeqEventType) 0;
   std::map<uint8_t, GraphResSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -180,27 +180,27 @@ bool GraphResSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -208,12 +208,12 @@ bool GraphResSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -222,13 +222,13 @@ bool GraphResSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -270,8 +270,8 @@ bool GraphResSnesTrack::ReadEvent(void) {
 
         int8_t midiKey = (octave * 12) + NOTE_KEY_TABLE[key];
         if (prevNoteSlurred && midiKey == prevNoteKey) {
-          desc << L"Duration: " << dur;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str(), CLR_TIE, ICON_NOTE);
+          desc << "Duration: " << dur;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str(), CLR_TIE, ICON_NOTE);
           MakePrevDurNoteEnd(GetTime() + dur);
           AddTime(len);
         }
@@ -281,7 +281,7 @@ bool GraphResSnesTrack::ReadEvent(void) {
                        midiKey,
                        vel,
                        dur,
-                       hasLength ? L"Note with Duration" : L"Note");
+                       hasLength ? "Note with Duration" : "Note");
           AddTime(len);
         }
 
@@ -307,8 +307,8 @@ bool GraphResSnesTrack::ReadEvent(void) {
 
     case EVENT_INSTANT_OCTAVE: {
       octave = statusByte & 15;
-      desc << L"Octave: " << octave;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Octave", desc.str(), CLR_CHANGESTATE);
+      desc << "Octave: " << octave;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Octave", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
@@ -322,15 +322,15 @@ bool GraphResSnesTrack::ReadEvent(void) {
       int8_t newVolL = GetByte(curOffset++);
       int8_t newVolR = GetByte(curOffset++);
       int8_t newVol = min(abs((int) newVolL) + abs((int) newVolR), 255) / 2; // workaround: convert to mono
-      AddMasterVol(beginOffset, curOffset - beginOffset, newVol, L"Master Volume L/R");
+      AddMasterVol(beginOffset, curOffset - beginOffset, newVol, "Master Volume L/R");
       break;
     }
 
     case EVENT_ECHO_VOLUME: {
       int8_t newVolL = GetByte(curOffset++);
       int8_t newVolR = GetByte(curOffset++);
-      desc << L"Left Volume: " << (int) newVolL << L"  Right Volume: " << (int) newVolR;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Volume", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Left Volume: " << (int) newVolL << "  Right Volume: " << (int) newVolR;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -345,7 +345,7 @@ bool GraphResSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_LOOP_START: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"", desc.str(), CLR_LOOP, ICON_STARTREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "", desc.str(), CLR_LOOP, ICON_STARTREP);
 
       if (loopStackPtr == 0) {
         // stack overflow
@@ -362,9 +362,9 @@ bool GraphResSnesTrack::ReadEvent(void) {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
       dest += beginOffset; // relative offset to address
-      desc << L"Times: " << count << L"  Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+      desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       if (loopStackPtr >= GRAPHRESSNES_LOOP_LEVEL_MAX) {
         // access violation
@@ -398,22 +398,22 @@ bool GraphResSnesTrack::ReadEvent(void) {
     case EVENT_DURATION_RATE: {
       uint8_t newDurationRate = GetByte(curOffset++);
       durationRate = newDurationRate;
-      desc << L"Duration Rate: " << newDurationRate << L"/8";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Duration Rate", desc.str(), CLR_DURNOTE);
+      desc << "Duration Rate: " << newDurationRate << "/8";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str(), CLR_DURNOTE);
       break;
     }
 
     case EVENT_DSP_WRITE: {
       uint8_t dspReg = GetByte(curOffset++);
       uint8_t dspValue = GetByte(curOffset++);
-      desc << L"Register: $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) dspReg
-          << L"  Value: $" << (int) dspValue;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Write to DSP", desc.str(), CLR_CHANGESTATE);
+      desc << "Register: $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) dspReg
+          << "  Value: $" << (int) dspValue;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Write to DSP", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
     case EVENT_NOISE_TOGGLE: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Noise On/Off", desc.str(), CLR_CHANGESTATE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Noise On/Off", desc.str(), CLR_CHANGESTATE, ICON_CONTROL);
       break;
     }
 
@@ -425,10 +425,10 @@ bool GraphResSnesTrack::ReadEvent(void) {
 
     case EVENT_MASTER_VOLUME_FADE: {
       uint8_t vol = GetByte(curOffset++);
-      desc << L"Delta Volume: " << vol;
+      desc << "Delta Volume: " << vol;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Master Volume Fade",
+                      "Master Volume Fade",
                       desc.str(),
                       CLR_VOLUME,
                       ICON_CONTROL);
@@ -462,13 +462,13 @@ bool GraphResSnesTrack::ReadEvent(void) {
       curOffset += 2;
       spcADSR = newADSR;
 
-      desc << L"ADSR: " << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) newADSR;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "ADSR: " << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) newADSR;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_RET: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"End Pattern", desc.str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "End Pattern", desc.str(), CLR_LOOP, ICON_ENDREP);
 
       if (callStackPtr == 0) {
         // access violation
@@ -485,8 +485,8 @@ bool GraphResSnesTrack::ReadEvent(void) {
       curOffset += 2;
       dest += beginOffset; // relative offset to address
 
-      desc << "Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, 3, L"Pattern Play", desc.str(), CLR_LOOP, ICON_STARTREP);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, 3, "Pattern Play", desc.str(), CLR_LOOP, ICON_STARTREP);
 
       if (callStackPtr >= GRAPHRESSNES_CALLSTACK_SIZE) {
         // stack overflow
@@ -507,15 +507,15 @@ bool GraphResSnesTrack::ReadEvent(void) {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
       dest += beginOffset; // relative offset to address
-      desc << "Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       uint32_t length = curOffset - beginOffset;
 
       curOffset = dest;
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
       }
       else {
-        bContinue = AddLoopForever(beginOffset, length, L"Jump");
+        bContinue = AddLoopForever(beginOffset, length, "Jump");
       }
       break;
     }
@@ -529,13 +529,13 @@ bool GraphResSnesTrack::ReadEvent(void) {
 
     case EVENT_DEFAULT_LENGTH: {
       defaultNoteLength = GetByte(curOffset++);
-      desc << L"Duration: " << defaultNoteLength;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Default Note Length", desc.str(), CLR_DURNOTE);
+      desc << "Duration: " << defaultNoteLength;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Default Note Length", desc.str(), CLR_DURNOTE);
       break;
     }
 
     case EVENT_SLUR:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Slur On", desc.str(), CLR_TIE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Slur On", desc.str(), CLR_TIE);
       break;
 
     case EVENT_END:
@@ -544,17 +544,17 @@ bool GraphResSnesTrack::ReadEvent(void) {
       break;
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"GraphResSnesSeq"));
+                                    "GraphResSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //std::wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //std::ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/GraphResSnesSeq.h
+++ b/src/main/formats/GraphResSnesSeq.h
@@ -46,7 +46,7 @@ class GraphResSnesSeq
     : public VGMSeq {
  public:
   GraphResSnesSeq
-      (RawFile *file, GraphResSnesVersion ver, uint32_t seqdata_offset, std::wstring newName = L"GraphRes SNES Seq");
+      (RawFile *file, GraphResSnesVersion ver, uint32_t seqdata_offset, std::string newName = "GraphRes SNES Seq");
   virtual ~GraphResSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/HOSAInstr.cpp
+++ b/src/main/formats/HOSAInstr.cpp
@@ -12,7 +12,7 @@
 //		Constructor
 //--------------------------------------------------------------
 HOSAInstrSet::HOSAInstrSet(RawFile *file, uint32_t offset)
-    : VGMInstrSet(HOSAFormat::name, file, offset, 0, L"HOSAWAH ") {
+    : VGMInstrSet(HOSAFormat::name, file, offset, 0, "HOSAWAH ") {
 }
 
 //==============================================================
@@ -35,12 +35,12 @@ bool HOSAInstrSet::GetHeaderInfo() {
   id = 0;                        //Bank number.
 
   //バイナリエディタ表示用
-  name = L"HOSAWAH";
+  name = "HOSAWAH";
 
   //ヘッダーobjectの生成
   VGMHeader *wdsHeader = AddHeader(dwOffset, sizeof(InstrHeader));
   wdsHeader->AddSig(dwOffset, 8);
-  wdsHeader->AddSimpleItem(dwOffset + 8, sizeof(uint32_t), L"Number of Instruments");
+  wdsHeader->AddSimpleItem(dwOffset + 8, sizeof(uint32_t), "Number of Instruments");
 
   //波形objectの生成
 //	sampColl = new PSXSampColl(HOSAFormat::name, this, 0x00160800); // moved to HOSAScanner
@@ -96,7 +96,7 @@ bool HOSAInstr::LoadInstr() {
   // Get the instr data
   GetBytes(dwOffset, sizeof(InstrInfo), &instrinfo);
   unLength = sizeof(InstrInfo) + sizeof(RgnInfo) * instrinfo.numRgns;
-  AddSimpleItem(dwOffset, sizeof(uint32_t), L"Number of Rgns");
+  AddSimpleItem(dwOffset, sizeof(uint32_t), "Number of Rgns");
 
   // Get the rgn data
   rgns = new RgnInfo[instrinfo.numRgns];
@@ -111,7 +111,7 @@ bool HOSAInstr::LoadInstr() {
     RgnInfo *rgninfo = &rgns[i];
     VGMRgn *rgn = new VGMRgn(this, dwOffset + sizeof(InstrInfo) + sizeof(RgnInfo) * i, sizeof(RgnInfo));
 
-    rgn->AddSimpleItem(rgn->dwOffset, 4, L"Sample Offset");
+    rgn->AddSimpleItem(rgn->dwOffset, 4, "Sample Offset");
     rgn->sampOffset = rgninfo->sampOffset; //+ ((VGMInstrSet*)this->vgmfile)->sampColl->dwOffset;
 
     rgn->velLow = 0x00;
@@ -121,7 +121,7 @@ bool HOSAInstr::LoadInstr() {
     cKeyLow = (rgninfo->note_range_high) + 1;
 
     rgn->AddUnityKey((int8_t) 0x3C + 0x3C - rgninfo->iSemiToneTune, rgn->dwOffset + 0x06);
-    rgn->AddSimpleItem(rgn->dwOffset + 0x07, 1, L"Semi Tone Tune");
+    rgn->AddSimpleItem(rgn->dwOffset + 0x07, 1, "Semi Tone Tune");
     rgn->fineTune = (short) ((double) rgninfo->iFineTune * (100.0 / 256.0));
 
     // Might want to simplify the code below.  I'm being nitpicky.
@@ -133,7 +133,7 @@ bool HOSAInstr::LoadInstr() {
     else rgn->pan = (double) (rgninfo->iPan - 0x80) / (double) 0x7F;
 
     // The ADSR value ordering is all messed up for the hell of it.  This was a bitch to reverse-engineer.
-    rgn->AddSimpleItem(rgn->dwOffset + 0x0C, 4, L"ADSR Values (non-standard ordering)");
+    rgn->AddSimpleItem(rgn->dwOffset + 0x0C, 4, "ADSR Values (non-standard ordering)");
     uint8_t Ar = (rgninfo->ADSR_vals >> 20) & 0x7F;
     uint8_t Dr = (rgninfo->ADSR_vals >> 16) & 0xF;
     uint8_t Sr = ((rgninfo->ADSR_vals >> 8) & 0xFF) >> 1;

--- a/src/main/formats/HOSAScanner.cpp
+++ b/src/main/formats/HOSAScanner.cpp
@@ -52,7 +52,7 @@ void HOSAScanner::Scan(RawFile *file, void *info) {
 }
 
 HOSASeq *HOSAScanner::SearchForHOSASeq(RawFile *file) {
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   uint32_t nFileLength = file->size();
   for (uint32_t i = 0; i + 4 < nFileLength; i++) {

--- a/src/main/formats/HOSASeq.cpp
+++ b/src/main/formats/HOSASeq.cpp
@@ -11,7 +11,7 @@ DECLARE_FORMAT(HOSA);
 //==============================================================
 //		Constructor
 //==============================================================
-HOSASeq::HOSASeq(RawFile *file, uint32_t offset, const std::wstring &name)
+HOSASeq::HOSASeq(RawFile *file, uint32_t offset, const std::string &name)
     : VGMSeq(HOSAFormat::name, file, offset, 0, name) {
   UseReverb();
   UseLinearAmplitudeScale();
@@ -44,7 +44,7 @@ bool HOSASeq::GetHeaderInfo(void) {
 //	Delect object is in "VGMContainerItem::~VGMContainerItem()"
   VGMHeader *hdr = AddHeader(dwOffset, 0x0050);
   hdr->AddSig(dwOffset, 4);
-  hdr->AddSimpleItem(dwOffset + 0x06, 1, L"Quantity of Tracks");
+  hdr->AddSimpleItem(dwOffset + 0x06, 1, "Quantity of Tracks");
 
   SetPPQN(0x30);                                //Timebase
 
@@ -226,7 +226,7 @@ bool HOSATrack::ReadEvent(void) {
           //Reverb
         case (0x02):
           curOffset++;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reverb Depth", L"", CLR_REVERB);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", "", CLR_REVERB);
           break;
           //------------
           //Instrument
@@ -263,7 +263,7 @@ bool HOSATrack::ReadEvent(void) {
           //Dal Segno. (Loop)
         case (0x09):
           curOffset++;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Dal Segno.(Loop)", L"", CLR_LOOP);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Dal Segno.(Loop)", "", CLR_LOOP);
           break;
           //------------
           //Unknown
@@ -283,7 +283,7 @@ bool HOSATrack::ReadEvent(void) {
       uint32_t beginOffset2 = curOffset;
       ReadDeltaTime(cCom_bit5, &iDeltaTimeCom);
       if (curOffset != beginOffset2) {
-        AddGenericEvent(beginOffset2, curOffset - beginOffset2, L"Delta time", L"", CLR_CHANGESTATE);
+        AddGenericEvent(beginOffset2, curOffset - beginOffset2, "Delta time", "", CLR_CHANGESTATE);
       };
 
       //----------------------------------

--- a/src/main/formats/HOSASeq.h
+++ b/src/main/formats/HOSASeq.h
@@ -9,7 +9,7 @@
 //--------------------------------------------------------------
 class HOSASeq: public VGMSeq {
  public:
-  HOSASeq(RawFile *file, uint32_t offset, const std::wstring &name = L"HOSA Seq");
+  HOSASeq(RawFile *file, uint32_t offset, const std::string &name = "HOSA Seq");
   virtual ~HOSASeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/HeartBeatPS1Scanner.cpp
+++ b/src/main/formats/HeartBeatPS1Scanner.cpp
@@ -139,7 +139,7 @@ std::vector<VGMFile *> HeartBeatPS1Scanner::SearchForHeartBeatPS1VGMFile(RawFile
 
     // valid file, open it as VGMFile
     if (total_instr_size != 0) {
-      //LogDebug(L"HeartBeatPS1InstrSet 0x%X", offset);
+      //LogDebug("HeartBeatPS1InstrSet 0x%X", offset);
     }
 
     if (seq_size != 0) {

--- a/src/main/formats/HeartBeatPS1Seq.cpp
+++ b/src/main/formats/HeartBeatPS1Seq.cpp
@@ -7,7 +7,7 @@
 
 DECLARE_FORMAT(HeartBeatPS1)
 
-HeartBeatPS1Seq::HeartBeatPS1Seq(RawFile *file, uint32_t offset, uint32_t length, const std::wstring &name)
+HeartBeatPS1Seq::HeartBeatPS1Seq(RawFile *file, uint32_t offset, uint32_t length, const std::string &name)
     : VGMSeqNoTrks(HeartBeatPS1Format::name, file, offset, name) {
   this->length() = length;
 
@@ -27,11 +27,11 @@ bool HeartBeatPS1Seq::GetHeaderInfo(void) {
 
   VGMHeader *header = VGMSeq::AddHeader(curOffset, 0x3c);
 
-  header->AddSimpleItem(curOffset, 4, L"Sequence Size");
-  header->AddSimpleItem(curOffset + 4, 2, L"Sequence ID");
-  header->AddSimpleItem(curOffset + 6, 1, L"Number of Instrument Set");
-  header->AddSimpleItem(curOffset + 7, 1, L"Load Position");
-  header->AddSimpleItem(curOffset + 8, 4, L"Reserved");
+  header->AddSimpleItem(curOffset, 4, "Sequence Size");
+  header->AddSimpleItem(curOffset + 4, 2, "Sequence ID");
+  header->AddSimpleItem(curOffset + 6, 1, "Number of Instrument Set");
+  header->AddSimpleItem(curOffset + 7, 1, "Load Position");
+  header->AddSimpleItem(curOffset + 8, 4, "Reserved");
 
   curOffset += 0x0c;
 
@@ -41,13 +41,13 @@ bool HeartBeatPS1Seq::GetHeaderInfo(void) {
     uint32_t sampcoll_size = GetWord(curOffset);
     uint32_t instrset_size = GetWord(curOffset + 0x04);
 
-    std::wostringstream instrHeaderName;
-    instrHeaderName << L"Instrument Set " << (instrset_index + 1);
+    std::ostringstream instrHeaderName;
+    instrHeaderName << "Instrument Set " << (instrset_index + 1);
     VGMHeader *instrHeader = header->AddHeader(curOffset, 0x0c, instrHeaderName.str());
 
-    instrHeader->AddSimpleItem(curOffset, 4, L"Sample Collection Size");
-    instrHeader->AddSimpleItem(curOffset + 4, 4, L"Instrument Set Size");
-    instrHeader->AddSimpleItem(curOffset + 8, 2, L"Instrument Set ID");
+    instrHeader->AddSimpleItem(curOffset, 4, "Sample Collection Size");
+    instrHeader->AddSimpleItem(curOffset + 4, 4, "Instrument Set Size");
+    instrHeader->AddSimpleItem(curOffset + 8, 2, "Instrument Set ID");
     instrHeader->AddUnknownItem(curOffset + 10, 2);
 
     total_instr_size += sampcoll_size;
@@ -70,15 +70,15 @@ bool HeartBeatPS1Seq::GetHeaderInfo(void) {
   // save sequence data offset
   seqHeaderOffset = offset() + HEARTBEATPS1_SND_HEADER_SIZE + total_instr_size;
 
-  VGMHeader *seqHeader = VGMSeq::AddHeader(seqHeaderOffset, 0x10, L"Sequence Header");
+  VGMHeader *seqHeader = VGMSeq::AddHeader(seqHeaderOffset, 0x10, "Sequence Header");
 
-  seqHeader->AddSimpleItem(seqHeaderOffset, 4, L"Signature");
-  seqHeader->AddSimpleItem(seqHeaderOffset + 4, 2, L"Version");
+  seqHeader->AddSimpleItem(seqHeaderOffset, 4, "Signature");
+  seqHeader->AddSimpleItem(seqHeaderOffset + 4, 2, "Version");
   seqHeader->AddUnknownItem(seqHeaderOffset + 6, 2);
-  seqHeader->AddSimpleItem(seqHeaderOffset + 8, 2, L"PPQN");
-  seqHeader->AddTempo(seqHeaderOffset + 10, 3, L"Initial Tempo");
-  seqHeader->AddSimpleItem(seqHeaderOffset + 13, 2, L"Time Signature");
-  seqHeader->AddSimpleItem(seqHeaderOffset + 15, 1, L"Number of Tracks");
+  seqHeader->AddSimpleItem(seqHeaderOffset + 8, 2, "PPQN");
+  seqHeader->AddTempo(seqHeaderOffset + 10, 3, "Initial Tempo");
+  seqHeader->AddSimpleItem(seqHeaderOffset + 13, 2, "Time Signature");
+  seqHeader->AddSimpleItem(seqHeaderOffset + 15, 1, "Number of Tracks");
 
   SetPPQN(GetShortBE(seqHeaderOffset + 8));
   nNumTracks = 16;
@@ -173,7 +173,7 @@ bool HeartBeatPS1Seq::ReadEvent(void) {
       switch (controlNum)        //control number
       {
         case 1:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Modulation", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Modulation", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
@@ -181,28 +181,28 @@ bool HeartBeatPS1Seq::ReadEvent(void) {
 
         // identical to CC#11?
         case 2:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Breath Controller?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Breath Controller?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 4:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Foot Controller?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Foot Controller?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 5:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Portamento Time?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Time?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 6 :
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN Data Entry", L"", CLR_MISC);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
@@ -214,7 +214,7 @@ bool HeartBeatPS1Seq::ReadEvent(void) {
           break;
 
         case 9:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control 9", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control 9", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
@@ -231,147 +231,147 @@ bool HeartBeatPS1Seq::ReadEvent(void) {
           break;
 
         case 20:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control 20", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control 20", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 21:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control 21", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control 21", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 22:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control 22", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control 22", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 23:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control 23", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control 23", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 32:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Bank LSB?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Bank LSB?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 52:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control 52", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control 52", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 53:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control 53", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control 53", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 54:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control 54", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control 54", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 55:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control 55", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control 55", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 56:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control 56", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control 56", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 64:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Hold 1?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Hold 1?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 69:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Hold 2?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Hold 2?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 71:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Resonance?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Resonance?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 72:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Release Time?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Release Time?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 73:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Attack Time?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Attack Time?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 74:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Cut Off Frequency?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Cut Off Frequency?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 75:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Decay Time?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Decay Time?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 76:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato Rate?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Rate?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 77:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato Depth?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Depth?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 78:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato Delay?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Delay?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 79:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control 79", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control 79", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
@@ -382,7 +382,7 @@ bool HeartBeatPS1Seq::ReadEvent(void) {
           break;
 
         case 92:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tremolo Depth?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
@@ -391,15 +391,15 @@ bool HeartBeatPS1Seq::ReadEvent(void) {
         case 98:
           switch (value) {
             case 20 :
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN 1 #20", L"", CLR_MISC);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #20", "", CLR_MISC);
               break;
 
             case 30 :
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN 1 #30", L"", CLR_MISC);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #30", "", CLR_MISC);
               break;
 
             default:
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN 1", L"", CLR_MISC);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1", "", CLR_MISC);
               break;
           }
 
@@ -412,15 +412,15 @@ bool HeartBeatPS1Seq::ReadEvent(void) {
         case 99 :
           switch (value) {
             case 20 :
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Start", L"", CLR_LOOP);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", CLR_LOOP);
               break;
 
             case 30 :
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", L"", CLR_LOOP);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", CLR_LOOP);
               break;
 
             default:
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN 2", L"", CLR_MISC);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 2", "", CLR_MISC);
               break;
           }
 
@@ -430,28 +430,28 @@ bool HeartBeatPS1Seq::ReadEvent(void) {
           break;
 
         case 121:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reset All Controllers", L"", CLR_MISC);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Reset All Controllers", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 126:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"MONO?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "MONO?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 127:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Poly?", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Poly?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         default:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control Event", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control Event", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }

--- a/src/main/formats/HeartBeatPS1Seq.h
+++ b/src/main/formats/HeartBeatPS1Seq.h
@@ -4,7 +4,7 @@
 class HeartBeatPS1Seq:
     public VGMSeqNoTrks {
  public:
-  HeartBeatPS1Seq(RawFile *file, uint32_t offset, uint32_t length = 0, const std::wstring &name = L"HeartBeatPS1Seq");
+  HeartBeatPS1Seq(RawFile *file, uint32_t offset, uint32_t length = 0, const std::string &name = "HeartBeatPS1Seq");
   virtual ~HeartBeatPS1Seq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/HeartBeatSnesInstr.cpp
+++ b/src/main/formats/HeartBeatSnesInstr.cpp
@@ -13,7 +13,7 @@ HeartBeatSnesInstrSet::HeartBeatSnesInstrSet(RawFile *file,
                                              uint16_t addrSRCNTable,
                                              uint8_t songIndex,
                                              uint32_t spcDirAddr,
-                                             const std::wstring &name) :
+                                             const std::string &name) :
     VGMInstrSet(HeartBeatSnesFormat::name, file, offset, length, name), version(ver),
     addrSRCNTable(addrSRCNTable),
     songIndex(songIndex),
@@ -65,8 +65,8 @@ bool HeartBeatSnesInstrSet::GetInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << instrNum;
+    std::ostringstream instrName;
+    instrName << "Instrument " << instrNum;
     HeartBeatSnesInstr *newInstr = new HeartBeatSnesInstr(this,
                                                           version,
                                                           addrInstrHeader,
@@ -105,7 +105,7 @@ HeartBeatSnesInstr::HeartBeatSnesInstr(VGMInstrSet *instrSet,
                                        uint16_t addrSRCNTable,
                                        uint8_t songIndex,
                                        uint32_t spcDirAddr,
-                                       const std::wstring &name) :
+                                       const std::string &name) :
     VGMInstr(instrSet, offset, 6, theBank, theInstrNum, name), version(ver),
     addrSRCNTable(addrSRCNTable),
     songIndex(songIndex),
@@ -165,9 +165,9 @@ HeartBeatSnesRgn::HeartBeatSnesRgn(HeartBeatSnesInstr *instr, HeartBeatSnesVersi
   }
 
   AddSampNum(srcn, offset, 1);
-  AddSimpleItem(offset + 1, 1, L"ADSR1");
-  AddSimpleItem(offset + 2, 1, L"ADSR2");
-  AddSimpleItem(offset + 3, 1, L"GAIN");
+  AddSimpleItem(offset + 1, 1, "ADSR1");
+  AddSimpleItem(offset + 2, 1, "ADSR2");
+  AddSimpleItem(offset + 3, 1, "GAIN");
   AddUnityKey(72 - (int) (coarse_tuning), offset + 4, 1);
   AddFineTune((int16_t) (fine_tuning * 100.0), offset + 5, 1);
   SNESConvADSR<VGMRgn>(this, adsr1, adsr2, gain);

--- a/src/main/formats/HeartBeatSnesInstr.h
+++ b/src/main/formats/HeartBeatSnesInstr.h
@@ -18,7 +18,7 @@ class HeartBeatSnesInstrSet:
                         uint16_t addrSRCNTable,
                         uint8_t songIndex,
                         uint32_t spcDirAddr,
-                        const std::wstring &name = L"HeartBeatSnesInstrSet");
+                        const std::string &name = "HeartBeatSnesInstrSet");
   virtual ~HeartBeatSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -48,7 +48,7 @@ class HeartBeatSnesInstr
                      uint16_t addrSRCNTable,
                      uint8_t songIndex,
                      uint32_t spcDirAddr,
-                     const std::wstring &name = L"HeartBeatSnesInstr");
+                     const std::string &name = "HeartBeatSnesInstr");
   virtual ~HeartBeatSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/HeartBeatSnesScanner.cpp
+++ b/src/main/formats/HeartBeatSnesScanner.cpp
@@ -106,7 +106,7 @@ void HeartBeatSnesScanner::Scan(RawFile *file, void *info) {
 
 void HeartBeatSnesScanner::SearchForHeartBeatSnesFromARAM(RawFile *file) {
   HeartBeatSnesVersion version = HEARTBEATSNES_NONE;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   // search song list
   uint32_t ofsReadSongList;

--- a/src/main/formats/HeartBeatSnesScanner.h
+++ b/src/main/formats/HeartBeatSnesScanner.h
@@ -8,7 +8,7 @@ class HeartBeatSnesScanner:
     public VGMScanner {
  public:
   HeartBeatSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~HeartBeatSnesScanner(void) {
   }

--- a/src/main/formats/HeartBeatSnesSeq.cpp
+++ b/src/main/formats/HeartBeatSnesSeq.cpp
@@ -31,7 +31,7 @@ const uint8_t HeartBeatSnesSeq::PAN_TABLE[22] = {
 HeartBeatSnesSeq::HeartBeatSnesSeq(RawFile *file,
                                    HeartBeatSnesVersion ver,
                                    uint32_t seqdataOffset,
-                                   std::wstring newName)
+                                   std::string newName)
     : VGMSeq(HeartBeatSnesFormat::name, file, seqdataOffset, 0, newName),
       version(ver) {
   bLoadTickByTick = true;
@@ -58,20 +58,20 @@ bool HeartBeatSnesSeq::GetHeaderInfo(void) {
     return false;
   }
 
-  header->AddSimpleItem(curOffset, 2, L"Instrument Table Pointer");
+  header->AddSimpleItem(curOffset, 2, "Instrument Table Pointer");
   curOffset += 2;
 
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t ofsTrackStart = GetShort(curOffset);
     if (ofsTrackStart == 0) {
       // example: Dragon Quest 6 - Brave Fight
-      header->AddSimpleItem(curOffset, 2, L"Track Pointer End");
+      header->AddSimpleItem(curOffset, 2, "Track Pointer End");
       curOffset += 2;
       break;
     }
 
-    std::wstringstream trackName;
-    trackName << L"Track Pointer " << (trackIndex + 1);
+    std::stringstream trackName;
+    trackName << "Track Pointer " << (trackIndex + 1);
     header->AddSimpleItem(curOffset, 2, trackName.str().c_str());
 
     curOffset += 2;
@@ -213,7 +213,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   HeartBeatSnesSeqEventType eventType = (HeartBeatSnesSeqEventType) 0;
   std::map<uint8_t, HeartBeatSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -223,27 +223,27 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -251,12 +251,12 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -268,7 +268,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
 
     case EVENT_NOTE_LENGTH: {
       spcNoteDuration = statusByte;
-      desc << L"Length: " << (int) spcNoteDuration;
+      desc << "Length: " << (int) spcNoteDuration;
 
       uint8_t noteParam = GetByte(curOffset);
       if (noteParam < 0x80) {
@@ -277,13 +277,13 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
         uint8_t velIndex = noteParam & 0x0f;
         spcNoteDurRate = HeartBeatSnesSeq::NOTE_DUR_TABLE[durIndex];
         spcNoteVolume = HeartBeatSnesSeq::NOTE_VEL_TABLE[velIndex];
-        desc << L"  Duration: " << (int) durIndex << L" (" << (int) spcNoteDurRate << L")" << L"  Velocity: "
-            << (int) velIndex << L" (" << (int) spcNoteVolume << L")";
+        desc << "  Duration: " << (int) durIndex << " (" << (int) spcNoteDurRate << ")" << "  Velocity: "
+            << (int) velIndex << " (" << (int) spcNoteVolume << ")";
       }
 
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Note Length & Param",
+                      "Note Length & Param",
                       desc.str().c_str(),
                       CLR_CHANGESTATE);
       break;
@@ -302,7 +302,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
         dur = (dur > 2) ? dur - 1 : 1;
       }
 
-      AddNoteByDur(beginOffset, curOffset - beginOffset, key, spcNoteVolume / 2, dur, L"Note");
+      AddNoteByDur(beginOffset, curOffset - beginOffset, key, spcNoteVolume / 2, dur, "Note");
       AddTime(spcNoteDuration);
       break;
     }
@@ -318,9 +318,9 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
         dur = (dur > 2) ? dur - 1 : 1;
       }
 
-      desc << L"Duration: " << (int) dur;
+      desc << "Duration: " << (int) dur;
       MakePrevDurNoteEnd(GetTime() + dur);
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str().c_str(), CLR_TIE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE);
       AddTime(spcNoteDuration);
       break;
     }
@@ -333,7 +333,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
     case EVENT_SLUR_ON: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Slur On",
+                      "Slur On",
                       desc.str().c_str(),
                       CLR_PORTAMENTO,
                       ICON_CONTROL);
@@ -344,7 +344,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
     case EVENT_SLUR_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Slur Off",
+                      "Slur Off",
                       desc.str().c_str(),
                       CLR_PORTAMENTO,
                       ICON_CONTROL);
@@ -396,11 +396,11 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
       uint8_t vibratoRate = GetByte(curOffset++);
       uint8_t vibratoDepth = GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) vibratoDelay << L"  Rate: " << (int) vibratoRate << L"  Depth: "
+      desc << "Delay: " << (int) vibratoDelay << "  Rate: " << (int) vibratoRate << "  Depth: "
           << (int) vibratoDepth;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato",
+                      "Vibrato",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -409,10 +409,10 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
 
     case EVENT_VIBRATO_FADE: {
       uint8_t fadeLength = GetByte(curOffset++);
-      desc << L"Length: " << (int) fadeLength;
+      desc << "Length: " << (int) fadeLength;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato Fade",
+                      "Vibrato Fade",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -422,7 +422,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
     case EVENT_VIBRATO_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato Off",
+                      "Vibrato Off",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -439,7 +439,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
       uint8_t fadeLength = GetByte(curOffset++);
       uint8_t newVol = GetByte(curOffset++);
 
-      desc << L"Length: " << (int) fadeLength << L"  Volume: " << (int) newVol;
+      desc << "Length: " << (int) fadeLength << "  Volume: " << (int) newVol;
       AddMastVolSlide(beginOffset, curOffset - beginOffset, fadeLength, newVol / 2);
       break;
     }
@@ -467,11 +467,11 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
       uint8_t tremoloRate = GetByte(curOffset++);
       uint8_t tremoloDepth = GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) tremoloDelay << L"  Rate: " << (int) tremoloRate << L"  Depth: "
+      desc << "Delay: " << (int) tremoloDelay << "  Rate: " << (int) tremoloRate << "  Depth: "
           << (int) tremoloDepth;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Tremolo",
+                      "Tremolo",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -481,7 +481,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
     case EVENT_TREMOLO_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Tremolo Off",
+                      "Tremolo Off",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -506,11 +506,11 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
       uint8_t pitchEnvLength = GetByte(curOffset++);
       int8_t pitchEnvSemitones = (int8_t) GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) pitchEnvDelay << L"  Length: " << (int) pitchEnvLength << L"  Semitones: "
+      desc << "Delay: " << (int) pitchEnvDelay << "  Length: " << (int) pitchEnvLength << "  Semitones: "
           << (int) pitchEnvSemitones;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Envelope (To)",
+                      "Pitch Envelope (To)",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -522,11 +522,11 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
       uint8_t pitchEnvLength = GetByte(curOffset++);
       int8_t pitchEnvSemitones = (int8_t) GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) pitchEnvDelay << L"  Length: " << (int) pitchEnvLength << L"  Semitones: "
+      desc << "Delay: " << (int) pitchEnvDelay << "  Length: " << (int) pitchEnvLength << "  Semitones: "
           << (int) pitchEnvSemitones;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Envelope (From)",
+                      "Pitch Envelope (From)",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -536,7 +536,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
     case EVENT_PITCH_ENVELOPE_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Envelope Off",
+                      "Pitch Envelope Off",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -552,10 +552,10 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
     case EVENT_ECHO_VOLUME: {
       uint8_t spcEVOL_L = GetByte(curOffset++);
       uint8_t spcEVOL_R = GetByte(curOffset++);
-      desc << L"Volume Left: " << (int) spcEVOL_L << L"  Volume Right: " << (int) spcEVOL_R;
+      desc << "Volume Left: " << (int) spcEVOL_L << "  Volume Right: " << (int) spcEVOL_R;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Volume",
+                      "Echo Volume",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -567,24 +567,24 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
       uint8_t spcEFB = GetByte(curOffset++);
       uint8_t spcFIR = GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) spcEDL << L"  Feedback: " << (int) spcEFB << L"  FIR: " << (int) spcFIR;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Delay: " << (int) spcEDL << "  Feedback: " << (int) spcEFB << "  FIR: " << (int) spcFIR;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      AddReverb(beginOffset, curOffset - beginOffset, 0, L"Echo Off");
+      AddReverb(beginOffset, curOffset - beginOffset, 0, "Echo Off");
       break;
     }
 
     case EVENT_ECHO_ON: {
-      AddReverb(beginOffset, curOffset - beginOffset, 100, L"Echo On");
+      AddReverb(beginOffset, curOffset - beginOffset, 100, "Echo On");
       break;
     }
 
     case EVENT_ECHO_FIR: {
       curOffset += 8; // FIR C0-C7
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo FIR", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -597,8 +597,8 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
       uint8_t sl = (adsr2 & 0xe0) >> 5;
       uint8_t sr = adsr2 & 0x1f;
 
-      desc << L"AR: " << (int) ar << L"  DR: " << (int) dr << L"  SL: " << (int) sl << L"  SR: " << (int) sr;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+      desc << "AR: " << (int) ar << "  DR: " << (int) dr << "  SL: " << (int) sl << "  SR: " << (int) sr;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -608,9 +608,9 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
       uint8_t velIndex = noteParam & 0x0f;
       spcNoteDurRate = HeartBeatSnesSeq::NOTE_DUR_TABLE[durIndex];
       spcNoteVolume = HeartBeatSnesSeq::NOTE_VEL_TABLE[velIndex];
-      desc << L"Duration: " << (int) durIndex << L" (" << (int) spcNoteDurRate << L")" << L"  Velocity: "
-          << (int) velIndex << L" (" << (int) spcNoteVolume << L")";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Note Param", desc.str().c_str(), CLR_CHANGESTATE);
+      desc << "Duration: " << (int) durIndex << " (" << (int) spcNoteDurRate << ")" << "  Velocity: "
+          << (int) velIndex << " (" << (int) spcNoteVolume << ")";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Note Param", desc.str().c_str(), CLR_CHANGESTATE);
       break;
     }
 
@@ -618,15 +618,15 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
       int16_t destOffset = GetShort(curOffset);
       curOffset += 2;
       uint16_t dest = parentSeq->dwOffset + destOffset;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       uint32_t length = curOffset - beginOffset;
 
       curOffset = dest;
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
       }
       else {
-        bContinue = AddLoopForever(beginOffset, length, L"Jump");
+        bContinue = AddLoopForever(beginOffset, length, "Jump");
       }
       break;
     }
@@ -635,10 +635,10 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
       int16_t destOffset = GetShort(curOffset);
       curOffset += 2;
       uint16_t dest = parentSeq->dwOffset + destOffset;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pattern Play",
+                      "Pattern Play",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -650,7 +650,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_RET: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pattern End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pattern End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
       curOffset = parentSeq->dwOffset + subReturnOffset;
       break;
     }
@@ -658,7 +658,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
     case EVENT_NOISE_ON: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Noise On",
+                      "Noise On",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -668,7 +668,7 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
     case EVENT_NOISE_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Noise Off",
+                      "Noise Off",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -677,10 +677,10 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
 
     case EVENT_NOISE_FREQ: {
       uint8_t newNCK = GetByte(curOffset++) & 0x1f;
-      desc << L"Noise Frequency (NCK): " << (int) newNCK;
+      desc << "Noise Frequency (NCK): " << (int) newNCK;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Noise Frequency",
+                      "Noise Frequency",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -698,30 +698,30 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
 
       switch (subEventType) {
         case SUBEVENT_UNKNOWN0:
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
           break;
 
         case SUBEVENT_UNKNOWN1: {
           uint8_t arg1 = GetByte(curOffset++);
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte
-              << std::dec << std::setfill(L' ') << std::setw(0)
-              << L"  Arg1: " << (int) arg1;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+              << std::dec << std::setfill(' ') << std::setw(0)
+              << "  Arg1: " << (int) arg1;
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
           break;
         }
 
         case SUBEVENT_UNKNOWN2: {
           uint8_t arg1 = GetByte(curOffset++);
           uint8_t arg2 = GetByte(curOffset++);
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte
-              << std::dec << std::setfill(L' ') << std::setw(0)
-              << L"  Arg1: " << (int) arg1
-              << L"  Arg2: " << (int) arg2;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+              << std::dec << std::setfill(' ') << std::setw(0)
+              << "  Arg1: " << (int) arg1
+              << "  Arg2: " << (int) arg2;
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
           break;
         }
 
@@ -729,13 +729,13 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
           uint8_t arg1 = GetByte(curOffset++);
           uint8_t arg2 = GetByte(curOffset++);
           uint8_t arg3 = GetByte(curOffset++);
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte
-              << std::dec << std::setfill(L' ') << std::setw(0)
-              << L"  Arg1: " << (int) arg1
-              << L"  Arg2: " << (int) arg2
-              << L"  Arg3: " << (int) arg3;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+              << std::dec << std::setfill(' ') << std::setw(0)
+              << "  Arg1: " << (int) arg1
+              << "  Arg2: " << (int) arg2
+              << "  Arg3: " << (int) arg3;
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
           break;
         }
 
@@ -744,23 +744,23 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
           uint8_t arg2 = GetByte(curOffset++);
           uint8_t arg3 = GetByte(curOffset++);
           uint8_t arg4 = GetByte(curOffset++);
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte
-              << std::dec << std::setfill(L' ') << std::setw(0)
-              << L"  Arg1: " << (int) arg1
-              << L"  Arg2: " << (int) arg2
-              << L"  Arg3: " << (int) arg3
-              << L"  Arg4: " << (int) arg4;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+              << std::dec << std::setfill(' ') << std::setw(0)
+              << "  Arg1: " << (int) arg1
+              << "  Arg2: " << (int) arg2
+              << "  Arg3: " << (int) arg3
+              << "  Arg4: " << (int) arg4;
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
           break;
         }
 
         case SUBEVENT_LOOP_COUNT: {
           loopCount = GetByte(curOffset++);
-          desc << L"Times: " << (int) loopCount;
+          desc << "Times: " << (int) loopCount;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"Loop Count",
+                          "Loop Count",
                           desc.str().c_str(),
                           CLR_LOOP,
                           ICON_STARTREP);
@@ -771,10 +771,10 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
           int16_t destOffset = GetShort(curOffset);
           curOffset += 2;
           uint16_t dest = parentSeq->dwOffset + destOffset;
-          desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+          desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"Loop Again",
+                          "Loop Again",
                           desc.str().c_str(),
                           CLR_LOOP,
                           ICON_ENDREP);
@@ -790,10 +790,10 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_ADSR_AR: {
           uint8_t newAR = GetByte(curOffset++) & 15;
-          desc << L"AR: " << (int) newAR;
+          desc << "AR: " << (int) newAR;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"ADSR Attack Rate",
+                          "ADSR Attack Rate",
                           desc.str().c_str(),
                           CLR_ADSR,
                           ICON_CONTROL);
@@ -802,10 +802,10 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_ADSR_DR: {
           uint8_t newDR = GetByte(curOffset++) & 7;
-          desc << L"DR: " << (int) newDR;
+          desc << "DR: " << (int) newDR;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"ADSR Decay Rate",
+                          "ADSR Decay Rate",
                           desc.str().c_str(),
                           CLR_ADSR,
                           ICON_CONTROL);
@@ -814,10 +814,10 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_ADSR_SL: {
           uint8_t newSL = GetByte(curOffset++) & 7;
-          desc << L"SL: " << (int) newSL;
+          desc << "SL: " << (int) newSL;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"ADSR Sustain Level",
+                          "ADSR Sustain Level",
                           desc.str().c_str(),
                           CLR_ADSR,
                           ICON_CONTROL);
@@ -826,10 +826,10 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_ADSR_RR: {
           uint8_t newSR = GetByte(curOffset++) & 15;
-          desc << L"SR: " << (int) newSR;
+          desc << "SR: " << (int) newSR;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"ADSR Release Rate",
+                          "ADSR Release Rate",
                           desc.str().c_str(),
                           CLR_ADSR,
                           ICON_CONTROL);
@@ -838,10 +838,10 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_ADSR_SR: {
           uint8_t newSR = GetByte(curOffset++) & 15;
-          desc << L"SR: " << (int) newSR;
+          desc << "SR: " << (int) newSR;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"ADSR Sustain Rate",
+                          "ADSR Sustain Rate",
                           desc.str().c_str(),
                           CLR_ADSR,
                           ICON_CONTROL);
@@ -851,19 +851,19 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
         case SUBEVENT_SURROUND: {
           bool invertLeft = GetByte(curOffset++) != 0;
           bool invertRight = GetByte(curOffset++) != 0;
-          desc << L"Invert Left: " << (invertLeft ? L"On" : L"Off") << L"  Invert Right: "
-              << (invertRight ? L"On" : L"Off");
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Surround", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
+          desc << "Invert Left: " << (invertLeft ? "On" : "Off") << "  Invert Right: "
+              << (invertRight ? "On" : "Off");
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Surround", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
           break;
         }
 
         default:
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-          pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+          pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                         LOG_LEVEL_ERR,
-                                        L"HudsonSnesSeq"));
+                                        "HudsonSnesSeq"));
           bContinue = false;
           break;
       }
@@ -872,17 +872,17 @@ bool HeartBeatSnesTrack::ReadEvent(void) {
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"HeartBeatSnesSeq"));
+                                    "HeartBeatSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/HeartBeatSnesSeq.h
+++ b/src/main/formats/HeartBeatSnesSeq.h
@@ -72,7 +72,7 @@ class HeartBeatSnesSeq
     : public VGMSeq {
  public:
   HeartBeatSnesSeq
-      (RawFile *file, HeartBeatSnesVersion ver, uint32_t seqdataOffset, std::wstring newName = L"HeartBeat SNES Seq");
+      (RawFile *file, HeartBeatSnesVersion ver, uint32_t seqdataOffset, std::string newName = "HeartBeat SNES Seq");
   virtual ~HeartBeatSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/HudsonSnesInstr.cpp
+++ b/src/main/formats/HudsonSnesInstr.cpp
@@ -12,7 +12,7 @@ HudsonSnesInstrSet::HudsonSnesInstrSet(RawFile *file,
                                        uint32_t length,
                                        uint32_t spcDirAddr,
                                        uint32_t addrSampTuningTable,
-                                       const std::wstring &name) :
+                                       const std::string &name) :
     VGMInstrSet(HudsonSnesFormat::name, file, offset, length, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrSampTuningTable(addrSampTuningTable) {
@@ -46,8 +46,8 @@ bool HudsonSnesInstrSet::GetInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << instrNum;
+    std::ostringstream instrName;
+    instrName << "Instrument " << instrNum;
     HudsonSnesInstr *newInstr =
         new HudsonSnesInstr(this, version, ofsInstrEntry, instrNum, spcDirAddr, addrSampTuningTable, instrName.str());
     aInstrs.push_back(newInstr);
@@ -76,7 +76,7 @@ HudsonSnesInstr::HudsonSnesInstr(VGMInstrSet *instrSet,
                                  uint8_t instrNum,
                                  uint32_t spcDirAddr,
                                  uint32_t addrSampTuningTable,
-                                 const std::wstring &name) :
+                                 const std::string &name) :
     VGMInstr(instrSet, offset, 4, 0, instrNum, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrSampTuningTable(addrSampTuningTable) {
@@ -123,10 +123,10 @@ HudsonSnesRgn::HudsonSnesRgn(HudsonSnesInstr *instr,
   uint8_t adsr2 = GetByte(dwOffset + 2);
   uint8_t gain = GetByte(dwOffset + 3);
 
-  AddSimpleItem(dwOffset, 1, L"SRCN");
-  AddSimpleItem(dwOffset + 1, 1, L"ADSR(1)");
-  AddSimpleItem(dwOffset + 2, 1, L"ADSR(2)");
-  AddSimpleItem(dwOffset + 3, 1, L"GAIN");
+  AddSimpleItem(dwOffset, 1, "SRCN");
+  AddSimpleItem(dwOffset + 1, 1, "ADSR(1)");
+  AddSimpleItem(dwOffset + 2, 1, "ADSR(2)");
+  AddSimpleItem(dwOffset + 3, 1, "GAIN");
 
   const double pitch_fixer = 4286.0 / 4096.0;  // from pitch table ($10be vs $1000)
   const double pitch_scale = GetShortBE(addrTuningEntry) / 256.0;
@@ -152,9 +152,9 @@ HudsonSnesRgn::HudsonSnesRgn(HudsonSnesInstr *instr,
   unityKey = 72 - static_cast<int>(coarse_tuning);
   fineTune = static_cast<int16_t>(fine_tuning * 100.0);
 
-  AddSimpleItem(addrTuningEntry, 2, L"Pitch Multiplier");
-  AddSimpleItem(addrTuningEntry + 2, 1, L"Coarse Tune");
-  AddSimpleItem(addrTuningEntry + 3, 1, L"Fine Tune");
+  AddSimpleItem(addrTuningEntry, 2, "Pitch Multiplier");
+  AddSimpleItem(addrTuningEntry + 2, 1, "Coarse Tune");
+  AddSimpleItem(addrTuningEntry + 3, 1, "Fine Tune");
   SNESConvADSR<VGMRgn>(this, adsr1, adsr2, gain);
 }
 

--- a/src/main/formats/HudsonSnesInstr.h
+++ b/src/main/formats/HudsonSnesInstr.h
@@ -17,7 +17,7 @@ class HudsonSnesInstrSet:
                      uint32_t length,
                      uint32_t spcDirAddr,
                      uint32_t addrSampTuningTable,
-                     const std::wstring &name = L"HudsonSnesInstrSet");
+                     const std::string &name = "HudsonSnesInstrSet");
   virtual ~HudsonSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -44,7 +44,7 @@ class HudsonSnesInstr
                   uint8_t instrNum,
                   uint32_t spcDirAddr,
                   uint32_t addrSampTuningTable,
-                  const std::wstring &name = L"HudsonSnesInstr");
+                  const std::string &name = "HudsonSnesInstr");
   virtual ~HudsonSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/HudsonSnesScanner.cpp
+++ b/src/main/formats/HudsonSnesScanner.cpp
@@ -119,7 +119,7 @@ void HudsonSnesScanner::Scan(RawFile *file, void *info) {
 
 void HudsonSnesScanner::SearchForHudsonSnesFromARAM(RawFile *file) {
   HudsonSnesVersion version = HUDSONSNES_NONE;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   // search for note length table
   uint32_t ofsNoteLenTable;

--- a/src/main/formats/HudsonSnesScanner.h
+++ b/src/main/formats/HudsonSnesScanner.h
@@ -8,7 +8,7 @@ class HudsonSnesScanner:
     public VGMScanner {
  public:
   HudsonSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~HudsonSnesScanner(void) {
   }

--- a/src/main/formats/HudsonSnesSeq.cpp
+++ b/src/main/formats/HudsonSnesSeq.cpp
@@ -9,7 +9,7 @@ DECLARE_FORMAT(HudsonSnes);
 #define MAX_TRACKS  8
 #define SEQ_PPQN    48
 
-HudsonSnesSeq::HudsonSnesSeq(RawFile *file, HudsonSnesVersion ver, uint32_t seqdataOffset, std::wstring newName)
+HudsonSnesSeq::HudsonSnesSeq(RawFile *file, HudsonSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(HudsonSnesFormat::name, file, seqdataOffset, 0, newName),
       version(ver),
       TimebaseShift(2),
@@ -50,7 +50,7 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
 
   // track addresses
   if (version == HUDSONSNES_V0 || version == HUDSONSNES_V1) {
-    VGMHeader *trackPtrHeader = header->AddHeader(curOffset, 0, L"Track Pointers");
+    VGMHeader *trackPtrHeader = header->AddHeader(curOffset, 0, "Track Pointers");
     if (!GetTrackPointersInHeaderInfo(trackPtrHeader, curOffset)) {
       return false;
     }
@@ -73,17 +73,17 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
 
     switch (eventType) {
       case HEADER_EVENT_END: {
-        header->AddSimpleItem(beginOffset, curOffset - beginOffset, L"Header End");
+        header->AddSimpleItem(beginOffset, curOffset - beginOffset, "Header End");
         goto header_end;
       }
 
       case HEADER_EVENT_TIMEBASE: {
-        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, L"Timebase");
-        aHeader->AddSimpleItem(beginOffset, 1, L"Event ID");
+        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, "Timebase");
+        aHeader->AddSimpleItem(beginOffset, 1, "Event ID");
 
         // actual music engine decreases timebase based on the following value.
         // however, we always use SEQ_PPQN and adjust note lengths when necessary instead.
-        aHeader->AddSimpleItem(curOffset, 1, L"Timebase");
+        aHeader->AddSimpleItem(curOffset, 1, "Timebase");
         TimebaseShift = GetByte(curOffset++) & 3;
 
         aHeader->unLength = curOffset - beginOffset;
@@ -91,8 +91,8 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
       }
 
       case HEADER_EVENT_TRACKS: {
-        VGMHeader *trackPtrHeader = header->AddHeader(beginOffset, 0, L"Track Pointers");
-        trackPtrHeader->AddSimpleItem(beginOffset, 1, L"Event ID");
+        VGMHeader *trackPtrHeader = header->AddHeader(beginOffset, 0, "Track Pointers");
+        trackPtrHeader->AddSimpleItem(beginOffset, 1, "Event ID");
         if (!GetTrackPointersInHeaderInfo(trackPtrHeader, curOffset)) {
           return false;
         }
@@ -101,10 +101,10 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
       }
 
       case HEADER_EVENT_INSTRUMENTS_V1: {
-        VGMHeader *instrHeader = header->AddHeader(beginOffset, 1, L"Instruments");
-        instrHeader->AddSimpleItem(beginOffset, 1, L"Event ID");
+        VGMHeader *instrHeader = header->AddHeader(beginOffset, 1, "Instruments");
+        instrHeader->AddSimpleItem(beginOffset, 1, "Event ID");
 
-        instrHeader->AddSimpleItem(curOffset, 1, L"Size");
+        instrHeader->AddSimpleItem(curOffset, 1, "Size");
         uint8_t tableSize = GetByte(curOffset++);
         if (curOffset + tableSize > 0x10000) {
           return false;
@@ -117,13 +117,13 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
         uint8_t tableLength = tableSize / 4;
         for (uint8_t instrNum = 0; instrNum < tableLength; instrNum++) {
           uint16_t addrInstrItem = InstrumentTableAddress + instrNum * 4;
-          std::wstringstream instrName;
-          instrName << L"Instrument " << instrNum;
+          std::stringstream instrName;
+          instrName << "Instrument " << instrNum;
           VGMHeader *aInstrHeader = instrHeader->AddHeader(addrInstrItem, 4, instrName.str().c_str());
-          aInstrHeader->AddSimpleItem(addrInstrItem, 1, L"SRCN");
-          aInstrHeader->AddSimpleItem(addrInstrItem + 1, 1, L"ADSR(1)");
-          aInstrHeader->AddSimpleItem(addrInstrItem + 2, 1, L"ADSR(2)");
-          aInstrHeader->AddSimpleItem(addrInstrItem + 3, 1, L"GAIN");
+          aInstrHeader->AddSimpleItem(addrInstrItem, 1, "SRCN");
+          aInstrHeader->AddSimpleItem(addrInstrItem + 1, 1, "ADSR(1)");
+          aInstrHeader->AddSimpleItem(addrInstrItem + 2, 1, "ADSR(2)");
+          aInstrHeader->AddSimpleItem(addrInstrItem + 3, 1, "GAIN");
         }
         curOffset += tableSize;
 
@@ -132,10 +132,10 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
       }
 
       case HEADER_EVENT_PERCUSSIONS_V1: {
-        VGMHeader *percHeader = header->AddHeader(beginOffset, 1, L"Percussions");
-        percHeader->AddSimpleItem(beginOffset, 1, L"Event ID");
+        VGMHeader *percHeader = header->AddHeader(beginOffset, 1, "Percussions");
+        percHeader->AddSimpleItem(beginOffset, 1, "Event ID");
 
-        percHeader->AddSimpleItem(curOffset, 1, L"Size");
+        percHeader->AddSimpleItem(curOffset, 1, "Size");
         uint8_t tableSize = GetByte(curOffset++);
         if (curOffset + tableSize > 0x10000) {
           return false;
@@ -147,13 +147,13 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
         uint8_t tableLength = tableSize / 4;
         for (uint8_t percNote = 0; percNote < tableLength; percNote++) {
           uint16_t addrPercItem = PercussionTableAddress + percNote * 4;
-          std::wstringstream percNoteName;
-          percNoteName << L"Percussion " << percNote;
+          std::stringstream percNoteName;
+          percNoteName << "Percussion " << percNote;
           VGMHeader *percNoteHeader = percHeader->AddHeader(addrPercItem, 4, percNoteName.str().c_str());
-          percNoteHeader->AddSimpleItem(addrPercItem, 1, L"Instrument");
-          percNoteHeader->AddSimpleItem(addrPercItem + 1, 1, L"Unity Key");
-          percNoteHeader->AddSimpleItem(addrPercItem + 2, 1, L"Volume");
-          percNoteHeader->AddSimpleItem(addrPercItem + 3, 1, L"Pan");
+          percNoteHeader->AddSimpleItem(addrPercItem, 1, "Instrument");
+          percNoteHeader->AddSimpleItem(addrPercItem + 1, 1, "Unity Key");
+          percNoteHeader->AddSimpleItem(addrPercItem + 2, 1, "Volume");
+          percNoteHeader->AddSimpleItem(addrPercItem + 3, 1, "Pan");
         }
         curOffset += tableSize;
 
@@ -162,10 +162,10 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
       }
 
       case HEADER_EVENT_INSTRUMENTS_V2: {
-        VGMHeader *instrHeader = header->AddHeader(beginOffset, 1, L"Instruments");
-        instrHeader->AddSimpleItem(beginOffset, 1, L"Event ID");
+        VGMHeader *instrHeader = header->AddHeader(beginOffset, 1, "Instruments");
+        instrHeader->AddSimpleItem(beginOffset, 1, "Event ID");
 
-        instrHeader->AddSimpleItem(curOffset, 1, L"Number of Items");
+        instrHeader->AddSimpleItem(curOffset, 1, "Number of Items");
         uint8_t tableSize = GetByte(curOffset++) * 4;
         if (curOffset + tableSize > 0x10000) {
           return false;
@@ -178,13 +178,13 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
         uint8_t tableLength = tableSize / 4;
         for (uint8_t instrNum = 0; instrNum < tableLength; instrNum++) {
           uint16_t addrInstrItem = InstrumentTableAddress + instrNum * 4;
-          std::wstringstream instrName;
-          instrName << L"Instrument " << instrNum;
+          std::stringstream instrName;
+          instrName << "Instrument " << instrNum;
           VGMHeader *aInstrHeader = instrHeader->AddHeader(addrInstrItem, 4, instrName.str().c_str());
-          aInstrHeader->AddSimpleItem(addrInstrItem, 1, L"SRCN");
-          aInstrHeader->AddSimpleItem(addrInstrItem + 1, 1, L"ADSR(1)");
-          aInstrHeader->AddSimpleItem(addrInstrItem + 2, 1, L"ADSR(2)");
-          aInstrHeader->AddSimpleItem(addrInstrItem + 3, 1, L"GAIN");
+          aInstrHeader->AddSimpleItem(addrInstrItem, 1, "SRCN");
+          aInstrHeader->AddSimpleItem(addrInstrItem + 1, 1, "ADSR(1)");
+          aInstrHeader->AddSimpleItem(addrInstrItem + 2, 1, "ADSR(2)");
+          aInstrHeader->AddSimpleItem(addrInstrItem + 3, 1, "GAIN");
         }
         curOffset += tableSize;
 
@@ -193,10 +193,10 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
       }
 
       case HEADER_EVENT_PERCUSSIONS_V2: {
-        VGMHeader *percHeader = header->AddHeader(beginOffset, 1, L"Percussions");
-        percHeader->AddSimpleItem(beginOffset, 1, L"Event ID");
+        VGMHeader *percHeader = header->AddHeader(beginOffset, 1, "Percussions");
+        percHeader->AddSimpleItem(beginOffset, 1, "Event ID");
 
-        percHeader->AddSimpleItem(curOffset, 1, L"Number of Items");
+        percHeader->AddSimpleItem(curOffset, 1, "Number of Items");
         uint8_t tableSize = GetByte(curOffset++) * 4;
         if (curOffset + tableSize > 0x10000) {
           return false;
@@ -208,13 +208,13 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
         uint8_t tableLength = tableSize / 4;
         for (uint8_t percNote = 0; percNote < tableLength; percNote++) {
           uint16_t addrPercItem = PercussionTableAddress + percNote * 4;
-          std::wstringstream percNoteName;
-          percNoteName << L"Percussion " << percNote;
+          std::stringstream percNoteName;
+          percNoteName << "Percussion " << percNote;
           VGMHeader *percNoteHeader = percHeader->AddHeader(addrPercItem, 4, percNoteName.str().c_str());
-          percNoteHeader->AddSimpleItem(addrPercItem, 1, L"Instrument");
-          percNoteHeader->AddSimpleItem(addrPercItem + 1, 1, L"Unity Key");
-          percNoteHeader->AddSimpleItem(addrPercItem + 2, 1, L"Volume");
-          percNoteHeader->AddSimpleItem(addrPercItem + 3, 1, L"Pan");
+          percNoteHeader->AddSimpleItem(addrPercItem, 1, "Instrument");
+          percNoteHeader->AddSimpleItem(addrPercItem + 1, 1, "Unity Key");
+          percNoteHeader->AddSimpleItem(addrPercItem + 2, 1, "Volume");
+          percNoteHeader->AddSimpleItem(addrPercItem + 3, 1, "Pan");
         }
         curOffset += tableSize;
 
@@ -223,10 +223,10 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
       }
 
       case HEADER_EVENT_05: {
-        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, L"Unknown");
-        aHeader->AddSimpleItem(beginOffset, 1, L"Event ID");
+        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, "Unknown");
+        aHeader->AddSimpleItem(beginOffset, 1, "Event ID");
 
-        aHeader->AddSimpleItem(curOffset, 1, L"Number of Items");
+        aHeader->AddSimpleItem(curOffset, 1, "Number of Items");
         uint8_t tableSize = GetByte(curOffset++) * 2;
         if (curOffset + tableSize > 0x10000) {
           return false;
@@ -240,10 +240,10 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
       }
 
       case HEADER_EVENT_06: {
-        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, L"Unknown");
-        aHeader->AddSimpleItem(beginOffset, 1, L"Event ID");
+        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, "Unknown");
+        aHeader->AddSimpleItem(beginOffset, 1, "Event ID");
 
-        aHeader->AddSimpleItem(curOffset, 1, L"Number of Items");
+        aHeader->AddSimpleItem(curOffset, 1, "Number of Items");
         uint8_t tableSize = GetByte(curOffset++) * 2;
         if (curOffset + tableSize > 0x10000) {
           return false;
@@ -257,24 +257,24 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
       }
 
       case HEADER_EVENT_ECHO_PARAM: {
-        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, L"Echo Param");
-        aHeader->AddSimpleItem(beginOffset, 1, L"Event ID");
+        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, "Echo Param");
+        aHeader->AddSimpleItem(beginOffset, 1, "Event ID");
 
-        aHeader->AddSimpleItem(curOffset, 1, L"Use Default Echo");
+        aHeader->AddSimpleItem(curOffset, 1, "Use Default Echo");
         uint8_t useDefaultEcho = GetByte(curOffset++);
 
         if (useDefaultEcho == 0) {
-          aHeader->AddSimpleItem(curOffset, 1, L"EVOL(L)");
+          aHeader->AddSimpleItem(curOffset, 1, "EVOL(L)");
           curOffset++;
-          aHeader->AddSimpleItem(curOffset, 1, L"EVOL(R)");
+          aHeader->AddSimpleItem(curOffset, 1, "EVOL(R)");
           curOffset++;
-          aHeader->AddSimpleItem(curOffset, 1, L"EDL");
+          aHeader->AddSimpleItem(curOffset, 1, "EDL");
           curOffset++;
-          aHeader->AddSimpleItem(curOffset, 1, L"EFB");
+          aHeader->AddSimpleItem(curOffset, 1, "EFB");
           curOffset++;
-		  aHeader->AddSimpleItem(curOffset, 1, L"FIR");
+		  aHeader->AddSimpleItem(curOffset, 1, "FIR");
           curOffset++;
-          aHeader->AddSimpleItem(curOffset, 1, L"EON");
+          aHeader->AddSimpleItem(curOffset, 1, "EON");
           curOffset++;
         }
 
@@ -283,10 +283,10 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
       }
 
       case HEADER_EVENT_NOTE_VELOCITY: {
-        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, L"Note Velocity");
-        aHeader->AddSimpleItem(beginOffset, 1, L"Event ID");
+        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, "Note Velocity");
+        aHeader->AddSimpleItem(beginOffset, 1, "Event ID");
 
-        aHeader->AddSimpleItem(curOffset, 1, L"Note Velocity On/Off");
+        aHeader->AddSimpleItem(curOffset, 1, "Note Velocity On/Off");
         uint8_t noteVelOn = GetByte(curOffset++);
         if (noteVelOn != 0) {
           NoteEventHasVelocity = true;
@@ -297,10 +297,10 @@ bool HudsonSnesSeq::GetHeaderInfo(void) {
       }
 
       case HEADER_EVENT_09: {
-        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, L"Unknown");
-        aHeader->AddSimpleItem(beginOffset, 1, L"Event ID");
+        VGMHeader *aHeader = header->AddHeader(beginOffset, 1, "Unknown");
+        aHeader->AddSimpleItem(beginOffset, 1, "Event ID");
 
-        aHeader->AddSimpleItem(curOffset, 1, L"Number of Items");
+        aHeader->AddSimpleItem(curOffset, 1, "Number of Items");
         uint8_t tableSize = GetByte(curOffset++) * 2;
         if (curOffset + tableSize > 0x10000) {
           return false;
@@ -334,7 +334,7 @@ bool HudsonSnesSeq::GetTrackPointersInHeaderInfo(VGMHeader *header, uint32_t &of
   }
 
   // flag field that indicates track availability
-  header->AddSimpleItem(curOffset, 1, L"Track Availability");
+  header->AddSimpleItem(curOffset, 1, "Track Availability");
   TrackAvailableBits = GetByte(curOffset++);
 
   // read track addresses (DSP channel 8 to 1)
@@ -345,8 +345,8 @@ bool HudsonSnesSeq::GetTrackPointersInHeaderInfo(VGMHeader *header, uint32_t &of
         return false;
       }
 
-      std::wstringstream trackName;
-      trackName << L"Track Pointer " << (trackIndex + 1);
+      std::stringstream trackName;
+      trackName << "Track Pointer " << (trackIndex + 1);
       header->AddSimpleItem(curOffset, 2, trackName.str().c_str());
       TrackAddresses[trackIndex] = GetShort(curOffset);
       curOffset += 2;
@@ -527,7 +527,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   HudsonSnesSeqEventType eventType = (HudsonSnesSeqEventType) 0;
   std::map<uint8_t, HudsonSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -537,27 +537,27 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -565,12 +565,12 @@ bool HudsonSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -579,24 +579,24 @@ bool HudsonSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_NOP: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
       break;
     }
 
     case EVENT_NOP1: {
       curOffset++;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
       break;
     }
 
@@ -666,7 +666,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
         if (prevNoteSlurred && key == prevNoteKey) {
           // tie
           MakePrevDurNoteEnd(GetTime() + dur);
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
         }
         else {
           // note
@@ -706,12 +706,12 @@ bool HudsonSnesTrack::ReadEvent(void) {
       uint8_t newQuantize = GetByte(curOffset++);
 	  spcNoteQuantize = newQuantize;
       if (newQuantize <= 8) {
-        desc << L"Length: " << (int) newQuantize << L"/8";
+        desc << "Length: " << (int) newQuantize << "/8";
       }
       else {
-        desc << L"Length: " << L"Full-Length - " << (int) (newQuantize - 8);
+        desc << "Length: " << "Full-Length - " << (int) (newQuantize - 8);
       }
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Duration Rate", desc.str().c_str(), CLR_DURNOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str().c_str(), CLR_DURNOTE);
       break;
     }
 
@@ -754,11 +754,11 @@ bool HudsonSnesTrack::ReadEvent(void) {
       uint8_t reverse = GetByte(curOffset++);
       bool reverseLeft = (reverse & 2) != 0;
       bool reverseRight = (reverse & 1) != 0;
-      desc << L"Reverse Left: " << (reverseLeft ? L"On" : L"Off") << L"Reverse Right: "
-          << (reverseRight ? L"On" : L"Off");
+      desc << "Reverse Left: " << (reverseLeft ? "On" : "Off") << "Reverse Right: "
+          << (reverseRight ? "On" : "Off");
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Reverse Phase",
+                      "Reverse Phase",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -775,14 +775,14 @@ bool HudsonSnesTrack::ReadEvent(void) {
         newVolume = 0xff;
       }
       spcVolume = (uint8_t) newVolume;
-      AddVol(beginOffset, curOffset - beginOffset, spcVolume >> 1, L"Volume (Relative)");
+      AddVol(beginOffset, curOffset - beginOffset, spcVolume >> 1, "Volume (Relative)");
       break;
     }
 
     case EVENT_LOOP_START: {
       uint8_t count = GetByte(curOffset);
-      desc << L"Loop Count: " << (int) count;
-      AddGenericEvent(beginOffset, 2, L"Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      desc << "Loop Count: " << (int) count;
+      AddGenericEvent(beginOffset, 2, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
 
       if (spcCallStackPtr + 3 > HUDSONSNES_CALLSTACK_SIZE) {
         // stack overflow
@@ -802,7 +802,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_LOOP_END: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       if (spcCallStackPtr < 3) {
         // access violation
@@ -826,8 +826,8 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
     case EVENT_SUBROUTINE: {
       uint16_t dest = GetShort(curOffset);
-      desc << "Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, 3, L"Pattern Play", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, 3, "Pattern Play", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
 
       if (spcCallStackPtr + 2 > HUDSONSNES_CALLSTACK_SIZE) {
         // stack overflow
@@ -848,15 +848,15 @@ bool HudsonSnesTrack::ReadEvent(void) {
     case EVENT_GOTO: {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       uint32_t length = curOffset - beginOffset;
 
       curOffset = dest;
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
       }
       else {
-        bContinue = AddLoopForever(beginOffset, length, L"Jump");
+        bContinue = AddLoopForever(beginOffset, length, "Jump");
       }
       break;
     }
@@ -872,10 +872,10 @@ bool HudsonSnesTrack::ReadEvent(void) {
       if (parentSeq->version == HUDSONSNES_V0 || parentSeq->version == HUDSONSNES_V1) {
         uint8_t lfoRate = GetByte(curOffset++);
         uint8_t lfoDepth = GetByte(curOffset++);
-        desc << L"Rate: " << (int) lfoRate << L"  Depth: " << (int) lfoDepth;
+        desc << "Rate: " << (int) lfoRate << "  Depth: " << (int) lfoDepth;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Vibrato",
+                        "Vibrato",
                         desc.str().c_str(),
                         CLR_MODULATION,
                         ICON_CONTROL);
@@ -884,10 +884,10 @@ bool HudsonSnesTrack::ReadEvent(void) {
         uint8_t arg1 = GetByte(curOffset++);
         uint8_t arg2 = GetByte(curOffset++);
         uint8_t arg3 = GetByte(curOffset++);
-        desc << L"Arg1: " << (int) arg1 << L"  Arg2: " << (int) arg2 << L"  Arg3: " << (int) arg3;
+        desc << "Arg1: " << (int) arg1 << "  Arg2: " << (int) arg2 << "  Arg3: " << (int) arg3;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Vibrato",
+                        "Vibrato",
                         desc.str().c_str(),
                         CLR_MODULATION,
                         ICON_CONTROL);
@@ -897,10 +897,10 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
     case EVENT_VIBRATO_DELAY: {
       uint8_t lfoDelay = GetByte(curOffset++);
-      desc << L"Delay: " << (int) lfoDelay;
+      desc << "Delay: " << (int) lfoDelay;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato Delay",
+                      "Vibrato Delay",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -910,10 +910,10 @@ bool HudsonSnesTrack::ReadEvent(void) {
     case EVENT_ECHO_VOLUME: {
       int8_t volumeLeft = GetByte(curOffset++);
       int8_t volumeRight = GetByte(curOffset++);
-      desc << L"Left Volume: " << (int) volumeLeft << L"  Right Volume: " << (int) volumeRight;
+      desc << "Left Volume: " << (int) volumeLeft << "  Right Volume: " << (int) volumeRight;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Volume",
+                      "Echo Volume",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -924,11 +924,11 @@ bool HudsonSnesTrack::ReadEvent(void) {
       uint8_t delay = GetByte(curOffset++);
       uint8_t feedback = GetByte(curOffset++);
       uint8_t filterIndex = GetByte(curOffset++);
-      desc << L"Echo Delay: " << (int) delay << L"  Echo Feedback: " << (int) feedback << L"  FIR: "
+      desc << "Echo Delay: " << (int) delay << "  Echo Feedback: " << (int) feedback << "  FIR: "
           << (int) filterIndex;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Parameter",
+                      "Echo Parameter",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -936,7 +936,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_ECHO_ON: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo On", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -948,7 +948,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
     case EVENT_TRANSPOSE_REL: {
       int8_t delta = GetByte(curOffset++);
-      AddTranspose(beginOffset, curOffset - beginOffset, transpose + delta, L"Transpose (Relative)");
+      AddTranspose(beginOffset, curOffset - beginOffset, transpose + delta, "Transpose (Relative)");
       break;
     }
 
@@ -957,10 +957,10 @@ bool HudsonSnesTrack::ReadEvent(void) {
       uint8_t depth = GetByte(curOffset++);
       uint8_t direction = GetByte(curOffset++);
       bool upTo = (direction != 0);
-      desc << L"Speed: " << (int) speed << L"  Depth: " << (int) depth << L"  Direction: " << (upTo ? L"Up" : L"Down");
+      desc << "Speed: " << (int) speed << "  Depth: " << (int) depth << "  Direction: " << (upTo ? "Up" : "Down");
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Attack Pitch Envelope On",
+                      "Attack Pitch Envelope On",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -970,7 +970,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
     case EVENT_PITCH_ATTACK_ENV_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Attack Pitch Envelope Off",
+                      "Attack Pitch Envelope Off",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -981,7 +981,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
       infiniteLoopPoint = curOffset;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Infinite Loop Point",
+                      "Infinite Loop Point",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -997,7 +997,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
     case EVENT_LOOP_POINT_ONCE: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Infinite Loop Point (Ignore after the Second Time)",
+                      "Infinite Loop Point (Ignore after the Second Time)",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -1031,7 +1031,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
       }
 
       spcVolume = VOLUME_TABLE[volIndex];
-      AddVol(beginOffset, curOffset - beginOffset, spcVolume >> 1, L"Volume From Table");
+      AddVol(beginOffset, curOffset - beginOffset, spcVolume >> 1, "Volume From Table");
       break;
     }
 
@@ -1061,7 +1061,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
         // end subroutine
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"End Pattern",
+                        "End Pattern",
                         desc.str().c_str(),
                         CLR_LOOP,
                         ICON_ENDREP);
@@ -1088,30 +1088,30 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
       switch (subEventType) {
         case SUBEVENT_UNKNOWN0:
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
           break;
 
         case SUBEVENT_UNKNOWN1: {
           uint8_t arg1 = GetByte(curOffset++);
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte
-              << std::dec << std::setfill(L' ') << std::setw(0)
-              << L"  Arg1: " << (int) arg1;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+              << std::dec << std::setfill(' ') << std::setw(0)
+              << "  Arg1: " << (int) arg1;
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
           break;
         }
 
         case SUBEVENT_UNKNOWN2: {
           uint8_t arg1 = GetByte(curOffset++);
           uint8_t arg2 = GetByte(curOffset++);
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte
-              << std::dec << std::setfill(L' ') << std::setw(0)
-              << L"  Arg1: " << (int) arg1
-              << L"  Arg2: " << (int) arg2;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+              << std::dec << std::setfill(' ') << std::setw(0)
+              << "  Arg1: " << (int) arg1
+              << "  Arg2: " << (int) arg2;
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
           break;
         }
 
@@ -1119,13 +1119,13 @@ bool HudsonSnesTrack::ReadEvent(void) {
           uint8_t arg1 = GetByte(curOffset++);
           uint8_t arg2 = GetByte(curOffset++);
           uint8_t arg3 = GetByte(curOffset++);
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte
-              << std::dec << std::setfill(L' ') << std::setw(0)
-              << L"  Arg1: " << (int) arg1
-              << L"  Arg2: " << (int) arg2
-              << L"  Arg3: " << (int) arg3;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+              << std::dec << std::setfill(' ') << std::setw(0)
+              << "  Arg1: " << (int) arg1
+              << "  Arg2: " << (int) arg2
+              << "  Arg3: " << (int) arg3;
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
           break;
         }
 
@@ -1134,19 +1134,19 @@ bool HudsonSnesTrack::ReadEvent(void) {
           uint8_t arg2 = GetByte(curOffset++);
           uint8_t arg3 = GetByte(curOffset++);
           uint8_t arg4 = GetByte(curOffset++);
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte
-              << std::dec << std::setfill(L' ') << std::setw(0)
-              << L"  Arg1: " << (int) arg1
-              << L"  Arg2: " << (int) arg2
-              << L"  Arg3: " << (int) arg3
-              << L"  Arg4: " << (int) arg4;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+              << std::dec << std::setfill(' ') << std::setw(0)
+              << "  Arg1: " << (int) arg1
+              << "  Arg2: " << (int) arg2
+              << "  Arg3: " << (int) arg3
+              << "  Arg4: " << (int) arg4;
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
           break;
         }
 
         case SUBEVENT_NOP: {
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
           break;
         }
 
@@ -1159,7 +1159,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_ECHO_OFF: {
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"Echo Off",
+                          "Echo Off",
                           desc.str().c_str(),
                           CLR_REVERB,
                           ICON_CONTROL);
@@ -1169,7 +1169,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_PERC_ON: {
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"Percussion On",
+                          "Percussion On",
                           desc.str().c_str(),
                           CLR_CHANGESTATE,
                           ICON_CONTROL);
@@ -1179,7 +1179,7 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_PERC_OFF: {
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"Percussion Off",
+                          "Percussion Off",
                           desc.str().c_str(),
                           CLR_CHANGESTATE,
                           ICON_CONTROL);
@@ -1188,10 +1188,10 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_VIBRATO_TYPE: {
           uint8_t vibratoType = subStatusByte - 0x05;
-          desc << L"Vibrato Type: " << (int) vibratoType;
+          desc << "Vibrato Type: " << (int) vibratoType;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"Vibrato Type",
+                          "Vibrato Type",
                           desc.str().c_str(),
                           CLR_LFO,
                           ICON_CONTROL);
@@ -1200,15 +1200,15 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_NOTE_VEL_OFF: {
           parentSeq->DisableNoteVelocity = true;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Note Velocity Off", desc.str().c_str(), CLR_MISC, ICON_CONTROL);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Note Velocity Off", desc.str().c_str(), CLR_MISC, ICON_CONTROL);
           break;
         }
 
         case SUBEVENT_MOV_IMM: {
           uint8_t reg = GetByte(curOffset++);
           uint8_t val = GetByte(curOffset++);
-          desc << L"Register: " << (int) reg << L"  Value: " << (int) val;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"MOV (Immediate)", desc.str().c_str(), CLR_MISC);
+          desc << "Register: " << (int) reg << "  Value: " << (int) val;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "MOV (Immediate)", desc.str().c_str(), CLR_MISC);
 
           if (reg < HUDSONSNES_USERRAM_SIZE) {
             parentSeq->UserRAM[reg] = val;
@@ -1220,8 +1220,8 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_MOV: {
           uint8_t regDst = GetByte(curOffset++);
           uint8_t regSrc = GetByte(curOffset++);
-          desc << L"Destination Register: " << (int) regDst << L"  Source Register: " << (int) regSrc;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"MOV", desc.str().c_str(), CLR_MISC);
+          desc << "Destination Register: " << (int) regDst << "  Source Register: " << (int) regSrc;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "MOV", desc.str().c_str(), CLR_MISC);
 
           if (regDst < HUDSONSNES_USERRAM_SIZE && regSrc < HUDSONSNES_USERRAM_SIZE) {
             uint8_t val = parentSeq->UserRAM[regSrc];
@@ -1234,8 +1234,8 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_CMP_IMM: {
           uint8_t reg = GetByte(curOffset++);
           uint8_t val = GetByte(curOffset++);
-          desc << L"Register: " << (int) reg << L"  Value: " << (int) val;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"CMP (Immediate)", desc.str().c_str(), CLR_MISC);
+          desc << "Register: " << (int) reg << "  Value: " << (int) val;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "CMP (Immediate)", desc.str().c_str(), CLR_MISC);
 
           if (reg < HUDSONSNES_USERRAM_SIZE) {
             parentSeq->UserCmpReg = parentSeq->UserRAM[reg] - val;
@@ -1247,8 +1247,8 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_CMP: {
           uint8_t regDst = GetByte(curOffset++);
           uint8_t regSrc = GetByte(curOffset++);
-          desc << L"Destination Register: " << (int) regDst << L"  Source Register: " << (int) regSrc;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"CMP", desc.str().c_str(), CLR_MISC);
+          desc << "Destination Register: " << (int) regDst << "  Source Register: " << (int) regSrc;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "CMP", desc.str().c_str(), CLR_MISC);
 
           if (regDst < HUDSONSNES_USERRAM_SIZE && regSrc < HUDSONSNES_USERRAM_SIZE) {
             parentSeq->UserCmpReg = parentSeq->UserRAM[regDst] - parentSeq->UserRAM[regSrc];
@@ -1260,8 +1260,8 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_BNE: {
           uint16_t dest = GetShort(curOffset);
           curOffset += 2;
-          desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"BNE", desc.str().c_str(), CLR_MISC);
+          desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "BNE", desc.str().c_str(), CLR_MISC);
 
           if (parentSeq->UserCmpReg != 0) {
             curOffset = dest;
@@ -1273,8 +1273,8 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_BEQ: {
           uint16_t dest = GetShort(curOffset);
           curOffset += 2;
-          desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"BEQ", desc.str().c_str(), CLR_MISC);
+          desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "BEQ", desc.str().c_str(), CLR_MISC);
 
           if (parentSeq->UserCmpReg != 0) {
             curOffset = dest;
@@ -1286,8 +1286,8 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_BCS: {
           uint16_t dest = GetShort(curOffset);
           curOffset += 2;
-          desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"BCS", desc.str().c_str(), CLR_MISC);
+          desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "BCS", desc.str().c_str(), CLR_MISC);
 
           if (parentSeq->UserCarry) {
             curOffset = dest;
@@ -1299,8 +1299,8 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_BCC: {
           uint16_t dest = GetShort(curOffset);
           curOffset += 2;
-          desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"BCC", desc.str().c_str(), CLR_MISC);
+          desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "BCC", desc.str().c_str(), CLR_MISC);
 
           if (!parentSeq->UserCarry) {
             curOffset = dest;
@@ -1312,8 +1312,8 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_BMI: {
           uint16_t dest = GetShort(curOffset);
           curOffset += 2;
-          desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"BMI", desc.str().c_str(), CLR_MISC);
+          desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "BMI", desc.str().c_str(), CLR_MISC);
 
           if ((parentSeq->UserCmpReg & 0x80) != 0) {
             curOffset = dest;
@@ -1325,8 +1325,8 @@ bool HudsonSnesTrack::ReadEvent(void) {
         case SUBEVENT_BPL: {
           uint16_t dest = GetShort(curOffset);
           curOffset += 2;
-          desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"BPL", desc.str().c_str(), CLR_MISC);
+          desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "BPL", desc.str().c_str(), CLR_MISC);
 
           if ((parentSeq->UserCmpReg & 0x80) == 0) {
             curOffset = dest;
@@ -1337,10 +1337,10 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_ADSR_AR: {
           uint8_t newAR = GetByte(curOffset++) & 15;
-          desc << L"AR: " << (int) newAR;
+          desc << "AR: " << (int) newAR;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"ADSR Attack Rate",
+                          "ADSR Attack Rate",
                           desc.str().c_str(),
                           CLR_ADSR,
                           ICON_CONTROL);
@@ -1349,10 +1349,10 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_ADSR_DR: {
           uint8_t newDR = GetByte(curOffset++) & 7;
-          desc << L"DR: " << (int) newDR;
+          desc << "DR: " << (int) newDR;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"ADSR Decay Rate",
+                          "ADSR Decay Rate",
                           desc.str().c_str(),
                           CLR_ADSR,
                           ICON_CONTROL);
@@ -1361,10 +1361,10 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_ADSR_SL: {
           uint8_t newSL = GetByte(curOffset++) & 7;
-          desc << L"SL: " << (int) newSL;
+          desc << "SL: " << (int) newSL;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"ADSR Sustain Level",
+                          "ADSR Sustain Level",
                           desc.str().c_str(),
                           CLR_ADSR,
                           ICON_CONTROL);
@@ -1373,10 +1373,10 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_ADSR_SR: {
           uint8_t newSR = GetByte(curOffset++) & 15;
-          desc << L"SR: " << (int) newSR;
+          desc << "SR: " << (int) newSR;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"ADSR Sustain Rate",
+                          "ADSR Sustain Rate",
                           desc.str().c_str(),
                           CLR_ADSR,
                           ICON_CONTROL);
@@ -1385,10 +1385,10 @@ bool HudsonSnesTrack::ReadEvent(void) {
 
         case SUBEVENT_ADSR_RR: {
           uint8_t newSR = GetByte(curOffset++) & 15;
-          desc << L"SR: " << (int) newSR;
+          desc << "SR: " << (int) newSR;
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"ADSR Release Rate",
+                          "ADSR Release Rate",
                           desc.str().c_str(),
                           CLR_ADSR,
                           ICON_CONTROL);
@@ -1396,12 +1396,12 @@ bool HudsonSnesTrack::ReadEvent(void) {
         }
 
         default:
-          desc << L"Subevent: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase
+          desc << "Subevent: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase
               << (int) subStatusByte;
-          AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-          pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+          AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+          pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                         LOG_LEVEL_ERR,
-                                        L"HudsonSnesSeq"));
+                                        "HudsonSnesSeq"));
           bContinue = false;
           break;
       }
@@ -1410,17 +1410,17 @@ bool HudsonSnesTrack::ReadEvent(void) {
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"HudsonSnesSeq"));
+                                    "HudsonSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/HudsonSnesSeq.h
+++ b/src/main/formats/HudsonSnesSeq.h
@@ -99,7 +99,7 @@ class HudsonSnesSeq
     : public VGMSeq {
  public:
   HudsonSnesSeq
-      (RawFile *file, HudsonSnesVersion ver, uint32_t seqdataOffset, std::wstring newName = L"Hudson SNES Seq");
+      (RawFile *file, HudsonSnesVersion ver, uint32_t seqdataOffset, std::string newName = "Hudson SNES Seq");
   virtual ~HudsonSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/ItikitiSnesInstr.cpp
+++ b/src/main/formats/ItikitiSnesInstr.cpp
@@ -4,7 +4,7 @@
 
 ItikitiSnesInstrSet::ItikitiSnesInstrSet(RawFile *file, uint32_t tuning_offset,
                                          uint32_t adsr_offset, uint16_t spc_dir_offset,
-                                         std::wstring name)
+                                         std::string name)
     : VGMInstrSet(ItikitiSnesFormat::name, file, adsr_offset, 0, std::move(name)),
       m_tuning_offset(tuning_offset), m_adsr_offset(adsr_offset), m_spc_dir_offset(spc_dir_offset),
       m_num_instruments_to_scan(128) {
@@ -29,8 +29,8 @@ bool ItikitiSnesInstrSet::GetInstrPointers() {
 
     srcns.push_back(srcn);
 
-    std::wostringstream instrument_name;
-    instrument_name << L"Instrument " << index;
+    std::ostringstream instrument_name;
+    instrument_name << "Instrument " << index;
     auto instrument =
         std::make_unique<ItikitiSnesInstr>(this, ins_tuning_offset, ins_adsr_offset, 0, srcn, srcn,
                                            spc_dir_offset(), instrument_name.str());
@@ -50,7 +50,7 @@ bool ItikitiSnesInstrSet::GetInstrPointers() {
 
 ItikitiSnesInstr::ItikitiSnesInstr(VGMInstrSet *instrument_set, uint32_t tuning_offset,
                                    uint32_t adsr_offset, uint32_t bank, uint32_t instrument_number,
-                                   uint8_t srcn, uint16_t spc_dir_offset, std::wstring name)
+                                   uint8_t srcn, uint16_t spc_dir_offset, std::string name)
     : VGMInstr(instrument_set, adsr_offset, 2, bank, instrument_number, std::move(name)),
       m_tuning_offset(tuning_offset), m_adsr_offset(adsr_offset), srcn(srcn),
       m_spc_dir_offset(spc_dir_offset) {
@@ -101,7 +101,7 @@ ItikitiSnesRgn::ItikitiSnesRgn(ItikitiSnesInstr *instrument, uint32_t tuning_off
   sampNum = srcn;
   unityKey = static_cast<uint8_t>(72 - static_cast<int>(coarse_tuning));
   fineTune = static_cast<int16_t>(fine_tuning * 100.0);
-  AddSimpleItem(adsr_offset, 1, L"ADSR1");
-  AddSimpleItem(adsr_offset + 1, 1, L"ADSR2");
+  AddSimpleItem(adsr_offset, 1, "ADSR1");
+  AddSimpleItem(adsr_offset + 1, 1, "ADSR2");
   SNESConvADSR<VGMRgn>(this, adsr1, adsr2, 0);
 }

--- a/src/main/formats/ItikitiSnesInstr.h
+++ b/src/main/formats/ItikitiSnesInstr.h
@@ -14,7 +14,7 @@ class ItikitiSnesInstrSet : public VGMInstrSet {
   friend ItikitiSnesRgn;
 
   ItikitiSnesInstrSet(RawFile *file, uint32_t tuning_offset, uint32_t adsr_offset,
-                      uint16_t spc_dir_offset, std::wstring name = L"ItikitiSnesInstrSet");
+                      uint16_t spc_dir_offset, std::string name = "ItikitiSnesInstrSet");
 
   bool GetHeaderInfo() override { return true; }
   bool GetInstrPointers() override;
@@ -32,7 +32,7 @@ class ItikitiSnesInstr : public VGMInstr {
  public:
   ItikitiSnesInstr(VGMInstrSet *instrument_set, uint32_t tuning_offset, uint32_t adsr_offset,
                    uint32_t bank, uint32_t instrument_number, uint8_t srcn, uint16_t spc_dir_offset,
-                   std::wstring name = L"ItikitiSnesInstr");
+                   std::string name = "ItikitiSnesInstr");
 
   bool LoadInstr() override;
 

--- a/src/main/formats/ItikitiSnesScanner.cpp
+++ b/src/main/formats/ItikitiSnesScanner.cpp
@@ -11,7 +11,7 @@ void ItikitiSnesScanner::Scan(RawFile *file, void *info) {
 }
 
 void ItikitiSnesScanner::ScanFromApuRam(RawFile *file) {
-  std::wstring name =
+  std::string name =
       file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   uint32_t song_header_offset{};

--- a/src/main/formats/ItikitiSnesScanner.h
+++ b/src/main/formats/ItikitiSnesScanner.h
@@ -4,7 +4,7 @@
 class ItikitiSnesScanner: public VGMScanner {
  public:
   ItikitiSnesScanner() {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
 
   void Scan(RawFile *file, void *info) override;

--- a/src/main/formats/ItikitiSnesSeq.cpp
+++ b/src/main/formats/ItikitiSnesSeq.cpp
@@ -9,7 +9,7 @@ static constexpr std::array<uint8_t, 16> kMasterNoteLengths = {
 static constexpr std::array<uint8_t, 7> kDefaultNoteLengths = {0xc0, 0x60, 0x48, 0x30,
                                                                0x24, 0x18, 0x0c};
 
-ItikitiSnesSeq::ItikitiSnesSeq(RawFile *file, uint32_t offset, std::wstring new_name)
+ItikitiSnesSeq::ItikitiSnesSeq(RawFile *file, uint32_t offset, std::string new_name)
     : VGMSeq(ItikitiSnesFormat::name, file, offset, 0, std::move(new_name)) {
   bLoadTickByTick = true;
   bAllowDiscontinuousTrackData = true;
@@ -30,7 +30,7 @@ bool ItikitiSnesSeq::GetHeaderInfo() {
 
   VGMHeader *header = AddHeader(dwOffset, 0);
   header->AddUnknownItem(dwOffset, 1);
-  header->AddSimpleItem(dwOffset + 1, 1, L"Number of Tracks");
+  header->AddSimpleItem(dwOffset + 1, 1, "Number of Tracks");
 
   nNumTracks = GetByte(dwOffset + 1);
   if (nNumTracks == 0 || nNumTracks > 8)
@@ -41,8 +41,8 @@ bool ItikitiSnesSeq::GetHeaderInfo() {
   m_base_offset = static_cast<uint16_t>(first_address) - first_offset;
 
   for (unsigned int track_index = 0; track_index < nNumTracks; track_index++) {
-    std::wstringstream track_name;
-    track_name << L"Track " << (track_index + 1);
+    std::stringstream track_name;
+    track_name << "Track " << (track_index + 1);
 
     const uint32_t offset_to_pointer = dwOffset + 2 + (2 * track_index);
     header->AddSimpleItem(offset_to_pointer, 2, track_name.str());
@@ -145,36 +145,36 @@ bool ItikitiSnesTrack::ReadEvent() {
   const auto event_type = seq->GetEventType(command);
 
   bool stop_parser = false;
-  std::wstringstream description;
+  std::stringstream description;
   switch (event_type) {
     case ItikitiSnesSeqEventType::EVENT_UNKNOWN0:
-      description << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2)
+      description << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2)
                   << std::uppercase << command;
-      AddUnknown(start, curOffset - start, L"Unknown Event", description.str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + description.str()),
-                                    LOG_LEVEL_DEBUG, L"ItikitiSnesSeq"));
+      AddUnknown(start, curOffset - start, "Unknown Event", description.str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + description.str()),
+                                    LOG_LEVEL_DEBUG, "ItikitiSnesSeq"));
       break;
 
     case ItikitiSnesSeqEventType::EVENT_UNKNOWN1: {
       const auto arg1 = GetByte(curOffset++);
-      description << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2)
-                  << std::uppercase << command << std::dec << std::setfill(L' ') << std::setw(0)
-                  << L"  Arg1: " << arg1;
-      AddUnknown(start, curOffset - start, L"Unknown Event", description.str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + description.str()),
-                                    LOG_LEVEL_DEBUG, L"ItikitiSnesSeq"));
+      description << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2)
+                  << std::uppercase << command << std::dec << std::setfill(' ') << std::setw(0)
+                  << "  Arg1: " << arg1;
+      AddUnknown(start, curOffset - start, "Unknown Event", description.str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + description.str()),
+                                    LOG_LEVEL_DEBUG, "ItikitiSnesSeq"));
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_UNKNOWN2: {
       const auto arg1 = GetByte(curOffset++);
       const auto arg2 = GetByte(curOffset++);
-      description << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2)
-                  << std::uppercase << command << std::dec << std::setfill(L' ') << std::setw(0)
-                  << L"  Arg1: " << arg1 << L"  Arg2: " << arg2;
-      AddUnknown(start, curOffset - start, L"Unknown Event", description.str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + description.str()),
-                                    LOG_LEVEL_DEBUG, L"ItikitiSnesSeq"));
+      description << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2)
+                  << std::uppercase << command << std::dec << std::setfill(' ') << std::setw(0)
+                  << "  Arg1: " << arg1 << "  Arg2: " << arg2;
+      AddUnknown(start, curOffset - start, "Unknown Event", description.str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + description.str()),
+                                    LOG_LEVEL_DEBUG, "ItikitiSnesSeq"));
       break;
     }
 
@@ -182,12 +182,12 @@ bool ItikitiSnesTrack::ReadEvent() {
       const auto arg1 = GetByte(curOffset++);
       const auto arg2 = GetByte(curOffset++);
       const auto arg3 = GetByte(curOffset++);
-      description << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2)
-                  << std::uppercase << command << std::dec << std::setfill(L' ') << std::setw(0)
-                  << L"  Arg1: " << arg1 << L"  Arg2: " << arg2 << L"  Arg3: " << arg3;
-      AddUnknown(start, curOffset - start, L"Unknown Event", description.str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + description.str()),
-                                    LOG_LEVEL_DEBUG, L"ItikitiSnesSeq"));
+      description << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2)
+                  << std::uppercase << command << std::dec << std::setfill(' ') << std::setw(0)
+                  << "  Arg1: " << arg1 << "  Arg2: " << arg2 << "  Arg3: " << arg3;
+      AddUnknown(start, curOffset - start, "Unknown Event", description.str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + description.str()),
+                                    LOG_LEVEL_DEBUG, "ItikitiSnesSeq"));
       break;
     }
 
@@ -208,7 +208,7 @@ bool ItikitiSnesTrack::ReadEvent() {
         AddRest(start, curOffset - start, len);
       } else if (tie) {
         MakePrevDurNoteEnd(GetTime() + dur);
-        AddGenericEvent(start, curOffset - start, L"Tie", description.str(), CLR_TIE, ICON_NOTE);
+        AddGenericEvent(start, curOffset - start, "Tie", description.str(), CLR_TIE, ICON_NOTE);
         AddTime(len);
       } else {
         const uint8_t key_index = command >> 3;
@@ -227,16 +227,16 @@ bool ItikitiSnesTrack::ReadEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_MASTER_VOLUME: {
       const uint8_t vol = GetByte(curOffset++);
-      description << L"Volume: " << vol;
-      AddGenericEvent(start, curOffset - start, L"Master Volume", description.str(), CLR_VOLUME,
+      description << "Volume: " << vol;
+      AddGenericEvent(start, curOffset - start, "Master Volume", description.str(), CLR_VOLUME,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ECHO_VOLUME: {
       const uint8_t vol = GetByte(curOffset++);
-      description << L"Volume: " << vol;
-      AddGenericEvent(start, curOffset - start, L"Echo Volume", description.str(), CLR_REVERB,
+      description << "Volume: " << vol;
+      AddGenericEvent(start, curOffset - start, "Echo Volume", description.str(), CLR_REVERB,
                       ICON_CONTROL);
       break;
     }
@@ -250,8 +250,8 @@ bool ItikitiSnesTrack::ReadEvent() {
     case ItikitiSnesSeqEventType::EVENT_ECHO_FEEDBACK_FIR: {
       const int8_t feedback = static_cast<int8_t>(GetByte(curOffset++));
       const uint8_t filter_index = GetByte(curOffset++);
-      description << L"Feedback: " << feedback << L"  FIR: " << filter_index;
-      AddGenericEvent(start, curOffset - start, L"Echo Feedback & FIR", description.str(),
+      description << "Feedback: " << feedback << "  FIR: " << filter_index;
+      AddGenericEvent(start, curOffset - start, "Echo Feedback & FIR", description.str(),
                       CLR_REVERB, ICON_CONTROL);
       break;
     }
@@ -272,8 +272,8 @@ bool ItikitiSnesTrack::ReadEvent() {
     case ItikitiSnesSeqEventType::EVENT_NOISE_FREQ: {
       // Driver bug: This command sets the noise frequency for the next track from the current.
       const uint8_t nck = GetByte(curOffset++) & 0x1f;
-      description << L"Noise Frequency (NCK): " << nck;
-      AddGenericEvent(start, curOffset - start, L"Noise Frequency", description.str(),
+      description << "Noise Frequency (NCK): " << nck;
+      AddGenericEvent(start, curOffset - start, "Noise Frequency", description.str(),
                       CLR_CHANGESTATE, ICON_CONTROL);
       break;
     }
@@ -281,8 +281,8 @@ bool ItikitiSnesTrack::ReadEvent() {
     case ItikitiSnesSeqEventType::EVENT_SELECT_NOTE_LENGTH_PATTERN: {
       const uint16_t bits = GetShort(curOffset);
       curOffset += 2;
-      description << L"Length Bits: 0x" << std::hex << std::setfill(L'0') << std::setw(4) << bits;
-      AddGenericEvent(start, curOffset - start, L"Note Length Pattern", description.str(),
+      description << "Length Bits: 0x" << std::hex << std::setfill('0') << std::setw(4) << bits;
+      AddGenericEvent(start, curOffset - start, "Note Length Pattern", description.str(),
                       CLR_DURNOTE);
 
       size_t size_written = 0;
@@ -304,9 +304,9 @@ bool ItikitiSnesTrack::ReadEvent() {
       const uint8_t arg5 = GetByte(curOffset++);
       const uint8_t arg6 = GetByte(curOffset++);
       const uint8_t arg7 = GetByte(curOffset++);
-      description << L"Lengths: " << arg1 << L", " << arg2 << L", " << arg3 << L", " << arg4
-                  << L", " << arg5 << L", " << arg6 << L", " << arg7;
-      AddGenericEvent(start, curOffset - start, L"Custom Note Length Pattern", description.str(),
+      description << "Lengths: " << arg1 << ", " << arg2 << ", " << arg3 << ", " << arg4
+                  << ", " << arg5 << ", " << arg6 << ", " << arg7;
+      AddGenericEvent(start, curOffset - start, "Custom Note Length Pattern", description.str(),
                       CLR_DURNOTE);
 
       m_note_length_table[0] = arg1;
@@ -321,8 +321,8 @@ bool ItikitiSnesTrack::ReadEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_NOTE_NUMBER_BASE: {
       const uint8_t note_number = GetByte(curOffset++);
-      description << L"Note Number: " << note_number;
-      AddGenericEvent(start, curOffset - start, L"Note Number Base", description.str(),
+      description << "Note Number: " << note_number;
+      AddGenericEvent(start, curOffset - start, "Note Number Base", description.str(),
                       CLR_CHANGESTATE, ICON_CONTROL);
       m_note_number_base = note_number;
       break;
@@ -373,38 +373,38 @@ bool ItikitiSnesTrack::ReadEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_AR: {
       const uint8_t ar = GetByte(curOffset++) & 15;
-      description << L"AR: " << ar;
-      AddGenericEvent(start, curOffset - start, L"ADSR Attack Rate", description.str(), CLR_ADSR,
+      description << "AR: " << ar;
+      AddGenericEvent(start, curOffset - start, "ADSR Attack Rate", description.str(), CLR_ADSR,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_DR: {
       const uint8_t dr = GetByte(curOffset++) & 7;
-      description << L"DR: " << dr;
-      AddGenericEvent(start, curOffset - start, L"ADSR Decay Rate", description.str(), CLR_ADSR,
+      description << "DR: " << dr;
+      AddGenericEvent(start, curOffset - start, "ADSR Decay Rate", description.str(), CLR_ADSR,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_SL: {
       const uint8_t sl = GetByte(curOffset++) & 7;
-      description << L"SL: " << sl;
-      AddGenericEvent(start, curOffset - start, L"ADSR Sustain Level", description.str(), CLR_ADSR,
+      description << "SL: " << sl;
+      AddGenericEvent(start, curOffset - start, "ADSR Sustain Level", description.str(), CLR_ADSR,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_SR: {
       const uint8_t sr = GetByte(curOffset++) & 15;
-      description << L"SR: " << sr;
-      AddGenericEvent(start, curOffset - start, L"ADSR Sustain Rate", description.str(), CLR_ADSR,
+      description << "SR: " << sr;
+      AddGenericEvent(start, curOffset - start, "ADSR Sustain Rate", description.str(), CLR_ADSR,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_DEFAULT: {
-      AddGenericEvent(start, curOffset - start, L"Default ADSR", description.str(), CLR_ADSR,
+      AddGenericEvent(start, curOffset - start, "Default ADSR", description.str(), CLR_ADSR,
                       ICON_CONTROL);
       break;
     }
@@ -418,7 +418,7 @@ bool ItikitiSnesTrack::ReadEvent() {
     case ItikitiSnesSeqEventType::EVENT_TRANSPOSE_REL: {
       const int8_t transpose_amount = static_cast<int8_t>(GetByte(curOffset++));
       const int8_t new_transpose = static_cast<int8_t>(std::max(-128, std::min(127, transpose + transpose_amount)));
-      AddTranspose(start, curOffset - start, new_transpose, L"Transpose (Relative)");
+      AddTranspose(start, curOffset - start, new_transpose, "Transpose (Relative)");
       break;
     }
 
@@ -426,15 +426,15 @@ bool ItikitiSnesTrack::ReadEvent() {
         const uint8_t delay = GetByte(curOffset++);
         const uint8_t rate = GetByte(curOffset++);
         const uint8_t depth = GetByte(curOffset++);
-        description << L"Delay: " << delay << L"  Rate: " << rate << L"  Depth: " << depth;
-        AddGenericEvent(start, curOffset - start, L"Vibrato", description.str(), CLR_MODULATION,
+        description << "Delay: " << delay << "  Rate: " << rate << "  Depth: " << depth;
+        AddGenericEvent(start, curOffset - start, "Vibrato", description.str(), CLR_MODULATION,
                         ICON_CONTROL);
         break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_VIBRATO_OFF: {
       // The command changes vibrato depth to 0.
-      AddGenericEvent(start, curOffset - start, L"Vibrato Off", description.str(), CLR_MODULATION,
+      AddGenericEvent(start, curOffset - start, "Vibrato Off", description.str(), CLR_MODULATION,
                       ICON_CONTROL);
       break;
     }
@@ -444,14 +444,14 @@ bool ItikitiSnesTrack::ReadEvent() {
       const uint8_t delay = GetByte(curOffset++);
       const uint8_t rate = GetByte(curOffset++);
       const uint8_t depth = GetByte(curOffset++);
-      description << L"Delay: " << delay << L"  Rate: " << rate << L"  Depth: " << depth;
-      AddGenericEvent(start, curOffset - start, L"Tremolo", description.str(), CLR_MODULATION,
+      description << "Delay: " << delay << "  Rate: " << rate << "  Depth: " << depth;
+      AddGenericEvent(start, curOffset - start, "Tremolo", description.str(), CLR_MODULATION,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_TREMOLO_OFF: {
-      AddGenericEvent(start, curOffset - start, L"Tremolo Off", description.str(), CLR_MODULATION,
+      AddGenericEvent(start, curOffset - start, "Tremolo Off", description.str(), CLR_MODULATION,
                       ICON_CONTROL);
       break;
     }
@@ -459,55 +459,55 @@ bool ItikitiSnesTrack::ReadEvent() {
     case ItikitiSnesSeqEventType::EVENT_PAN_LFO_ON: {
       const uint8_t depth = GetByte(curOffset++);
       const uint8_t rate = GetByte(curOffset++);
-      description << L"Depth: " << depth << L"  Rate: " << rate;
-      AddGenericEvent(start, curOffset - start, L"Pan LFO", description.str(), CLR_MODULATION,
+      description << "Depth: " << depth << "  Rate: " << rate;
+      AddGenericEvent(start, curOffset - start, "Pan LFO", description.str(), CLR_MODULATION,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_PAN_LFO_OFF: {
-      AddGenericEvent(start, curOffset - start, L"Pan LFO Off", description.str(), CLR_MODULATION,
+      AddGenericEvent(start, curOffset - start, "Pan LFO Off", description.str(), CLR_MODULATION,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_NOISE_ON: {
-      AddGenericEvent(start, curOffset - start, L"Noise On", description.str(), CLR_CHANGESTATE,
+      AddGenericEvent(start, curOffset - start, "Noise On", description.str(), CLR_CHANGESTATE,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_NOISE_OFF: {
-      AddGenericEvent(start, curOffset - start, L"Noise Off", description.str(), CLR_CHANGESTATE,
+      AddGenericEvent(start, curOffset - start, "Noise Off", description.str(), CLR_CHANGESTATE,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_PITCH_MOD_ON: {
-      AddGenericEvent(start, curOffset - start, L"Pitch Modulation On", description.str(),
+      AddGenericEvent(start, curOffset - start, "Pitch Modulation On", description.str(),
                       CLR_CHANGESTATE, ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_PITCH_MOD_OFF: {
-      AddGenericEvent(start, curOffset - start, L"Pitch Modulation Off", description.str(),
+      AddGenericEvent(start, curOffset - start, "Pitch Modulation Off", description.str(),
                       CLR_CHANGESTATE, ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ECHO_ON: {
-      AddReverb(start, curOffset - start, 40, L"Echo On");
+      AddReverb(start, curOffset - start, 40, "Echo On");
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ECHO_OFF: {
-      AddReverb(start, curOffset - start, 0, L"Echo Off");
+      AddReverb(start, curOffset - start, 0, "Echo Off");
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_PORTAMENTO_ON: {
       const uint8_t speed = GetByte(curOffset++); // in ticks
-      AddPortamentoTime(start, curOffset - start, speed, L"Portamento");
+      AddPortamentoTime(start, curOffset - start, speed, "Portamento");
       AddPortamentoNoItem(true);
       break;
     }
@@ -520,26 +520,26 @@ bool ItikitiSnesTrack::ReadEvent() {
     case ItikitiSnesSeqEventType::EVENT_SPECIAL: {
       const uint8_t value = GetByte(curOffset++);
       if (value <= 0x7f) {
-        description << L"Range: " << value << L" semitones";
-        AddGenericEvent(start, curOffset - start, L"Note Randomization On", description.str(),
+        description << "Range: " << value << " semitones";
+        AddGenericEvent(start, curOffset - start, "Note Randomization On", description.str(),
                         CLR_CHANGESTATE, ICON_CONTROL);
       } else if (value == 0x83) {
         // Detailed behavior has not yet been analyzed
-        AddGenericEvent(start, curOffset - start, L"Change Volume Mode (Global)", description.str(),
+        AddGenericEvent(start, curOffset - start, "Change Volume Mode (Global)", description.str(),
                         CLR_VOLUME, ICON_CONTROL);
       } else {
-        description << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2)
-                    << std::uppercase << command << std::dec << std::setfill(L' ') << std::setw(0)
-                    << L"  Arg1: " << value;
-        AddUnknown(start, curOffset - start, L"Unknown Event", description.str());
-        pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + description.str()),
-                                      LOG_LEVEL_DEBUG, L"ItikitiSnesSeq"));
+        description << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2)
+                    << std::uppercase << command << std::dec << std::setfill(' ') << std::setw(0)
+                    << "  Arg1: " << value;
+        AddUnknown(start, curOffset - start, "Unknown Event", description.str());
+        pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + description.str()),
+                                      LOG_LEVEL_DEBUG, "ItikitiSnesSeq"));
       }
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_NOTE_RANDOMIZATION_OFF: {
-      AddGenericEvent(start, curOffset - start, L"Note Randomization Off", description.str(),
+      AddGenericEvent(start, curOffset - start, "Note Randomization Off", description.str(),
                       CLR_CHANGESTATE, ICON_CONTROL);
       break;
     }
@@ -547,25 +547,25 @@ bool ItikitiSnesTrack::ReadEvent() {
     case ItikitiSnesSeqEventType::EVENT_PITCH_SLIDE: {
       const uint8_t length = GetByte(curOffset++); // in ticks
       const int8_t semitones = static_cast<int8_t>(GetByte(curOffset++));
-      description << L"Length: " << length << L"  Key: " << semitones << L" semitones";
-      AddGenericEvent(start, curOffset - start, L"Pitch Slide", description.str(), CLR_PITCHBEND,
+      description << "Length: " << length << "  Key: " << semitones << " semitones";
+      AddGenericEvent(start, curOffset - start, "Pitch Slide", description.str(), CLR_PITCHBEND,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_LOOP_START: {
       const uint8_t count = GetByte(curOffset++);
-      description << L"Repeat Count: ";
+      description << "Repeat Count: ";
       if (count == 0)
-        description << L"Infinite";
+        description << "Infinite";
       else
         description << (count + 1);
-      AddGenericEvent(start, curOffset - start, L"Loop Start", description.str(), CLR_LOOP,
+      AddGenericEvent(start, curOffset - start, "Loop Start", description.str(), CLR_LOOP,
                       ICON_STARTREP);
 
       if (m_loop_level + 1 >= kItikitiSnesSeqMaxLoopLevel) {
-        pRoot->AddLogItem(new LogItem(std::wstring(L"Loop Start: nesting level is too much"),
-                                      LOG_LEVEL_WARN, L"ItikitiSnesSeq"));
+        pRoot->AddLogItem(new LogItem(std::string("Loop Start: nesting level is too much"),
+                                      LOG_LEVEL_WARN, "ItikitiSnesSeq"));
         stop_parser = true;
         break;
       }
@@ -579,15 +579,15 @@ bool ItikitiSnesTrack::ReadEvent() {
     case ItikitiSnesSeqEventType::EVENT_GOTO: {
       const uint16_t dest = ReadDecodedOffset(curOffset);
       curOffset += 2;
-      description << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+      description << "Destination: $" << std::hex << std::setfill('0') << std::setw(4)
                   << std::uppercase << dest;
       const auto length = curOffset - start;
 
       curOffset = dest;
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(start, length, L"Jump", description.str(), CLR_LOOPFOREVER);
+        AddGenericEvent(start, length, "Jump", description.str(), CLR_LOOPFOREVER);
       } else {
-        stop_parser = !AddLoopForever(start, length, L"Jump");
+        stop_parser = !AddLoopForever(start, length, "Jump");
       }
       break;
     }
@@ -598,7 +598,7 @@ bool ItikitiSnesTrack::ReadEvent() {
         stop_parser = !AddLoopForever(start, curOffset - start);
         curOffset = m_loop_start_addresses[m_loop_level];
       } else {
-        AddGenericEvent(start, curOffset - start, L"Loop End", description.str(), CLR_LOOP,
+        AddGenericEvent(start, curOffset - start, "Loop End", description.str(), CLR_LOOP,
                         ICON_ENDREP);
 
         m_loop_counts[m_loop_level]--;
@@ -618,9 +618,9 @@ bool ItikitiSnesTrack::ReadEvent() {
       const uint16_t dest = ReadDecodedOffset(curOffset);
       curOffset += 2;
 
-      description << L"Count: " << target_count << L"  Destination: $" << std::hex << std::setfill(L'0')
+      description << "Count: " << target_count << "  Destination: $" << std::hex << std::setfill('0')
                   << std::setw(4) << std::uppercase << dest;
-      AddGenericEvent(start, curOffset - start, L"Loop Break / Jump to Volta", description.str(),
+      AddGenericEvent(start, curOffset - start, "Loop Break / Jump to Volta", description.str(),
                       CLR_LOOP, ICON_ENDREP);
       
       if (++m_alt_loop_count == target_count) {
@@ -631,11 +631,11 @@ bool ItikitiSnesTrack::ReadEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_UNDEFINED:
     default:
-      description << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2)
+      description << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2)
                   << std::uppercase << command;
-      AddUnknown(start, curOffset - start, L"Unknown Event", description.str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + description.str()),
-                                    LOG_LEVEL_ERR, L"ItikitiSnesSeq"));
+      AddUnknown(start, curOffset - start, "Unknown Event", description.str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + description.str()),
+                                    LOG_LEVEL_ERR, "ItikitiSnesSeq"));
       stop_parser = true;
       break;
   }

--- a/src/main/formats/ItikitiSnesSeq.h
+++ b/src/main/formats/ItikitiSnesSeq.h
@@ -66,7 +66,7 @@ enum class ItikitiSnesSeqEventType {
 
 class ItikitiSnesSeq : public VGMSeq {
  public:
-  ItikitiSnesSeq(RawFile *file, uint32_t offset, std::wstring new_name = L"Square ITIKITI SNES Seq");
+  ItikitiSnesSeq(RawFile *file, uint32_t offset, std::string new_name = "Square ITIKITI SNES Seq");
 
   bool GetHeaderInfo() override;
   bool GetTrackPointers() override;

--- a/src/main/formats/KonamiGXSeq.cpp
+++ b/src/main/formats/KonamiGXSeq.cpp
@@ -22,8 +22,8 @@ bool KonamiGXSeq::GetHeaderInfo(void) {
   //nNumTracks = GetByte(dwOffset+8);
   SetPPQN(0x30);
 
-  wostringstream theName;
-  theName << L"Konami GX Seq";
+  ostringstream theName;
+  theName << "Konami GX Seq";
   name = theName.str();
   return true;
 }
@@ -271,13 +271,13 @@ bool KonamiGXTrack::ReadEvent(void) {
 
       case 0xFD:
         curOffset += 4;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop", L"", CLR_LOOP);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", CLR_LOOP);
         break;
 
       case 0xFE:
         bInJump = true;
         jump_return_offset = curOffset + 4;
-        AddGenericEvent(beginOffset, jump_return_offset - beginOffset, L"Jump", L"", CLR_LOOP);
+        AddGenericEvent(beginOffset, jump_return_offset - beginOffset, "Jump", "", CLR_LOOP);
         curOffset = GetWordBE(curOffset);
         //if (curOffset > 0x100000)
         //	return 0;

--- a/src/main/formats/KonamiPS1Scanner.cpp
+++ b/src/main/formats/KonamiPS1Scanner.cpp
@@ -7,10 +7,10 @@ void KonamiPS1Scanner::Scan(RawFile *file, void *info) {
     int numSeqFiles = 0;
     while (offset < file->size()) {
         if (KonamiPS1Seq::IsKDT1Seq(file, offset)) {
-            std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+            std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
             if (numSeqFiles >= 1) {
-                std::wstringstream postfix;
-                postfix << L" (" << (numSeqFiles + 1) << L")";
+                std::stringstream postfix;
+                postfix << " (" << (numSeqFiles + 1) << ")";
                 name += postfix.str();
             }
 

--- a/src/main/formats/KonamiPS1Seq.cpp
+++ b/src/main/formats/KonamiPS1Seq.cpp
@@ -8,7 +8,7 @@ DECLARE_FORMAT(KonamiPS1);
 //  KonamiPS1Seq
 //  ************
 
-KonamiPS1Seq::KonamiPS1Seq(RawFile *file, uint32_t offset, const std::wstring &name)
+KonamiPS1Seq::KonamiPS1Seq(RawFile *file, uint32_t offset, const std::string &name)
     : VGMSeq(KonamiPS1Format::name, file, offset, kHeaderSize + file->GetWord(offset + 4), name) {
     bLoadTickByTick = true;
 
@@ -26,16 +26,16 @@ bool KonamiPS1Seq::GetHeaderInfo(void) {
 
     VGMHeader *header = AddHeader(dwOffset, kHeaderSize);
     header->AddSig(dwOffset, 4);
-    header->AddSimpleItem(dwOffset + kOffsetToFileSize, 4, L"Size");
-    header->AddSimpleItem(dwOffset + kOffsetToTimebase, 4, L"Timebase");
+    header->AddSimpleItem(dwOffset + kOffsetToFileSize, 4, "Size");
+    header->AddSimpleItem(dwOffset + kOffsetToTimebase, 4, "Timebase");
     SetPPQN(GetWord(dwOffset + kOffsetToTimebase));
-    header->AddSimpleItem(dwOffset + kOffsetToTrackCount, 4, L"Number Of Tracks");
+    header->AddSimpleItem(dwOffset + kOffsetToTrackCount, 4, "Number Of Tracks");
 
     uint32_t numTracks = GetWord(dwOffset + kOffsetToTrackCount);
-    VGMHeader *trackSizeHeader = AddHeader(dwOffset + kHeaderSize, 2 * numTracks, L"Track Size");
+    VGMHeader *trackSizeHeader = AddHeader(dwOffset + kHeaderSize, 2 * numTracks, "Track Size");
     for (uint32_t trackIndex = 0; trackIndex < numTracks; trackIndex++) {
-        std::wstringstream itemName;
-        itemName << L"Track " << (trackIndex + 1) << L" Size";
+        std::stringstream itemName;
+        itemName << "Track " << (trackIndex + 1) << " Size";
         trackSizeHeader->AddSimpleItem(trackSizeHeader->dwOffset + (trackIndex * 2), 2, itemName.str());
     }
 
@@ -121,9 +121,9 @@ bool KonamiPS1Track::ReadEvent(void) {
         uint32_t delta = ReadVarLen(curOffset);
         AddTime(delta);
 
-        std::wstringstream description;
-        description << L"Duration: " << delta;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Delta Time", description.str(), CLR_REST, ICON_REST);
+        std::stringstream description;
+        description << "Duration: " << delta;
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", description.str(), CLR_REST, ICON_REST);
 
         skipDeltaTime = true;
         return true;
@@ -145,7 +145,7 @@ bool KonamiPS1Track::ReadEvent(void) {
         prevVel = velocity;
     }
     else {
-        std::wstringstream description;
+        std::stringstream description;
 
         uint8_t paramByte;
         if (command == 0x4a) {
@@ -169,8 +169,8 @@ bool KonamiPS1Track::ReadEvent(void) {
             break;
 
         case 6:
-            description << L"Parameter: " << paramByte;
-            AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN Data Entry", description.str(), CLR_MISC);
+            description << "Parameter: " << paramByte;
+            AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry", description.str(), CLR_MISC);
             if (readMode == READMODE_CONVERT_TO_MIDI) {
                 pMidiTrack->AddControllerEvent(channel, command, paramByte);
             }
@@ -189,21 +189,21 @@ bool KonamiPS1Track::ReadEvent(void) {
             break;
 
         case 15:
-            description << L"Parameter: " << paramByte;
-            AddGenericEvent(beginOffset, curOffset - beginOffset, L"Stereo Widening (?)", description.str(), CLR_PAN, ICON_CONTROL);
+            description << "Parameter: " << paramByte;
+            AddGenericEvent(beginOffset, curOffset - beginOffset, "Stereo Widening (?)", description.str(), CLR_PAN, ICON_CONTROL);
             if (readMode == READMODE_CONVERT_TO_MIDI) {
                 pMidiTrack->AddControllerEvent(channel, command, paramByte);
             }
             break;
 
         case 64:
-            description << L"Parameter: " << paramByte;
+            description << "Parameter: " << paramByte;
             AddSustainEvent(beginOffset, curOffset - beginOffset, paramByte);
             break;
 
         case 70:
-            description << L"Parameter: " << paramByte;
-            AddGenericEvent(beginOffset, curOffset - beginOffset, L"Set Channel", description.str(), CLR_PAN, ICON_CONTROL);
+            description << "Parameter: " << paramByte;
+            AddGenericEvent(beginOffset, curOffset - beginOffset, "Set Channel", description.str(), CLR_PAN, ICON_CONTROL);
             if (readMode == READMODE_CONVERT_TO_MIDI) {
                 pMidiTrack->AddControllerEvent(channel, command, paramByte);
             }
@@ -220,7 +220,7 @@ bool KonamiPS1Track::ReadEvent(void) {
             // In the KCET driver for Silent Hill 2 (PlayStation 2), the equation was changed to ((x * 2) + 10),
             // which appears to give a more accurate real-world tempo, so I've decided to use it universally.
             uint8_t bpm = static_cast<uint8_t>(std::min<unsigned int>(paramByte * 2 + 10, 255));
-            AddTempoBPM(beginOffset, curOffset - beginOffset, bpm, L"Tempo (10-255 BPM, divisible by two)");
+            AddTempoBPM(beginOffset, curOffset - beginOffset, bpm, "Tempo (10-255 BPM, divisible by two)");
             break;
         }
 
@@ -234,20 +234,20 @@ bool KonamiPS1Track::ReadEvent(void) {
 
         case 74:
             // Not sure how it will work for a chord (polyphonic track)
-            AddNoteOff(beginOffset, curOffset - beginOffset, prevKey, L"Note Off (Reset Running Status)");
+            AddNoteOff(beginOffset, curOffset - beginOffset, prevKey, "Note Off (Reset Running Status)");
             break;
 
         case 75:
             // Not sure how it will work for a chord (polyphonic track)
-            AddNoteOff(beginOffset, curOffset - beginOffset, prevKey, L"Note Off (Sustain Running Status)");
+            AddNoteOff(beginOffset, curOffset - beginOffset, prevKey, "Note Off (Sustain Running Status)");
             break;
 
         case 76:
-            AddTempoBPM(beginOffset, curOffset - beginOffset, paramByte, L"Tempo (0-127 BPM)");
+            AddTempoBPM(beginOffset, curOffset - beginOffset, paramByte, "Tempo (0-127 BPM)");
             break;
 
         case 77:
-            AddTempoBPM(beginOffset, curOffset - beginOffset, paramByte + 128, L"Tempo (128-255 BPM)");
+            AddTempoBPM(beginOffset, curOffset - beginOffset, paramByte + 128, "Tempo (128-255 BPM)");
             break;
 
         case 91:
@@ -255,8 +255,8 @@ bool KonamiPS1Track::ReadEvent(void) {
             break;
 
         case 99:
-            description << L"Parameter: " << paramByte;
-            AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN (LSB)", description.str(), CLR_MISC);
+            description << "Parameter: " << paramByte;
+            AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN (LSB)", description.str(), CLR_MISC);
             if (readMode == READMODE_CONVERT_TO_MIDI) {
                 pMidiTrack->AddControllerEvent(channel, command, paramByte);
             }
@@ -264,14 +264,14 @@ bool KonamiPS1Track::ReadEvent(void) {
 
         case 100:
             if (paramByte == 20) {
-                AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Start", L"", CLR_LOOP);
+                AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", CLR_LOOP);
             }
             else if (paramByte == 30) {
-                AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", L"", CLR_LOOP);
+                AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", CLR_LOOP);
             }
             else {
-                description << L"Parameter: " << paramByte;
-                AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN (LSB)", description.str(), CLR_MISC);
+                description << "Parameter: " << paramByte;
+                AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN (LSB)", description.str(), CLR_MISC);
             }
             if (readMode == READMODE_CONVERT_TO_MIDI) {
                 pMidiTrack->AddControllerEvent(channel, command, paramByte);
@@ -279,8 +279,8 @@ bool KonamiPS1Track::ReadEvent(void) {
             break;
 
         case 118:
-            description << L"Parameter: " << paramByte;
-            AddGenericEvent(beginOffset, curOffset - beginOffset, L"Seq Beat", description.str(), CLR_MISC);
+            description << "Parameter: " << paramByte;
+            AddGenericEvent(beginOffset, curOffset - beginOffset, "Seq Beat", description.str(), CLR_MISC);
             if (readMode == READMODE_CONVERT_TO_MIDI) {
                 pMidiTrack->AddControllerEvent(channel, command, paramByte);
             }

--- a/src/main/formats/KonamiPS1Seq.h
+++ b/src/main/formats/KonamiPS1Seq.h
@@ -12,7 +12,7 @@ public:
     static constexpr uint32_t kOffsetToTrackCount = 0x0c;
     static constexpr uint32_t kOffsetToTrackSizes = 0x10;
 
-    KonamiPS1Seq(RawFile *file, uint32_t offset, const std::wstring &name = L"KonamiPS1Seq");
+    KonamiPS1Seq(RawFile *file, uint32_t offset, const std::string &name = "KonamiPS1Seq");
 
     virtual ~KonamiPS1Seq() {
     }

--- a/src/main/formats/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnesInstr.cpp
@@ -20,7 +20,7 @@ KonamiSnesInstrSet::KonamiSnesInstrSet(RawFile *file,
                                        uint8_t firstBankedInstr,
                                        uint32_t percInstrOffset,
                                        uint32_t spcDirAddr,
-                                       const std::wstring &name) :
+                                       const std::string &name) :
     VGMInstrSet(KonamiSnesFormat::name, file, offset, 0, name), version(ver),
     bankedInstrOffset(bankedInstrOffset),
     firstBankedInstr(firstBankedInstr),
@@ -78,8 +78,8 @@ bool KonamiSnesInstrSet::GetInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << instr;
+    std::ostringstream instrName;
+    instrName << "Instrument " << instr;
     KonamiSnesInstr *newInstr = new KonamiSnesInstr(this,
                                                     version,
                                                     addrInstrHeader,
@@ -96,7 +96,7 @@ bool KonamiSnesInstrSet::GetInstrPointers() {
 
   // percussive samples
   KonamiSnesInstr
-      *newInstr = new KonamiSnesInstr(this, version, percInstrOffset, 127, 0, spcDirAddr, true, L"Percussions");
+      *newInstr = new KonamiSnesInstr(this, version, percInstrOffset, 127, 0, spcDirAddr, true, "Percussions");
   aInstrs.push_back(newInstr);
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
@@ -120,7 +120,7 @@ KonamiSnesInstr::KonamiSnesInstr(VGMInstrSet *instrSet,
                                  uint32_t theInstrNum,
                                  uint32_t spcDirAddr,
                                  bool percussion,
-                                 const std::wstring &name) :
+                                 const std::string &name) :
     VGMInstr(instrSet, offset, KonamiSnesInstr::ExpectedSize(ver), theBank, theInstrNum, name),
     spcDirAddr(spcDirAddr),
     percussion(percussion) {
@@ -234,9 +234,9 @@ KonamiSnesRgn::KonamiSnesRgn(KonamiSnesInstr *instr, KonamiSnesVersion ver, uint
   AddSampNum(srcn, offset, 1);
   AddUnityKey(72 - (int) (coarse_tuning), offset + 1, 1);
   AddFineTune((int16_t) (fine_tuning * 100.0), offset + 2, 1);
-  AddSimpleItem(offset + 3, 1, L"ADSR1");
-  AddSimpleItem(offset + 4, 1, use_adsr ? L"ADSR2" : L"GAIN");
-  AddSimpleItem(offset + 5, 1, L"Pan");
+  AddSimpleItem(offset + 3, 1, "ADSR1");
+  AddSimpleItem(offset + 4, 1, use_adsr ? "ADSR2" : "GAIN");
+  AddSimpleItem(offset + 5, 1, "Pan");
   // volume is *decreased* by final volume value
   // so it is impossible to convert it in 100% accuracy
   // the following value 72.0 is chosen as a "average channel volume level (before pan processing)"

--- a/src/main/formats/KonamiSnesInstr.h
+++ b/src/main/formats/KonamiSnesInstr.h
@@ -18,7 +18,7 @@ class KonamiSnesInstrSet:
                      uint8_t firstBankedInstr,
                      uint32_t percInstrOffset,
                      uint32_t spcDirAddr,
-                     const std::wstring &name = L"KonamiSnesInstrSet");
+                     const std::string &name = "KonamiSnesInstrSet");
   virtual ~KonamiSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -48,7 +48,7 @@ class KonamiSnesInstr
                   uint32_t theInstrNum,
                   uint32_t spcDirAddr,
                   bool percussion,
-                  const std::wstring &name = L"KonamiSnesInstr");
+                  const std::string &name = "KonamiSnesInstr");
   virtual ~KonamiSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/KonamiSnesScanner.cpp
+++ b/src/main/formats/KonamiSnesScanner.cpp
@@ -499,8 +499,8 @@ void KonamiSnesScanner::SearchForKonamiSnesFromARAM(RawFile *file) {
 
   bool hasSongList;
 
-  std::wstring basefilename = RawFile::removeExtFromPath(file->GetFileName());
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : basefilename;
+  std::string basefilename = RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : basefilename;
 
   // TODO: Unsupported games
   // Tiny Toon Adventures: Buster Bus
@@ -633,14 +633,14 @@ void KonamiSnesScanner::SearchForKonamiSnesFromARAM(RawFile *file) {
   // scan for DIR address
   uint32_t ofsSetDIR;
   uint16_t spcDirAddr;
-  std::map<std::wstring, std::vector<uint8_t>>::iterator itrDSP;
+  std::map<std::string, std::vector<uint8_t>>::iterator itrDSP;
   if (file->SearchBytePattern(ptnSetDIRGG4, ofsSetDIR)) {
     spcDirAddr = file->GetByte(ofsSetDIR + 4) << 8;
   }
   else if (file->SearchBytePattern(ptnSetDIRCNTR3, ofsSetDIR)) {
     spcDirAddr = file->GetByte(ofsSetDIR + 1) << 8;
   }
-  else if ((itrDSP = file->tag.binaries.find(L"dsp")) != file->tag.binaries.end()) {
+  else if ((itrDSP = file->tag.binaries.find("dsp")) != file->tag.binaries.end()) {
     // read DIR from SPC700 snapshot
     spcDirAddr = itrDSP->second[0x5d] << 8;
   }

--- a/src/main/formats/KonamiSnesScanner.h
+++ b/src/main/formats/KonamiSnesScanner.h
@@ -8,7 +8,7 @@ class KonamiSnesScanner:
     public VGMScanner {
  public:
   KonamiSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~KonamiSnesScanner(void) {
   }

--- a/src/main/formats/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnesSeq.cpp
@@ -44,7 +44,7 @@ const uint8_t KonamiSnesSeq::PAN_TABLE[] = {
     0xfe, 0xfe
 };
 
-KonamiSnesSeq::KonamiSnesSeq(RawFile *file, KonamiSnesVersion ver, uint32_t seqdataOffset, std::wstring newName)
+KonamiSnesSeq::KonamiSnesSeq(RawFile *file, KonamiSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(KonamiSnesFormat::name, file, seqdataOffset), version(ver) {
   name = newName;
 
@@ -72,7 +72,7 @@ bool KonamiSnesSeq::GetHeaderInfo(void) {
   // For instance: Ganbare Goemon 3 - Title
   nNumTracks = MAX_TRACKS;
 
-  VGMHeader *seqHeader = AddHeader(dwOffset, nNumTracks * 2, L"Sequence Header");
+  VGMHeader *seqHeader = AddHeader(dwOffset, nNumTracks * 2, "Sequence Header");
   for (uint32_t trackNumber = 0; trackNumber < nNumTracks; trackNumber++) {
     uint32_t trackPointerOffset = dwOffset + (trackNumber * 2);
     if (trackPointerOffset + 2 > 0x10000) {
@@ -80,7 +80,7 @@ bool KonamiSnesSeq::GetHeaderInfo(void) {
     }
 
     uint16_t trkOff = GetShort(trackPointerOffset);
-    seqHeader->AddPointer(trackPointerOffset, 2, trkOff, true, L"Track Pointer");
+    seqHeader->AddPointer(trackPointerOffset, 2, trkOff, true, "Track Pointer");
 
     assert(trkOff >= dwOffset);
 
@@ -321,7 +321,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   KonamiSnesSeqEventType eventType = (KonamiSnesSeqEventType) 0;
   std::map<uint8_t, KonamiSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -331,27 +331,27 @@ bool KonamiSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -359,12 +359,12 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -373,13 +373,13 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -389,14 +389,14 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
       uint8_t arg5 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4
-          << L"  Arg5: " << (int) arg5;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4
+          << "  Arg5: " << (int) arg5;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -444,7 +444,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
         // TODO: Note volume can be changed during a tied note
         // See the end of Konami Logo sequence for example
         MakePrevDurNoteEnd(GetTime() + dur);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
       }
       else {
         AddNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur);
@@ -457,7 +457,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_PERCUSSION_ON: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Percussion On", desc.str().c_str(), CLR_CHANGESTATE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Percussion On", desc.str().c_str(), CLR_CHANGESTATE);
       if (!percussion) {
         AddProgramChange(beginOffset, curOffset - beginOffset, 127 << 7, true);
         percussion = true;
@@ -466,7 +466,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_PERCUSSION_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Percussion Off", desc.str().c_str(), CLR_CHANGESTATE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Percussion Off", desc.str().c_str(), CLR_CHANGESTATE);
       if (percussion) {
         AddProgramChange(beginOffset, curOffset - beginOffset, instrument, true);
         percussion = false;
@@ -478,9 +478,9 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t newGAINAmount = GetByte(curOffset++);
       uint8_t newGAIN = ConvertGAINAmountToGAIN(newGAINAmount);
 
-      desc << L"GAIN: " << (int) newGAINAmount << L" ($" << std::hex << std::setfill(L'0') << std::setw(2)
-          << std::uppercase << (int) newGAIN << L")";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"GAIN", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+      desc << "GAIN: " << (int) newGAINAmount << " ($" << std::hex << std::setfill('0') << std::setw(2)
+          << std::uppercase << (int) newGAIN << ")";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "GAIN", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -492,7 +492,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
       }
 
       double cents = GetTuningInSemitones(newTuning) * 100.0;
-      AddFineTuning(beginOffset, curOffset - beginOffset, cents, L"Instant Fine Tuning");
+      AddFineTuning(beginOffset, curOffset - beginOffset, cents, "Instant Fine Tuning");
       break;
     }
 
@@ -523,12 +523,12 @@ bool KonamiSnesTrack::ReadEvent(void) {
         }
 
         MakePrevDurNoteEnd(GetTime() + dur);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
         AddTime(noteLength);
         prevNoteSlurred = (noteDurationRate == parentSeq->NOTE_DUR_RATE_MAX);
       }
       else {
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
         AddTime(noteLength);
       }
       break;
@@ -576,7 +576,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
       if (instrumentPanOff) {
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Per-Instrument Pan Off",
+                        "Per-Instrument Pan Off",
                         desc.str().c_str(),
                         CLR_PAN,
                         ICON_CONTROL);
@@ -584,7 +584,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
       else if (instrumentPanOn) {
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Per-Instrument Pan On",
+                        "Per-Instrument Pan On",
                         desc.str().c_str(),
                         CLR_PAN,
                         ICON_CONTROL);
@@ -631,11 +631,11 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t vibratoDelay = GetByte(curOffset++);
       uint8_t vibratoRate = GetByte(curOffset++);
       uint8_t vibratoDepth = GetByte(curOffset++);
-      desc << L"Delay: " << (int) vibratoDelay << L"  Rate: " << (int) vibratoRate << L"  Depth: "
+      desc << "Delay: " << (int) vibratoDelay << "  Rate: " << (int) vibratoRate << "  Depth: "
           << (int) vibratoDepth;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato",
+                      "Vibrato",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -646,11 +646,11 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t envRate = GetByte(curOffset++);
       uint16_t envPitchMask = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Rate: " << (int) envRate << L"  Pitch Mask: $" << std::hex << std::setfill(L'0') << std::setw(4)
+      desc << "Rate: " << (int) envRate << "  Pitch Mask: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) envPitchMask;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Random Pitch",
+                      "Random Pitch",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -658,7 +658,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_LOOP_START: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
       loopReturnAddr = curOffset;
       break;
     }
@@ -668,13 +668,13 @@ bool KonamiSnesTrack::ReadEvent(void) {
       int8_t volumeDelta = GetByte(curOffset++);
       int8_t pitchDelta = GetByte(curOffset++);
 
-      desc << L"Times: " << (int) times << L"  Volume Delta: " << (int) volumeDelta << L"  Pitch Delta: "
+      desc << "Times: " << (int) times << "  Volume Delta: " << (int) volumeDelta << "  Pitch Delta: "
           << (int) pitchDelta;
       if (times == 0) {
-        bContinue = AddLoopForever(beginOffset, curOffset - beginOffset, L"Loop End");
+        bContinue = AddLoopForever(beginOffset, curOffset - beginOffset, "Loop End");
       }
       else {
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
       }
 
       bool loopAgain;
@@ -705,7 +705,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
     case EVENT_LOOP_START_2: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Loop Start #2",
+                      "Loop Start #2",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -718,15 +718,15 @@ bool KonamiSnesTrack::ReadEvent(void) {
       int8_t volumeDelta = GetByte(curOffset++);
       int8_t pitchDelta = GetByte(curOffset++);
 
-      desc << L"Times: " << (int) times << L"  Volume Delta: " << (int) volumeDelta << L"  Pitch Delta: "
+      desc << "Times: " << (int) times << "  Volume Delta: " << (int) volumeDelta << "  Pitch Delta: "
           << (int) pitchDelta;
       if (times == 0) {
-        bContinue = AddLoopForever(beginOffset, curOffset - beginOffset, L"Loop End #2");
+        bContinue = AddLoopForever(beginOffset, curOffset - beginOffset, "Loop End #2");
       }
       else {
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Loop End #2",
+                        "Loop End #2",
                         desc.str().c_str(),
                         CLR_LOOP,
                         ICON_STARTREP);
@@ -769,8 +769,8 @@ bool KonamiSnesTrack::ReadEvent(void) {
     case EVENT_TEMPO_FADE: {
       uint8_t newTempo = GetByte(curOffset++);
       uint8_t fadeSpeed = GetByte(curOffset++);
-      desc << L"BPM: " << parentSeq->GetTempoInBPM(newTempo) << L"  Fade Length: " << (int) fadeSpeed;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tempo Fade", desc.str().c_str(), CLR_TEMPO, ICON_TEMPO);
+      desc << "BPM: " << parentSeq->GetTempoInBPM(newTempo) << "  Fade Length: " << (int) fadeSpeed;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tempo Fade", desc.str().c_str(), CLR_TEMPO, ICON_TEMPO);
       break;
     }
 
@@ -782,15 +782,15 @@ bool KonamiSnesTrack::ReadEvent(void) {
 
     case EVENT_ADSR1: {
       uint8_t newADSR1 = GetByte(curOffset++);
-      desc << L"ADSR(1): $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) newADSR1;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR(1)", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+      desc << "ADSR(1): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) newADSR1;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(1)", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR2: {
       uint8_t newADSR2 = GetByte(curOffset++);
-      desc << L"ADSR(2): $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) newADSR2;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR(2)", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+      desc << "ADSR(2): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) newADSR2;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(2)", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -804,10 +804,10 @@ bool KonamiSnesTrack::ReadEvent(void) {
     case EVENT_VOLUME_FADE: {
       uint8_t newVolume = GetByte(curOffset++);
       uint8_t fadeSpeed = GetByte(curOffset++);
-      desc << L"Volume: " << (int) newVolume << L"  Fade Length: " << (int) fadeSpeed;
+      desc << "Volume: " << (int) newVolume << "  Fade Length: " << (int) fadeSpeed;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Volume Fade",
+                      "Volume Fade",
                       desc.str().c_str(),
                       CLR_VOLUME,
                       ICON_CONTROL);
@@ -816,10 +816,10 @@ bool KonamiSnesTrack::ReadEvent(void) {
 
     case EVENT_PORTAMENTO: {
       uint8_t portamentoSpeed = GetByte(curOffset++);
-      desc << L"Portamento Speed: " << (int) portamentoSpeed;
+      desc << "Portamento Speed: " << (int) portamentoSpeed;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Portamento",
+                      "Portamento",
                       desc.str().c_str(),
                       CLR_PORTAMENTO,
                       ICON_CONTROL);
@@ -830,11 +830,11 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t pitchEnvDelay = GetByte(curOffset++);
       uint8_t pitchEnvSpeed = GetByte(curOffset++);
       uint8_t pitchEnvDepth = GetByte(curOffset++);
-      desc << L"Delay: " << (int) pitchEnvDelay << L"  Speed: " << (int) pitchEnvSpeed << L"  Depth: "
+      desc << "Delay: " << (int) pitchEnvDelay << "  Speed: " << (int) pitchEnvSpeed << "  Depth: "
           << (int) -pitchEnvDepth;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Envelope",
+                      "Pitch Envelope",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -847,11 +847,11 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t pitchEnvOffset = GetByte(curOffset++);
       int16_t pitchDelta = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Delay: " << (int) pitchEnvDelay << L"  Length: " << (int) pitchEnvLength << L"  Offset: "
-          << (int) -pitchEnvOffset << L" semitones" << L"  Delta: " << (pitchDelta / 256.0) << L" semitones";
+      desc << "Delay: " << (int) pitchEnvDelay << "  Length: " << (int) pitchEnvLength << "  Offset: "
+          << (int) -pitchEnvOffset << " semitones" << "  Delta: " << (pitchDelta / 256.0) << " semitones";
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Envelope",
+                      "Pitch Envelope",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -869,10 +869,10 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Arg1: " << (int) arg1 << L"  Arg2: " << (int) arg2 << L"  Arg3: " << (int) arg3;
+      desc << "Arg1: " << (int) arg1 << "  Arg2: " << (int) arg2 << "  Arg3: " << (int) arg3;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Slide",
+                      "Pitch Slide",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -883,18 +883,18 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Arg1: " << (int) arg1 << L"  Arg2: " << (int) arg2 << L"  Arg3: " << (int) arg3;
+      desc << "Arg1: " << (int) arg1 << "  Arg2: " << (int) arg2 << "  Arg3: " << (int) arg3;
 
       if (arg2 != 0) {
         uint8_t arg4 = GetByte(curOffset++);
         uint8_t arg5 = GetByte(curOffset++);
         uint8_t arg6 = GetByte(curOffset++);
-        desc << L"Arg4: " << (int) arg4 << L"  Arg5: " << (int) arg5 << L"  Arg6: " << (int) arg6;
+        desc << "Arg4: " << (int) arg4 << "  Arg5: " << (int) arg5 << "  Arg6: " << (int) arg6;
       }
 
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Slide",
+                      "Pitch Slide",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -910,11 +910,11 @@ bool KonamiSnesTrack::ReadEvent(void) {
 
       uint8_t pitchSlideNoteNumber = (pitchSlideNote & 0x7f) + transpose;
 
-      desc << L"Delay: " << (int) pitchSlideDelay << L"  Length: " << (int) pitchSlideLength << L"  Final Note: "
-          << (int) pitchSlideNoteNumber << L"  Delta: " << (pitchDelta / 256.0) << L" semitones";
+      desc << "Delay: " << (int) pitchSlideDelay << "  Length: " << (int) pitchSlideLength << "  Final Note: "
+          << (int) pitchSlideNoteNumber << "  Delta: " << (pitchDelta / 256.0) << " semitones";
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Slide",
+                      "Pitch Slide",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -926,10 +926,10 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t echoVolumeL = GetByte(curOffset++);
       uint8_t echoVolumeR = GetByte(curOffset++);
 
-      desc << L"EON: " << (int) echoChannels << L"  EVOL(L): " << (int) echoVolumeL << L"  EVOL(R): "
+      desc << "EON: " << (int) echoChannels << "  EVOL(L): " << (int) echoVolumeL << "  EVOL(R): "
           << (int) echoVolumeR;
 
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -938,11 +938,11 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t echoFeedback = GetByte(curOffset++);
       uint8_t echoArg3 = GetByte(curOffset++);
 
-      desc << L"EDL: " << (int) echoDelay << L"  EFB: " << (int) echoFeedback << L"  Arg3: " << (int) echoArg3;
+      desc << "EDL: " << (int) echoDelay << "  EFB: " << (int) echoFeedback << "  Arg3: " << (int) echoArg3;
 
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Param",
+                      "Echo Param",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -952,7 +952,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
     case EVENT_LOOP_WITH_VOLTA_START: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Loop With Volta Start",
+                      "Loop With Volta Start",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -966,7 +966,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
     case EVENT_LOOP_WITH_VOLTA_END: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Loop With Volta End",
+                      "Loop With Volta End",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -994,17 +994,17 @@ bool KonamiSnesTrack::ReadEvent(void) {
     case EVENT_PAN_FADE: {
       uint8_t newPan = GetByte(curOffset++);
       uint8_t fadeSpeed = GetByte(curOffset++);
-      desc << L"Pan: " << (int) newPan << L"  Fade Length: " << (int) fadeSpeed;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan Fade", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
+      desc << "Pan: " << (int) newPan << "  Fade Length: " << (int) fadeSpeed;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
       break;
     }
 
     case EVENT_VIBRATO_FADE: {
       uint8_t fadeSpeed = GetByte(curOffset++);
-      desc << L"Fade Length: " << (int) fadeSpeed;
+      desc << "Fade Length: " << (int) fadeSpeed;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato Fade",
+                      "Vibrato Fade",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -1017,30 +1017,30 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint8_t newGAINAmount = GetByte(curOffset++);
       uint8_t newGAIN = ConvertGAINAmountToGAIN(newGAINAmount);
 
-      desc << L"ADSR(1): $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) newADSR1
-          << L"  ADSR(2): $" << (int) newADSR2 << L"  GAIN: $" << (int) newGAIN;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR(2)", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+      desc << "ADSR(1): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) newADSR1
+          << "  ADSR(2): $" << (int) newADSR2 << "  GAIN: $" << (int) newGAIN;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(2)", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_GOTO: {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       uint32_t length = curOffset - beginOffset;
 
       assert(dest >= dwOffset);
 
       if (curOffset < 0x10000 && GetByte(curOffset) == 0xff) {
-        AddGenericEvent(curOffset, 1, L"End of Track", L"", CLR_TRACKEND, ICON_TRACKEND);
+        AddGenericEvent(curOffset, 1, "End of Track", "", CLR_TRACKEND, ICON_TRACKEND);
       }
 
       curOffset = dest;
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
       }
       else {
-        bContinue = AddLoopForever(beginOffset, length, L"Jump");
+        bContinue = AddLoopForever(beginOffset, length, "Jump");
       }
       break;
     }
@@ -1049,10 +1049,10 @@ bool KonamiSnesTrack::ReadEvent(void) {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
 
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pattern Play",
+                      "Pattern Play",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -1069,7 +1069,7 @@ bool KonamiSnesTrack::ReadEvent(void) {
       if (inSubroutine) {
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"End Pattern",
+                        "End Pattern",
                         desc.str().c_str(),
                         CLR_TRACKEND,
                         ICON_ENDREP);
@@ -1085,17 +1085,17 @@ bool KonamiSnesTrack::ReadEvent(void) {
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"KonamiSnesSeq"));
+                                    "KonamiSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //std::wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //std::ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //LogDebug(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/KonamiSnesSeq.h
+++ b/src/main/formats/KonamiSnesSeq.h
@@ -58,7 +58,7 @@ class KonamiSnesSeq
     : public VGMSeq {
  public:
   KonamiSnesSeq
-      (RawFile *file, KonamiSnesVersion ver, uint32_t seqdataOffset, std::wstring newName = L"Konami SNES Seq");
+      (RawFile *file, KonamiSnesVersion ver, uint32_t seqdataOffset, std::string newName = "Konami SNES Seq");
   virtual ~KonamiSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/MP2kScanner.cpp
+++ b/src/main/formats/MP2kScanner.cpp
@@ -50,7 +50,7 @@ static bool test_pointer_validity(RawFile *file, off_t offset, uint32_t inGBA_le
 }
 
 MP2kScanner::MP2kScanner(void) {
-//	USE_EXTENSION(L"gba")
+//	USE_EXTENSION("gba")
 }
 
 MP2kScanner::~MP2kScanner(void) {

--- a/src/main/formats/MP2kSeq.h
+++ b/src/main/formats/MP2kSeq.h
@@ -13,7 +13,7 @@
 
 class MP2kSeq final : public VGMSeq {
    public:
-    MP2kSeq(RawFile *file, uint32_t offset, std::wstring name = L"MP2kSeq");
+    MP2kSeq(RawFile *file, uint32_t offset, std::string name = "MP2kSeq");
     ~MP2kSeq() = default;
 
     bool GetHeaderInfo(void) override;

--- a/src/main/formats/MoriSnesInstr.cpp
+++ b/src/main/formats/MoriSnesInstr.cpp
@@ -11,7 +11,7 @@ MoriSnesInstrSet::MoriSnesInstrSet(RawFile *file,
                                    uint32_t spcDirAddr,
                                    std::vector<uint16_t> instrumentAddresses,
                                    std::map<uint16_t, MoriSnesInstrHintDir> instrumentHints,
-                                   const std::wstring &name) :
+                                   const std::string &name) :
     VGMInstrSet(MoriSnesFormat::name, file, 0, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     instrumentAddresses(instrumentAddresses),
@@ -108,8 +108,8 @@ bool MoriSnesInstrSet::GetInstrPointers() {
       }
     }
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << instrNum;
+    std::ostringstream instrName;
+    instrName << "Instrument " << instrNum;
     MoriSnesInstr *newInstr =
         new MoriSnesInstr(this, version, instrNum, spcDirAddr, instrumentHints[instrAddress], instrName.str());
     aInstrs.push_back(newInstr);
@@ -138,7 +138,7 @@ MoriSnesInstr::MoriSnesInstr(VGMInstrSet *instrSet,
                              uint8_t instrNum,
                              uint32_t spcDirAddr,
                              const MoriSnesInstrHintDir &instrHintDir,
-                             const std::wstring &name) :
+                             const std::string &name) :
     VGMInstr(instrSet, instrHintDir.startAddress, instrHintDir.size, 0, instrNum, name), version(ver),
     spcDirAddr(spcDirAddr),
     instrHintDir(instrHintDir) {
@@ -148,7 +148,7 @@ MoriSnesInstr::~MoriSnesInstr() {
 }
 
 bool MoriSnesInstr::LoadInstr() {
-  AddSimpleItem(dwOffset, 1, L"Melody/Percussion");
+  AddSimpleItem(dwOffset, 1, "Melody/Percussion");
 
   if (!instrHintDir.percussion) {
     MoriSnesInstrHint *instrHint = &instrHintDir.instrHint;
@@ -159,7 +159,7 @@ bool MoriSnesInstr::LoadInstr() {
       return false;
     }
 
-    AddSimpleItem(instrHint->seqAddress, instrHint->seqSize, L"Envelope Sequence");
+    AddSimpleItem(instrHint->seqAddress, instrHint->seqSize, "Envelope Sequence");
 
     uint16_t addrSampStart = GetShort(offDirEnt);
     MoriSnesRgn *rgn = new MoriSnesRgn(this, version, spcDirAddr, *instrHint);
@@ -176,12 +176,12 @@ bool MoriSnesInstr::LoadInstr() {
         return false;
       }
 
-      std::wostringstream seqOffsetName;
-      seqOffsetName << L"Sequence Offset " << (int) percNoteKey;
+      std::ostringstream seqOffsetName;
+      seqOffsetName << "Sequence Offset " << (int) percNoteKey;
       AddSimpleItem(dwOffset + 1 + (percNoteKey * 2), 2, seqOffsetName.str().c_str());
 
-      std::wostringstream seqName;
-      seqName << L"Envelope Sequence " << (int) percNoteKey;
+      std::ostringstream seqName;
+      seqName << "Envelope Sequence " << (int) percNoteKey;
       AddSimpleItem(instrHint->seqAddress, instrHint->seqSize, seqName.str().c_str());
 
       uint16_t addrSampStart = GetShort(offDirEnt);
@@ -232,10 +232,10 @@ MoriSnesRgn::MoriSnesRgn(MoriSnesInstr *instr,
   }
 
   AddSampNum(srcn, rgnAddress, 1);
-  AddSimpleItem(rgnAddress + 1, 1, L"ADSR1");
-  AddSimpleItem(rgnAddress + 2, 1, L"ADSR2");
-  AddSimpleItem(rgnAddress + 3, 1, L"GAIN");
-  AddSimpleItem(rgnAddress + 4, 1, L"Key-Off Delay");
+  AddSimpleItem(rgnAddress + 1, 1, "ADSR1");
+  AddSimpleItem(rgnAddress + 2, 1, "ADSR2");
+  AddSimpleItem(rgnAddress + 3, 1, "GAIN");
+  AddSimpleItem(rgnAddress + 4, 1, "Key-Off Delay");
   AddUnityKey(72 - (int) (coarse_tuning), rgnAddress + 5, 1);
   AddFineTune((int16_t) (fine_tuning * 100.0), rgnAddress + 6, 1);
   if (instrHint.pan > 0) {

--- a/src/main/formats/MoriSnesInstr.h
+++ b/src/main/formats/MoriSnesInstr.h
@@ -51,7 +51,7 @@ class MoriSnesInstrSet:
                    uint32_t spcDirAddr,
                    std::vector<uint16_t> instrumentAddresses,
                    std::map<uint16_t, MoriSnesInstrHintDir> instrumentHints,
-                   const std::wstring &name = L"MoriSnesInstrSet");
+                   const std::string &name = "MoriSnesInstrSet");
   virtual ~MoriSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -78,7 +78,7 @@ class MoriSnesInstr
                 uint8_t instrNum,
                 uint32_t spcDirAddr,
                 const MoriSnesInstrHintDir &instrHintDir,
-                const std::wstring &name = L"MoriSnesInstr");
+                const std::string &name = "MoriSnesInstr");
   virtual ~MoriSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/MoriSnesScanner.cpp
+++ b/src/main/formats/MoriSnesScanner.cpp
@@ -49,7 +49,7 @@ void MoriSnesScanner::Scan(RawFile *file, void *info) {
 
 void MoriSnesScanner::SearchForMoriSnesFromARAM(RawFile *file) {
   MoriSnesVersion version = MORISNES_NONE;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   // scan for song list table
   uint32_t ofsLoadSeq;

--- a/src/main/formats/MoriSnesScanner.h
+++ b/src/main/formats/MoriSnesScanner.h
@@ -8,7 +8,7 @@ class MoriSnesScanner:
     public VGMScanner {
  public:
   MoriSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~MoriSnesScanner(void) {
   }

--- a/src/main/formats/MoriSnesSeq.cpp
+++ b/src/main/formats/MoriSnesSeq.cpp
@@ -9,7 +9,7 @@ DECLARE_FORMAT(MoriSnes);
 #define MAX_TRACKS  10
 #define SEQ_PPQN    48
 
-MoriSnesSeq::MoriSnesSeq(RawFile *file, MoriSnesVersion ver, uint32_t seqdataOffset, std::wstring newName)
+MoriSnesSeq::MoriSnesSeq(RawFile *file, MoriSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(MoriSnesFormat::name, file, seqdataOffset, 0, newName),
       version(ver) {
   bLoadTickByTick = true;
@@ -51,7 +51,7 @@ bool MoriSnesSeq::GetHeaderInfo(void) {
     uint32_t beginOffset = curOffset;
     uint8_t statusByte = GetByte(curOffset++);
     if (statusByte == 0xff) {
-      header->AddSimpleItem(beginOffset, curOffset - beginOffset, L"Header End");
+      header->AddSimpleItem(beginOffset, curOffset - beginOffset, "Header End");
       break;
     }
 
@@ -70,8 +70,8 @@ bool MoriSnesSeq::GetHeaderInfo(void) {
       curOffset += 2;
       TrackStartAddress[trackIndex] = curOffset + ofsTrackStart;
 
-      std::wstringstream trackName;
-      trackName << L"Track " << (trackIndex + 1) << L" Offset";
+      std::stringstream trackName;
+      trackName << "Track " << (trackIndex + 1) << " Offset";
       header->AddSimpleItem(beginOffset, curOffset - beginOffset, trackName.str().c_str());
     }
     else {
@@ -200,13 +200,13 @@ bool MoriSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   // note param
   uint8_t newDelta = spcDeltaTime;
   if (statusByte < 0x80) {
     newDelta = statusByte;
-    desc << L"Delta Time: " << (int) newDelta;
+    desc << "Delta Time: " << (int) newDelta;
     if (newDelta != 0) {
       spcDeltaTime = newDelta;
     }
@@ -214,20 +214,20 @@ bool MoriSnesTrack::ReadEvent(void) {
     statusByte = GetByte(curOffset);
     if (statusByte < 0x80) {
       spcNoteDuration = statusByte;
-      desc << L"  Dulation: " << (int) spcNoteDuration;
+      desc << "  Dulation: " << (int) spcNoteDuration;
       curOffset++;
 
       statusByte = GetByte(curOffset);
       if (statusByte < 0x80) {
         spcNoteVelocity = statusByte;
-        desc << L"  Velocity: " << (int) spcNoteVelocity;
+        desc << "  Velocity: " << (int) spcNoteVelocity;
         curOffset++;
       }
     }
 
-    AddGenericEvent(beginOffset, curOffset - beginOffset, L"Note Param", desc.str().c_str(), CLR_DURNOTE);
+    AddGenericEvent(beginOffset, curOffset - beginOffset, "Note Param", desc.str().c_str(), CLR_DURNOTE);
     beginOffset = curOffset;
-    desc.str(L"");
+    desc.str("");
 
     if (curOffset >= 0x10000) {
       return false;
@@ -244,27 +244,27 @@ bool MoriSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -272,12 +272,12 @@ bool MoriSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -286,13 +286,13 @@ bool MoriSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -300,20 +300,20 @@ bool MoriSnesTrack::ReadEvent(void) {
     case EVENT_NOTE_WITH_PARAM: {
       uint8_t keyOffset = statusByte & 0x1f;
 
-      wchar_t *eventName;
+      char* eventName;
       if (eventType == EVENT_NOTE_WITH_PARAM) {
         uint8_t noteParam = GetByte(curOffset++);
         if (noteParam <= 0x7f) {
           spcNoteDuration = noteParam;
-          eventName = L"Note with Duration";
+          eventName = "Note with Duration";
         }
         else {
           spcNoteVelocity = (noteParam & 0x7f);
-          eventName = L"Note with Velocity";
+          eventName = "Note with Velocity";
         }
       }
       else {
-        eventName = L"Note";
+        eventName = "Note";
       }
 
       bool tied = (spcNoteDuration == 0);
@@ -326,7 +326,7 @@ bool MoriSnesTrack::ReadEvent(void) {
       auto prevTiedNoteIter = std::find(tiedNoteKeys.begin(), tiedNoteKeys.end(), key);
       if (prevTiedNoteIter != tiedNoteKeys.end()) {
         MakePrevDurNoteEnd(GetTime() + dur);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
 
         if (!tied) {
           // finish tied note
@@ -348,7 +348,7 @@ bool MoriSnesTrack::ReadEvent(void) {
       int16_t instrOffset = GetShort(curOffset);
       curOffset += 2;
       uint16_t instrAddress = curOffset + instrOffset;
-      desc << L"Envelope: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) instrAddress;
+      desc << "Envelope: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) instrAddress;
 
       uint8_t instrNum;
       for (instrNum = 0; instrNum < parentSeq->InstrumentAddresses.size(); instrNum++) {
@@ -365,7 +365,7 @@ bool MoriSnesTrack::ReadEvent(void) {
 
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Program Change",
+                      "Program Change",
                       desc.str().c_str(),
                       CLR_PROGCHANGE,
                       ICON_PROGCHANGE);
@@ -385,7 +385,7 @@ bool MoriSnesTrack::ReadEvent(void) {
         AddPan(beginOffset, curOffset - beginOffset, midiPan);
       }
       else {
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Random Pan", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Random Pan", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
       }
       break;
     }
@@ -406,8 +406,8 @@ bool MoriSnesTrack::ReadEvent(void) {
 
     case EVENT_PRIORITY: {
       uint8_t newPriority = GetByte(curOffset++);
-      desc << L"Priority: " << (int) newPriority;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Priority", desc.str().c_str(), CLR_PRIORITY);
+      desc << "Priority: " << (int) newPriority;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Priority", desc.str().c_str(), CLR_PRIORITY);
       break;
     }
 
@@ -421,13 +421,13 @@ bool MoriSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_ECHO_ON: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo On", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       AddReverbNoItem(40);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       AddReverbNoItem(0);
       break;
     }
@@ -437,11 +437,11 @@ bool MoriSnesTrack::ReadEvent(void) {
       int8_t volume = GetByte(curOffset++);
       int8_t feedback = GetByte(curOffset++);
       uint8_t filterIndex = GetByte(curOffset++);
-      desc << L"Delay: " << (int) delay << L"  FIR: " << (int) volume << L"  volume: " << (int) feedback << L"  FIR: "
+      desc << "Delay: " << (int) delay << "  FIR: " << (int) volume << "  volume: " << (int) feedback << "  FIR: "
           << (int) filterIndex;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Param",
+                      "Echo Param",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -452,15 +452,15 @@ bool MoriSnesTrack::ReadEvent(void) {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
       dest += curOffset; // relative offset to address
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       uint32_t length = curOffset - beginOffset;
 
       curOffset = dest;
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
       }
       else {
-        bContinue = AddLoopForever(beginOffset, length, L"Jump");
+        bContinue = AddLoopForever(beginOffset, length, "Jump");
       }
       break;
     }
@@ -469,10 +469,10 @@ bool MoriSnesTrack::ReadEvent(void) {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
       dest += curOffset; // relative offset to address
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pattern Play",
+                      "Pattern Play",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -496,7 +496,7 @@ bool MoriSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_RET: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"End Pattern", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "End Pattern", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       if (spcCallStackPtr < 2) {
         // access violation
@@ -511,8 +511,8 @@ bool MoriSnesTrack::ReadEvent(void) {
 
     case EVENT_LOOP_START: {
       uint8_t count = GetByte(curOffset++);
-      desc << L"Loop Count: " << (int) count;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      desc << "Loop Count: " << (int) count;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
 
       if (spcCallStackPtr + 3 > MORISNES_CALLSTACK_SIZE) {
         // stack overflow
@@ -529,7 +529,7 @@ bool MoriSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_LOOP_END: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       if (spcCallStackPtr < 3) {
         // access violation
@@ -560,7 +560,7 @@ bool MoriSnesTrack::ReadEvent(void) {
     case EVENT_NOTE_NUMBER: {
       int8_t newNoteNumber = GetByte(curOffset++);
       spcNoteNumberBase = newNoteNumber;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Note Number Base", desc.str().c_str(), CLR_NOTEON);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Note Number Base", desc.str().c_str(), CLR_NOTEON);
       break;
     }
 
@@ -579,8 +579,8 @@ bool MoriSnesTrack::ReadEvent(void) {
     case EVENT_WAIT: {
       // do not stop tied note here
       // example: Gokinjo Bouken Tai - Battle (28:0000, Sax at 3rd channel)
-      desc << L"Duration: " << spcDeltaTime;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Wait", desc.str().c_str(), CLR_REST, ICON_REST);
+      desc << "Duration: " << spcDeltaTime;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Wait", desc.str().c_str(), CLR_REST, ICON_REST);
       AddTime(spcDeltaTime);
       break;
     }
@@ -602,7 +602,7 @@ bool MoriSnesTrack::ReadEvent(void) {
     case EVENT_TRANSPOSE_REL: {
       int8_t delta = GetByte(curOffset++);
       spcTranspose += delta;
-      AddTranspose(beginOffset, curOffset - beginOffset, spcTranspose, L"Transpose (Relative)");
+      AddTranspose(beginOffset, curOffset - beginOffset, spcTranspose, "Transpose (Relative)");
       break;
     }
 
@@ -616,12 +616,12 @@ bool MoriSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_KEY_ON: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Key On", desc.str().c_str(), CLR_NOTEON, ICON_NOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Key On", desc.str().c_str(), CLR_NOTEON, ICON_NOTE);
       break;
     }
 
     case EVENT_KEY_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Key Off", desc.str().c_str(), CLR_NOTEOFF, ICON_NOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Key Off", desc.str().c_str(), CLR_NOTEOFF, ICON_NOTE);
       break;
     }
 
@@ -631,7 +631,7 @@ bool MoriSnesTrack::ReadEvent(void) {
       int newVolume = min(max(spcVolume + delta, 0), 0xff);
       spcVolume += newVolume;
 
-      AddVol(beginOffset, curOffset - beginOffset, spcVolume / 2, L"Volume (Relative)");
+      AddVol(beginOffset, curOffset - beginOffset, spcVolume / 2, "Volume (Relative)");
       break;
     }
 
@@ -643,8 +643,8 @@ bool MoriSnesTrack::ReadEvent(void) {
 
     case EVENT_TIMEBASE: {
       bool fast = ((GetByte(curOffset++) & 1) != 0);
-      desc << L"Timebase: " << (fast ? SEQ_PPQN : SEQ_PPQN / 2);
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Timebase", desc.str().c_str(), CLR_TEMPO, ICON_TEMPO);
+      desc << "Timebase: " << (fast ? SEQ_PPQN : SEQ_PPQN / 2);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Timebase", desc.str().c_str(), CLR_TEMPO, ICON_TEMPO);
 
       if (parentSeq->fastTempo != fast) {
         AddTempoBPMNoItem(parentSeq->GetTempoInBPM(parentSeq->spcTempo, fast));
@@ -654,19 +654,19 @@ bool MoriSnesTrack::ReadEvent(void) {
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"MoriSnesSeq"));
+                                    "MoriSnesSeq"));
       bContinue = false;
       break;
   }
 
   //assert(curOffset >= dwOffset);
 
-  //wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   // increase delta-time
@@ -954,8 +954,8 @@ void MoriSnesTrack::ParseInstrumentEvents(uint16_t offset, uint8_t instrNum, boo
 
       default:
 //#ifdef _WIN32
-//			std::wostringstream ssTrace;
-//			ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+//			std::ostringstream ssTrace;
+//			ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
 //			OutputDebugString(ssTrace.str().c_str());
 //#endif
 

--- a/src/main/formats/MoriSnesSeq.h
+++ b/src/main/formats/MoriSnesSeq.h
@@ -50,7 +50,7 @@ enum MoriSnesSeqEventType {
 class MoriSnesSeq
     : public VGMSeq {
  public:
-  MoriSnesSeq(RawFile *file, MoriSnesVersion ver, uint32_t seqdataOffset, std::wstring newName = L"Mint SNES Seq");
+  MoriSnesSeq(RawFile *file, MoriSnesVersion ver, uint32_t seqdataOffset, std::string newName = "Mint SNES Seq");
   virtual ~MoriSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/NDSInstrSet.cpp
+++ b/src/main/formats/NDSInstrSet.cpp
@@ -28,13 +28,13 @@ constexpr double INTR_FREQUENCY = 64 * 2728.0 / 33e6;
 // ***********
 
 NDSInstrSet::NDSInstrSet(RawFile *file, uint32_t offset, uint32_t length, VGMSampColl *psg_samples,
-                         std::wstring name)
+                         std::string name)
     : VGMInstrSet(NDSFormat::name, file, offset, length, name), m_psg_samples(psg_samples) {
 }
 
 bool NDSInstrSet::GetInstrPointers() {
   uint32_t nInstruments = GetWord(dwOffset + 0x38);
-  VGMHeader *instrptrHdr = AddHeader(dwOffset + 0x38, nInstruments * 4 + 4, L"Instrument Pointers");
+  VGMHeader *instrptrHdr = AddHeader(dwOffset + 0x38, nInstruments * 4 + 4, "Instrument Pointers");
 
   for (uint32_t i = 0; i < nInstruments; i++) {
     uint32_t instrPtrOff = dwOffset + 0x3C + i * 4;
@@ -47,9 +47,9 @@ bool NDSInstrSet::GetInstrPointers() {
     uint32_t pInstr = temp >> 8;
     aInstrs.push_back(new NDSInstr(this, pInstr + dwOffset, 0, 0, i, instrType));
 
-    VGMHeader *hdr = instrptrHdr->AddHeader(instrPtrOff, 4, L"Pointer");
-    hdr->AddSimpleItem(instrPtrOff, 1, L"Type");
-    hdr->AddSimpleItem(instrPtrOff + 1, 3, L"Offset");
+    VGMHeader *hdr = instrptrHdr->AddHeader(instrPtrOff, 4, "Pointer");
+    hdr->AddSimpleItem(instrPtrOff, 1, "Type");
+    hdr->AddSimpleItem(instrPtrOff + 1, 3, "Offset");
   }
 
   return true;
@@ -61,14 +61,14 @@ bool NDSInstrSet::GetInstrPointers() {
 
 NDSInstr::NDSInstr(NDSInstrSet *instrSet, uint32_t offset, uint32_t length, uint32_t theBank,
                    uint32_t theInstrNum, uint8_t theInstrType)
-    : VGMInstr(instrSet, offset, length, theBank, theInstrNum, L"Instrument", 0), instrType(theInstrType) {
+    : VGMInstr(instrSet, offset, length, theBank, theInstrNum, "Instrument", 0), instrType(theInstrType) {
 }
 
 bool NDSInstr::LoadInstr() {
   // All of the undefined case values below are used for tone or noise channels
   switch (instrType) {
     case 0x01: {
-      name = L"Single-Region Instrument";
+      name = "Single-Region Instrument";
       unLength = 10;
 
       VGMRgn *rgn = AddRgn(dwOffset, 10, GetShort(dwOffset));
@@ -80,9 +80,9 @@ bool NDSInstr::LoadInstr() {
     case 0x02: {
       /* PSG Tone */
       uint8_t dutyCycle = GetByte(dwOffset) & 0x07;
-      std::wstring dutyCycles[8] = {L"12.5%", L"25%", L"37.5%", L"50%",
-                                    L"62.5%", L"75%", L"87.5%", L"0%"};
-      name = L"PSG Wave (" + dutyCycles[dutyCycle] + L")";
+      std::string dutyCycles[8] = {"12.5%", "25%", "37.5%", "50%",
+                                    "62.5%", "75%", "87.5%", "0%"};
+      name = "PSG Wave (" + dutyCycles[dutyCycle] + ")";
       unLength = 10;
 
       VGMRgn *rgn = AddRgn(dwOffset, 10, dutyCycle);
@@ -95,7 +95,7 @@ bool NDSInstr::LoadInstr() {
     }
 
     case 0x03: {
-      name = L"PSG Noise";
+      name = "PSG Noise";
       unLength = 10;
 
       /* The noise sample is the 8th in our PSG sample collection */
@@ -109,7 +109,7 @@ bool NDSInstr::LoadInstr() {
     }
 
     case 0x10: {
-      name = L"Drumset";
+      name = "Drumset";
 
       uint8_t lowKey = GetByte(dwOffset);
       uint8_t highKey = GetByte(dwOffset + 1);
@@ -126,7 +126,7 @@ bool NDSInstr::LoadInstr() {
     }
 
     case 0x11: {
-      name = L"Multi-Region Instrument";
+      name = "Multi-Region Instrument";
       uint8_t keyRanges[8];
       uint8_t nRgns = 0;
       for (int i = 0; i < 8; i++) {
@@ -253,7 +253,7 @@ uint16_t NDSInstr::GetFallingRate(uint8_t DecayTime) {
 // NDSWaveArch
 // ***********
 
-NDSWaveArch::NDSWaveArch(RawFile *file, uint32_t offset, uint32_t length, wstring name)
+NDSWaveArch::NDSWaveArch(RawFile *file, uint32_t offset, uint32_t length, string name)
     : VGMSampColl(NDSFormat::name, file, offset, length, name) {
 }
 
@@ -298,8 +298,8 @@ bool NDSWaveArch::GetSampleInfo() {
       dataLength = loopOff + nonLoopLength;
     }
 
-    std::wostringstream name;
-    name << L"Sample " << (float)samples.size();
+    std::ostringstream name;
+    name << "Sample " << (float)samples.size();
     NDSSamp *samp = new NDSSamp(this, pSample, dataStart + dataLength - pSample, dataStart,
                                 dataLength, nChannels, bps, rate, waveType, name.str());
 
@@ -320,7 +320,7 @@ bool NDSWaveArch::GetSampleInfo() {
   return true;
 }
 
-NDSPSG::NDSPSG(RawFile *file) : VGMSampColl(NDSFormat::name, file, 0, 0, L"NDS PSG samples") {
+NDSPSG::NDSPSG(RawFile *file) : VGMSampColl(NDSFormat::name, file, 0, 0, "NDS PSG samples") {
 }
 
 bool NDSPSG::GetSampleInfo() {
@@ -338,7 +338,7 @@ bool NDSPSG::GetSampleInfo() {
 
 NDSSamp::NDSSamp(VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t dataOffset,
                  uint32_t dataLen, uint8_t nChannels, uint16_t theBPS, uint32_t theRate,
-                 uint8_t theWaveType, wstring name)
+                 uint8_t theWaveType, string name)
     : VGMSamp(sampColl, offset, length, dataOffset, dataLen, nChannels, theBPS, theRate, name),
       waveType(theWaveType) {
 }
@@ -516,7 +516,7 @@ NDSPSGSamp::NDSPSGSamp(VGMSampColl *sampcoll, uint8_t duty_cycle) : VGMSamp(samp
   SetLoopLengthMeasure(LM_SAMPLES);
   ulUncompressedSize = 32768 * bps / 8;
 
-  name = L"PSG_duty_" + std::to_wstring(duty_cycle);
+  name = "PSG_duty_" + std::to_string(duty_cycle);
 }
 
 void NDSPSGSamp::ConvertToStdWave(uint8_t *buf) {

--- a/src/main/formats/NDSInstrSet.h
+++ b/src/main/formats/NDSInstrSet.h
@@ -21,7 +21,7 @@ class NDSInstr;
 class NDSInstrSet : public VGMInstrSet {
 public:
   NDSInstrSet(RawFile *file, uint32_t offset, uint32_t length, VGMSampColl *psg_samples,
-              std::wstring name = L"NDS Instrument Bank");
+              std::string name = "NDS Instrument Bank");
   virtual bool GetInstrPointers();
 
   std::vector<VGMSampColl *> sampCollWAList;
@@ -75,7 +75,7 @@ static const int IMA_IndexTable[9] = {-1, -1, -1, -1, 2, 4, 6, 8};
 class NDSWaveArch : public VGMSampColl {
 public:
   NDSWaveArch(RawFile *file, uint32_t offset, uint32_t length,
-              std::wstring name = L"NDS Wave Archive");
+              std::string name = "NDS Wave Archive");
   ~NDSWaveArch() override = default;
 
   bool GetHeaderInfo() override;
@@ -99,7 +99,7 @@ class NDSSamp : public VGMSamp {
 public:
   NDSSamp(VGMSampColl *sampColl, uint32_t offset = 0, uint32_t length = 0, uint32_t dataOffset = 0,
           uint32_t dataLength = 0, uint8_t channels = 1, uint16_t bps = 16, uint32_t rate = 0,
-          uint8_t waveType = 0, std::wstring name = L"Sample");
+          uint8_t waveType = 0, std::string name = "Sample");
 
   virtual double GetCompressionRatio();  // ratio of space conserved.  should generally be > 1
   // used to calculate both uncompressed sample size and loopOff after conversion

--- a/src/main/formats/NDSScanner.cpp
+++ b/src/main/formats/NDSScanner.cpp
@@ -36,9 +36,9 @@ uint32_t NDSScanner::LoadFromSDAT(RawFile *file, uint32_t baseOff) {
   uint32_t nSeqs;
   uint32_t nBnks;
   uint32_t nWAs;
-  vector<wstring> seqNames;
-  vector<wstring> bnkNames;
-  vector<wstring> waNames;
+  vector<string> seqNames;
+  vector<string> bnkNames;
+  vector<string> waNames;
   vector<uint16_t> seqFileIDs;
   vector<uint16_t> bnkFileIDs;
   vector<uint16_t> waFileIDs;
@@ -69,43 +69,37 @@ uint32_t NDSScanner::LoadFromSDAT(RawFile *file, uint32_t baseOff) {
 
   for (uint32_t i = 0; i < nSeqs; i++) {
     char temp[32];        //that 32 is totally arbitrary, i should change it
-    wchar_t wtemp[32];
     if (hasSYMB) {
       file->GetBytes(file->GetWord(pSeqNamePtrList + 4 + i * 4) + SYMBoff, 32, temp);
-      mbstowcs(wtemp, temp, 32);
     }
     else {
-      swprintf(wtemp, 32, L"SSEQ_%04d", i);
+      snprintf(temp, 32, "SSEQ_%04d", i);
     }
-    seqNames.push_back(wtemp);
+    seqNames.push_back(temp);
   }
 
   for (uint32_t i = 0; i < nBnks; i++) {
     char temp[32];        //that 32 is totally arbitrary, i should change it
-    wchar_t wtemp[32];
 
     if (hasSYMB) {
       file->GetBytes(file->GetWord(pBnkNamePtrList + 4 + i * 4) + SYMBoff, 32, temp);
-      mbstowcs(wtemp, temp, 32);
     }
     else {
-      swprintf(wtemp, 32, L"SBNK_%04d", i);
+      snprintf(temp, 32, "SBNK_%04d", i);
     }
-    bnkNames.push_back(wtemp);
+    bnkNames.push_back(temp);
   }
 
   for (uint32_t i = 0; i < nWAs; i++) {
     char temp[32];        //that 32 is totally arbitrary, i should change it
-    wchar_t wtemp[32];
 
     if (hasSYMB) {
       file->GetBytes(file->GetWord(pWANamePtrList + 4 + i * 4) + SYMBoff, 32, temp);
-      mbstowcs(wtemp, temp, 32);
     }
     else {
-      swprintf(wtemp, 32, L"SWAR_%04d", i);
+      snprintf(temp, 32, "SWAR_%04d", i);
     }
-    waNames.push_back(wtemp);
+    waNames.push_back(temp);
   }
 
   uint32_t pSeqInfoPtrList = file->GetWord(INFOoff + 8) + INFOoff;
@@ -184,8 +178,8 @@ uint32_t NDSScanner::LoadFromSDAT(RawFile *file, uint32_t baseOff) {
       uint32_t fileSize = file->GetWord(offset);
       NDSWaveArch *NewNDSwa = new NDSWaveArch(file, pWAFatData, fileSize, waNames[i]);
       if (!NewNDSwa->LoadVGMFile()) {
-        pRoot->AddLogItem(new LogItem(FormatString<wstring>(L"Failed to load NDSWaveArch at 0x%08x\n",
-                                                            pWAFatData).c_str(), LOG_LEVEL_ERR, L"NDSScanner"));
+        pRoot->AddLogItem(new LogItem(FormatString<string>("Failed to load NDSWaveArch at 0x%08x\n",
+                                                            pWAFatData).c_str(), LOG_LEVEL_ERR, "NDSScanner"));
         WAs.push_back(NULL);
         delete NewNDSwa;
         continue;
@@ -222,8 +216,8 @@ uint32_t NDSScanner::LoadFromSDAT(RawFile *file, uint32_t baseOff) {
           NewNDSInstrSet->sampCollWAList.push_back(NULL);
       }
       if (!NewNDSInstrSet->LoadVGMFile()) {
-        pRoot->AddLogItem(new LogItem((L"Failed to load NDSInstrSet at " + std::to_wstring(
-                                                            pBnkFatData)).c_str(), LOG_LEVEL_ERR, L"NDSScanner"));
+        pRoot->AddLogItem(new LogItem(("Failed to load NDSInstrSet at " + std::to_string(
+                                                            pBnkFatData)).c_str(), LOG_LEVEL_ERR, "NDSScanner"));
       }
       pair<uint16_t, NDSInstrSet *> theBank(*iter, NewNDSInstrSet);
       BNKs.push_back(theBank);
@@ -244,9 +238,9 @@ uint32_t NDSScanner::LoadFromSDAT(RawFile *file, uint32_t baseOff) {
       uint32_t fileSize = file->GetWord(offset);
       NDSSeq *NewNDSSeq = new NDSSeq(file, pSeqFatData, fileSize, seqNames[i]);
       if (!NewNDSSeq->LoadVGMFile()) {
-        pRoot->AddLogItem(new LogItem(FormatString<wstring>(L"Failed to load NDSSeq at 0x%08x\n", pSeqFatData).c_str(),
+        pRoot->AddLogItem(new LogItem(FormatString<string>("Failed to load NDSSeq at 0x%08x\n", pSeqFatData).c_str(),
                                       LOG_LEVEL_ERR,
-                                      L"NDSScanner"));
+                                      "NDSScanner"));
       }
 
       VGMColl *coll = new VGMColl(seqNames[i]);

--- a/src/main/formats/NDSScanner.h
+++ b/src/main/formats/NDSScanner.h
@@ -5,8 +5,8 @@ class NDSScanner:
     public VGMScanner {
  public:
   NDSScanner(void) {
-    USE_EXTENSION(L"nds")
-    USE_EXTENSION(L"sdat")
+    USE_EXTENSION("nds")
+    USE_EXTENSION("sdat")
   }
   virtual ~NDSScanner(void) {
   }

--- a/src/main/formats/NDSSeq.cpp
+++ b/src/main/formats/NDSSeq.cpp
@@ -5,27 +5,27 @@ DECLARE_FORMAT(NDS);
 
 using namespace std;
 
-NDSSeq::NDSSeq(RawFile *file, uint32_t offset, uint32_t length, wstring name)
+NDSSeq::NDSSeq(RawFile *file, uint32_t offset, uint32_t length, string name)
     : VGMSeq(NDSFormat::name, file, offset, length, name) {
 }
 
 bool NDSSeq::GetHeaderInfo(void) {
-  VGMHeader *SSEQHdr = AddHeader(dwOffset, 0x10, L"SSEQ Chunk Header");
+  VGMHeader *SSEQHdr = AddHeader(dwOffset, 0x10, "SSEQ Chunk Header");
   SSEQHdr->AddSig(dwOffset, 8);
-  SSEQHdr->AddSimpleItem(dwOffset + 8, 4, L"Size");
-  SSEQHdr->AddSimpleItem(dwOffset + 12, 2, L"Header Size");
+  SSEQHdr->AddSimpleItem(dwOffset + 8, 4, "Size");
+  SSEQHdr->AddSimpleItem(dwOffset + 12, 2, "Header Size");
   SSEQHdr->AddUnknownItem(dwOffset + 14, 2);
-  //SeqChunkHdr->AddSimpleItem(dwOffset, 4, L"Blah");
+  //SeqChunkHdr->AddSimpleItem(dwOffset, 4, "Blah");
   unLength = GetShort(dwOffset + 8);
   SetPPQN(0x30);
   return true;        //successful
 }
 
 bool NDSSeq::GetTrackPointers(void) {
-  VGMHeader *DATAHdr = AddHeader(dwOffset + 0x10, 0xC, L"DATA Chunk Header");
+  VGMHeader *DATAHdr = AddHeader(dwOffset + 0x10, 0xC, "DATA Chunk Header");
   DATAHdr->AddSig(dwOffset + 0x10, 4);
-  DATAHdr->AddSimpleItem(dwOffset + 0x10 + 4, 4, L"Size");
-  DATAHdr->AddSimpleItem(dwOffset + 0x10 + 8, 4, L"Data Pointer");
+  DATAHdr->AddSimpleItem(dwOffset + 0x10 + 4, 4, "Size");
+  DATAHdr->AddSimpleItem(dwOffset + 0x10 + 8, 4, "Data Pointer");
   uint32_t offset = dwOffset + 0x1C;
   uint8_t b = GetByte(offset);
   aTracks.push_back(new NDSTrack(this));
@@ -33,8 +33,8 @@ bool NDSSeq::GetTrackPointers(void) {
   //FE XX XX signifies multiple tracks, each true bit in the XX values signifies there is a track for that channel
   if (b == 0xFE)
   {
-    VGMHeader *TrkPtrs = AddHeader(offset, 0, L"Track Pointers");
-    TrkPtrs->AddSimpleItem(offset, 3, L"Valid Tracks");
+    VGMHeader *TrkPtrs = AddHeader(offset, 0, "Track Pointers");
+    TrkPtrs->AddSimpleItem(offset, 3, "Valid Tracks");
     offset += 3;    //but all we need to do is check for subsequent 0x93 track pointer events
     b = GetByte(offset);
     uint32_t songDelay = 0;
@@ -51,7 +51,7 @@ bool NDSSeq::GetTrackPointers(void) {
         } while (c & 0x80);
       }
       songDelay += value;
-      TrkPtrs->AddSimpleItem(beginOffset, offset - beginOffset, L"Delay");
+      TrkPtrs->AddSimpleItem(beginOffset, offset - beginOffset, "Delay");
       //songDelay += SeqTrack::ReadVarLen(++offset);
       b = GetByte(offset);
       break;
@@ -60,7 +60,7 @@ bool NDSSeq::GetTrackPointers(void) {
     //Track/Channel assignment and pointer.  Channel # is irrelevant
     while (b == 0x93)
     {
-      TrkPtrs->AddSimpleItem(offset, 5, L"Track Pointer");
+      TrkPtrs->AddSimpleItem(offset, 5, "Track Pointer");
       uint32_t trkOffset = GetByte(offset + 2) + (GetByte(offset + 3) << 8) +
           (GetByte(offset + 4) << 16) + dwOffset + 0x1C;
       NDSTrack *newTrack = new NDSTrack(this, trkOffset);
@@ -122,7 +122,7 @@ bool NDSTrack::ReadEvent(void) {
       // [loveemu] open track, however should not handle in this function
       case 0x93:
         curOffset += 4;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Open Track");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Open Track");
         break;
 
       case 0x94: {
@@ -133,7 +133,7 @@ bool NDSTrack::ReadEvent(void) {
         // Add an End Track if it exists afterward, for completeness sake
         if (readMode == READMODE_ADD_TO_UI && !IsOffsetUsed(curOffset)) {
           if (GetByte(curOffset) == 0xFF) {
-            AddGenericEvent(curOffset, 1, L"End of Track", L"", CLR_TRACKEND, ICON_TRACKEND);
+            AddGenericEvent(curOffset, 1, "End of Track", "", CLR_TRACKEND, ICON_TRACKEND);
           }
         }
 
@@ -141,11 +141,11 @@ bool NDSTrack::ReadEvent(void) {
         // See Zelda The Spirit Tracks - SSEQ_0018 (overworld train theme)
         bool bContinue = true;
         if (IsOffsetUsed(jumpAddr)) {
-          AddLoopForever(beginOffset, 4, L"Loop");
+          AddLoopForever(beginOffset, 4, "Loop");
           bContinue = false;
         }
         else {
-          AddGenericEvent(beginOffset, 4, L"Jump", L"", CLR_LOOPFOREVER);
+          AddGenericEvent(beginOffset, 4, "Jump", "", CLR_LOOPFOREVER);
         }
 
         curOffset = jumpAddr;
@@ -155,7 +155,7 @@ bool NDSTrack::ReadEvent(void) {
       case 0x95:
         hasLoopReturnOffset = true;
         loopReturnOffset = curOffset + 3;
-        AddGenericEvent(beginOffset, curOffset + 3 - beginOffset, L"Call", L"", CLR_LOOP);
+        AddGenericEvent(beginOffset, curOffset + 3 - beginOffset, "Call", "", CLR_LOOP);
         curOffset = GetByte(curOffset) + (GetByte(curOffset + 1) << 8)
             + (GetByte(curOffset + 2) << 16) + parentSeq->dwOffset + 0x1C;
         break;
@@ -172,7 +172,7 @@ bool NDSTrack::ReadEvent(void) {
         randMax = (signed) GetShort(curOffset);
         curOffset += 2;
 
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Cmd with Random Value");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Cmd with Random Value");
         break;
       }
 
@@ -181,12 +181,12 @@ bool NDSTrack::ReadEvent(void) {
         uint8_t subStatusByte = GetByte(curOffset++);
         uint8_t varNumber = GetByte(curOffset++);
 
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Cmd with Variable");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Cmd with Variable");
         break;
       }
 
       case 0xA2: {
-        AddUnknown(beginOffset, curOffset - beginOffset, L"If");
+        AddUnknown(beginOffset, curOffset - beginOffset, "If");
         break;
       }
 
@@ -205,10 +205,10 @@ bool NDSTrack::ReadEvent(void) {
       case 0xBD: {
         uint8_t varNumber;
         int16_t val;
-        const wchar_t *eventName[] = {
-            L"Set Variable", L"Add Variable", L"Sub Variable", L"Mul Variable", L"Div Variable",
-            L"Shift Vabiable", L"Rand Variable", L"", L"If Variable ==", L"If Variable >=",
-            L"If Variable >", L"If Variable <=", L"If Variable <", L"If Variable !="
+        const char* eventName[] = {
+            "Set Variable", "Add Variable", "Sub Variable", "Mul Variable", "Div Variable",
+            "Shift Vabiable", "Rand Variable", "", "If Variable ==", "If Variable >=",
+            "If Variable >", "If Variable <=", "If Variable <", "If Variable !="
         };
 
         varNumber = GetByte(curOffset++);
@@ -233,7 +233,7 @@ bool NDSTrack::ReadEvent(void) {
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_BOSS1_)
       case 0xC2: {
         uint8_t mvol = GetByte(curOffset++);
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Master Volume");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Master Volume");
         break;
       }
 
@@ -241,7 +241,7 @@ bool NDSTrack::ReadEvent(void) {
       case 0xC3: {
         int8_t transpose = (signed) GetByte(curOffset++);
         AddTranspose(beginOffset, curOffset - beginOffset, transpose);
-//			AddGenericEvent(beginOffset, curOffset-beginOffset, L"Transpose", NULL, BG_CLR_GREEN);
+//			AddGenericEvent(beginOffset, curOffset-beginOffset, "Transpose", NULL, BG_CLR_GREEN);
         break;
       }
 
@@ -262,52 +262,52 @@ bool NDSTrack::ReadEvent(void) {
       // [loveemu] (ex: Children of Mana: SEQ_BGM000)
       case 0xC6:
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Priority", L"", CLR_CHANGESTATE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Priority", "", CLR_CHANGESTATE);
         break;
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_ARR1_)
       case 0xC7: {
         uint8_t notewait = GetByte(curOffset++);
         noteWithDelta = (notewait != 0);
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Notewait Mode");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Notewait Mode");
         break;
       }
 
       // [loveemu] (ex: Hanjuku Hero DS: NSE_42)
       case 0xC8:
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Tie");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Tie");
         break;
 
       // [loveemu] (ex: Hanjuku Hero DS: NSE_50)
       case 0xC9:
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Portamento Control");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Portamento Control");
         break;
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_ARR1_)
       case 0xCA: {
         uint8_t amount = GetByte(curOffset++);
-        AddModulation(beginOffset, curOffset - beginOffset, amount, L"Modulation Depth");
+        AddModulation(beginOffset, curOffset - beginOffset, amount, "Modulation Depth");
         break;
       }
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_ARR1_)
       case 0xCB:
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Modulation Speed");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Modulation Speed");
         break;
 
       // [loveemu] (ex: Children of Mana: SEQ_BGM001)
       case 0xCC:
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Modulation Type");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Modulation Type");
         break;
 
       // [loveemu] (ex: Phoenix Wright - Ace Attorney: BGM021)
       case 0xCD:
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Modulation Range");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Modulation Range");
         break;
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_ARR1_)
@@ -327,31 +327,31 @@ bool NDSTrack::ReadEvent(void) {
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_WIND_)
       case 0xD0:
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Attack Rate");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Attack Rate");
         break;
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_WIND_)
       case 0xD1:
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Decay Rate");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Decay Rate");
         break;
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_WIND_)
       case 0xD2:
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Sustain Level");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Sustain Level");
         break;
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_WIND_)
       case 0xD3:
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Release Rate");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Release Rate");
         break;
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_WIND_)
       case 0xD4:
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Loop Start");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Loop Start");
         break;
 
       case 0xD5: {
@@ -363,13 +363,13 @@ bool NDSTrack::ReadEvent(void) {
       // [loveemu]
       case 0xD6:
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Print Variable");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Print Variable");
         break;
 
       // [loveemu] (ex: Children of Mana: SEQ_BGM001)
       case 0xE0:
         curOffset += 2;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Modulation Delay");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Modulation Delay");
         break;
 
       case 0xE1: {
@@ -382,12 +382,12 @@ bool NDSTrack::ReadEvent(void) {
       // [loveemu] (ex: Hippatte! Puzzle Bobble: SEQ_1pbgm03)
       case 0xE3:
         curOffset += 2;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Sweep Pitch");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Sweep Pitch");
         break;
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_WIND_)
       case 0xFC:
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Loop End");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Loop End");
         break;
 
       case 0xFD: {
@@ -399,7 +399,7 @@ bool NDSTrack::ReadEvent(void) {
           bContinue = false;
         }
 
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Return", L"", CLR_LOOP);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Return", "", CLR_LOOP);
         curOffset = loopReturnOffset;
         return bContinue;
 	  }
@@ -407,7 +407,7 @@ bool NDSTrack::ReadEvent(void) {
       // [loveemu] allocate track, however should not handle in this function
       case 0xFE:
         curOffset += 2;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Allocate Track");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Allocate Track");
         break;
 
       case 0xFF:

--- a/src/main/formats/NDSSeq.h
+++ b/src/main/formats/NDSSeq.h
@@ -6,7 +6,7 @@
 class NDSSeq:
     public VGMSeq {
  public:
-  NDSSeq(RawFile *file, uint32_t offset, uint32_t length = 0, std::wstring theName = L"NDSSeq");
+  NDSSeq(RawFile *file, uint32_t offset, uint32_t length = 0, std::string theName = "NDSSeq");
 
   virtual bool GetHeaderInfo(void);
   virtual bool GetTrackPointers(void);

--- a/src/main/formats/NamcoSnesInstr.cpp
+++ b/src/main/formats/NamcoSnesInstr.cpp
@@ -10,7 +10,7 @@ NamcoSnesInstrSet::NamcoSnesInstrSet(RawFile *file,
                                      NamcoSnesVersion ver,
                                      uint32_t spcDirAddr,
                                      uint16_t addrTuningTable,
-                                     const std::wstring &name) :
+                                     const std::string &name) :
     VGMInstrSet(NamcoSnesFormat::name, file, addrTuningTable, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrTuningTable(addrTuningTable) {
@@ -57,8 +57,8 @@ bool NamcoSnesInstrSet::GetInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << srcn;
+    std::ostringstream instrName;
+    instrName << "Instrument " << srcn;
     NamcoSnesInstr *newInstr = new NamcoSnesInstr(this, version, srcn, spcDirAddr, ofsTuningEntry, instrName.str());
     aInstrs.push_back(newInstr);
   }
@@ -86,7 +86,7 @@ NamcoSnesInstr::NamcoSnesInstr(VGMInstrSet *instrSet,
                                uint8_t srcn,
                                uint32_t spcDirAddr,
                                uint16_t addrTuningEntry,
-                               const std::wstring &name) :
+                               const std::string &name) :
     VGMInstr(instrSet, addrTuningEntry, 0, 0, srcn, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrTuningEntry(addrTuningEntry) {
@@ -139,7 +139,7 @@ NamcoSnesRgn::NamcoSnesRgn(NamcoSnesInstr *instr,
     fine_tuning += 1.0;
   }
 
-  AddSimpleItem(addrTuningEntry, 2, L"Sample Rate");
+  AddSimpleItem(addrTuningEntry, 2, "Sample Rate");
   unityKey = 71 - (int) coarse_tuning;
   fineTune = (int16_t) (fine_tuning * 100.0);
 

--- a/src/main/formats/NamcoSnesInstr.h
+++ b/src/main/formats/NamcoSnesInstr.h
@@ -15,7 +15,7 @@ class NamcoSnesInstrSet:
                     NamcoSnesVersion ver,
                     uint32_t spcDirAddr,
                     uint16_t addrTuningTable,
-                    const std::wstring &name = L"NamcoSnesInstrSet");
+                    const std::string &name = "NamcoSnesInstrSet");
   virtual ~NamcoSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -41,7 +41,7 @@ class NamcoSnesInstr
                  uint8_t srcn,
                  uint32_t spcDirAddr,
                  uint16_t addrTuningEntry,
-                 const std::wstring &name = L"NamcoSnesInstr");
+                 const std::string &name = "NamcoSnesInstr");
   virtual ~NamcoSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/NamcoSnesScanner.cpp
+++ b/src/main/formats/NamcoSnesScanner.cpp
@@ -120,7 +120,7 @@ void NamcoSnesScanner::Scan(RawFile *file, void *info) {
 
 void NamcoSnesScanner::SearchForNamcoSnesFromARAM(RawFile *file) {
   NamcoSnesVersion version = NAMCOSNES_NONE;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   // search song list
   uint32_t ofsReadSongList;

--- a/src/main/formats/NamcoSnesScanner.h
+++ b/src/main/formats/NamcoSnesScanner.h
@@ -8,7 +8,7 @@ class NamcoSnesScanner:
     public VGMScanner {
  public:
   NamcoSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~NamcoSnesScanner(void) {
   }

--- a/src/main/formats/NamcoSnesSeq.cpp
+++ b/src/main/formats/NamcoSnesSeq.cpp
@@ -10,7 +10,7 @@ DECLARE_FORMAT(NamcoSnes);
 #define MAX_TRACKS  8
 #define SEQ_PPQN    48
 
-NamcoSnesSeq::NamcoSnesSeq(RawFile *file, NamcoSnesVersion ver, uint32_t seqdataOffset, std::wstring newName)
+NamcoSnesSeq::NamcoSnesSeq(RawFile *file, NamcoSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeqNoTrks(NamcoSnesFormat::name, file, seqdataOffset, newName),
       version(ver) {
   bAllowDiscontinuousTrackData = true;
@@ -105,10 +105,10 @@ void NamcoSnesSeq::LoadEventMap() {
   //ControlChangeMap[0x0e] = (NamcoSnesSeqControlType)0;
   //ControlChangeMap[0x0f] = (NamcoSnesSeqControlType)0;
 
-  ControlChangeNames[CONTROL_PROGCHANGE] = L"Program Change";
-  ControlChangeNames[CONTROL_VOLUME] = L"Volume";
-  ControlChangeNames[CONTROL_PAN] = L"Pan";
-  ControlChangeNames[CONTROL_ADSR] = L"ADSR";
+  ControlChangeNames[CONTROL_PROGCHANGE] = "Program Change";
+  ControlChangeNames[CONTROL_VOLUME] = "Volume";
+  ControlChangeNames[CONTROL_PAN] = "Pan";
+  ControlChangeNames[CONTROL_ADSR] = "ADSR";
 }
 
 bool NamcoSnesSeq::ReadEvent(void) {
@@ -120,7 +120,7 @@ bool NamcoSnesSeq::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   NamcoSnesSeqEventType eventType = (NamcoSnesSeqEventType) 0;
   std::map<uint8_t, NamcoSnesSeqEventType>::iterator pEventType = EventMap.find(statusByte);
@@ -134,27 +134,27 @@ bool NamcoSnesSeq::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -162,43 +162,43 @@ bool NamcoSnesSeq::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_DELTA_TIME: {
       spcDeltaTime = GetByte(curOffset++);
-      desc << L"Duration: " << spcDeltaTime;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Delta Time", desc.str(), CLR_CHANGESTATE);
+      desc << "Duration: " << spcDeltaTime;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
     case EVENT_OPEN_TRACKS: {
       uint8_t targetChannels = GetByte(curOffset++);
 
-      desc << L"Tracks:";
+      desc << "Tracks:";
       for (uint8_t trackIndex = 0; trackIndex < 8; trackIndex++) {
         if ((targetChannels & (0x80 >> trackIndex)) != 0) {
-          desc << L" " << (trackIndex + 1);
+          desc << " " << (trackIndex + 1);
         }
       }
 
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Open Tracks", desc.str(), CLR_MISC, ICON_TRACK);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Open Tracks", desc.str(), CLR_MISC, ICON_TRACK);
       break;
     }
 
     case EVENT_CALL: {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pattern Play",
+                      "Pattern Play",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -218,7 +218,7 @@ bool NamcoSnesSeq::ReadEvent(void) {
         // end of subroutine
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Pattern End",
+                        "Pattern End",
                         desc.str().c_str(),
                         CLR_LOOP,
                         ICON_ENDREP);
@@ -230,8 +230,8 @@ bool NamcoSnesSeq::ReadEvent(void) {
 
     case EVENT_DELTA_MULTIPLIER: {
       spcDeltaTimeScale = GetByte(curOffset++);
-      desc << L"Delta Time Scale: " << spcDeltaTimeScale;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Delta Time Multiplier", desc.str(), CLR_MISC, ICON_TEMPO);
+      desc << "Delta Time Scale: " << spcDeltaTimeScale;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time Multiplier", desc.str(), CLR_MISC, ICON_TEMPO);
       break;
     }
 
@@ -245,9 +245,9 @@ bool NamcoSnesSeq::ReadEvent(void) {
       uint8_t count = GetByte(curOffset++);
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Times: " << count << L"  Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+      desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Again", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       loopCount++;
       if (loopCount == count) {
@@ -266,9 +266,9 @@ bool NamcoSnesSeq::ReadEvent(void) {
       uint8_t count = GetByte(curOffset++);
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Times: " << count << L"  Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+      desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       loopCount++;
       if (loopCount == count) {
@@ -284,11 +284,11 @@ bool NamcoSnesSeq::ReadEvent(void) {
       uint8_t count = GetByte(curOffset++);
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Times: " << count << L"  Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+      desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Loop Again (Alt)",
+                      "Loop Again (Alt)",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_ENDREP);
@@ -310,9 +310,9 @@ bool NamcoSnesSeq::ReadEvent(void) {
       uint8_t count = GetByte(curOffset++);
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Times: " << count << L"  Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+      desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       loopCountAlt++;
       if (loopCountAlt == count) {
@@ -327,20 +327,20 @@ bool NamcoSnesSeq::ReadEvent(void) {
     case EVENT_GOTO: {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       uint32_t length = curOffset - beginOffset;
 
       // scan end event
       if (curOffset + 1 <= 0x10000 && GetByte(curOffset) == 0x03 && (subReturnAddress & 0xff00) == 0) {
-        AddGenericEvent(curOffset, 1, L"End of Track", L"", CLR_TRACKEND, ICON_TRACKEND);
+        AddGenericEvent(curOffset, 1, "End of Track", "", CLR_TRACKEND, ICON_TRACKEND);
       }
 
       curOffset = dest;
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
       }
       else {
-        bContinue = AddLoopForever(beginOffset, length, L"Jump");
+        bContinue = AddLoopForever(beginOffset, length, "Jump");
       }
       break;
     }
@@ -349,7 +349,7 @@ bool NamcoSnesSeq::ReadEvent(void) {
       uint8_t targetChannels = GetByte(curOffset++);
       uint16_t dur = spcDeltaTime * spcDeltaTimeScale;
 
-      desc << L"Values:";
+      desc << "Values:";
       for (uint8_t trackIndex = 0; trackIndex < 8; trackIndex++) {
         if ((targetChannels & (0x80 >> trackIndex)) != 0) {
           uint8_t keyByte = GetByte(curOffset++);
@@ -359,22 +359,22 @@ bool NamcoSnesSeq::ReadEvent(void) {
           if (keyByte >= NOTE_NUMBER_PERCUSSION_MIN) {
             key = keyByte - NOTE_NUMBER_PERCUSSION_MIN;
             noteType = NOTE_PERCUSSION;
-            desc << L" [" << (trackIndex + 1) << L"] " << L"Perc " << key;
+            desc << " [" << (trackIndex + 1) << "] " << "Perc " << key;
           }
           else if (keyByte >= NOTE_NUMBER_NOISE_MIN) {
             key = keyByte & 0x1f;
             noteType = NOTE_NOISE;
-            desc << L" [" << (trackIndex + 1) << L"] " << L"Noise " << key;
+            desc << " [" << (trackIndex + 1) << "] " << "Noise " << key;
           }
           else if (keyByte == NOTE_NUMBER_REST) {
             noteType = prevNoteType[trackIndex];
-            desc << L" [" << (trackIndex + 1) << L"] " << L"Rest";
+            desc << " [" << (trackIndex + 1) << "] " << "Rest";
           }
           else {
             key = keyByte;
             noteType = NOTE_MELODY;
-            desc << L" [" << (trackIndex + 1) << L"] " << key << L" (" << MidiEvent::GetNoteName(key + transpose)
-                << L")";
+            desc << " [" << (trackIndex + 1) << "] " << key << " (" << MidiEvent::GetNoteName(key + transpose)
+                << ")";
           }
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
@@ -417,74 +417,74 @@ bool NamcoSnesSeq::ReadEvent(void) {
         }
       }
 
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Note", desc.str(), CLR_DURNOTE, ICON_NOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Note", desc.str(), CLR_DURNOTE, ICON_NOTE);
       AddTime(dur);
       break;
     }
 
     case EVENT_ECHO_DELAY: {
       uint8_t echoDelay = GetByte(curOffset++);
-      desc << L"Echo Delay: " << echoDelay;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Delay", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Echo Delay: " << echoDelay;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Delay", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_UNKNOWN_0B: {
       uint8_t targetChannels = GetByte(curOffset++);
 
-      desc << L"Values:";
+      desc << "Values:";
       for (uint8_t trackIndex = 0; trackIndex < 8; trackIndex++) {
         if ((targetChannels & (0x80 >> trackIndex)) != 0) {
           uint8_t newValue = GetByte(curOffset++);
-          desc << L" [" << (trackIndex + 1) << L"] " << newValue;
+          desc << " [" << (trackIndex + 1) << "] " << newValue;
         }
       }
 
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_ECHO: {
       bool echoOn = (GetByte(curOffset++) != 0);
-      desc << L"Echo Write: " << (echoOn ? L"On" : L"Off");
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Echo Write: " << (echoOn ? "On" : "Off");
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_WAIT: {
       uint16_t dur = spcDeltaTime * spcDeltaTimeScale;
-      desc << L"Delta Time: " << spcDeltaTime;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Wait", desc.str(), CLR_TIE);
+      desc << "Delta Time: " << spcDeltaTime;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Wait", desc.str(), CLR_TIE);
       AddTime(dur);
       break;
     }
 
     case EVENT_ECHO_FEEDBACK: {
       int8_t echoFeedback = GetByte(curOffset++);
-      desc << L"Echo Feedback: " << echoFeedback;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Feedback", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Echo Feedback: " << echoFeedback;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Feedback", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_FIR: {
       uint8_t echoFilter = GetByte(curOffset++);
-      desc << L"Echo FIR: " << echoFilter;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo FIR", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Echo FIR: " << echoFilter;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_VOLUME: {
       int8_t echoVolumeLeft = GetByte(curOffset++);
       int8_t echoVolumeRight = GetByte(curOffset++);
-      desc << L"Echo Volume Left: " << echoVolumeLeft << L"  Echo Volume Right: " << echoVolumeRight;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Volume", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Echo Volume Left: " << echoVolumeLeft << "  Echo Volume Right: " << echoVolumeRight;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_ADDRESS: {
       uint16_t echoAddress = GetByte(curOffset++) << 8;
-      desc << L"ESA: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) echoAddress;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Address", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "ESA: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) echoAddress;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Address", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -494,17 +494,17 @@ bool NamcoSnesSeq::ReadEvent(void) {
 
       NamcoSnesSeqControlType controlType = (NamcoSnesSeqControlType) 0;
       std::map<uint8_t, NamcoSnesSeqControlType>::iterator pControlType = ControlChangeMap.find(controlTypeIndex);
-      std::wstring controlName = L"Unknown Event";
+      std::string controlName = "Unknown Event";
       if (pControlType != ControlChangeMap.end()) {
         controlType = pControlType->second;
         controlName = ControlChangeNames[controlType];
       }
 
-      desc << L"Values:";
+      desc << "Values:";
       for (uint8_t trackIndex = 0; trackIndex < 8; trackIndex++) {
         if ((targetChannels & (0x80 >> trackIndex)) != 0) {
           uint8_t newValue = GetByte(curOffset++);
-          desc << L" [" << (trackIndex + 1) << L"] " << newValue;
+          desc << " [" << (trackIndex + 1) << "] " << newValue;
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             channel = trackIndex;
@@ -567,17 +567,17 @@ bool NamcoSnesSeq::ReadEvent(void) {
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"NamcoSnesSeq"));
+                                    "NamcoSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //std::wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //std::ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/NamcoSnesSeq.h
+++ b/src/main/formats/NamcoSnesSeq.h
@@ -49,7 +49,7 @@ enum NamcoSnesSeqNoteType {
 class NamcoSnesSeq
     : public VGMSeqNoTrks {
  public:
-  NamcoSnesSeq(RawFile *file, NamcoSnesVersion ver, uint32_t seqdataOffset, std::wstring newName = L"Namco SNES Seq");
+  NamcoSnesSeq(RawFile *file, NamcoSnesVersion ver, uint32_t seqdataOffset, std::string newName = "Namco SNES Seq");
   virtual ~NamcoSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);
@@ -60,7 +60,7 @@ class NamcoSnesSeq
   NamcoSnesVersion version;
   std::map<uint8_t, NamcoSnesSeqEventType> EventMap;
   std::map<uint8_t, NamcoSnesSeqControlType> ControlChangeMap;
-  std::map<NamcoSnesSeqControlType, std::wstring> ControlChangeNames;
+  std::map<NamcoSnesSeqControlType, std::string> ControlChangeNames;
 
  private:
   void LoadEventMap(void);

--- a/src/main/formats/NeverlandSnesScanner.cpp
+++ b/src/main/formats/NeverlandSnesScanner.cpp
@@ -64,8 +64,8 @@ void NeverlandSnesScanner::Scan(RawFile *file, void *info) {
 void NeverlandSnesScanner::SearchForNeverlandSnesFromARAM(RawFile *file) {
   NeverlandSnesVersion version = NEVERLANDSNES_NONE;
 
-  std::wstring basefilename = RawFile::removeExtFromPath(file->GetFileName());
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : basefilename;
+  std::string basefilename = RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : basefilename;
 
   uint32_t ofsLoadSong;
   uint16_t addrSeqHeader;

--- a/src/main/formats/NeverlandSnesScanner.h
+++ b/src/main/formats/NeverlandSnesScanner.h
@@ -6,7 +6,7 @@ class NeverlandSnesScanner:
     public VGMScanner {
  public:
   NeverlandSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~NeverlandSnesScanner(void) {
   }

--- a/src/main/formats/NeverlandSnesSeq.cpp
+++ b/src/main/formats/NeverlandSnesSeq.cpp
@@ -43,13 +43,13 @@ bool NeverlandSnesSeq::GetHeaderInfo(void) {
     return false;
   }
 
-  header->AddSimpleItem(dwOffset, 3, L"Signature");
+  header->AddSimpleItem(dwOffset, 3, "Signature");
   header->AddUnknownItem(dwOffset + 3, 1);
 
   const size_t NAME_SIZE = 12;
   char rawName[NAME_SIZE + 1] = {0};
   GetBytes(dwOffset + 4, NAME_SIZE, rawName);
-  header->AddSimpleItem(dwOffset + 4, 12, L"Song Name");
+  header->AddSimpleItem(dwOffset + 4, 12, "Song Name");
 
   // trim name text
   for (int i = NAME_SIZE - 1; i >= 0; i--) {
@@ -61,33 +61,33 @@ bool NeverlandSnesSeq::GetHeaderInfo(void) {
   // set name to the sequence
   if (rawName[0] != ('\0')) {
     std::string nameStr = std::string(rawName);
-    name = string2wstring(nameStr);
+    name = nameStr;
   }
   else {
-    name = L"NeverlandSnesSeq";
+    name = "NeverlandSnesSeq";
   }
 
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t trackSignPtr = dwOffset + 0x10 + trackIndex;
     uint8_t trackSign = GetByte(trackSignPtr);
 
-    std::wstringstream trackSignName;
-    trackSignName << L"Track " << (trackIndex + 1) << L" Entry";
+    std::stringstream trackSignName;
+    trackSignName << "Track " << (trackIndex + 1) << " Entry";
     header->AddSimpleItem(trackSignPtr, 1, trackSignName.str());
 
     uint16_t sectionListOffsetPtr = dwOffset + 0x20 + (trackIndex * 2);
     if (trackSign != 0xff) {
       uint16_t sectionListAddress = GetShortAddress(sectionListOffsetPtr);
 
-      std::wstringstream playlistName;
-      playlistName << L"Track " << (trackIndex + 1) << L" Playlist Pointer";
+      std::stringstream playlistName;
+      playlistName << "Track " << (trackIndex + 1) << " Playlist Pointer";
       header->AddSimpleItem(sectionListOffsetPtr, 2, playlistName.str());
 
       NeverlandSnesTrack *track = new NeverlandSnesTrack(this, sectionListAddress);
       aTracks.push_back(track);
     }
     else {
-      header->AddSimpleItem(sectionListOffsetPtr, 2, L"NULL");
+      header->AddSimpleItem(sectionListOffsetPtr, 2, "NULL");
     }
   }
 
@@ -141,7 +141,7 @@ bool NeverlandSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   NeverlandSnesSeqEventType eventType = (NeverlandSnesSeqEventType) 0;
   std::map<uint8_t, NeverlandSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -151,27 +151,27 @@ bool NeverlandSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -179,12 +179,12 @@ bool NeverlandSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -193,28 +193,28 @@ bool NeverlandSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
-      pRoot->AddLogItem(new LogItem(std::wstring(L"Unknown Event - ") + desc.str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      pRoot->AddLogItem(new LogItem(std::string("Unknown Event - ") + desc.str(),
                                     LOG_LEVEL_ERR,
-                                    std::wstring(L"NeverlandSnesSeq")));
+                                    std::string("NeverlandSnesSeq")));
       bContinue = false;
       break;
   }
 
-  //std::wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //std::ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnesInstr.cpp
@@ -10,7 +10,7 @@ NinSnesInstrSet::NinSnesInstrSet(RawFile *file,
                                  NinSnesVersion ver,
                                  uint32_t offset,
                                  uint32_t spcDirAddr,
-                                 const std::wstring &name) :
+                                 const std::string &name) :
     VGMInstrSet(NinSnesFormat::name, file, offset, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     konamiTuningTableAddress(0),
@@ -91,8 +91,8 @@ bool NinSnesInstrSet::GetInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << instr;
+    std::ostringstream instrName;
+    instrName << "Instrument " << instr;
     NinSnesInstr *newInstr =
         new NinSnesInstr(this, version, addrInstrHeader, instr >> 7, instr & 0x7f, spcDirAddr, instrName.str());
     newInstr->konamiTuningTableAddress = konamiTuningTableAddress;
@@ -123,7 +123,7 @@ NinSnesInstr::NinSnesInstr(VGMInstrSet *instrSet,
                            uint32_t theBank,
                            uint32_t theInstrNum,
                            uint32_t spcDirAddr,
-                           const std::wstring &name) :
+                           const std::string &name) :
     VGMInstr(instrSet, offset, NinSnesInstr::ExpectedSize(ver), theBank, theInstrNum, name), version(ver),
     spcDirAddr(spcDirAddr),
     konamiTuningTableAddress(0),
@@ -239,9 +239,9 @@ NinSnesRgn::NinSnesRgn(NinSnesInstr *instr,
   }
 
   AddSampNum(srcn, offset, 1);
-  AddSimpleItem(offset + 1, 1, L"ADSR1");
-  AddSimpleItem(offset + 2, 1, L"ADSR2");
-  AddSimpleItem(offset + 3, 1, L"GAIN");
+  AddSimpleItem(offset + 1, 1, "ADSR1");
+  AddSimpleItem(offset + 2, 1, "ADSR2");
+  AddSimpleItem(offset + 3, 1, "GAIN");
   if (version == NINSNES_EARLIER) {
     AddUnityKey(96 - (int) (coarse_tuning), offset + 4, 1);
     AddFineTune((int16_t) (fine_tuning * 100.0), offset + 4, 1);
@@ -267,7 +267,7 @@ NinSnesRgn::NinSnesRgn(NinSnesInstr *instr,
     unityKey = 71 - coarse_tuning;
     fineTune = (int16_t) (fine_tune_real * 100.0);
 
-    AddSimpleItem(offset + 4, 2, L"Tuning (Unused)");
+    AddSimpleItem(offset + 4, 2, "Tuning (Unused)");
   }
   else {
     AddUnityKey(96 - (int) (coarse_tuning), offset + 4, 1);

--- a/src/main/formats/NinSnesInstr.h
+++ b/src/main/formats/NinSnesInstr.h
@@ -15,7 +15,7 @@ class NinSnesInstrSet:
                   NinSnesVersion ver,
                   uint32_t offset,
                   uint32_t spcDirAddr,
-                  const std::wstring &name = L"NinSnesInstrSet");
+                  const std::string &name = "NinSnesInstrSet");
   virtual ~NinSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -44,7 +44,7 @@ class NinSnesInstr
                uint32_t theBank,
                uint32_t theInstrNum,
                uint32_t spcDirAddr,
-               const std::wstring &name = L"NinSnesInstr");
+               const std::string &name = "NinSnesInstr");
   virtual ~NinSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/NinSnesScanner.cpp
+++ b/src/main/formats/NinSnesScanner.cpp
@@ -904,8 +904,8 @@ void NinSnesScanner::Scan(RawFile *file, void *info) {
 void NinSnesScanner::SearchForNinSnesFromARAM(RawFile *file) {
   NinSnesVersion version = NINSNES_NONE;
 
-  std::wstring basefilename = RawFile::removeExtFromPath(file->GetFileName());
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : basefilename;
+  std::string basefilename = RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : basefilename;
 
   // get section pointer address
   uint32_t ofsIncSectionPtr;

--- a/src/main/formats/NinSnesScanner.h
+++ b/src/main/formats/NinSnesScanner.h
@@ -6,7 +6,7 @@ class NinSnesScanner:
     public VGMScanner {
  public:
   NinSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~NinSnesScanner(void) {
   }

--- a/src/main/formats/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnesSeq.cpp
@@ -18,7 +18,7 @@ NinSnesSeq::NinSnesSeq(RawFile *file,
                        uint8_t percussion_base,
                        const std::vector<uint8_t> &theVolumeTable,
                        const std::vector<uint8_t> &theDurRateTable,
-                       std::wstring theName)
+                       std::string theName)
     : VGMMultiSectionSeq(NinSnesFormat::name, file, offset, 0, theName), version(ver),
       header(NULL),
       volumeTable(theVolumeTable),
@@ -119,7 +119,7 @@ bool NinSnesSeq::ReadEvent(long stopTime) {
   if (sectionAddress == 0) {
     // End
     if (!IsOffsetUsed(beginOffset)) {
-      header->AddSimpleItem(beginOffset, curOffset - beginOffset, L"Section Playlist End");
+      header->AddSimpleItem(beginOffset, curOffset - beginOffset, "Section Playlist End");
     }
     bContinue = false;
   }
@@ -184,11 +184,11 @@ bool NinSnesSeq::ReadEvent(long stopTime) {
 
     // add event to sequence
     if (!IsOffsetUsed(beginOffset)) {
-      header->AddSimpleItem(beginOffset, curOffset - beginOffset, L"Playlist Jump");
+      header->AddSimpleItem(beginOffset, curOffset - beginOffset, "Playlist Jump");
 
       // add the last event too, if available
       if (curOffset + 1 < 0x10000 && GetShort(curOffset) == 0x0000) {
-        header->AddSimpleItem(curOffset, 2, L"Playlist End");
+        header->AddSimpleItem(curOffset, 2, "Playlist End");
       }
     }
 
@@ -214,14 +214,14 @@ bool NinSnesSeq::ReadEvent(long stopTime) {
 
     // Play the section
     if (!IsOffsetUsed(beginOffset)) {
-      header->AddSimpleItem(beginOffset, curOffset - beginOffset, L"Section Pointer");
+      header->AddSimpleItem(beginOffset, curOffset - beginOffset, "Section Pointer");
     }
 
     NinSnesSection *section = (NinSnesSection *) GetSectionFromOffset(sectionAddress);
     if (section == NULL) {
       section = new NinSnesSection(this, sectionAddress);
       if (!section->Load()) {
-        pRoot->AddLogItem(new LogItem(L"Failed to load section\n", LOG_LEVEL_ERR, L"NinSnesSeq"));
+        pRoot->AddLogItem(new LogItem("Failed to load section\n", LOG_LEVEL_ERR, "NinSnesSeq"));
         return false;
       }
       AddSection(section);
@@ -653,22 +653,22 @@ bool NinSnesSection::GetTrackPointers() {
         }
       }
 
-      std::wstringstream trackName;
-      trackName << L"Track " << (trackIndex + 1);
+      std::stringstream trackName;
+      trackName << "Track " << (trackIndex + 1);
       track = new NinSnesTrack(this, startAddress, 0, trackName.str());
 
       numActiveTracks++;
     }
     else {
       // add an inactive track
-      track = new NinSnesTrack(this, curOffset, 2, L"NULL");
+      track = new NinSnesTrack(this, curOffset, 2, "NULL");
       track->available = false;
     }
     track->shared = &parentSeq->sharedTrackData[trackIndex];
     aTracks.push_back(track);
 
-    wchar_t name[32];
-    swprintf(name, 32, L"Track Pointer #%d", trackIndex + 1);
+    char name[32];
+    snprintf(name, 32, "Track Pointer #%d", trackIndex + 1);
 
     header->AddSimpleItem(curOffset, 2, name);
     curOffset += 2;
@@ -713,7 +713,7 @@ void NinSnesTrackSharedData::ResetVars(void) {
 //  NinSnesTrack
 //  ************
 
-NinSnesTrack::NinSnesTrack(NinSnesSection *parentSection, long offset, long length, const std::wstring &theName)
+NinSnesTrack::NinSnesTrack(NinSnesSection *parentSection, long offset, long length, const std::string &theName)
     : SeqTrack(parentSection->parentSeq, offset, length, theName),
       parentSection(parentSection),
       shared(NULL),
@@ -745,7 +745,7 @@ bool NinSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   NinSnesSeqEventType eventType = (NinSnesSeqEventType) 0;
   std::map<uint8_t, NinSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -755,28 +755,28 @@ bool NinSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0: {
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -784,12 +784,12 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -798,24 +798,24 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_NOP: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
       break;
     }
 
     case EVENT_NOP1: {
       curOffset++;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
       break;
     }
 
@@ -860,7 +860,7 @@ bool NinSnesTrack::ReadEvent(void) {
       OnEventNoteParam:
       // param #0: duration
       shared->spcNoteDuration = statusByte;
-      desc << L"Duration: " << (int) shared->spcNoteDuration;
+      desc << "Duration: " << (int) shared->spcNoteDuration;
 
       // param #1: quantize and velocity (optional)
       if (curOffset + 1 < 0x10000 && GetByte(curOffset) <= 0x7f) {
@@ -872,13 +872,13 @@ bool NinSnesTrack::ReadEvent(void) {
         shared->spcNoteDurRate = parentSeq->durRateTable[durIndex];
         shared->spcNoteVolume = parentSeq->volumeTable[velIndex];
 
-        desc << L"  Quantize: " << (int) durIndex << L" (" << (int) shared->spcNoteDurRate << L"/256)"
-            << L"  Velocity: " << (int) velIndex << L" (" << (int) shared->spcNoteVolume << L"/256)";
+        desc << "  Quantize: " << (int) durIndex << " (" << (int) shared->spcNoteDurRate << "/256)"
+            << "  Velocity: " << (int) velIndex << " (" << (int) shared->spcNoteVolume << "/256)";
       }
 
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Note Param",
+                      "Note Param",
                       desc.str().c_str(),
                       CLR_DURNOTE,
                       ICON_CONTROL);
@@ -891,7 +891,7 @@ bool NinSnesTrack::ReadEvent(void) {
       duration = min(max(duration, (uint8_t) 1), (uint8_t) (shared->spcNoteDuration - 2));
 
       // Note: Konami engine can have volume=0
-      AddNoteByDur(beginOffset, curOffset - beginOffset, noteNumber, shared->spcNoteVolume / 2, duration, L"Note");
+      AddNoteByDur(beginOffset, curOffset - beginOffset, noteNumber, shared->spcNoteVolume / 2, duration, "Note");
       AddTime(shared->spcNoteDuration);
       break;
     }
@@ -899,9 +899,9 @@ bool NinSnesTrack::ReadEvent(void) {
     case EVENT_TIE: {
       uint8_t duration = (shared->spcNoteDuration * shared->spcNoteDurRate) >> 8;
       duration = min(max(duration, (uint8_t) 1), (uint8_t) (shared->spcNoteDuration - 2));
-      desc << L"Duration: " << (int) duration;
+      desc << "Duration: " << (int) duration;
       MakePrevDurNoteEnd(GetTime() + duration);
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str().c_str(), CLR_TIE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE);
       AddTime(shared->spcNoteDuration);
       break;
     }
@@ -932,7 +932,7 @@ bool NinSnesTrack::ReadEvent(void) {
                        noteNumber,
                        shared->spcNoteVolume / 2,
                        duration,
-                       L"Percussion Note");
+                       "Percussion Note");
       AddTime(shared->spcNoteDuration);
       break;
     }
@@ -991,11 +991,11 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t vibratoRate = GetByte(curOffset++);
       uint8_t vibratoDepth = GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) vibratoDelay << L"  Rate: " << (int) vibratoRate << L"  Depth: "
+      desc << "Delay: " << (int) vibratoDelay << "  Rate: " << (int) vibratoRate << "  Depth: "
           << (int) vibratoDepth;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato",
+                      "Vibrato",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -1005,7 +1005,7 @@ bool NinSnesTrack::ReadEvent(void) {
     case EVENT_VIBRATO_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato Off",
+                      "Vibrato Off",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -1022,7 +1022,7 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t fadeLength = GetByte(curOffset++);
       uint8_t newVol = GetByte(curOffset++);
 
-      desc << L"Length: " << (int) fadeLength << L"  Volume: " << (int) newVol;
+      desc << "Length: " << (int) fadeLength << "  Volume: " << (int) newVol;
       AddMastVolSlide(beginOffset, curOffset - beginOffset, fadeLength, newVol / 2);
       break;
     }
@@ -1062,11 +1062,11 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t tremoloRate = GetByte(curOffset++);
       uint8_t tremoloDepth = GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) tremoloDelay << L"  Rate: " << (int) tremoloRate << L"  Depth: "
+      desc << "Delay: " << (int) tremoloDelay << "  Rate: " << (int) tremoloRate << "  Depth: "
           << (int) tremoloDepth;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Tremolo",
+                      "Tremolo",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -1076,7 +1076,7 @@ bool NinSnesTrack::ReadEvent(void) {
     case EVENT_TREMOLO_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Tremolo Off",
+                      "Tremolo Off",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -1105,11 +1105,11 @@ bool NinSnesTrack::ReadEvent(void) {
       shared->loopStartAddress = dest;
       shared->loopCount = times;
 
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest
-          << std::dec << std::setfill(L' ') << std::setw(0) << L"  Times: " << (int) times;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest
+          << std::dec << std::setfill(' ') << std::setw(0) << "  Times: " << (int) times;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pattern Play",
+                      "Pattern Play",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -1117,10 +1117,10 @@ bool NinSnesTrack::ReadEvent(void) {
       // Add the next "END" event to UI
       if (curOffset < 0x10000 && GetByte(curOffset) == parentSeq->STATUS_END) {
         if (shared->loopCount == 0) {
-          AddGenericEvent(curOffset, 1, L"Section End", desc.str().c_str(), CLR_TRACKEND, ICON_TRACKEND);
+          AddGenericEvent(curOffset, 1, "Section End", desc.str().c_str(), CLR_TRACKEND, ICON_TRACKEND);
         }
         else {
-          AddGenericEvent(curOffset, 1, L"Pattern End", desc.str().c_str(), CLR_TRACKEND, ICON_TRACKEND);
+          AddGenericEvent(curOffset, 1, "Pattern End", desc.str().c_str(), CLR_TRACKEND, ICON_TRACKEND);
         }
       }
 
@@ -1130,10 +1130,10 @@ bool NinSnesTrack::ReadEvent(void) {
 
     case EVENT_VIBRATO_FADE: {
       uint8_t fadeLength = GetByte(curOffset++);
-      desc << L"Length: " << (int) fadeLength;
+      desc << "Length: " << (int) fadeLength;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato Fade",
+                      "Vibrato Fade",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -1145,11 +1145,11 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t pitchEnvLength = GetByte(curOffset++);
       int8_t pitchEnvSemitones = (int8_t) GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) pitchEnvDelay << L"  Length: " << (int) pitchEnvLength << L"  Semitones: "
+      desc << "Delay: " << (int) pitchEnvDelay << "  Length: " << (int) pitchEnvLength << "  Semitones: "
           << (int) pitchEnvSemitones;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Envelope (To)",
+                      "Pitch Envelope (To)",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -1161,11 +1161,11 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t pitchEnvLength = GetByte(curOffset++);
       int8_t pitchEnvSemitones = (int8_t) GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) pitchEnvDelay << L"  Length: " << (int) pitchEnvLength << L"  Semitones: "
+      desc << "Delay: " << (int) pitchEnvDelay << "  Length: " << (int) pitchEnvLength << "  Semitones: "
           << (int) pitchEnvSemitones;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Envelope (From)",
+                      "Pitch Envelope (From)",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -1175,7 +1175,7 @@ bool NinSnesTrack::ReadEvent(void) {
     case EVENT_PITCH_ENVELOPE_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Envelope Off",
+                      "Pitch Envelope Off",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -1193,7 +1193,7 @@ bool NinSnesTrack::ReadEvent(void) {
       // In Quintet games (at least in Terranigma), the fine tuning command overwrites the fractional part of instrument tuning.
       // In other words, we cannot calculate the tuning amount without reading the instrument table.
       uint8_t newTuning = GetByte(curOffset++);
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Fine Tuning", desc.str().c_str(), CLR_PITCHBEND, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc.str().c_str(), CLR_PITCHBEND, ICON_CONTROL);
       AddFineTuningNoItem((newTuning / 256.0) * 61.8); // obviously not correct, but better than nothing?
       break;
     }
@@ -1203,25 +1203,25 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t spcEVOL_L = GetByte(curOffset++);
       uint8_t spcEVOL_R = GetByte(curOffset++);
 
-      desc << L"Channels: ";
+      desc << "Channels: ";
       for (int channelNo = MAX_TRACKS - 1; channelNo >= 0; channelNo--) {
         if ((spcEON & (1 << channelNo)) != 0) {
           desc << (int) channelNo;
           parentSeq->aTracks[channelNo]->AddReverbNoItem(40);
         }
         else {
-          desc << L"-";
+          desc << "-";
           parentSeq->aTracks[channelNo]->AddReverbNoItem(0);
         }
       }
 
-      desc << L"  Volume Left: " << (int) spcEVOL_L << L"  Volume Right: " << (int) spcEVOL_R;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      desc << "  Volume Left: " << (int) spcEVOL_L << "  Volume Right: " << (int) spcEVOL_R;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -1230,8 +1230,8 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t spcEFB = GetByte(curOffset++);
       uint8_t spcFIR = GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) spcEDL << L"  Feedback: " << (int) spcEFB << L"  FIR: " << (int) spcFIR;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Param", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Delay: " << (int) spcEDL << "  Feedback: " << (int) spcEFB << "  FIR: " << (int) spcFIR;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -1240,11 +1240,11 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t spcEVOL_L = GetByte(curOffset++);
       uint8_t spcEVOL_R = GetByte(curOffset++);
 
-      desc << L"Length: " << (int) fadeLength << L"  Volume Left: " << (int) spcEVOL_L << L"  Volume Right: "
+      desc << "Length: " << (int) fadeLength << "  Volume Left: " << (int) spcEVOL_L << "  Volume Right: "
           << (int) spcEVOL_R;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Volume Fade",
+                      "Echo Volume Fade",
                       desc.str().c_str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -1256,11 +1256,11 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t pitchSlideLength = GetByte(curOffset++);
       uint8_t pitchSlideTargetNote = GetByte(curOffset++);
 
-      desc << L"Delay: " << (int) pitchSlideDelay << L"  Length: " << (int) pitchSlideLength << L"  Note: "
+      desc << "Delay: " << (int) pitchSlideDelay << "  Length: " << (int) pitchSlideLength << "  Note: "
           << (int) (pitchSlideTargetNote - 0x80);
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Slide",
+                      "Pitch Slide",
                       desc.str().c_str(),
                       CLR_PITCHBEND,
                       ICON_CONTROL);
@@ -1271,10 +1271,10 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t percussionBase = GetByte(curOffset++);
       parentSeq->spcPercussionBase = percussionBase;
 
-      desc << L"Percussion Base: " << (int) percussionBase;
+      desc << "Percussion Base: " << (int) percussionBase;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Percussion Base",
+                      "Percussion Base",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -1288,7 +1288,7 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t newProgNum = GetByte(curOffset++);
       uint8_t adsr1 = GetByte(curOffset++);
       uint8_t adsr2 = GetByte(curOffset++);
-      AddProgramChange(beginOffset, curOffset - beginOffset, newProgNum, true, L"Program Change & ADSR");
+      AddProgramChange(beginOffset, curOffset - beginOffset, newProgNum, true, "Program Change & ADSR");
       break;
     }
 
@@ -1297,7 +1297,7 @@ bool NinSnesTrack::ReadEvent(void) {
       // KONAMI EVENTS START >>
 
     case EVENT_KONAMI_LOOP_START: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
       shared->konamiLoopStart = curOffset;
       shared->konamiLoopCount = 0;
       break;
@@ -1308,9 +1308,9 @@ bool NinSnesTrack::ReadEvent(void) {
       int8_t volumeDelta = GetByte(curOffset++);
       int8_t pitchDelta = GetByte(curOffset++);
 
-      desc << L"Times: " << (int) times << L"  Volume Delta: " << (int) volumeDelta << L"  Pitch Delta: "
-          << (int) pitchDelta << L"/16 semitones";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      desc << "Times: " << (int) times << "  Volume Delta: " << (int) volumeDelta << "  Pitch Delta: "
+          << (int) pitchDelta << "/16 semitones";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       shared->konamiLoopCount++;
       if (shared->konamiLoopCount != times) {
@@ -1325,9 +1325,9 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t adsr1 = GetByte(curOffset++);
       uint8_t adsr2 = GetByte(curOffset++);
       uint8_t gain = GetByte(curOffset++);
-      desc << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << L"ADSR(1): $" << adsr1
-          << L"  ADSR(2): $" << adsr2 << L"  GAIN: $" << gain;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR/GAIN", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << "ADSR(1): $" << adsr1
+          << "  ADSR(2): $" << adsr2 << "  GAIN: $" << gain;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR/GAIN", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -1338,25 +1338,25 @@ bool NinSnesTrack::ReadEvent(void) {
     case EVENT_LEMMINGS_NOTE_PARAM: {
       // param #0: duration
       shared->spcNoteDuration = statusByte;
-      desc << L"Duration: " << (int) shared->spcNoteDuration;
+      desc << "Duration: " << (int) shared->spcNoteDuration;
 
       // param #1: quantize (optional)
       if (curOffset + 1 < 0x10000 && GetByte(curOffset) <= 0x7f) {
         uint8_t durByte = GetByte(curOffset++);
         shared->spcNoteDurRate = (durByte << 1) + (durByte >> 1) + (durByte & 1); // approx percent?
-        desc << L"  Quantize: " << durByte << L" (" << shared->spcNoteDurRate << L"/256)";
+        desc << "  Quantize: " << durByte << " (" << shared->spcNoteDurRate << "/256)";
 
         // param #2: velocity (optional)
         if (curOffset + 1 < 0x10000 && GetByte(curOffset) <= 0x7f) {
           uint8_t velByte = GetByte(curOffset++);
           shared->spcNoteVolume = velByte << 1;
-          desc << L"  Velocity: " << velByte << L" (" << shared->spcNoteVolume << L"/256)";
+          desc << "  Velocity: " << velByte << " (" << shared->spcNoteVolume << "/256)";
         }
       }
 
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Note Param",
+                      "Note Param",
                       desc.str().c_str(),
                       CLR_DURNOTE,
                       ICON_CONTROL);
@@ -1374,7 +1374,7 @@ bool NinSnesTrack::ReadEvent(void) {
 
       // param #0: duration
       shared->spcNoteDuration = statusByte;
-      desc << L"Duration: " << (int) shared->spcNoteDuration;
+      desc << "Duration: " << (int) shared->spcNoteDuration;
 
       // param #1,2...: quantize/velocity (optional)
       while (curOffset + 1 < 0x10000 && GetByte(curOffset) <= 0x7f) {
@@ -1382,18 +1382,18 @@ bool NinSnesTrack::ReadEvent(void) {
         if (noteParam < 0x40) { // 00..3f
           uint8_t durIndex = noteParam & 0x3f;
           shared->spcNoteDurRate = parentSeq->intelliDurVolTable[durIndex];
-          desc << L"  Quantize: " << durIndex << L" (" << shared->spcNoteDurRate << L"/256)";
+          desc << "  Quantize: " << durIndex << " (" << shared->spcNoteDurRate << "/256)";
         }
         else { // 40..7f
           uint8_t velIndex = noteParam & 0x3f;
           shared->spcNoteVolume = parentSeq->intelliDurVolTable[velIndex];
-          desc << L"  Velocity: " << velIndex << L" (" << shared->spcNoteVolume << L"/256)";
+          desc << "  Velocity: " << velIndex << " (" << shared->spcNoteVolume << "/256)";
         }
       }
 
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Note Param",
+                      "Note Param",
                       desc.str().c_str(),
                       CLR_DURNOTE,
                       ICON_CONTROL);
@@ -1401,23 +1401,23 @@ bool NinSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_INTELLI_ECHO_ON: {
-      AddReverb(beginOffset, curOffset - beginOffset, 40, L"Echo On");
+      AddReverb(beginOffset, curOffset - beginOffset, 40, "Echo On");
       break;
     }
 
     case EVENT_INTELLI_ECHO_OFF: {
-      AddReverb(beginOffset, curOffset - beginOffset, 0, L"Echo Off");
+      AddReverb(beginOffset, curOffset - beginOffset, 0, "Echo Off");
       break;
     }
 
     case EVENT_INTELLI_LEGATO_ON: {
       // TODO: cancel keyoff of note (i.e. full duration)
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Legato On", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Legato On", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
       break;
     }
 
     case EVENT_INTELLI_LEGATO_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Legato Off", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Legato Off", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
       break;
     }
 
@@ -1425,8 +1425,8 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t offset = GetByte(curOffset++);
       uint16_t dest = curOffset + offset;
 
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Conditional Jump (Short)", desc.str().c_str(), CLR_MISC);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump (Short)", desc.str().c_str(), CLR_MISC);
 
       // condition for branch has not been researched yet
       curOffset = dest;
@@ -1437,8 +1437,8 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t offset = GetByte(curOffset++);
       uint16_t dest = curOffset + offset;
 
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Jump (Short)", desc.str().c_str(), CLR_MISC);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Jump (Short)", desc.str().c_str(), CLR_MISC);
 
       curOffset = dest;
       break;
@@ -1448,21 +1448,21 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t param = GetByte(curOffset++);
       if (param < 0xf0) {
         // wait for APU port #2
-        desc << L"Value: " << param;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Wait for APU Port #2", desc.str(), CLR_CHANGESTATE);
+        desc << "Value: " << param;
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Wait for APU Port #2", desc.str(), CLR_CHANGESTATE);
       }
       else {
         // set/clear bitflag in $ca
         uint8_t bit = param & 7;
         bool bitValue = (param & 8) == 0;
 
-        desc << L"Status: " << (bitValue ? L"On" : L"Off");
+        desc << "Status: " << (bitValue ? "On" : "Off");
         switch (bit) {
           case 0:
             parentSeq->intelliUseCustomPercTable = bitValue;
             AddGenericEvent(beginOffset,
                             curOffset - beginOffset,
-                            L"Use Custom Percussion Table",
+                            "Use Custom Percussion Table",
                             desc.str(),
                             CLR_CHANGESTATE);
             break;
@@ -1471,13 +1471,13 @@ bool NinSnesTrack::ReadEvent(void) {
             parentSeq->intelliUseCustomNoteParam = bitValue;
             AddGenericEvent(beginOffset,
                             curOffset - beginOffset,
-                            L"Use Custom Note Param",
+                            "Use Custom Note Param",
                             desc.str(),
                             CLR_CHANGESTATE);
             break;
 
           default:
-            AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+            AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
         }
       }
       break;
@@ -1485,8 +1485,8 @@ bool NinSnesTrack::ReadEvent(void) {
 
     case EVENT_INTELLI_WRITE_APU_PORT: {
       uint8_t value = GetByte(curOffset++);
-      desc << L"Value: " << value;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Write APU Port", desc.str(), CLR_CHANGESTATE);
+      desc << "Value: " << value;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Write APU Port", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
@@ -1502,15 +1502,15 @@ bool NinSnesTrack::ReadEvent(void) {
         parentSeq->intelliVoiceParamTableSize = param;
         parentSeq->intelliVoiceParamTable = curOffset;
         curOffset += parentSeq->intelliVoiceParamTableSize * 4;
-        desc << L"Number of Items: " << parentSeq->intelliVoiceParamTableSize;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Voice Param Table", desc.str(), CLR_MISC);
+        desc << "Number of Items: " << parentSeq->intelliVoiceParamTableSize;
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Voice Param Table", desc.str(), CLR_MISC);
       }
       else {
         if (parentSeq->version == NINSNES_INTELLI_FE3 || parentSeq->version == NINSNES_INTELLI_TA) {
           uint8_t instrNum = param & 0x3f;
           curOffset += 6;
-          desc << L"Instrument: " << instrNum;
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Overwrite Instrument Region", desc.str(), CLR_MISC);
+          desc << "Instrument: " << instrNum;
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Overwrite Instrument Region", desc.str(), CLR_MISC);
         }
         else {
           AddUnknown(beginOffset, curOffset - beginOffset);
@@ -1521,7 +1521,7 @@ bool NinSnesTrack::ReadEvent(void) {
 
     case EVENT_INTELLI_LOAD_VOICE_PARAM: {
       uint8_t paramIndex = GetByte(curOffset++);
-      desc << L"Index: " << paramIndex;
+      desc << "Index: " << paramIndex;
 
       if (paramIndex < parentSeq->intelliVoiceParamTableSize) {
         uint16_t addrVoiceParam = parentSeq->intelliVoiceParamTable + (paramIndex * 4);
@@ -1582,7 +1582,7 @@ bool NinSnesTrack::ReadEvent(void) {
 
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Load Voice Param",
+                      "Load Voice Param",
                       desc.str(),
                       CLR_PROGCHANGE,
                       ICON_PROGCHANGE);
@@ -1592,9 +1592,9 @@ bool NinSnesTrack::ReadEvent(void) {
     case EVENT_INTELLI_ADSR: {
       uint8_t adsr1 = GetByte(curOffset++);
       uint8_t adsr2 = GetByte(curOffset++);
-      desc << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << L"ADSR(1): $" << adsr1
-          << L"  ADSR(2): $" << adsr2;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << "ADSR(1): $" << adsr1
+          << "  ADSR(2): $" << adsr2;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -1603,21 +1603,21 @@ bool NinSnesTrack::ReadEvent(void) {
       uint8_t sustain_rate = GetByte(curOffset++);
       uint8_t sustain_level = GetByte(curOffset++);
 	  uint8_t adsr2 = (sustain_level << 5) | sustain_rate;
-      desc << L"ADSR(1): $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << adsr1
-          << L"  Sustain Rate: " << std::dec << sustain_rate << L"  Sustain Level: " << sustain_level
-          << L"  (ADSR(2): $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << adsr2 << L")";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "ADSR(1): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << adsr1
+          << "  Sustain Rate: " << std::dec << sustain_rate << "  Sustain Level: " << sustain_level
+          << "  (ADSR(2): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << adsr2 << ")";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_INTELLI_GAIN_SUSTAIN_TIME_AND_RATE: {
       uint8_t sustainDurRate = GetByte(curOffset++);
       uint8_t sustainGAIN = GetByte(curOffset++);
-      desc << L"Duration for Sustain: " << sustainDurRate << L"/256" << std::hex << std::setfill(L'0') << std::setw(2)
-          << std::uppercase << L"  GAIN for Sustain: $" << sustainGAIN;
+      desc << "Duration for Sustain: " << sustainDurRate << "/256" << std::hex << std::setfill('0') << std::setw(2)
+          << std::uppercase << "  GAIN for Sustain: $" << sustainGAIN;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"GAIN Sustain Time/Rate",
+                      "GAIN Sustain Time/Rate",
                       desc.str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -1626,8 +1626,8 @@ bool NinSnesTrack::ReadEvent(void) {
 
     case EVENT_INTELLI_GAIN_SUSTAIN_TIME: {
       uint8_t sustainDurRate = GetByte(curOffset++);
-      desc << L"Duration for Sustain: " << sustainDurRate << L"/256";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"GAIN Sustain Time", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << "Duration for Sustain: " << sustainDurRate << "/256";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "GAIN Sustain Time", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -1635,8 +1635,8 @@ bool NinSnesTrack::ReadEvent(void) {
       // This event will update GAIN immediately,
       // however, note that Fire Emblem 4 does not switch to GAIN mode until note off.
       uint8_t gain = GetByte(curOffset++);
-      desc << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << L"  GAIN: $" << gain;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"GAIN (Release Rate)", desc.str(), CLR_ADSR, ICON_CONTROL);
+      desc << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << "  GAIN: $" << gain;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "GAIN (Release Rate)", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -1670,28 +1670,28 @@ bool NinSnesTrack::ReadEvent(void) {
           }
 
           if (param == 0x80) {
-            desc << L"Status: " << (bitValue ? L"On" : L"Off");
+            desc << "Status: " << (bitValue ? "On" : "Off");
             AddGenericEvent(beginOffset,
                             curOffset - beginOffset,
-                            L"Use Custom Note Param",
+                            "Use Custom Note Param",
                             desc.str(),
                             CLR_CHANGESTATE);
           }
           else if (param == 0x40) {
-            desc << L"Status: " << (bitValue ? L"On" : L"Off");
+            desc << "Status: " << (bitValue ? "On" : "Off");
             AddGenericEvent(beginOffset,
                             curOffset - beginOffset,
-                            L"Use Custom Percussion Table",
+                            "Use Custom Percussion Table",
                             desc.str(),
                             CLR_CHANGESTATE);
           }
           else {
-            desc << L"Value: $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << param;
+            desc << "Value: $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << param;
             if (type == 0x01) {
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"Set Flags On", desc.str(), CLR_CHANGESTATE);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "Set Flags On", desc.str(), CLR_CHANGESTATE);
             }
             else {
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"Set Flags Off", desc.str(), CLR_CHANGESTATE);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "Set Flags Off", desc.str(), CLR_CHANGESTATE);
             }
           }
 
@@ -1700,13 +1700,13 @@ bool NinSnesTrack::ReadEvent(void) {
 
         case 0x03:
           // TODO: cancel keyoff of note (i.e. full duration)
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Legato On", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Legato On", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
           break;
 
         case 0x04:
           AddGenericEvent(beginOffset,
                           curOffset - beginOffset,
-                          L"Legato Off",
+                          "Legato Off",
                           desc.str(),
                           CLR_PORTAMENTO,
                           ICON_CONTROL);
@@ -1750,11 +1750,11 @@ bool NinSnesTrack::ReadEvent(void) {
       // << INTELLIGENT SYSTEMS EVENTS END
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-      pRoot->AddLogItem(new LogItem(std::wstring(L"Unknown Event - ") + desc.str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      pRoot->AddLogItem(new LogItem(std::string("Unknown Event - ") + desc.str(),
                                     LOG_LEVEL_ERR,
-                                    std::wstring(L"NinSnesSeq")));
+                                    std::string("NinSnesSeq")));
       bContinue = false;
       break;
   }
@@ -1763,10 +1763,10 @@ bool NinSnesTrack::ReadEvent(void) {
   // (because it often gets interrupted by the end of other track)
   if (curOffset + 1 <= 0x10000 && statusByte != parentSeq->STATUS_END && GetByte(curOffset) == parentSeq->STATUS_END) {
     if (shared->loopCount == 0) {
-      AddGenericEvent(curOffset, 1, L"Section End", desc.str().c_str(), CLR_TRACKEND, ICON_TRACKEND);
+      AddGenericEvent(curOffset, 1, "Section End", desc.str().c_str(), CLR_TRACKEND, ICON_TRACKEND);
     }
     else {
-      AddGenericEvent(curOffset, 1, L"Pattern End", desc.str().c_str(), CLR_TRACKEND, ICON_TRACKEND);
+      AddGenericEvent(curOffset, 1, "Pattern End", desc.str().c_str(), CLR_TRACKEND, ICON_TRACKEND);
     }
   }
 

--- a/src/main/formats/NinSnesSeq.h
+++ b/src/main/formats/NinSnesSeq.h
@@ -113,7 +113,7 @@ class NinSnesSeq:
              uint8_t percussion_base = 0,
              const std::vector<uint8_t> &theVolumeTable = std::vector<uint8_t>(),
              const std::vector<uint8_t> &theDurRateTable = std::vector<uint8_t>(),
-             std::wstring theName = L"NinSnes Seq");
+             std::string theName = "NinSnes Seq");
   virtual ~NinSnesSeq();
 
   virtual bool GetHeaderInfo();
@@ -185,7 +185,7 @@ class NinSnesTrack
     : public SeqTrack {
  public:
   NinSnesTrack
-      (NinSnesSection *parentSection, long offset = 0, long length = 0, const std::wstring &theName = L"NinSnes Track");
+      (NinSnesSection *parentSection, long offset = 0, long length = 0, const std::string &theName = "NinSnes Track");
 
   virtual void ResetVars(void);
   virtual bool ReadEvent(void);

--- a/src/main/formats/OrgSeq.cpp
+++ b/src/main/formats/OrgSeq.cpp
@@ -14,7 +14,7 @@ bool OrgSeq::GetHeaderInfo(void) {
   waitTime = GetShort(dwOffset + 6);
   beatsPerMeasure = GetByte(dwOffset + 8);
   SetPPQN(GetByte(dwOffset + 9));
-  name = L"Org Seq";
+  name = "Org Seq";
 
   uint32_t notesSoFar = 0;        //this must be used to determine the length of the entire seq
 

--- a/src/main/formats/PS1Seq.cpp
+++ b/src/main/formats/PS1Seq.cpp
@@ -15,7 +15,7 @@ PS1Seq::~PS1Seq(void) {
 
 
 bool PS1Seq::GetHeaderInfo(void) {
-  name() = L"PS1 SEQ";
+  name() = "PS1 SEQ";
 
   SetPPQN(GetShortBE(offset() + 8));
   nNumTracks = 16;
@@ -25,10 +25,10 @@ bool PS1Seq::GetHeaderInfo(void) {
   if (numer == 0 || numer > 32)                //sanity check
     return false;
 
-  VGMHeader *seqHeader = VGMSeq::AddHeader(offset(), 11, L"Sequence Header");
-  seqHeader->AddSimpleItem(offset(), 4, L"ID");
-  seqHeader->AddSimpleItem(offset() + 0x04, 4, L"Version");
-  seqHeader->AddSimpleItem(offset() + 0x08, 2, L"Resolution of quarter note");
+  VGMHeader *seqHeader = VGMSeq::AddHeader(offset(), 11, "Sequence Header");
+  seqHeader->AddSimpleItem(offset(), 4, "ID");
+  seqHeader->AddSimpleItem(offset() + 0x04, 4, "Version");
+  seqHeader->AddSimpleItem(offset() + 0x08, 2, "Resolution of quarter note");
   seqHeader->AddTempo(offset() + 0x0A, 3);
   seqHeader->AddSig(offset() + 0x0D, 2); // Rhythm (Numerator) and Rhythm (Denominator) (2^n)
 
@@ -39,7 +39,7 @@ bool PS1Seq::GetHeaderInfo(void) {
       delete newPS1Seq;
     }
     //short relOffset = (short)GetShortBE(curOffset);
-    //AddGenericEvent(beginOffset, 4, L"Jump Relative", NULL, BG_CLR_PINK);
+    //AddGenericEvent(beginOffset, 4, "Jump Relative", NULL, BG_CLR_PINK);
     //curOffset += relOffset;
   }
   else {
@@ -72,7 +72,7 @@ bool PS1Seq::ReadEvent(void) {
   //if (status_byte == 0)				//Jump Relative
   //{
   //	short relOffset = (short)GetShortBE(curOffset);
-  //	AddGenericEvent(beginOffset, 4, L"Jump Relative", NULL, BG_CLR_PINK);
+  //	AddGenericEvent(beginOffset, 4, "Jump Relative", NULL, BG_CLR_PINK);
   //	curOffset += relOffset;
 
   //	curOffset += 4;		//skip the first 4 bytes (no idea)
@@ -107,11 +107,11 @@ bool PS1Seq::ReadEvent(void) {
       }
 
       if (no_next_data) {
-        std::wostringstream message;
-        message << L"SEQ parser has reached zero-filled data at 0x" << std::hex << std::uppercase
+        std::ostringstream message;
+        message << "SEQ parser has reached zero-filled data at 0x" << std::hex << std::uppercase
                 << beginOffset
-                << L". Parser terminates the analysis because it is considered to be out of bounds of the song data.";
-        pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_WARN, L"PS1Seq"));
+                << ". Parser terminates the analysis because it is considered to be out of bounds of the song data.";
+        pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_WARN, "PS1Seq"));
         return false;
       }
     }
@@ -144,13 +144,13 @@ bool PS1Seq::ReadEvent(void) {
       {
         //bank select
         case 0 :
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Bank Select", L"", CLR_MISC);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Bank Select", "", CLR_MISC);
           AddBankSelectNoItem(value);
           break;
 
         //data entry
         case 6 :
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN Data Entry", L"", CLR_MISC);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
@@ -185,15 +185,15 @@ bool PS1Seq::ReadEvent(void) {
         case 98 :
           switch (value) {
             case 20 :
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN 1 #20", L"", CLR_MISC);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #20", "", CLR_MISC);
               break;
 
             case 30 :
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN 1 #30", L"", CLR_MISC);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #30", "", CLR_MISC);
               break;
 
             default:
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN 1", L"", CLR_MISC);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1", "", CLR_MISC);
               break;
           }
 
@@ -206,15 +206,15 @@ bool PS1Seq::ReadEvent(void) {
         case 99 :
           switch (value) {
             case 20 :
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Start", L"", CLR_LOOP);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", CLR_LOOP);
               break;
 
             case 30 :
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", L"", CLR_LOOP);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", CLR_LOOP);
               break;
 
             default:
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"NRPN 2", L"", CLR_MISC);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 2", "", CLR_MISC);
               break;
           }
 
@@ -225,7 +225,7 @@ bool PS1Seq::ReadEvent(void) {
 
         //(0x64) RPN 1 (LSB), no effect?
         case 100 :
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"RPN 1", L"", CLR_MISC);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "RPN 1", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
@@ -233,7 +233,7 @@ bool PS1Seq::ReadEvent(void) {
 
         //(0x65) RPN 2 (MSB), no effect?
         case 101 :
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"RPN 2", L"", CLR_MISC);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "RPN 2", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
@@ -241,14 +241,14 @@ bool PS1Seq::ReadEvent(void) {
 
         //reset all controllers
         case 121 :
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reset All Controllers", L"", CLR_MISC);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Reset All Controllers", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
           break;
 
         default:
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Control Event", L"", CLR_UNKNOWN);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Control Event", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->AddControllerEvent(channel, controlNum, value);
           }
@@ -284,7 +284,7 @@ bool PS1Seq::ReadEvent(void) {
             return false;
 
           default :
-            AddUnknown(beginOffset, curOffset - beginOffset, L"Meta Event");
+            AddUnknown(beginOffset, curOffset - beginOffset, "Meta Event");
             return false;
         }
       }

--- a/src/main/formats/PSXSPU.cpp
+++ b/src/main/formats/PSXSPU.cpp
@@ -114,8 +114,8 @@ bool PSXSampColl::GetSampleInfo() {
           i += 16;
         }
 
-        wostringstream name;
-        name << L"Sample " << samples.size();
+        ostringstream name;
+        name << "Sample " << samples.size();
         PSXSamp *samp = new PSXSamp(this,
                                     beginOffset,
                                     i - beginOffset,
@@ -151,8 +151,8 @@ bool PSXSampColl::GetSampleInfo() {
         offSampEnd += 16;
       } while (!lastBlock);
 
-      wostringstream name;
-      name << L"Sample " << sampleIndex;
+      ostringstream name;
+      name << "Sample " << sampleIndex;
       PSXSamp *samp = new PSXSamp(this,
                                   dwOffset + it->offset,
                                   it->size,
@@ -272,7 +272,7 @@ const std::vector<PSXSampColl *> PSXSampColl::SearchForPSXADPCMs(RawFile *file, 
 
 PSXSamp::PSXSamp(VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t dataOffset,
                  uint32_t dataLen, uint8_t nChannels, uint16_t theBPS,
-                 uint32_t theRate, wstring name, bool bSetloopOnConversion)
+                 uint32_t theRate, string name, bool bSetloopOnConversion)
     : VGMSamp(sampColl, offset, length, dataOffset, dataLen, nChannels, theBPS, theRate, name),
       bSetLoopOnConversion(bSetloopOnConversion) {
   bPSXLoopInfoPrioritizing = true;
@@ -298,13 +298,13 @@ void PSXSamp::ConvertToStdWave(uint8_t *buf) {
   for (uint32_t k = 0; k < dataLength; k += 0x10)                //for every adpcm chunk
   {
     if (dwOffset + k + 16 > vgmfile->GetEndOffset()) {
-      std::wstring log = L"\"" + name + L"\" unexpected EOF.";
-      pRoot->AddLogItem(new LogItem(log.c_str(), LOG_LEVEL_WARN, L"PSXSamp"));
+      std::string log = "\"" + name + "\" unexpected EOF.";
+      pRoot->AddLogItem(new LogItem(log.c_str(), LOG_LEVEL_WARN, "PSXSamp"));
       break;
     }
     else if (!addrOutOfVirtFile && k + 16 > unLength) {
-      std::wstring log = L"\"" + name + L"\" unexpected end of PSXSamp.";
-      pRoot->AddLogItem(new LogItem(log.c_str(), LOG_LEVEL_WARN, L"PSXSamp"));
+      std::string log = "\"" + name + "\" unexpected end of PSXSamp.";
+      pRoot->AddLogItem(new LogItem(log.c_str(), LOG_LEVEL_WARN, "PSXSamp"));
       addrOutOfVirtFile = true;
     }
 

--- a/src/main/formats/PSXSPU.h
+++ b/src/main/formats/PSXSPU.h
@@ -160,7 +160,7 @@ void PSXConvADSR(T *realADSR,
       ((Sm & ~0x01) != 0) ||
       ((Sd & ~0x01) != 0) ||
       ((Sr & ~0x7F) != 0)) {
-    pRoot->AddLogItem(new LogItem(L"PSX ADSR Out Of Range.", LOG_LEVEL_ERR, L"PSXConvADSR"));
+    pRoot->AddLogItem(new LogItem("PSX ADSR Out Of Range.", LOG_LEVEL_ERR, "PSXConvADSR"));
     return;
   }
 
@@ -380,7 +380,7 @@ class PSXSamp
  public:
   PSXSamp(VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t dataOffset,
           uint32_t dataLen, uint8_t nChannels, uint16_t theBPS,
-          uint32_t theRate, std::wstring name, bool bSetLoopOnConversion = true);
+          uint32_t theRate, std::string name, bool bSetLoopOnConversion = true);
   virtual ~PSXSamp(void);
 
   // ratio of space conserved.  should generally be > 1

--- a/src/main/formats/PandoraBoxSnesInstr.cpp
+++ b/src/main/formats/PandoraBoxSnesInstr.cpp
@@ -13,7 +13,7 @@ PandoraBoxSnesInstrSet::PandoraBoxSnesInstrSet(RawFile *file,
                                                uint16_t addrGlobalInstrTable,
                                                uint8_t globalInstrumentCount,
                                                const std::map<uint8_t, uint16_t> &instrADSRHints,
-                                               const std::wstring &name) :
+                                               const std::string &name) :
     VGMInstrSet(PandoraBoxSnesFormat::name, file, addrLocalInstrTable, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrLocalInstrTable(addrLocalInstrTable),
@@ -78,8 +78,8 @@ bool PandoraBoxSnesInstrSet::GetInstrPointers() {
       adsr = instrADSRHints[srcn];
     }
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << srcn;
+    std::ostringstream instrName;
+    instrName << "Instrument " << srcn;
     PandoraBoxSnesInstr *newInstr =
         new PandoraBoxSnesInstr(this, version, addrLocalInstrItem, instrNum, srcn, spcDirAddr, adsr, instrName.str());
     aInstrs.push_back(newInstr);
@@ -110,7 +110,7 @@ PandoraBoxSnesInstr::PandoraBoxSnesInstr(VGMInstrSet *instrSet,
                                          uint8_t srcn,
                                          uint32_t spcDirAddr,
                                          uint16_t adsr,
-                                         const std::wstring &name) :
+                                         const std::string &name) :
     VGMInstr(instrSet, offset, 1, 0, theInstrNum, name), version(ver),
     spcDirAddr(spcDirAddr),
     srcn(srcn),
@@ -151,7 +151,7 @@ PandoraBoxSnesRgn::PandoraBoxSnesRgn(PandoraBoxSnesInstr *instr,
   uint8_t adsr1 = adsr >> 8;
   uint8_t adsr2 = adsr & 0xff;
 
-  AddSimpleItem(dwOffset, 1, L"Global Instrument #");
+  AddSimpleItem(dwOffset, 1, "Global Instrument #");
 
   sampNum = srcn;
   unityKey = 45; // o3a = $1000

--- a/src/main/formats/PandoraBoxSnesInstr.h
+++ b/src/main/formats/PandoraBoxSnesInstr.h
@@ -18,7 +18,7 @@ class PandoraBoxSnesInstrSet:
                          uint16_t addrGlobalInstrTable,
                          uint8_t globalInstrumentCount,
                          const std::map<uint8_t, uint16_t> &instrADSRHints = std::map<uint8_t, uint16_t>(),
-                         const std::wstring &name = L"PandoraBoxSnesInstrSet");
+                         const std::string &name = "PandoraBoxSnesInstrSet");
   virtual ~PandoraBoxSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -50,7 +50,7 @@ class PandoraBoxSnesInstr
                       uint8_t srcn,
                       uint32_t spcDirAddr,
                       uint16_t adsr = 0x8fe0,
-                      const std::wstring &name = L"PandoraBoxSnesInstr");
+                      const std::string &name = "PandoraBoxSnesInstr");
   virtual ~PandoraBoxSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/PandoraBoxSnesScanner.cpp
+++ b/src/main/formats/PandoraBoxSnesScanner.cpp
@@ -92,7 +92,7 @@ void PandoraBoxSnesScanner::Scan(RawFile *file, void *info) {
 
 void PandoraBoxSnesScanner::SearchForPandoraBoxSnesFromARAM(RawFile *file) {
   PandoraBoxSnesVersion version = PANDORABOXSNES_NONE;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   uint32_t ofsLoadSeq;
   uint16_t addrSeqHeader;

--- a/src/main/formats/PandoraBoxSnesScanner.h
+++ b/src/main/formats/PandoraBoxSnesScanner.h
@@ -6,7 +6,7 @@ class PandoraBoxSnesScanner:
     public VGMScanner {
  public:
   PandoraBoxSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~PandoraBoxSnesScanner(void) {
   }

--- a/src/main/formats/PandoraBoxSnesSeq.cpp
+++ b/src/main/formats/PandoraBoxSnesSeq.cpp
@@ -18,7 +18,7 @@ const uint8_t PandoraBoxSnesSeq::VOLUME_TABLE[16] = {
 PandoraBoxSnesSeq::PandoraBoxSnesSeq(RawFile *file,
                                      PandoraBoxSnesVersion ver,
                                      uint32_t seqdataOffset,
-                                     std::wstring newName)
+                                     std::string newName)
     : VGMSeq(PandoraBoxSnesFormat::name, file, seqdataOffset, 0, newName), version(ver) {
   bLoadTickByTick = true;
   bAllowDiscontinuousTrackData = true;
@@ -47,8 +47,8 @@ bool PandoraBoxSnesSeq::GetHeaderInfo(void) {
     return false;
   }
 
-  AddSimpleItem(dwOffset + 6, 1, L"Tempo");
-  AddSimpleItem(dwOffset + 7, 1, L"Timebase");
+  AddSimpleItem(dwOffset + 6, 1, "Tempo");
+  AddSimpleItem(dwOffset + 7, 1, "Timebase");
 
   uint8_t timebase = GetByte(dwOffset + 7);
   assert((timebase % 4) == 0);
@@ -58,12 +58,12 @@ bool PandoraBoxSnesSeq::GetHeaderInfo(void) {
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t ofsTrackStart = GetShort(curOffset);
     if (ofsTrackStart != 0xffff) {
-      std::wstringstream trackName;
-      trackName << L"Track Pointer " << (trackIndex + 1);
+      std::stringstream trackName;
+      trackName << "Track Pointer " << (trackIndex + 1);
       header->AddSimpleItem(curOffset, 2, trackName.str());
     }
     else {
-      header->AddSimpleItem(curOffset, 2, L"NULL");
+      header->AddSimpleItem(curOffset, 2, "NULL");
     }
     curOffset += 2;
   }
@@ -173,7 +173,7 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   PandoraBoxSnesSeqEventType eventType = (PandoraBoxSnesSeqEventType) 0;
   std::map<uint8_t, PandoraBoxSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -183,27 +183,27 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -211,12 +211,12 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -225,18 +225,18 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_NOP: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP", desc.str(), CLR_MISC, ICON_BINARY);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str(), CLR_MISC, ICON_BINARY);
       break;
     }
 
@@ -277,7 +277,7 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
         if (prevNoteSlurred && key == prevNoteKey) {
           // tie
           MakePrevDurNoteEnd(GetTime() + dur);
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str(), CLR_TIE, ICON_NOTE);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str(), CLR_TIE, ICON_NOTE);
         }
         else {
           // note
@@ -293,15 +293,15 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
 
     case EVENT_OCTAVE: {
       octave = (statusByte - 0x40);
-      desc << L"Octave: " << octave;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Octave", desc.str(), CLR_CHANGESTATE);
+      desc << "Octave: " << octave;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Octave", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
     case EVENT_QUANTIZE: {
       spcNoteQuantize = (statusByte - 0x48);
-      desc << L"Length: " << spcNoteQuantize << L"/8";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Duration Rate", desc.str(), CLR_DURNOTE);
+      desc << "Length: " << spcNoteQuantize << "/8";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str(), CLR_DURNOTE);
       break;
     }
 
@@ -309,9 +309,9 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
       uint8_t newVolumeIndex = (statusByte - 0x50);
 
       uint8_t newVolume = GetVolume(newVolumeIndex);
-      desc << L"Volume Index: " << spcVolumeIndex << L" (" << newVolume << L")";
+      desc << "Volume Index: " << spcVolumeIndex << " (" << newVolume << ")";
 
-      AddVol(beginOffset, curOffset - beginOffset, newVolume, L"Volume From Table");
+      AddVol(beginOffset, curOffset - beginOffset, newVolume, "Volume From Table");
       break;
     }
 
@@ -330,8 +330,8 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
 
     case EVENT_TUNING: {
       int8_t newTuning = GetByte(curOffset++);
-      desc << L"Hearz: " << (newTuning >= 0 ? L"+" : L"") << newTuning << L" Hz";
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Fine Tuning", desc.str(), CLR_TRANSPOSE, ICON_CONTROL);
+      desc << "Hearz: " << (newTuning >= 0 ? "+" : "") << newTuning << " Hz";
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc.str(), CLR_TRANSPOSE, ICON_CONTROL);
       break;
     }
 
@@ -370,9 +370,9 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
       }
 
       uint8_t newVolume = GetVolume(spcVolumeIndex);
-      desc << L"Volume Index: " << spcVolumeIndex << L" (" << newVolume << L")";
+      desc << "Volume Index: " << spcVolumeIndex << " (" << newVolume << ")";
 
-      AddVol(beginOffset, curOffset - beginOffset, newVolume, L"Increase Volume");
+      AddVol(beginOffset, curOffset - beginOffset, newVolume, "Increase Volume");
       break;
     }
 
@@ -382,9 +382,9 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
       }
 
       uint8_t newVolume = GetVolume(spcVolumeIndex);
-      desc << L"Volume Index: " << spcVolumeIndex << L" (" << newVolume << L")";
+      desc << "Volume Index: " << spcVolumeIndex << " (" << newVolume << ")";
 
-      AddVol(beginOffset, curOffset - beginOffset, newVolume, L"Decrease Volume");
+      AddVol(beginOffset, curOffset - beginOffset, newVolume, "Decrease Volume");
       break;
     }
 
@@ -395,22 +395,22 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
       uint8_t arg4 = GetByte(curOffset++);
       uint8_t arg5 = GetByte(curOffset++);
 
-      desc << L"Arg1: " << arg1 <<
-          L"  Arg2: " << arg2 <<
-          L"  Arg3: " << arg3 <<
-          L"  Arg4: " << arg4 <<
-          L"  Arg5: " << arg5;
+      desc << "Arg1: " << arg1 <<
+          "  Arg2: " << arg2 <<
+          "  Arg3: " << arg3 <<
+          "  Arg4: " << arg4 <<
+          "  Arg5: " << arg5;
 
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato Param", desc.str(), CLR_MODULATION, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Param", desc.str(), CLR_MODULATION, ICON_CONTROL);
       break;
     }
 
     case EVENT_VIBRATO: {
       bool vibratoOn = (GetByte(curOffset++) != 0);
-      desc << L"Vibrato: " << (vibratoOn ? L"On" : L"Off");
+      desc << "Vibrato: " << (vibratoOn ? "On" : "Off");
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato On/Off",
+                      "Vibrato On/Off",
                       desc.str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -418,19 +418,19 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_ECHO_OFF: {
-      AddReverb(beginOffset, curOffset - beginOffset, 0, L"Echo Off");
+      AddReverb(beginOffset, curOffset - beginOffset, 0, "Echo Off");
       break;
     }
 
     case EVENT_ECHO_ON: {
-      AddReverb(beginOffset, curOffset - beginOffset, 40, L"Echo On");
+      AddReverb(beginOffset, curOffset - beginOffset, 40, "Echo On");
       break;
     }
 
     case EVENT_LOOP_START: {
       uint8_t count = GetByte(curOffset++);
-      desc << L"Times: " << (int) count;
-      AddGenericEvent(beginOffset, 2, L"Loop Start", desc.str(), CLR_LOOP, ICON_STARTREP);
+      desc << "Times: " << (int) count;
+      AddGenericEvent(beginOffset, 2, "Loop Start", desc.str(), CLR_LOOP, ICON_STARTREP);
 
       if (spcCallStackPtr + 5 > PANDORABOXSNES_CALLSTACK_SIZE) {
         // stack overflow
@@ -459,11 +459,11 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
 
       if (spcCallStack[spcCallStackPtr - 1] == 0xff) {
         // infinite loop
-        bContinue = AddLoopForever(beginOffset, curOffset - beginOffset, L"Loop End");
+        bContinue = AddLoopForever(beginOffset, curOffset - beginOffset, "Loop End");
       }
       else {
         // regular loop
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", desc.str(), CLR_LOOP, ICON_ENDREP);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str(), CLR_LOOP, ICON_ENDREP);
 
         // decrease repeat count (0 becomes an infinite loop, as a result)
         spcCallStack[spcCallStackPtr - 1]--;
@@ -486,7 +486,7 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_LOOP_BREAK: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Break", desc.str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str(), CLR_LOOP, ICON_ENDREP);
 
       if (spcCallStackPtr < 5) {
         // access violation
@@ -505,9 +505,9 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
     case EVENT_DSP_WRITE: {
       uint8_t dspReg = GetByte(curOffset++);
       uint8_t dspValue = GetByte(curOffset++);
-      desc << L"Register: $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) dspReg
-          << L"  Value: $" << (int) dspValue;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Write to DSP", desc.str(), CLR_CHANGESTATE);
+      desc << "Register: $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) dspReg
+          << "  Value: $" << (int) dspValue;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Write to DSP", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
@@ -516,21 +516,21 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
 
       uint8_t newTarget = param & 3;
       if (newTarget != 0) {
-        desc << L"Channel Type: " << newTarget;
+        desc << "Channel Type: " << newTarget;
       }
       else {
-        desc << L"Channel Type: " << newTarget << L" (Keep Current)";
+        desc << "Channel Type: " << newTarget << " (Keep Current)";
       }
 
       if ((param & 0x80) == 0) {
         uint8_t newNCK = (param >> 2) & 15;
-        desc << L"  Noise Frequency (NCK): " << newNCK;
+        desc << "  Noise Frequency (NCK): " << newNCK;
       }
       else {
-        desc << L"  Noise Frequency (NCK): " << L" (Keep Current)";
+        desc << "  Noise Frequency (NCK): " << " (Keep Current)";
       }
 
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Noise Param", desc.str(), CLR_CHANGESTATE, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Noise Param", desc.str(), CLR_CHANGESTATE, ICON_CONTROL);
       break;
     }
 
@@ -547,13 +547,13 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
       uint8_t sr = (srRate * 0x1f) / 127;
       spcADSR = ((0x80 | (dr << 4) | ar) << 8) | ((sl << 5) | sr);
 
-      desc << L"AR: " << arRate << L"/127" << L" (" << ar << L")" <<
-          L"  DR: " << drRate << L"/127" << L" (" << dr << L")" <<
-          L"  SR: " << srRate << L"/127" << L" (" << sr << L")" <<
-          L"  SL: " << slRate << L"/127" << L" (" << sl << L")" <<
-          L"  Arg5: " << xxRate << L"/127";
+      desc << "AR: " << arRate << "/127" << " (" << ar << ")" <<
+          "  DR: " << drRate << "/127" << " (" << dr << ")" <<
+          "  SR: " << srRate << "/127" << " (" << sr << ")" <<
+          "  SL: " << slRate << "/127" << " (" << sl << ")" <<
+          "  Arg5: " << xxRate << "/127";
 
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
@@ -572,17 +572,17 @@ bool PandoraBoxSnesTrack::ReadEvent(void) {
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"PandoraBoxSnesSeq"));
+                                    "PandoraBoxSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //std::wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //std::ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/PandoraBoxSnesSeq.h
+++ b/src/main/formats/PandoraBoxSnesSeq.h
@@ -47,7 +47,7 @@ class PandoraBoxSnesSeq
   PandoraBoxSnesSeq(RawFile *file,
                     PandoraBoxSnesVersion ver,
                     uint32_t seqdata_offset,
-                    std::wstring newName = L"PandoraBox SNES Seq");
+                    std::string newName = "PandoraBox SNES Seq");
   virtual ~PandoraBoxSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/PrismSnesInstr.cpp
+++ b/src/main/formats/PrismSnesInstr.cpp
@@ -13,7 +13,7 @@ PrismSnesInstrSet::PrismSnesInstrSet(RawFile *file,
                                      uint16_t addrADSR2Table,
                                      uint16_t addrTuningTableHigh,
                                      uint16_t addrTuningTableLow,
-                                     const std::wstring &name) :
+                                     const std::string &name) :
     VGMInstrSet(PrismSnesFormat::name, file, addrADSR1Table, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrADSR1Table(addrADSR1Table),
@@ -70,8 +70,8 @@ bool PrismSnesInstrSet::GetInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << srcn;
+    std::ostringstream instrName;
+    instrName << "Instrument " << srcn;
     PrismSnesInstr *newInstr = new PrismSnesInstr(this,
                                                   version,
                                                   srcn,
@@ -110,7 +110,7 @@ PrismSnesInstr::PrismSnesInstr(VGMInstrSet *instrSet,
                                uint16_t addrADSR2Entry,
                                uint16_t addrTuningEntryHigh,
                                uint16_t addrTuningEntryLow,
-                               const std::wstring &name) :
+                               const std::string &name) :
     VGMInstr(instrSet, addrADSR1Entry, 0, srcn >> 7, srcn & 0x7f, name), version(ver),
     srcn(srcn),
     spcDirAddr(spcDirAddr),
@@ -166,8 +166,8 @@ PrismSnesRgn::PrismSnesRgn(PrismSnesInstr *instr,
   double coarse_tuning;
   fine_tuning = modf(tuning / 256.0, &coarse_tuning) * 100.0;
 
-  AddSimpleItem(addrADSR1Entry, 1, L"ADSR1");
-  AddSimpleItem(addrADSR2Entry, 1, L"ADSR2");
+  AddSimpleItem(addrADSR1Entry, 1, "ADSR1");
+  AddSimpleItem(addrADSR2Entry, 1, "ADSR2");
   AddUnityKey(93 - (int) coarse_tuning, addrTuningEntryHigh, 1);
   AddFineTune((int16_t) fine_tuning, addrTuningEntryLow, 1);
 

--- a/src/main/formats/PrismSnesInstr.h
+++ b/src/main/formats/PrismSnesInstr.h
@@ -18,7 +18,7 @@ class PrismSnesInstrSet:
                     uint16_t addrADSR2Table,
                     uint16_t addrTuningTableHigh,
                     uint16_t addrTuningTableLow,
-                    const std::wstring &name = L"PrismSnesInstrSet");
+                    const std::string &name = "PrismSnesInstrSet");
   virtual ~PrismSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -50,7 +50,7 @@ class PrismSnesInstr
                  uint16_t addrADSR2Entry,
                  uint16_t addrTuningEntryHigh,
                  uint16_t addrTuningEntryLow,
-                 const std::wstring &name = L"PrismSnesInstr");
+                 const std::string &name = "PrismSnesInstr");
   virtual ~PrismSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/PrismSnesScanner.cpp
+++ b/src/main/formats/PrismSnesScanner.cpp
@@ -127,7 +127,7 @@ void PrismSnesScanner::Scan(RawFile *file, void *info) {
 
 void PrismSnesScanner::SearchForPrismSnesFromARAM(RawFile *file) {
   PrismSnesVersion version = PRISMSNES_NONE;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   // search song list
   uint32_t ofsLoadSeq;

--- a/src/main/formats/PrismSnesScanner.h
+++ b/src/main/formats/PrismSnesScanner.h
@@ -6,7 +6,7 @@ class PrismSnesScanner:
     public VGMScanner {
  public:
   PrismSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~PrismSnesScanner(void) {
   }

--- a/src/main/formats/PrismSnesSeq.cpp
+++ b/src/main/formats/PrismSnesSeq.cpp
@@ -24,7 +24,7 @@ const uint8_t PrismSnesSeq::PAN_TABLE_2[21] = {
     0x7f, 0x7f, 0x7f, 0x7f, 0x7f,
 };
 
-PrismSnesSeq::PrismSnesSeq(RawFile *file, PrismSnesVersion ver, uint32_t seqdataOffset, std::wstring newName)
+PrismSnesSeq::PrismSnesSeq(RawFile *file, PrismSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(PrismSnesFormat::name, file, seqdataOffset, 0, newName), version(ver),
       envContainer(NULL) {
   bLoadTickByTick = true;
@@ -43,7 +43,7 @@ PrismSnesSeq::~PrismSnesSeq(void) {
 
 void PrismSnesSeq::DemandEnvelopeContainer(uint32_t offset) {
   if (envContainer == NULL) {
-    envContainer = AddHeader(offset, 0, L"Envelopes");
+    envContainer = AddHeader(offset, 0, "Envelopes");
   }
 
   if (offset < envContainer->dwOffset) {
@@ -73,26 +73,26 @@ bool PrismSnesSeq::GetHeaderInfo(void) {
 
     uint8_t channel = GetByte(curOffset);
     if (channel >= 0x80) {
-      header->AddSimpleItem(curOffset, 1, L"Header End");
+      header->AddSimpleItem(curOffset, 1, "Header End");
       break;
     }
     if (trackIndex >= MAX_TRACKS) {
       return false;
     }
 
-    std::wstringstream trackName;
-    trackName << L"Track " << (trackIndex + 1);
+    std::stringstream trackName;
+    trackName << "Track " << (trackIndex + 1);
     VGMHeader *trackHeader = header->AddHeader(curOffset, 4, trackName.str());
 
-    trackHeader->AddSimpleItem(curOffset, 1, L"Logical Channel");
+    trackHeader->AddSimpleItem(curOffset, 1, "Logical Channel");
     curOffset++;
 
     uint8_t a01 = GetByte(curOffset);
-    trackHeader->AddSimpleItem(curOffset, 1, L"Physical Channel + Flags");
+    trackHeader->AddSimpleItem(curOffset, 1, "Physical Channel + Flags");
     curOffset++;
 
     uint16_t addrTrackStart = GetShort(curOffset);
-    trackHeader->AddSimpleItem(curOffset, 2, L"Track Pointer");
+    trackHeader->AddSimpleItem(curOffset, 2, "Track Pointer");
     curOffset += 2;
 
     PrismSnesTrack *track = new PrismSnesTrack(this, addrTrackStart);
@@ -258,7 +258,7 @@ bool PrismSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   PrismSnesSeqEventType eventType = (PrismSnesSeqEventType) 0;
   std::map<uint8_t, PrismSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -268,27 +268,27 @@ bool PrismSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -296,12 +296,12 @@ bool PrismSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -310,19 +310,19 @@ bool PrismSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_NOP2: {
       curOffset += 2;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP", desc.str(), CLR_MISC, ICON_BINARY);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str(), CLR_MISC, ICON_BINARY);
       break;
     }
 
@@ -348,16 +348,16 @@ bool PrismSnesTrack::ReadEvent(void) {
 
       if (prevNoteSlurred && key == prevNoteKey) {
         MakePrevDurNoteEnd(GetTime() + dur);
-        desc << L"Abs Key: " << key << L" (" << MidiEvent::GetNoteName(key) << L"  Velocity: " << vel << L"  Duration: "
+        desc << "Abs Key: " << key << " (" << MidiEvent::GetNoteName(key) << "  Velocity: " << vel << "  Duration: "
             << dur;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Note (Tied)", desc.str(), CLR_DURNOTE, ICON_NOTE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Note (Tied)", desc.str(), CLR_DURNOTE, ICON_NOTE);
       }
       else {
         if (eventType == EVENT_NOISE_NOTE) {
-          AddNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur, L"Noise Note");
+          AddNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur, "Noise Note");
         }
         else {
-          AddNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur, L"Note");
+          AddNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur, "Note");
         }
       }
       AddTime(len);
@@ -386,12 +386,12 @@ bool PrismSnesTrack::ReadEvent(void) {
 
       uint8_t dur = GetDuration(curOffset, len, durDelta);
 
-      desc << L"Note Number (From): " << noteNumberFrom << L" ("
-          << ((noteFrom & 0x80) != 0 ? L"Noise" : MidiEvent::GetNoteName(noteNumberFrom)) << L")" <<
-          L"  Note Number (To): " << noteNumberTo << L" ("
-          << ((noteTo & 0x80) != 0 ? L"Noise" : MidiEvent::GetNoteName(noteNumberTo)) << L")" <<
-          L"  Length: " << len << L"  Duration: " << dur;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pitch Slide", desc.str(), CLR_PITCHBEND, ICON_CONTROL);
+      desc << "Note Number (From): " << noteNumberFrom << " ("
+          << ((noteFrom & 0x80) != 0 ? "Noise" : MidiEvent::GetNoteName(noteNumberFrom)) << ")" <<
+          "  Note Number (To): " << noteNumberTo << " ("
+          << ((noteTo & 0x80) != 0 ? "Noise" : MidiEvent::GetNoteName(noteNumberTo)) << ")" <<
+          "  Length: " << len << "  Duration: " << dur;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc.str(), CLR_PITCHBEND, ICON_CONTROL);
 
       AddNoteByDurNoItem(noteNumberFrom, vel, dur);
       AddTime(len);
@@ -411,8 +411,8 @@ bool PrismSnesTrack::ReadEvent(void) {
 
       uint8_t dur = GetDuration(curOffset, len, durDelta);
 
-      desc << L"Length: " << len << L"  Duration: " << dur;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie with Duration", desc.str(), CLR_TIE, ICON_NOTE);
+      desc << "Length: " << len << "  Duration: " << dur;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie with Duration", desc.str(), CLR_TIE, ICON_NOTE);
       MakePrevDurNoteEnd(GetTime() + dur);
       AddTime(len);
       break;
@@ -420,7 +420,7 @@ bool PrismSnesTrack::ReadEvent(void) {
 
     case EVENT_TIE: {
       prevNoteSlurred = true;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str(), CLR_TIE, ICON_NOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str(), CLR_TIE, ICON_NOTE);
       break;
     }
 
@@ -428,9 +428,9 @@ bool PrismSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint16_t arg2 = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Arg1: " << arg1 << L"  Arg2: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase
+      desc << "Arg1: " << arg1 << "  Arg2: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase
           << arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -440,8 +440,8 @@ bool PrismSnesTrack::ReadEvent(void) {
         return false;
       }
 
-      desc << L"Duration: " << len;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Rest", desc.str(), CLR_REST, ICON_REST);
+      desc << "Duration: " << len;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Rest", desc.str(), CLR_REST, ICON_REST);
       AddTime(len);
       break;
     }
@@ -455,8 +455,8 @@ bool PrismSnesTrack::ReadEvent(void) {
     case EVENT_CONDITIONAL_JUMP: {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Conditional Jump", desc.str(), CLR_LOOP);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump", desc.str(), CLR_LOOP);
 
       if (parentSeq->conditionSwitch) {
         curOffset = dest;
@@ -466,14 +466,14 @@ bool PrismSnesTrack::ReadEvent(void) {
 
     case EVENT_CONDITION: {
       parentSeq->conditionSwitch = true;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Condition On", desc.str(), CLR_CHANGESTATE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Condition On", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
     case EVENT_RESTORE_ECHO_PARAM: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Restore Echo Param",
+                      "Restore Echo Param",
                       desc.str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -481,77 +481,77 @@ bool PrismSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_SAVE_ECHO_PARAM: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Save Echo Param", desc.str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Save Echo Param", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_SLUR_OFF: {
       slur = false;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Slur Off", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Slur Off", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
       break;
     }
 
     case EVENT_SLUR_ON: {
       slur = true;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Slur On", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Slur On", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
       break;
     }
 
     case EVENT_VOLUME_ENVELOPE: {
       uint16_t envelopeAddress = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Envelope: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << envelopeAddress;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Volume Envelope", desc.str(), CLR_VOLUME, ICON_CONTROL);
+      desc << "Envelope: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << envelopeAddress;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Volume Envelope", desc.str(), CLR_VOLUME, ICON_CONTROL);
       AddVolumeEnvelope(envelopeAddress);
       break;
     }
 
     case EVENT_DEFAULT_PAN_TABLE_1: {
       panTable.assign(std::begin(PrismSnesSeq::PAN_TABLE_1), std::end(PrismSnesSeq::PAN_TABLE_1));
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Default Pan Table #1", desc.str(), CLR_PAN, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Default Pan Table #1", desc.str(), CLR_PAN, ICON_CONTROL);
       break;
     }
 
     case EVENT_DEFAULT_PAN_TABLE_2: {
       panTable.assign(std::begin(PrismSnesSeq::PAN_TABLE_2), std::end(PrismSnesSeq::PAN_TABLE_2));
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Default Pan Table #2", desc.str(), CLR_PAN, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Default Pan Table #2", desc.str(), CLR_PAN, ICON_CONTROL);
       break;
     }
 
     case EVENT_INC_APU_PORT_3: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Increment APU Port 3", desc.str(), CLR_CHANGESTATE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Increment APU Port 3", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
     case EVENT_INC_APU_PORT_2: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Increment APU Port 2", desc.str(), CLR_CHANGESTATE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Increment APU Port 2", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
     case EVENT_PLAY_SONG_3: {
       uint8_t songIndex = GetByte(curOffset++);
-      desc << L"Song Index: " << songIndex;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Play Song (3)", desc.str(), CLR_CHANGESTATE);
+      desc << "Song Index: " << songIndex;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Play Song (3)", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
     case EVENT_PLAY_SONG_2: {
       uint8_t songIndex = GetByte(curOffset++);
-      desc << L"Song Index: " << songIndex;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Play Song (2)", desc.str(), CLR_CHANGESTATE);
+      desc << "Song Index: " << songIndex;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Play Song (2)", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
     case EVENT_PLAY_SONG_1: {
       uint8_t songIndex = GetByte(curOffset++);
-      desc << L"Song Index: " << songIndex;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Play Song (1)", desc.str(), CLR_CHANGESTATE);
+      desc << "Song Index: " << songIndex;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Play Song (1)", desc.str(), CLR_CHANGESTATE);
       break;
     }
 
     case EVENT_TRANSPOSE_REL: {
       int8_t delta = GetByte(curOffset++);
-      AddTranspose(beginOffset, curOffset - beginOffset, transpose + delta, L"Transpose (Relative)");
+      AddTranspose(beginOffset, curOffset - beginOffset, transpose + delta, "Transpose (Relative)");
       break;
     }
 
@@ -559,9 +559,9 @@ bool PrismSnesTrack::ReadEvent(void) {
       uint16_t envelopeAddress = GetShort(curOffset);
       curOffset += 2;
       uint16_t envelopeSpeed = GetByte(curOffset++);
-      desc << L"Envelope: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << envelopeAddress
-          << L"  Speed: " << std::dec << std::setfill(L' ') << std::setw(0) << envelopeSpeed;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan Envelope", desc.str(), CLR_PAN, ICON_CONTROL);
+      desc << "Envelope: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << envelopeAddress
+          << "  Speed: " << std::dec << std::setfill(' ') << std::setw(0) << envelopeSpeed;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan Envelope", desc.str(), CLR_PAN, ICON_CONTROL);
       AddPanEnvelope(envelopeAddress);
       break;
     }
@@ -569,8 +569,8 @@ bool PrismSnesTrack::ReadEvent(void) {
     case EVENT_PAN_TABLE: {
       uint16_t panTableAddress = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Pan Table: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << panTableAddress;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan Table", desc.str(), CLR_PAN, ICON_CONTROL);
+      desc << "Pan Table: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << panTableAddress;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan Table", desc.str(), CLR_PAN, ICON_CONTROL);
 
       // update pan table
       if (panTableAddress + 21 <= 0x10000) {
@@ -585,14 +585,14 @@ bool PrismSnesTrack::ReadEvent(void) {
 
     case EVENT_DEFAULT_LENGTH_OFF: {
       defaultLength = 0;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Default Length Off", desc.str(), CLR_DURNOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Default Length Off", desc.str(), CLR_DURNOTE);
       break;
     }
 
     case EVENT_DEFAULT_LENGTH: {
       defaultLength = GetByte(curOffset++);
-      desc << L"Duration: " << defaultLength;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Default Length", desc.str(), CLR_DURNOTE);
+      desc << "Duration: " << defaultLength;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Default Length", desc.str(), CLR_DURNOTE);
       break;
     }
 
@@ -600,9 +600,9 @@ bool PrismSnesTrack::ReadEvent(void) {
       uint8_t count = GetByte(curOffset++);
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Loop Count: " << count << L"  Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+      desc << "Loop Count: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Until", desc.str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Until", desc.str(), CLR_LOOP, ICON_ENDREP);
 
       bool doJump;
       if (loopCount == 0) {
@@ -630,9 +630,9 @@ bool PrismSnesTrack::ReadEvent(void) {
       uint8_t count = GetByte(curOffset++);
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Loop Count: " << count << L"  Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+      desc << "Loop Count: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Until (Alt)", desc.str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Until (Alt)", desc.str(), CLR_LOOP, ICON_ENDREP);
 
       bool doJump;
       if (loopCountAlt == 0) {
@@ -657,7 +657,7 @@ bool PrismSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_RET: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pattern End", desc.str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pattern End", desc.str(), CLR_LOOP, ICON_ENDREP);
 
       if (subReturnAddr != 0) {
         curOffset = subReturnAddr;
@@ -670,8 +670,8 @@ bool PrismSnesTrack::ReadEvent(void) {
     case EVENT_CALL: {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pattern Play", desc.str(), CLR_LOOP, ICON_STARTREP);
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pattern Play", desc.str(), CLR_LOOP, ICON_STARTREP);
 
       subReturnAddr = curOffset;
       curOffset = dest;
@@ -682,19 +682,19 @@ bool PrismSnesTrack::ReadEvent(void) {
     case EVENT_GOTO: {
       uint16_t dest = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
       uint32_t length = curOffset - beginOffset;
 
       if (curOffset < 0x10000 && GetByte(curOffset) == 0xff) {
-        AddGenericEvent(curOffset, 1, L"End of Track", L"", CLR_TRACKEND, ICON_TRACKEND);
+        AddGenericEvent(curOffset, 1, "End of Track", "", CLR_TRACKEND, ICON_TRACKEND);
       }
 
       curOffset = dest;
       if (!IsOffsetUsed(dest)) {
-        AddGenericEvent(beginOffset, length, L"Jump", desc.str(), CLR_LOOPFOREVER);
+        AddGenericEvent(beginOffset, length, "Jump", desc.str(), CLR_LOOPFOREVER);
       }
       else {
-        bContinue = AddLoopForever(beginOffset, length, L"Jump");
+        bContinue = AddLoopForever(beginOffset, length, "Jump");
       }
 
       if (curOffset < dwOffset) {
@@ -719,13 +719,13 @@ bool PrismSnesTrack::ReadEvent(void) {
 
     case EVENT_VIBRATO_DELAY: {
       uint8_t lfoDelay = GetByte(curOffset++);
-      desc << L"Delay: " << (int) lfoDelay;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato Delay", desc.str(), CLR_MODULATION, ICON_CONTROL);
+      desc << "Delay: " << (int) lfoDelay;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Delay", desc.str(), CLR_MODULATION, ICON_CONTROL);
       break;
     }
 
     case EVENT_VIBRATO_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato Off", desc.str(), CLR_MODULATION, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Off", desc.str(), CLR_MODULATION, ICON_CONTROL);
       break;
     }
 
@@ -733,8 +733,8 @@ bool PrismSnesTrack::ReadEvent(void) {
       uint8_t lfoDelay = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Delay: " << (int) lfoDelay << L"  Arg2: " << (int) arg2 << L"  Arg3: " << (int) arg3;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Vibrato", desc.str(), CLR_MODULATION, ICON_CONTROL);
+      desc << "Delay: " << (int) lfoDelay << "  Arg2: " << (int) arg2 << "  Arg3: " << (int) arg3;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc.str(), CLR_MODULATION, ICON_CONTROL);
       break;
     }
 
@@ -749,7 +749,7 @@ bool PrismSnesTrack::ReadEvent(void) {
       else {
         spcVolume += delta;
       }
-      AddVol(beginOffset, curOffset - beginOffset, spcVolume / 2, L"Volume (Relative)");
+      AddVol(beginOffset, curOffset - beginOffset, spcVolume / 2, "Volume (Relative)");
       break;
     }
 
@@ -787,10 +787,10 @@ bool PrismSnesTrack::ReadEvent(void) {
     case EVENT_GAIN_ENVELOPE_REST: {
       uint16_t envelopeAddress = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Envelope: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << envelopeAddress;
+      desc << "Envelope: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << envelopeAddress;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"GAIN Envelope (Rest)",
+                      "GAIN Envelope (Rest)",
                       desc.str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -801,11 +801,11 @@ bool PrismSnesTrack::ReadEvent(void) {
     case EVENT_GAIN_ENVELOPE_DECAY_TIME: {
       uint8_t dur = GetByte(curOffset++);
       uint8_t gain = GetByte(curOffset++);
-      desc << L"Duration: Full-Length - " << dur << L"  GAIN: $" << std::hex << std::setfill(L'0') << std::setw(2)
+      desc << "Duration: Full-Length - " << dur << "  GAIN: $" << std::hex << std::setfill('0') << std::setw(2)
           << std::uppercase << gain;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"GAIN Envelope Decay Time",
+                      "GAIN Envelope Decay Time",
                       desc.str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -814,31 +814,31 @@ bool PrismSnesTrack::ReadEvent(void) {
 
     case EVENT_MANUAL_DURATION_OFF: {
       manualDuration = false;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Manual Duration Off", desc.str(), CLR_DURNOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Manual Duration Off", desc.str(), CLR_DURNOTE);
       break;
     }
 
     case EVENT_MANUAL_DURATION_ON: {
       manualDuration = true;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Manual Duration On", desc.str(), CLR_DURNOTE);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Manual Duration On", desc.str(), CLR_DURNOTE);
       break;
     }
 
     case EVENT_AUTO_DURATION_THRESHOLD: {
       manualDuration = false;
       autoDurationThreshold = GetByte(curOffset++);
-      desc << L"Duration: Full-Length - " << autoDurationThreshold;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Auto Duration Threshold", desc.str(), CLR_DURNOTE);
+      desc << "Duration: Full-Length - " << autoDurationThreshold;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Auto Duration Threshold", desc.str(), CLR_DURNOTE);
       break;
     }
 
     case EVENT_GAIN_ENVELOPE_SUSTAIN: {
       uint16_t envelopeAddress = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Envelope: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << envelopeAddress;
+      desc << "Envelope: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << envelopeAddress;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"GAIN Envelope (Sustain)",
+                      "GAIN Envelope (Sustain)",
                       desc.str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -849,10 +849,10 @@ bool PrismSnesTrack::ReadEvent(void) {
     case EVENT_ECHO_VOLUME_ENVELOPE: {
       uint16_t envelopeAddress = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Envelope: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << envelopeAddress;
+      desc << "Envelope: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << envelopeAddress;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Echo Volume Envelope",
+                      "Echo Volume Envelope",
                       desc.str(),
                       CLR_REVERB,
                       ICON_CONTROL);
@@ -864,19 +864,19 @@ bool PrismSnesTrack::ReadEvent(void) {
       int8_t echoVolumeLeft = GetByte(curOffset++);
       int8_t echoVolumeRight = GetByte(curOffset++);
       int8_t echoVolumeMono = GetByte(curOffset++);
-      desc << L"Left Volume: " << echoVolumeLeft << L"  Right Volume: " << echoVolumeRight << L"  Mono Volume: "
+      desc << "Left Volume: " << echoVolumeLeft << "  Right Volume: " << echoVolumeRight << "  Mono Volume: "
           << echoVolumeMono;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Volume", desc.str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      AddReverb(beginOffset, curOffset - beginOffset, 0, L"Echo Off");
+      AddReverb(beginOffset, curOffset - beginOffset, 0, "Echo Off");
       break;
     }
 
     case EVENT_ECHO_ON: {
-      AddReverb(beginOffset, curOffset - beginOffset, 40, L"Echo On");
+      AddReverb(beginOffset, curOffset - beginOffset, 40, "Echo On");
       break;
     }
 
@@ -885,9 +885,9 @@ bool PrismSnesTrack::ReadEvent(void) {
       int8_t echoVolumeLeft = GetByte(curOffset++);
       int8_t echoVolumeRight = GetByte(curOffset++);
       int8_t echoVolumeMono = GetByte(curOffset++);
-      desc << L"Feedback: " << echoFeedback << L"  Left Volume: " << echoVolumeLeft << L"  Right Volume: "
-          << echoVolumeRight << L"  Mono Volume: " << echoVolumeMono;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Param", desc.str(), CLR_REVERB, ICON_CONTROL);
+      desc << "Feedback: " << echoFeedback << "  Left Volume: " << echoVolumeLeft << "  Right Volume: "
+          << echoVolumeRight << "  Mono Volume: " << echoVolumeMono;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc.str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
@@ -896,24 +896,24 @@ bool PrismSnesTrack::ReadEvent(void) {
       if (param >= 0x80) {
         uint8_t adsr1 = GetByte(curOffset++);
         uint8_t adsr2 = GetByte(curOffset++);
-        desc << L"ADSR(1): $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << adsr1 <<
-            L"  ADSR(2): $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << adsr2;
+        desc << "ADSR(1): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << adsr1 <<
+            "  ADSR(2): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << adsr2;
       }
       else {
         uint8_t instrNum = GetByte(curOffset++);
-        desc << L"Instrument: " << instrNum;
+        desc << "Instrument: " << instrNum;
       }
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
       break;
     }
 
     case EVENT_GAIN_ENVELOPE_DECAY: {
       uint16_t envelopeAddress = GetShort(curOffset);
       curOffset += 2;
-      desc << L"Envelope: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << envelopeAddress;
+      desc << "Envelope: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << envelopeAddress;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"GAIN Envelope (Decay)",
+                      "GAIN Envelope (Decay)",
                       desc.str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -934,19 +934,19 @@ bool PrismSnesTrack::ReadEvent(void) {
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
-      pRoot->AddLogItem(new LogItem(std::wstring(L"Unknown Event - ") + desc.str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      pRoot->AddLogItem(new LogItem(std::string("Unknown Event - ") + desc.str(),
                                     LOG_LEVEL_ERR,
-                                    std::wstring(L"PrismSnesSeq")));
+                                    std::string("PrismSnesSeq")));
       bContinue = false;
       break;
   }
 
   //assert(curOffset >= parentSeq->dwOffset);
 
-  //std::wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //std::ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;
@@ -1011,14 +1011,14 @@ void PrismSnesTrack::AddVolumeEnvelope(uint16_t envelopeAddress) {
   parentSeq->DemandEnvelopeContainer(envelopeAddress);
 
   if (!IsOffsetUsed(envelopeAddress)) {
-    std::wostringstream envelopeName;
-    envelopeName << L"Volume Envelope ($" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase
-        << envelopeAddress << L")";
+    std::ostringstream envelopeName;
+    envelopeName << "Volume Envelope ($" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase
+        << envelopeAddress << ")";
     VGMHeader *envHeader = parentSeq->envContainer->AddHeader(envelopeAddress, 0, envelopeName.str());
 
     uint16_t envOffset = 0;
     while (envelopeAddress + envOffset + 2 <= 0x10000) {
-      std::wostringstream eventName;
+      std::ostringstream eventName;
 
       uint8_t volumeFrom = GetByte(envelopeAddress + envOffset);
       int8_t volumeDelta = GetByte(envelopeAddress + envOffset + 1);
@@ -1026,7 +1026,7 @@ void PrismSnesTrack::AddVolumeEnvelope(uint16_t envelopeAddress) {
         // $00 $00 $xx $yy sets offset to $yyxx
         uint16_t newAddress = GetByte(envelopeAddress + envOffset + 2);
 
-        eventName << L"Jump to $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << newAddress;
+        eventName << "Jump to $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << newAddress;
         envHeader->AddSimpleItem(envelopeAddress + envOffset, 4, eventName.str());
         envOffset += 4;
         break;
@@ -1034,8 +1034,8 @@ void PrismSnesTrack::AddVolumeEnvelope(uint16_t envelopeAddress) {
 
       uint8_t envelopeSpeed = GetByte(envelopeAddress + envOffset + 2);
       uint8_t deltaTime = GetByte(envelopeAddress + envOffset + 3);
-      eventName << L"Volume: " << volumeFrom << L"  Volume Delta: " << volumeDelta << L"  Envelope Speed: "
-          << envelopeSpeed << L"  Delta-Time: " << deltaTime;
+      eventName << "Volume: " << volumeFrom << "  Volume Delta: " << volumeDelta << "  Envelope Speed: "
+          << envelopeSpeed << "  Delta-Time: " << deltaTime;
       envHeader->AddSimpleItem(envelopeAddress + envOffset, 4, eventName.str());
       envOffset += 4;
 
@@ -1052,28 +1052,28 @@ void PrismSnesTrack::AddPanEnvelope(uint16_t envelopeAddress) {
   parentSeq->DemandEnvelopeContainer(envelopeAddress);
 
   if (!IsOffsetUsed(envelopeAddress)) {
-    std::wostringstream envelopeName;
-    envelopeName << L"Pan Envelope ($" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase
-        << envelopeAddress << L")";
+    std::ostringstream envelopeName;
+    envelopeName << "Pan Envelope ($" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase
+        << envelopeAddress << ")";
     VGMHeader *envHeader = parentSeq->envContainer->AddHeader(envelopeAddress, 0, envelopeName.str());
 
     uint16_t envOffset = 0;
     while (envOffset < 0x100) {
-      std::wostringstream eventName;
+      std::ostringstream eventName;
 
       uint8_t newPan = GetByte(envelopeAddress + envOffset);
       if (newPan >= 0x80) {
         // $ff $xx sets offset to $xx
         uint8_t newOffset = GetByte(envelopeAddress + envOffset + 1);
 
-        eventName << L"Jump to $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase
+        eventName << "Jump to $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase
             << (envelopeAddress + newOffset);
         envHeader->AddSimpleItem(envelopeAddress + envOffset, 2, eventName.str());
         envOffset += 2;
         break;
       }
 
-      eventName << L"Pan: " << newPan;
+      eventName << "Pan: " << newPan;
       envHeader->AddSimpleItem(envelopeAddress + envOffset, 1, eventName.str());
       envOffset++;
 
@@ -1090,21 +1090,21 @@ void PrismSnesTrack::AddEchoVolumeEnvelope(uint16_t envelopeAddress) {
   parentSeq->DemandEnvelopeContainer(envelopeAddress);
 
   if (!IsOffsetUsed(envelopeAddress)) {
-    std::wostringstream envelopeName;
-    envelopeName << L"Echo Volume Envelope ($" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase
-        << envelopeAddress << L")";
+    std::ostringstream envelopeName;
+    envelopeName << "Echo Volume Envelope ($" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase
+        << envelopeAddress << ")";
     VGMHeader *envHeader = parentSeq->envContainer->AddHeader(envelopeAddress, 0, envelopeName.str());
 
     uint16_t envOffset = 0;
     while (envOffset < 0x100) {
-      std::wostringstream eventName;
+      std::ostringstream eventName;
 
       uint8_t deltaTime = GetByte(envelopeAddress + envOffset);
       if (deltaTime == 0xff) {
         // $ff $xx sets offset to $xx
         uint8_t newOffset = GetByte(envelopeAddress + envOffset + 1);
 
-        eventName << L"Jump to $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase
+        eventName << "Jump to $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase
             << (envelopeAddress + newOffset);
         envHeader->AddSimpleItem(envelopeAddress + envOffset, 2, eventName.str());
         envOffset += 2;
@@ -1114,8 +1114,8 @@ void PrismSnesTrack::AddEchoVolumeEnvelope(uint16_t envelopeAddress) {
       int8_t echoVolumeLeft = GetByte(envelopeAddress + envOffset + 1);
       int8_t echoVolumeRight = GetByte(envelopeAddress + envOffset + 2);
       int8_t echoVolumeMono = GetByte(envelopeAddress + envOffset + 3);
-      eventName << L"Delta-Time: " << deltaTime << L"  Left Volume: " << echoVolumeLeft << L"  Right Volume: "
-          << echoVolumeRight << L"  Mono Volume: " << echoVolumeMono;
+      eventName << "Delta-Time: " << deltaTime << "  Left Volume: " << echoVolumeLeft << "  Right Volume: "
+          << echoVolumeRight << "  Mono Volume: " << echoVolumeMono;
       envHeader->AddSimpleItem(envelopeAddress + envOffset, 4, eventName.str());
       envOffset += 4;
 
@@ -1132,21 +1132,21 @@ void PrismSnesTrack::AddGAINEnvelope(uint16_t envelopeAddress) {
   parentSeq->DemandEnvelopeContainer(envelopeAddress);
 
   if (!IsOffsetUsed(envelopeAddress)) {
-    std::wostringstream envelopeName;
-    envelopeName << L"GAIN Envelope ($" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase
-        << envelopeAddress << L")";
+    std::ostringstream envelopeName;
+    envelopeName << "GAIN Envelope ($" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase
+        << envelopeAddress << ")";
     VGMHeader *envHeader = parentSeq->envContainer->AddHeader(envelopeAddress, 0, envelopeName.str());
 
     uint16_t envOffset = 0;
     while (envOffset < 0x100) {
-      std::wostringstream eventName;
+      std::ostringstream eventName;
 
       uint8_t gain = GetByte(envelopeAddress + envOffset);
       if (gain == 0xff) {
         // $ff $xx sets offset to $xx
         uint8_t newOffset = GetByte(envelopeAddress + envOffset + 1);
 
-        eventName << L"Jump to $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase
+        eventName << "Jump to $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase
             << (envelopeAddress + newOffset);
         envHeader->AddSimpleItem(envelopeAddress + envOffset, 2, eventName.str());
         envOffset += 2;
@@ -1154,8 +1154,8 @@ void PrismSnesTrack::AddGAINEnvelope(uint16_t envelopeAddress) {
       }
 
       uint8_t deltaTime = GetByte(envelopeAddress + envOffset + 1);
-      eventName << L"GAIN: $" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << gain << std::dec
-          << std::setfill(L' ') << std::setw(0) << L", Delta-Time: " << deltaTime;
+      eventName << "GAIN: $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << gain << std::dec
+          << std::setfill(' ') << std::setw(0) << ", Delta-Time: " << deltaTime;
       envHeader->AddSimpleItem(envelopeAddress + envOffset, 2, eventName.str());
       envOffset += 2;
 
@@ -1172,9 +1172,9 @@ void PrismSnesTrack::AddPanTable(uint16_t panTableAddress) {
   parentSeq->DemandEnvelopeContainer(panTableAddress);
 
   if (!IsOffsetUsed(panTableAddress)) {
-    std::wostringstream eventName;
-    eventName << L"Pan Table ($" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << panTableAddress
-        << L")";
+    std::ostringstream eventName;
+    eventName << "Pan Table ($" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << panTableAddress
+        << ")";
     parentSeq->envContainer->AddSimpleItem(panTableAddress, 21, eventName.str());
   }
 }

--- a/src/main/formats/PrismSnesSeq.h
+++ b/src/main/formats/PrismSnesSeq.h
@@ -72,7 +72,7 @@ enum PrismSnesSeqEventType {
 class PrismSnesSeq
     : public VGMSeq {
  public:
-  PrismSnesSeq(RawFile *file, PrismSnesVersion ver, uint32_t seqdataOffset, std::wstring newName = L"I'Max SNES Seq");
+  PrismSnesSeq(RawFile *file, PrismSnesVersion ver, uint32_t seqdataOffset, std::string newName = "I'Max SNES Seq");
   virtual ~PrismSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/RareSnesInstr.cpp
+++ b/src/main/formats/RareSnesInstr.cpp
@@ -8,7 +8,7 @@
 // RareSnesInstrSet
 // ****************
 
-RareSnesInstrSet::RareSnesInstrSet(RawFile *file, uint32_t offset, uint32_t spcDirAddr, const std::wstring &name) :
+RareSnesInstrSet::RareSnesInstrSet(RawFile *file, uint32_t offset, uint32_t spcDirAddr, const std::string &name) :
     VGMInstrSet(RareSnesFormat::name, file, offset, 0, name),
     spcDirAddr(spcDirAddr),
     maxSRCNValue(255) {
@@ -21,7 +21,7 @@ RareSnesInstrSet::RareSnesInstrSet(RawFile *file,
                                    const std::map<uint8_t, int8_t> &instrUnityKeyHints,
                                    const std::map<uint8_t, int16_t> &instrPitchHints,
                                    const std::map<uint8_t, uint16_t> &instrADSRHints,
-                                   const std::wstring &name) :
+                                   const std::string &name) :
     VGMInstrSet(RareSnesFormat::name, file, offset, 0, name),
     spcDirAddr(spcDirAddr),
     maxSRCNValue(255),
@@ -152,8 +152,8 @@ bool RareSnesInstrSet::GetInstrPointers() {
       adsr = itrADSR->second;
     }
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << inst;
+    std::ostringstream instrName;
+    instrName << "Instrument " << inst;
     RareSnesInstr *newInstr = new RareSnesInstr(this,
                                                 dwOffset + inst,
                                                 inst >> 7,
@@ -184,7 +184,7 @@ RareSnesInstr::RareSnesInstr(VGMInstrSet *instrSet,
                              int8_t transpose,
                              int16_t pitch,
                              uint16_t adsr,
-                             const std::wstring &name) :
+                             const std::string &name) :
     VGMInstr(instrSet, offset, 1, theBank, theInstrNum, name),
     spcDirAddr(spcDirAddr),
     transpose(transpose),

--- a/src/main/formats/RareSnesInstr.h
+++ b/src/main/formats/RareSnesInstr.h
@@ -10,14 +10,14 @@
 class RareSnesInstrSet:
     public VGMInstrSet {
  public:
-  RareSnesInstrSet(RawFile *file, uint32_t offset, uint32_t spcDirAddr, const std::wstring &name = L"RareSnesInstrSet");
+  RareSnesInstrSet(RawFile *file, uint32_t offset, uint32_t spcDirAddr, const std::string &name = "RareSnesInstrSet");
   RareSnesInstrSet(RawFile *file,
                    uint32_t offset,
                    uint32_t spcDirAddr,
                    const std::map<uint8_t, int8_t> &instrUnityKeyHints,
                    const std::map<uint8_t, int16_t> &instrPitchHints,
                    const std::map<uint8_t, uint16_t> &instrADSRHints,
-                   const std::wstring &name = L"RareSnesInstrSet");
+                   const std::string &name = "RareSnesInstrSet");
   virtual ~RareSnesInstrSet(void);
 
   virtual void Initialize();
@@ -52,7 +52,7 @@ class RareSnesInstr
                 int8_t transpose = 0,
                 int16_t pitch = 0,
                 uint16_t adsr = 0x8FE0,
-                const std::wstring &name = L"RareSnesInstr");
+                const std::string &name = "RareSnesInstr");
   virtual ~RareSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/RareSnesScanner.cpp
+++ b/src/main/formats/RareSnesScanner.cpp
@@ -118,7 +118,7 @@ void RareSnesScanner::SearchForRareSnesFromARAM(RawFile *file) {
   uint32_t ofsVCmdExecASM;
   uint32_t addrSeqHeader;
   uint32_t addrVCmdTable;
-  wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   // find a sequence
   if (file->SearchBytePattern(ptnSongLoadDKC2, ofsSongLoadASM)) {

--- a/src/main/formats/RareSnesScanner.h
+++ b/src/main/formats/RareSnesScanner.h
@@ -6,7 +6,7 @@ class RareSnesScanner:
     public VGMScanner {
  public:
   RareSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~RareSnesScanner(void) {
   }

--- a/src/main/formats/RareSnesSeq.cpp
+++ b/src/main/formats/RareSnesSeq.cpp
@@ -32,7 +32,7 @@ const uint16_t RareSnesSeq::NOTE_PITCH_TABLE[128] = {
     0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff
 };
 
-RareSnesSeq::RareSnesSeq(RawFile *file, RareSnesVersion ver, uint32_t seqdataOffset, wstring newName)
+RareSnesSeq::RareSnesSeq(RawFile *file, RareSnesVersion ver, uint32_t seqdataOffset, string newName)
     : VGMSeq(RareSnesFormat::name, file, seqdataOffset), version(ver) {
   name = newName;
 
@@ -68,15 +68,15 @@ void RareSnesSeq::ResetVars(void) {
 bool RareSnesSeq::GetHeaderInfo(void) {
   SetPPQN(SEQ_PPQN);
 
-  VGMHeader *seqHeader = AddHeader(dwOffset, MAX_TRACKS * 2 + 2, L"Sequence Header");
+  VGMHeader *seqHeader = AddHeader(dwOffset, MAX_TRACKS * 2 + 2, "Sequence Header");
   uint32_t curHeaderOffset = dwOffset;
   for (int i = 0; i < MAX_TRACKS; i++) {
     uint16_t trkOff = GetShort(curHeaderOffset);
-    seqHeader->AddPointer(curHeaderOffset, 2, trkOff, (trkOff != 0), L"Track Pointer");
+    seqHeader->AddPointer(curHeaderOffset, 2, trkOff, (trkOff != 0), "Track Pointer");
     curHeaderOffset += 2;
   }
   initialTempo = GetByte(curHeaderOffset);
-  seqHeader->AddTempo(curHeaderOffset++, 1, L"Tempo");
+  seqHeader->AddTempo(curHeaderOffset++, 1, "Tempo");
   seqHeader->AddUnknownItem(curHeaderOffset++, 1);
 
   return true;        //successful
@@ -297,7 +297,7 @@ bool RareSnesTrack::ReadEvent(void) {
   uint8_t newMidiVol, newMidiPan;
   bool bContinue = true;
 
-  wstringstream desc;
+  stringstream desc;
 
   if (statusByte >= 0x80) {
     uint8_t noteByte = statusByte;
@@ -328,8 +328,8 @@ bool RareSnesTrack::ReadEvent(void) {
     }
 
     if (noteByte == 0x80) {
-      //wostringstream ssTrace;
-      //ssTrace << L"Rest: " << dur << L" " << defNoteDur << L" " << (useLongDur ? L"L" : L"S") << std::endl;
+      //ostringstream ssTrace;
+      //ssTrace << "Rest: " << dur << " " << defNoteDur << " " << (useLongDur ? "L" : "S") << std::endl;
       //LogDebug(ssTrace.str().c_str());
 
       AddRest(beginOffset, curOffset - beginOffset, dur);
@@ -353,8 +353,8 @@ bool RareSnesTrack::ReadEvent(void) {
       spcNotePitch = RareSnesSeq::NOTE_PITCH_TABLE[spcKey];
       spcNotePitch = (spcNotePitch * (1024 + spcTuning) + (spcTuning < 0 ? 1023 : 0)) / 1024;
 
-      //wostringstream ssTrace;
-      //ssTrace << L"Note: " << key << L" " << dur << L" " << defNoteDur << L" " << (useLongDur ? L"L" : L"S") << L" P=" << spcNotePitch << std::endl;
+      //ostringstream ssTrace;
+      //ssTrace << "Note: " << key << " " << dur << " " << defNoteDur << " " << (useLongDur ? "L" : "S") << " P=" << spcNotePitch << std::endl;
       //LogDebug(ssTrace.str().c_str());
 
       uint8_t vel = 127;
@@ -371,27 +371,27 @@ bool RareSnesTrack::ReadEvent(void) {
 
     switch (eventType) {
       case EVENT_UNKNOWN0:
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
         break;
 
       case EVENT_UNKNOWN1: {
         uint8_t arg1 = GetByte(curOffset++);
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-            << std::dec << std::setfill(L' ') << std::setw(0)
-            << L"  Arg1: " << (int) arg1;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+            << std::dec << std::setfill(' ') << std::setw(0)
+            << "  Arg1: " << (int) arg1;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
         break;
       }
 
       case EVENT_UNKNOWN2: {
         uint8_t arg1 = GetByte(curOffset++);
         uint8_t arg2 = GetByte(curOffset++);
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-            << std::dec << std::setfill(L' ') << std::setw(0)
-            << L"  Arg1: " << (int) arg1
-            << L"  Arg2: " << (int) arg2;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+            << std::dec << std::setfill(' ') << std::setw(0)
+            << "  Arg1: " << (int) arg1
+            << "  Arg2: " << (int) arg2;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
         break;
       }
 
@@ -399,12 +399,12 @@ bool RareSnesTrack::ReadEvent(void) {
         uint8_t arg1 = GetByte(curOffset++);
         uint8_t arg2 = GetByte(curOffset++);
         uint8_t arg3 = GetByte(curOffset++);
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-            << std::dec << std::setfill(L' ') << std::setw(0)
-            << L"  Arg1: " << (int) arg1
-            << L"  Arg2: " << (int) arg2
-            << L"  Arg3: " << (int) arg3;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+            << std::dec << std::setfill(' ') << std::setw(0)
+            << "  Arg1: " << (int) arg1
+            << "  Arg2: " << (int) arg2
+            << "  Arg3: " << (int) arg3;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
         break;
       }
 
@@ -413,13 +413,13 @@ bool RareSnesTrack::ReadEvent(void) {
         uint8_t arg2 = GetByte(curOffset++);
         uint8_t arg3 = GetByte(curOffset++);
         uint8_t arg4 = GetByte(curOffset++);
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-            << std::dec << std::setfill(L' ') << std::setw(0)
-            << L"  Arg1: " << (int) arg1
-            << L"  Arg2: " << (int) arg2
-            << L"  Arg3: " << (int) arg3
-            << L"  Arg4: " << (int) arg4;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+            << std::dec << std::setfill(' ') << std::setw(0)
+            << "  Arg1: " << (int) arg1
+            << "  Arg2: " << (int) arg2
+            << "  Arg3: " << (int) arg3
+            << "  Arg4: " << (int) arg4;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
         break;
       }
 
@@ -444,7 +444,7 @@ bool RareSnesTrack::ReadEvent(void) {
         spcInstr = newProg;
         spcVolL = newVolL;
         spcVolR = newVolR;
-        AddProgramChange(beginOffset, curOffset - beginOffset, newProg, true, L"Program Change, Volume");
+        AddProgramChange(beginOffset, curOffset - beginOffset, newProg, true, "Program Change, Volume");
         AddVolLRNoItem(spcVolL, spcVolR);
         break;
       }
@@ -455,7 +455,7 @@ bool RareSnesTrack::ReadEvent(void) {
 
         spcVolL = newVolL;
         spcVolR = newVolR;
-        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, L"Volume L/R");
+        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, "Volume L/R");
         break;
       }
 
@@ -464,21 +464,21 @@ bool RareSnesTrack::ReadEvent(void) {
 
         spcVolL = newVol;
         spcVolR = newVol;
-        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, L"Volume");
+        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, "Volume");
         break;
       }
 
       case EVENT_GOTO: {
         uint16_t dest = GetShort(curOffset);
         curOffset += 2;
-        desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+        desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
         uint32_t length = curOffset - beginOffset;
 
         curOffset = dest;
         if (!IsOffsetUsed(dest) || rptNestLevel != 0) // nest level check is required for Stickerbrush Symphony
-          AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+          AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
         else
-          bContinue = AddLoopForever(beginOffset, length, L"Jump");
+          bContinue = AddLoopForever(beginOffset, length, "Jump");
         break;
       }
 
@@ -487,17 +487,17 @@ bool RareSnesTrack::ReadEvent(void) {
         uint16_t dest = GetShort(curOffset);
         curOffset += 2;
 
-        desc << L"Times: " << (int) times << L"  Destination: $" << std::hex << std::setfill(L'0') << std::setw(4)
+        desc << "Times: " << (int) times << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
             << std::uppercase << (int) dest;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        (times == 1 ? L"Pattern Play" : L"Pattern Repeat"),
+                        (times == 1 ? "Pattern Play" : "Pattern Repeat"),
                         desc.str().c_str(),
                         CLR_LOOP,
                         ICON_STARTREP);
 
         if (rptNestLevel == RARESNES_RPTNESTMAX) {
-          pRoot->AddLogItem(new LogItem(L"Subroutine nest level overflow\n", LOG_LEVEL_ERR, L"RareSnesSeq"));
+          pRoot->AddLogItem(new LogItem("Subroutine nest level overflow\n", LOG_LEVEL_ERR, "RareSnesSeq"));
           bContinue = false;
           break;
         }
@@ -514,16 +514,16 @@ bool RareSnesTrack::ReadEvent(void) {
         uint16_t dest = GetShort(curOffset);
         curOffset += 2;
 
-        desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+        desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Pattern Play",
+                        "Pattern Play",
                         desc.str().c_str(),
                         CLR_LOOP,
                         ICON_STARTREP);
 
         if (rptNestLevel == RARESNES_RPTNESTMAX) {
-          pRoot->AddLogItem(new LogItem(L"Subroutine nest level overflow\n", LOG_LEVEL_ERR, L"RareSnesSeq"));
+          pRoot->AddLogItem(new LogItem("Subroutine nest level overflow\n", LOG_LEVEL_ERR, "RareSnesSeq"));
           bContinue = false;
           break;
         }
@@ -539,13 +539,13 @@ bool RareSnesTrack::ReadEvent(void) {
       case EVENT_RET: {
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"End Pattern",
+                        "End Pattern",
                         desc.str().c_str(),
                         CLR_TRACKEND,
                         ICON_ENDREP);
 
         if (rptNestLevel == 0) {
-          pRoot->AddLogItem(new LogItem(L"Subroutine nest level overflow\n", LOG_LEVEL_ERR, L"RareSnesSeq"));
+          pRoot->AddLogItem(new LogItem("Subroutine nest level overflow\n", LOG_LEVEL_ERR, "RareSnesSeq"));
           bContinue = false;
           break;
         }
@@ -575,7 +575,7 @@ bool RareSnesTrack::ReadEvent(void) {
 
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Default Duration On",
+                        "Default Duration On",
                         desc.str().c_str(),
                         CLR_DURNOTE,
                         ICON_NOTE);
@@ -586,7 +586,7 @@ bool RareSnesTrack::ReadEvent(void) {
         defNoteDur = 0;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Default Duration Off",
+                        "Default Duration Off",
                         desc.str().c_str(),
                         CLR_DURNOTE,
                         ICON_NOTE);
@@ -596,7 +596,7 @@ bool RareSnesTrack::ReadEvent(void) {
         curOffset += 5;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Pitch Slide Up",
+                        "Pitch Slide Up",
                         desc.str().c_str(),
                         CLR_PITCHBEND,
                         ICON_CONTROL);
@@ -607,7 +607,7 @@ bool RareSnesTrack::ReadEvent(void) {
         curOffset += 5;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Pitch Slide Down",
+                        "Pitch Slide Down",
                         desc.str().c_str(),
                         CLR_PITCHBEND,
                         ICON_CONTROL);
@@ -617,7 +617,7 @@ bool RareSnesTrack::ReadEvent(void) {
       case EVENT_PITCHSLIDEOFF:
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Pitch Slide Off",
+                        "Pitch Slide Off",
                         desc.str().c_str(),
                         CLR_PITCHBEND,
                         ICON_CONTROL);
@@ -638,7 +638,7 @@ bool RareSnesTrack::ReadEvent(void) {
         AddTempoBPM(beginOffset,
                     curOffset - beginOffset,
                     parentSeq->GetTempoInBPM(parentSeq->tempo, parentSeq->timerFreq),
-                    L"Tempo Add");
+                    "Tempo Add");
         break;
       }
 
@@ -646,7 +646,7 @@ bool RareSnesTrack::ReadEvent(void) {
         curOffset += 3;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Vibrato (Short)",
+                        "Vibrato (Short)",
                         desc.str().c_str(),
                         CLR_MODULATION,
                         ICON_CONTROL);
@@ -656,7 +656,7 @@ bool RareSnesTrack::ReadEvent(void) {
       case EVENT_VIBRATOOFF:
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Vibrato Off",
+                        "Vibrato Off",
                         desc.str().c_str(),
                         CLR_MODULATION,
                         ICON_CONTROL);
@@ -666,7 +666,7 @@ bool RareSnesTrack::ReadEvent(void) {
         curOffset += 4;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Vibrato",
+                        "Vibrato",
                         desc.str().c_str(),
                         CLR_MODULATION,
                         ICON_CONTROL);
@@ -676,7 +676,7 @@ bool RareSnesTrack::ReadEvent(void) {
       case EVENT_TREMOLOOFF:
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Tremolo Off",
+                        "Tremolo Off",
                         desc.str().c_str(),
                         CLR_MODULATION,
                         ICON_CONTROL);
@@ -686,7 +686,7 @@ bool RareSnesTrack::ReadEvent(void) {
         curOffset += 4;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Tremolo",
+                        "Tremolo",
                         desc.str().c_str(),
                         CLR_MODULATION,
                         ICON_CONTROL);
@@ -698,16 +698,16 @@ bool RareSnesTrack::ReadEvent(void) {
         curOffset += 2;
         spcADSR = newADSR;
 
-        desc << L"ADSR: " << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) newADSR;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"ADSR", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+        desc << "ADSR: " << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) newADSR;
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
         break;
       }
 
       case EVENT_MASTVOL: {
         // TODO: At least it's not Master Volume in Donkey Kong Country 2
         uint8_t newVol = GetByte(curOffset++);
-        desc << L"Volume: " << newVol;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Master Volume?", desc.str(), CLR_VOLUME, ICON_CONTROL);
+        desc << "Volume: " << newVol;
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Master Volume?", desc.str(), CLR_VOLUME, ICON_CONTROL);
         break;
       }
 
@@ -715,18 +715,18 @@ bool RareSnesTrack::ReadEvent(void) {
         int8_t newVolL = (int8_t) GetByte(curOffset++);
         int8_t newVolR = (int8_t) GetByte(curOffset++);
         int8_t newVol = min(abs((int) newVolL) + abs((int) newVolR), 255) / 2; // workaround: convert to mono
-        AddMasterVol(beginOffset, curOffset - beginOffset, newVol, L"Master Volume L/R");
+        AddMasterVol(beginOffset, curOffset - beginOffset, newVol, "Master Volume L/R");
         break;
       }
 
       case EVENT_TUNING: {
         int8_t newTuning = (int8_t) GetByte(curOffset++);
         spcTuning = newTuning;
-        desc << L"Tuning: " << (int) newTuning << L" (" << (int) (GetTuningInSemitones(newTuning) * 100 + 0.5)
-            << L" cents)";
+        desc << "Tuning: " << (int) newTuning << " (" << (int) (GetTuningInSemitones(newTuning) * 100 + 0.5)
+            << " cents)";
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Tuning",
+                        "Tuning",
                         desc.str().c_str(),
                         CLR_PITCHBEND,
                         ICON_CONTROL);
@@ -737,11 +737,11 @@ bool RareSnesTrack::ReadEvent(void) {
       {
         int8_t newTransp = (int8_t) GetByte(curOffset++);
         spcTranspose = spcTransposeAbs = newTransp;
-        //AddTranspose(beginOffset, curOffset-beginOffset, 0, L"Transpose (Abs)");
+        //AddTranspose(beginOffset, curOffset-beginOffset, 0, "Transpose (Abs)");
 
         // add event without MIDI event
-        desc << L"Transpose: " << newTransp;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Transpose", desc.str(), CLR_TRANSPOSE, ICON_CONTROL);
+        desc << "Transpose: " << newTransp;
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Transpose", desc.str(), CLR_TRANSPOSE, ICON_CONTROL);
 
         cKeyCorrection = SEQ_KEYOFS;
         break;
@@ -750,13 +750,13 @@ bool RareSnesTrack::ReadEvent(void) {
       case EVENT_TRANSPREL: {
         int8_t deltaTransp = (int8_t) GetByte(curOffset++);
         spcTranspose = (spcTranspose + deltaTransp) & 0xff;
-        //AddTranspose(beginOffset, curOffset-beginOffset, spcTransposeAbs - spcTranspose, L"Transpose (Rel)");
+        //AddTranspose(beginOffset, curOffset-beginOffset, spcTransposeAbs - spcTranspose, "Transpose (Rel)");
 
         // add event without MIDI event
-        desc << L"Transpose: " << deltaTransp;
+        desc << "Transpose: " << deltaTransp;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Transpose (Relative)",
+                        "Transpose (Relative)",
                         desc.str(),
                         CLR_TRANSPOSE,
                         ICON_CONTROL);
@@ -772,10 +772,10 @@ bool RareSnesTrack::ReadEvent(void) {
         parentSeq->midiReverb = min(abs((int) newVolL) + abs((int) newVolR), 255) / 2;
         // TODO: update MIDI reverb value for each tracks?
 
-        desc << L"Feedback: " << (int) newFeedback << L"  Volume: " << (int) newVolL << L", " << (int) newVolR;
+        desc << "Feedback: " << (int) newFeedback << "  Volume: " << (int) newVolL << ", " << (int) newVolR;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Echo Param",
+                        "Echo Param",
                         desc.str().c_str(),
                         CLR_REVERB,
                         ICON_CONTROL);
@@ -783,11 +783,11 @@ bool RareSnesTrack::ReadEvent(void) {
       }
 
       case EVENT_ECHOON:
-        AddReverb(beginOffset, curOffset - beginOffset, parentSeq->midiReverb, L"Echo On");
+        AddReverb(beginOffset, curOffset - beginOffset, parentSeq->midiReverb, "Echo On");
         break;
 
       case EVENT_ECHOOFF:
-        AddReverb(beginOffset, curOffset - beginOffset, 0, L"Echo Off");
+        AddReverb(beginOffset, curOffset - beginOffset, 0, "Echo Off");
         break;
 
       case EVENT_ECHOFIR: {
@@ -795,16 +795,16 @@ bool RareSnesTrack::ReadEvent(void) {
         GetBytes(curOffset, 8, newFIR);
         curOffset += 8;
 
-        desc << L"Filter: ";
+        desc << "Filter: ";
         for (int iFIRIndex = 0; iFIRIndex < 8; iFIRIndex++) {
           if (iFIRIndex != 0)
-            desc << L" ";
-          desc << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) newFIR[iFIRIndex];
+            desc << " ";
+          desc << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) newFIR[iFIRIndex];
         }
 
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Echo FIR",
+                        "Echo FIR",
                         desc.str().c_str(),
                         CLR_REVERB,
                         ICON_CONTROL);
@@ -813,10 +813,10 @@ bool RareSnesTrack::ReadEvent(void) {
 
       case EVENT_NOISECLK: {
         uint8_t newCLK = GetByte(curOffset++);
-        desc << L"CLK: " << (int) newCLK;
+        desc << "CLK: " << (int) newCLK;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Noise Frequency",
+                        "Noise Frequency",
                         desc.str().c_str(),
                         CLR_CHANGESTATE,
                         ICON_CONTROL);
@@ -826,7 +826,7 @@ bool RareSnesTrack::ReadEvent(void) {
       case EVENT_NOISEON:
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Noise On",
+                        "Noise On",
                         desc.str().c_str(),
                         CLR_CHANGESTATE,
                         ICON_CONTROL);
@@ -835,7 +835,7 @@ bool RareSnesTrack::ReadEvent(void) {
       case EVENT_NOISEOFF:
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Noise Off",
+                        "Noise Off",
                         desc.str().c_str(),
                         CLR_CHANGESTATE,
                         ICON_CONTROL);
@@ -843,10 +843,10 @@ bool RareSnesTrack::ReadEvent(void) {
 
       case EVENT_SETALTNOTE1:
         altNoteByte1 = GetByte(curOffset++);
-        desc << L"Note: " << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) altNoteByte1;
+        desc << "Note: " << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) altNoteByte1;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Set Alt Note 1",
+                        "Set Alt Note 1",
                         desc.str().c_str(),
                         CLR_CHANGESTATE,
                         ICON_NOTE);
@@ -854,10 +854,10 @@ bool RareSnesTrack::ReadEvent(void) {
 
       case EVENT_SETALTNOTE2:
         altNoteByte2 = GetByte(curOffset++);
-        desc << L"Note: " << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) altNoteByte2;
+        desc << "Note: " << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) altNoteByte2;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Set Alt Note 2",
+                        "Set Alt Note 2",
                         desc.str().c_str(),
                         CLR_CHANGESTATE,
                         ICON_NOTE);
@@ -867,7 +867,7 @@ bool RareSnesTrack::ReadEvent(void) {
         curOffset += 4;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Pitch Slide Down (Short)",
+                        "Pitch Slide Down (Short)",
                         desc.str().c_str(),
                         CLR_PITCHBEND,
                         ICON_CONTROL);
@@ -878,7 +878,7 @@ bool RareSnesTrack::ReadEvent(void) {
         curOffset += 4;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Pitch Slide Up (Short)",
+                        "Pitch Slide Up (Short)",
                         desc.str().c_str(),
                         CLR_PITCHBEND,
                         ICON_CONTROL);
@@ -889,7 +889,7 @@ bool RareSnesTrack::ReadEvent(void) {
         useLongDur = true;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Long Duration On",
+                        "Long Duration On",
                         desc.str().c_str(),
                         CLR_DURNOTE,
                         ICON_NOTE);
@@ -899,7 +899,7 @@ bool RareSnesTrack::ReadEvent(void) {
         useLongDur = false;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Long Duration Off",
+                        "Long Duration Off",
                         desc.str().c_str(),
                         CLR_DURNOTE,
                         ICON_NOTE);
@@ -922,11 +922,11 @@ bool RareSnesTrack::ReadEvent(void) {
 
         // add event without MIDI events
         CalcVolPanFromVolLR(spcVolL, spcVolR, newMidiVol, newMidiPan);
-        desc << L"Left Volume: " << newVolL << L"  Right Volume: " << newVolR << L"  AR: " << (int) ar << L"  DR: "
-            << (int) dr << L"  SL: " << (int) sl << L"  SR: " << (int) sr;
+        desc << "Left Volume: " << newVolL << "  Right Volume: " << newVolR << "  AR: " << (int) ar << "  DR: "
+            << (int) dr << "  SL: " << (int) sl << "  SR: " << (int) sr;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Set Vol/ADSR Preset 1",
+                        "Set Vol/ADSR Preset 1",
                         desc.str(),
                         CLR_VOLUME,
                         ICON_CONTROL);
@@ -950,11 +950,11 @@ bool RareSnesTrack::ReadEvent(void) {
 
         // add event without MIDI events
         CalcVolPanFromVolLR(spcVolL, spcVolR, newMidiVol, newMidiPan);
-        desc << L"Left Volume: " << newVolL << L"  Right Volume: " << newVolR << L"  AR: " << (int) ar << L"  DR: "
-            << (int) dr << L"  SL: " << (int) sl << L"  SR: " << (int) sr;
+        desc << "Left Volume: " << newVolL << "  Right Volume: " << newVolR << "  AR: " << (int) ar << "  DR: "
+            << (int) dr << "  SL: " << (int) sl << "  SR: " << (int) sr;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Set Vol/ADSR Preset 2",
+                        "Set Vol/ADSR Preset 2",
                         desc.str(),
                         CLR_VOLUME,
                         ICON_CONTROL);
@@ -978,11 +978,11 @@ bool RareSnesTrack::ReadEvent(void) {
 
         // add event without MIDI events
         CalcVolPanFromVolLR(spcVolL, spcVolR, newMidiVol, newMidiPan);
-        desc << L"Left Volume: " << newVolL << L"  Right Volume: " << newVolR << L"  AR: " << (int) ar << L"  DR: "
-            << (int) dr << L"  SL: " << (int) sl << L"  SR: " << (int) sr;
+        desc << "Left Volume: " << newVolL << "  Right Volume: " << newVolR << "  AR: " << (int) ar << "  DR: "
+            << (int) dr << "  SL: " << (int) sl << "  SR: " << (int) sr;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Set Vol/ADSR Preset 3",
+                        "Set Vol/ADSR Preset 3",
                         desc.str(),
                         CLR_VOLUME,
                         ICON_CONTROL);
@@ -1006,11 +1006,11 @@ bool RareSnesTrack::ReadEvent(void) {
 
         // add event without MIDI events
         CalcVolPanFromVolLR(spcVolL, spcVolR, newMidiVol, newMidiPan);
-        desc << L"Left Volume: " << newVolL << L"  Right Volume: " << newVolR << L"  AR: " << (int) ar << L"  DR: "
-            << (int) dr << L"  SL: " << (int) sl << L"  SR: " << (int) sr;
+        desc << "Left Volume: " << newVolL << "  Right Volume: " << newVolR << "  AR: " << (int) ar << "  DR: "
+            << (int) dr << "  SL: " << (int) sl << "  SR: " << (int) sr;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Set Vol/ADSR Preset 4",
+                        "Set Vol/ADSR Preset 4",
                         desc.str(),
                         CLR_VOLUME,
                         ICON_CONTROL);
@@ -1034,11 +1034,11 @@ bool RareSnesTrack::ReadEvent(void) {
 
         // add event without MIDI events
         CalcVolPanFromVolLR(spcVolL, spcVolR, newMidiVol, newMidiPan);
-        desc << L"Left Volume: " << newVolL << L"  Right Volume: " << newVolR << L"  AR: " << (int) ar << L"  DR: "
-            << (int) dr << L"  SL: " << (int) sl << L"  SR: " << (int) sr;
+        desc << "Left Volume: " << newVolL << "  Right Volume: " << newVolR << "  AR: " << (int) ar << "  DR: "
+            << (int) dr << "  SL: " << (int) sl << "  SR: " << (int) sr;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Set Vol/ADSR Preset 5",
+                        "Set Vol/ADSR Preset 5",
                         desc.str(),
                         CLR_VOLUME,
                         ICON_CONTROL);
@@ -1048,31 +1048,31 @@ bool RareSnesTrack::ReadEvent(void) {
       case EVENT_GETVOLADSRPRESET1:
         spcVolL = parentSeq->presetVolL[0];
         spcVolR = parentSeq->presetVolR[0];
-        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, L"Get Vol/ADSR Preset 1");
+        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, "Get Vol/ADSR Preset 1");
         break;
 
       case EVENT_GETVOLADSRPRESET2:
         spcVolL = parentSeq->presetVolL[1];
         spcVolR = parentSeq->presetVolR[1];
-        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, L"Get Vol/ADSR Preset 2");
+        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, "Get Vol/ADSR Preset 2");
         break;
 
       case EVENT_GETVOLADSRPRESET3:
         spcVolL = parentSeq->presetVolL[2];
         spcVolR = parentSeq->presetVolR[2];
-        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, L"Get Vol/ADSR Preset 3");
+        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, "Get Vol/ADSR Preset 3");
         break;
 
       case EVENT_GETVOLADSRPRESET4:
         spcVolL = parentSeq->presetVolL[3];
         spcVolR = parentSeq->presetVolR[3];
-        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, L"Get Vol/ADSR Preset 4");
+        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, "Get Vol/ADSR Preset 4");
         break;
 
       case EVENT_GETVOLADSRPRESET5:
         spcVolL = parentSeq->presetVolL[4];
         spcVolR = parentSeq->presetVolR[4];
-        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, L"Get Vol/ADSR Preset 5");
+        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, "Get Vol/ADSR Preset 5");
         break;
 
       case EVENT_TIMERFREQ: {
@@ -1081,7 +1081,7 @@ bool RareSnesTrack::ReadEvent(void) {
         AddTempoBPM(beginOffset,
                     curOffset - beginOffset,
                     parentSeq->GetTempoInBPM(parentSeq->tempo, parentSeq->timerFreq),
-                    L"Timer Frequency");
+                    "Timer Frequency");
         break;
       }
 
@@ -1093,15 +1093,15 @@ bool RareSnesTrack::ReadEvent(void) {
 
       case EVENT_RESETADSR:
         spcADSR = 0x8FE0;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reset ADSR", L"ADSR: 8FE0", CLR_ADSR, ICON_CONTROL);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Reset ADSR", "ADSR: 8FE0", CLR_ADSR, ICON_CONTROL);
         break;
 
       case EVENT_RESETADSRSOFT:
         spcADSR = 0x8EE0;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Reset ADSR (Soft)",
-                        L"ADSR: 8EE0",
+                        "Reset ADSR (Soft)",
+                        "ADSR: 8EE0",
                         CLR_ADSR,
                         ICON_CONTROL);
         break;
@@ -1111,12 +1111,12 @@ bool RareSnesTrack::ReadEvent(void) {
         int8_t newTransp = (int8_t) GetByte(curOffset++);
         int8_t newTuning = (int8_t) GetByte(curOffset++);
 
-        desc << L"Program Number: " << (int) newProg << L"  Transpose: " << (int) newTransp << L"  Tuning: "
-            << (int) newTuning << L" (" << (int) (GetTuningInSemitones(newTuning) * 100 + 0.5) << L" cents)";;
+        desc << "Program Number: " << (int) newProg << "  Transpose: " << (int) newTransp << "  Tuning: "
+            << (int) newTuning << " (" << (int) (GetTuningInSemitones(newTuning) * 100 + 0.5) << " cents)";;
 
         // instrument
         spcInstr = newProg;
-        AddProgramChange(beginOffset, curOffset - beginOffset, newProg, true, L"Program Change, Transpose, Tuning");
+        AddProgramChange(beginOffset, curOffset - beginOffset, newProg, true, "Program Change, Transpose, Tuning");
 
         // transpose
         spcTranspose = spcTransposeAbs = newTransp;
@@ -1136,10 +1136,10 @@ bool RareSnesTrack::ReadEvent(void) {
         uint16_t newADSR = GetShortBE(curOffset);
         curOffset += 2;
 
-        desc << L"Program Number: " << (int) newProg << L"  Transpose: " << (int) newTransp << L"  Tuning: "
-            << (int) newTuning << L" (" << (int) (GetTuningInSemitones(newTuning) * 100 + 0.5) << L" cents)";;
-        desc << L"  Volume: " << (int) newVolL << L", " << (int) newVolR;
-        desc << L"  ADSR: " << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) newADSR;
+        desc << "Program Number: " << (int) newProg << "  Transpose: " << (int) newTransp << "  Tuning: "
+            << (int) newTuning << " (" << (int) (GetTuningInSemitones(newTuning) * 100 + 0.5) << " cents)";;
+        desc << "  Volume: " << (int) newVolL << ", " << (int) newVolR;
+        desc << "  ADSR: " << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) newADSR;
 
         // instrument
         spcInstr = newProg;
@@ -1147,7 +1147,7 @@ bool RareSnesTrack::ReadEvent(void) {
                          curOffset - beginOffset,
                          newProg,
                          true,
-                         L"Program Change, Transpose, Tuning, Volume L/R, ADSR");
+                         "Program Change, Transpose, Tuning, Volume L/R, ADSR");
 
         // transpose
         spcTranspose = spcTransposeAbs = newTransp;
@@ -1169,10 +1169,10 @@ bool RareSnesTrack::ReadEvent(void) {
 
       case EVENT_ECHODELAY: {
         uint8_t newEDL = GetByte(curOffset++);
-        desc << L"Delay: " << (int) newEDL;
+        desc << "Delay: " << (int) newEDL;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Echo Delay",
+                        "Echo Delay",
                         desc.str().c_str(),
                         CLR_REVERB,
                         ICON_CONTROL);
@@ -1192,11 +1192,11 @@ bool RareSnesTrack::ReadEvent(void) {
 
         // add event without MIDI events
         CalcVolPanFromVolLR(parentSeq->presetVolL[0], parentSeq->presetVolR[0], newMidiVol, newMidiPan);
-        desc << L"Left Volume 1: " << newVolL1 << L"  Right Volume 1: " << newVolR1 << L"  Left Volume 2: " << newVolL2
-            << L"  Right Volume 2: " << newVolR2;
+        desc << "Left Volume 1: " << newVolL1 << "  Right Volume 1: " << newVolR1 << "  Left Volume 2: " << newVolL2
+            << "  Right Volume 2: " << newVolR2;
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Set Volume Preset",
+                        "Set Volume Preset",
                         desc.str(),
                         CLR_VOLUME,
                         ICON_CONTROL);
@@ -1206,37 +1206,37 @@ bool RareSnesTrack::ReadEvent(void) {
       case EVENT_GETVOLPRESET1:
         spcVolL = parentSeq->presetVolL[0];
         spcVolR = parentSeq->presetVolR[0];
-        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, L"Get Volume Preset 1");
+        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, "Get Volume Preset 1");
         break;
 
       case EVENT_GETVOLPRESET2:
         spcVolL = parentSeq->presetVolL[1];
         spcVolR = parentSeq->presetVolR[1];
-        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, L"Get Volume Preset 2");
+        AddVolLR(beginOffset, curOffset - beginOffset, spcVolL, spcVolR, "Get Volume Preset 2");
         break;
 
       case EVENT_LFOOFF:
         AddGenericEvent(beginOffset,
                         curOffset - beginOffset,
-                        L"Pitch Slide/Vibrato/Tremolo Off",
+                        "Pitch Slide/Vibrato/Tremolo Off",
                         desc.str(),
                         CLR_CHANGESTATE,
                         ICON_CONTROL);
         break;
 
       default:
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-        pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+        pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                       LOG_LEVEL_ERR,
-                                      L"RareSnesSeq"));
+                                      "RareSnesSeq"));
         bContinue = false;
         break;
     }
   }
 
-  //wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //LogDebug(ssTrace.str().c_str());
 
   return bContinue;
@@ -1252,13 +1252,13 @@ void RareSnesTrack::AddVolLR(uint32_t offset,
                              uint32_t length,
                              int8_t spcVolL,
                              int8_t spcVolR,
-                             const std::wstring &sEventName) {
+                             const std::string &sEventName) {
   uint8_t newMidiVol;
   uint8_t newMidiPan;
   CalcVolPanFromVolLR(spcVolL, spcVolR, newMidiVol, newMidiPan);
 
-  std::wostringstream desc;
-  desc << L"Left Volume: " << spcVolL << L"  Right Volume: " << spcVolR;
+  std::ostringstream desc;
+  desc << "Left Volume: " << spcVolL << "  Right Volume: " << spcVolR;
   AddGenericEvent(offset, length, sEventName, desc.str(), CLR_VOLUME, ICON_CONTROL);
 
   // add MIDI events only if updated

--- a/src/main/formats/RareSnesSeq.h
+++ b/src/main/formats/RareSnesSeq.h
@@ -82,7 +82,7 @@ enum RareSnesSeqEventType {
 class RareSnesSeq
     : public VGMSeq {
  public:
-  RareSnesSeq(RawFile *file, RareSnesVersion ver, uint32_t seqdata_offset, std::wstring newName = L"Rare SNES Seq");
+  RareSnesSeq(RawFile *file, RareSnesVersion ver, uint32_t seqdata_offset, std::string newName = "Rare SNES Seq");
   virtual ~RareSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);
@@ -126,7 +126,7 @@ class RareSnesTrack
                 uint32_t length,
                 int8_t spcVolL,
                 int8_t spcVolR,
-                const std::wstring &sEventName = L"Volume L/R");
+                const std::string &sEventName = "Volume L/R");
   void AddVolLRNoItem(int8_t spcVolL, int8_t spcVolR);
 
  private:

--- a/src/main/formats/SNESDSP.cpp
+++ b/src/main/formats/SNESDSP.cpp
@@ -327,14 +327,14 @@ SNESSampColl::SNESSampColl(const std::string &format, VGMInstrSet *instrset, uin
 }
 
 SNESSampColl::SNESSampColl(const std::string &format, RawFile *rawfile, uint32_t offset,
-                           const std::vector<uint8_t> &targetSRCNs, std::wstring name) :
+                           const std::vector<uint8_t> &targetSRCNs, std::string name) :
     VGMSampColl(format, rawfile, offset, 0, name),
     spcDirAddr(offset),
     targetSRCNs(targetSRCNs) {
 }
 
 SNESSampColl::SNESSampColl(const std::string &format, VGMInstrSet *instrset, uint32_t offset,
-                           const std::vector<uint8_t> &targetSRCNs, std::wstring name) :
+                           const std::vector<uint8_t> &targetSRCNs, std::string name) :
     VGMSampColl(format, instrset->rawfile, instrset, offset, 0, name),
     spcDirAddr(offset),
     targetSRCNs(targetSRCNs) {
@@ -356,10 +356,10 @@ void SNESSampColl::SetDefaultTargets(uint32_t maxNumSamps) {
 }
 
 bool SNESSampColl::GetSampleInfo() {
-  spcDirHeader = AddHeader(spcDirAddr, 0, L"Sample DIR");
+  spcDirHeader = AddHeader(spcDirAddr, 0, "Sample DIR");
   for (std::vector<uint8_t>::iterator itr = this->targetSRCNs.begin(); itr != this->targetSRCNs.end(); ++itr) {
     uint8_t srcn = (*itr);
-    std::wostringstream name;
+    std::ostringstream name;
 
     uint32_t offDirEnt = spcDirAddr + (srcn * 4);
     if (!SNESSampColl::IsValidSampleDir(GetRawFile(), offDirEnt, true)) {
@@ -372,15 +372,15 @@ bool SNESSampColl::GetSampleInfo() {
     bool loop;
     uint32_t length = SNESSamp::GetSampleLength(GetRawFile(), addrSampStart, loop);
 
-    name << L"SA " << srcn;
+    name << "SA " << srcn;
     spcDirHeader->AddSimpleItem(offDirEnt, 2, name.str().c_str());
 
-    name.str(L"");
-    name << L"LSA " << srcn;
+    name.str("");
+    name << "LSA " << srcn;
     spcDirHeader->AddSimpleItem(offDirEnt + 2, 2, name.str().c_str());
 
-    name.str(L"");
-    name << L"Sample " << srcn;
+    name.str("");
+    name << "Sample " << srcn;
     SNESSamp *samp = new SNESSamp(this, addrSampStart, length, addrSampStart, length, addrSampLoop, name.str());
     samples.push_back(samp);
   }
@@ -420,7 +420,7 @@ bool SNESSampColl::IsValidSampleDir(RawFile *file, uint32_t spcDirEntAddr, bool 
 //  ********
 
 SNESSamp::SNESSamp(VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t dataOffset,
-                   uint32_t dataLen, uint32_t loopOffset, std::wstring name)
+                   uint32_t dataLen, uint32_t loopOffset, std::string name)
     : VGMSamp(sampColl, offset, length, dataOffset, dataLen, 1, 16, 32000, name),
       brrLoopOffset(loopOffset) {
 }
@@ -464,9 +464,9 @@ void SNESSamp::ConvertToStdWave(uint8_t *buf) {
   for (uint32_t k = 0; k + 9 <= dataLength; k += 9)                //for every adpcm chunk
   {
     if (dwOffset + k + 9 > GetRawFile()->size()) {
-      wchar_t log[512];
-      swprintf(log, 512, L"\"%s\" unexpected EOF.", name.c_str());
-      pRoot->AddLogItem(new LogItem(log, LOG_LEVEL_WARN, L"SNESSamp"));
+      char log[512];
+      snprintf(log, 512, "\"%s\" unexpected EOF.", name.c_str());
+      pRoot->AddLogItem(new LogItem(log, LOG_LEVEL_WARN, "SNESSamp"));
       break;
     }
 

--- a/src/main/formats/SNESDSP.h
+++ b/src/main/formats/SNESDSP.h
@@ -104,8 +104,8 @@ class SNESSampColl
  public:
   SNESSampColl(const std::string& format, RawFile* rawfile, uint32_t offset, uint32_t maxNumSamps = 256);
   SNESSampColl(const std::string& format, VGMInstrSet* instrset, uint32_t offset, uint32_t maxNumSamps = 256);
-  SNESSampColl(const std::string& format, RawFile* rawfile, uint32_t offset, const std::vector<uint8_t>& targetSRCNs, std::wstring name = L"SNESSampColl");
-  SNESSampColl(const std::string& format, VGMInstrSet* instrset, uint32_t offset, const std::vector<uint8_t>& targetSRCNs, std::wstring name = L"SNESSampColl");
+  SNESSampColl(const std::string& format, RawFile* rawfile, uint32_t offset, const std::vector<uint8_t>& targetSRCNs, std::string name = "SNESSampColl");
+  SNESSampColl(const std::string& format, VGMInstrSet* instrset, uint32_t offset, const std::vector<uint8_t>& targetSRCNs, std::string name = "SNESSampColl");
   virtual ~SNESSampColl();
 
   virtual bool GetSampleInfo();
@@ -128,7 +128,7 @@ class SNESSamp
     : public VGMSamp {
  public:
   SNESSamp(VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t dataOffset,
-           uint32_t dataLen, uint32_t loopOffset, std::wstring name = L"BRR");
+           uint32_t dataLen, uint32_t loopOffset, std::string name = "BRR");
   virtual ~SNESSamp(void);
 
   static uint32_t GetSampleLength(RawFile *file, uint32_t offset, bool &loop);

--- a/src/main/formats/SegSatSeq.cpp
+++ b/src/main/formats/SegSatSeq.cpp
@@ -23,7 +23,7 @@ bool SegSatSeq::GetHeaderInfo(void) {
   //if (nNumTracks == 0 || nNumTracks > 24)		//if there are no tracks or there are more tracks than allowed
   //	return FALSE;							//return an error, the sequence shall be deleted
 
-  name() = L"Sega Saturn Seq";
+  name() = "Sega Saturn Seq";
 
   return true;
 }
@@ -78,7 +78,7 @@ bool SegSatSeq::ReadEvent(void) {
       curOffset += 2;
       remainingEventsInLoop = GetByte(curOffset++);
       loopEndPos = curOffset;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reference Event", L"", CLR_LOOP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Reference Event", "", CLR_LOOP);
       curOffset = loopOffset;
       bInLoop = true;
     }

--- a/src/main/formats/SoftCreatSnesScanner.cpp
+++ b/src/main/formats/SoftCreatSnesScanner.cpp
@@ -65,7 +65,7 @@ void SoftCreatSnesScanner::Scan(RawFile *file, void *info) {
 
 void SoftCreatSnesScanner::SearchForSoftCreatSnesFromARAM(RawFile *file) {
   SoftCreatSnesVersion version = SOFTCREATSNES_NONE;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   // search song list
   uint32_t ofsLoadSeq;

--- a/src/main/formats/SoftCreatSnesScanner.h
+++ b/src/main/formats/SoftCreatSnesScanner.h
@@ -6,7 +6,7 @@ class SoftCreatSnesScanner:
     public VGMScanner {
  public:
   SoftCreatSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~SoftCreatSnesScanner(void) {
   }

--- a/src/main/formats/SoftCreatSnesSeq.cpp
+++ b/src/main/formats/SoftCreatSnesSeq.cpp
@@ -13,7 +13,7 @@ SoftCreatSnesSeq::SoftCreatSnesSeq(RawFile *file,
                                    SoftCreatSnesVersion ver,
                                    uint32_t seqdataOffset,
                                    uint8_t headerAlignSize,
-                                   std::wstring newName)
+                                   std::string newName)
     : VGMSeq(SoftCreatSnesFormat::name, file, seqdataOffset, 0, newName), version(ver),
       headerAlignSize(headerAlignSize) {
   bLoadTickByTick = true;
@@ -48,10 +48,10 @@ bool SoftCreatSnesSeq::GetHeaderInfo(void) {
       return false;
     }
 
-    std::wstringstream trackName;
-    trackName << L"Track Pointer " << (trackIndex + 1);
-    header->AddSimpleItem(addrTrackLowPtr, 1, trackName.str() + L" (LSB)");
-    header->AddSimpleItem(addrTrackHighPtr, 1, trackName.str() + L" (MSB)");
+    std::stringstream trackName;
+    trackName << "Track Pointer " << (trackIndex + 1);
+    header->AddSimpleItem(addrTrackLowPtr, 1, trackName.str() + " (LSB)");
+    header->AddSimpleItem(addrTrackHighPtr, 1, trackName.str() + " (MSB)");
 
     uint16_t addrTrackStart = GetByte(addrTrackLowPtr) | (GetByte(addrTrackHighPtr) << 8);
     if (addrTrackStart != 0xffff) {
@@ -102,7 +102,7 @@ bool SoftCreatSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   SoftCreatSnesSeqEventType eventType = (SoftCreatSnesSeqEventType) 0;
   std::map<uint8_t, SoftCreatSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -112,27 +112,27 @@ bool SoftCreatSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -140,12 +140,12 @@ bool SoftCreatSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
@@ -154,28 +154,28 @@ bool SoftCreatSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
       break;
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"SoftCreatSnesSeq"));
+                                    "SoftCreatSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //std::wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //std::ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/SoftCreatSnesSeq.h
+++ b/src/main/formats/SoftCreatSnesSeq.h
@@ -20,7 +20,7 @@ class SoftCreatSnesSeq
                    SoftCreatSnesVersion ver,
                    uint32_t seqdata_offset,
                    uint8_t headerAlignSize,
-                   std::wstring newName = L"SoftCreat SNES Seq");
+                   std::string newName = "SoftCreat SNES Seq");
   virtual ~SoftCreatSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/SonyPS2Format.h
+++ b/src/main/formats/SonyPS2Format.h
@@ -21,7 +21,7 @@ typedef struct _VersCk {
 class SonyPS2Coll:
     public VGMColl {
  public:
-  SonyPS2Coll(std::wstring name = L"Unnamed Collection") : VGMColl(name) { }
+  SonyPS2Coll(std::string name = "Unnamed Collection") : VGMColl(name) { }
   virtual ~SonyPS2Coll() { }
 };
 

--- a/src/main/formats/SonyPS2InstrSet.cpp
+++ b/src/main/formats/SonyPS2InstrSet.cpp
@@ -17,35 +17,35 @@ SonyPS2InstrSet::~SonyPS2InstrSet(void) {
 
 
 bool SonyPS2InstrSet::GetHeaderInfo() {
-  name = L"Sony PS2 InstrSet";
+  name = "Sony PS2 InstrSet";
 
   // VERSION CHUNK
   uint32_t curOffset = dwOffset;
   GetBytes(curOffset, 16, &versCk);
-  VGMHeader *versCkHdr = AddHeader(curOffset, versCk.chunkSize, L"Version Chunk");
-  versCkHdr->AddSimpleItem(curOffset, 4, L"Creator");
-  versCkHdr->AddSimpleItem(curOffset + 4, 4, L"Type");
-  versCkHdr->AddSimpleItem(curOffset + 8, 4, L"Chunk Size");
-  versCkHdr->AddSimpleItem(curOffset + 12, 2, L"Reserved");
-  versCkHdr->AddSimpleItem(curOffset + 14, 1, L"Major Version");
-  versCkHdr->AddSimpleItem(curOffset + 15, 1, L"Minor Version");
+  VGMHeader *versCkHdr = AddHeader(curOffset, versCk.chunkSize, "Version Chunk");
+  versCkHdr->AddSimpleItem(curOffset, 4, "Creator");
+  versCkHdr->AddSimpleItem(curOffset + 4, 4, "Type");
+  versCkHdr->AddSimpleItem(curOffset + 8, 4, "Chunk Size");
+  versCkHdr->AddSimpleItem(curOffset + 12, 2, "Reserved");
+  versCkHdr->AddSimpleItem(curOffset + 14, 1, "Major Version");
+  versCkHdr->AddSimpleItem(curOffset + 15, 1, "Minor Version");
 
   // HEADER CHUNK
   curOffset += versCk.chunkSize;
   GetBytes(curOffset, 64, &hdrCk);
   unLength = hdrCk.fileSize;
 
-  VGMHeader *hdrCkHdr = AddHeader(curOffset, hdrCk.chunkSize, L"Header Chunk");
-  hdrCkHdr->AddSimpleItem(curOffset, 4, L"Creator");
-  hdrCkHdr->AddSimpleItem(curOffset + 4, 4, L"Type");
-  hdrCkHdr->AddSimpleItem(curOffset + 8, 4, L"Chunk Size");
-  hdrCkHdr->AddSimpleItem(curOffset + 12, 4, L"Entire Header Size");
-  hdrCkHdr->AddSimpleItem(curOffset + 16, 4, L"Body Size");
-  hdrCkHdr->AddSimpleItem(curOffset + 20, 4, L"Program Chunk Addr");
-  hdrCkHdr->AddSimpleItem(curOffset + 24, 4, L"SampleSet Chunk Addr");
-  hdrCkHdr->AddSimpleItem(curOffset + 28, 4, L"Sample Chunk Addr");
-  hdrCkHdr->AddSimpleItem(curOffset + 32, 4, L"VAG Info Chunk Addr");
-  //hdrCkHdr->AddSimpleItem(curOffset+36, 4, L"Sound Effect Timbre Chunk Addr");
+  VGMHeader *hdrCkHdr = AddHeader(curOffset, hdrCk.chunkSize, "Header Chunk");
+  hdrCkHdr->AddSimpleItem(curOffset, 4, "Creator");
+  hdrCkHdr->AddSimpleItem(curOffset + 4, 4, "Type");
+  hdrCkHdr->AddSimpleItem(curOffset + 8, 4, "Chunk Size");
+  hdrCkHdr->AddSimpleItem(curOffset + 12, 4, "Entire Header Size");
+  hdrCkHdr->AddSimpleItem(curOffset + 16, 4, "Body Size");
+  hdrCkHdr->AddSimpleItem(curOffset + 20, 4, "Program Chunk Addr");
+  hdrCkHdr->AddSimpleItem(curOffset + 24, 4, "SampleSet Chunk Addr");
+  hdrCkHdr->AddSimpleItem(curOffset + 28, 4, "Sample Chunk Addr");
+  hdrCkHdr->AddSimpleItem(curOffset + 32, 4, "VAG Info Chunk Addr");
+  //hdrCkHdr->AddSimpleItem(curOffset+36, 4, "Sound Effect Timbre Chunk Addr");
 
   // PROGRAM CHUNK
   // this is handled in GetInstrPointers()
@@ -56,20 +56,20 @@ bool SonyPS2InstrSet::GetHeaderInfo() {
   sampSetCk.sampleSetOffsetAddr = new uint32_t[sampSetCk.maxSampleSetNumber + 1];
   sampSetCk.sampleSetParam = new SampSetParam[sampSetCk.maxSampleSetNumber + 1];
 
-  VGMHeader *sampSetCkHdr = AddHeader(curOffset, sampSetCk.chunkSize, L"SampleSet Chunk");
-  sampSetCkHdr->AddSimpleItem(curOffset, 4, L"Creator");
-  sampSetCkHdr->AddSimpleItem(curOffset + 4, 4, L"Type");
-  sampSetCkHdr->AddSimpleItem(curOffset + 8, 4, L"Chunk Size");
-  sampSetCkHdr->AddSimpleItem(curOffset + 12, 4, L"Max SampleSet Number");
+  VGMHeader *sampSetCkHdr = AddHeader(curOffset, sampSetCk.chunkSize, "SampleSet Chunk");
+  sampSetCkHdr->AddSimpleItem(curOffset, 4, "Creator");
+  sampSetCkHdr->AddSimpleItem(curOffset + 4, 4, "Type");
+  sampSetCkHdr->AddSimpleItem(curOffset + 8, 4, "Chunk Size");
+  sampSetCkHdr->AddSimpleItem(curOffset + 12, 4, "Max SampleSet Number");
 
   GetBytes(curOffset + 16, (sampSetCk.maxSampleSetNumber + 1) * sizeof(uint32_t), sampSetCk.sampleSetOffsetAddr);
   VGMHeader *sampSetParamOffsetHdr = sampSetCkHdr->AddHeader(curOffset + 16,
                                                              (sampSetCk.maxSampleSetNumber + 1) * sizeof(uint32_t),
-                                                             L"SampleSet Param Offsets");
+                                                             "SampleSet Param Offsets");
   VGMHeader *sampSetParamsHdr = sampSetCkHdr->AddHeader(curOffset + 16 + (sampSetCk.maxSampleSetNumber + 1) * sizeof(uint32_t),
-                              (sampSetCk.maxSampleSetNumber + 1) * sizeof(SampSetParam), L"SampleSet Params");
+                              (sampSetCk.maxSampleSetNumber + 1) * sizeof(SampSetParam), "SampleSet Params");
   for (uint32_t i = 0; i <= sampSetCk.maxSampleSetNumber; i++) {
-    sampSetParamOffsetHdr->AddSimpleItem(curOffset + 16 + i * sizeof(uint32_t), 4, L"Offset");
+    sampSetParamOffsetHdr->AddSimpleItem(curOffset + 16 + i * sizeof(uint32_t), 4, "Offset");
     if (sampSetCk.sampleSetOffsetAddr[i] == 0xFFFFFFFF)
       continue;
     GetBytes(curOffset + sampSetCk.sampleSetOffsetAddr[i], sizeof(uint8_t) * 4, sampSetCk.sampleSetParam + i);
@@ -79,13 +79,13 @@ bool SonyPS2InstrSet::GetHeaderInfo() {
              sampSetCk.sampleSetParam[i].sampleIndex);
     VGMHeader *sampSetParamHdr = sampSetParamsHdr->AddHeader(curOffset + sampSetCk.sampleSetOffsetAddr[i],
                                                              sizeof(uint8_t) * 4 + nSamples * sizeof(uint16_t),
-                                                             L"SampleSet Param");
-    sampSetParamHdr->AddSimpleItem(curOffset + sampSetCk.sampleSetOffsetAddr[i], 1, L"Vel Curve");
-    sampSetParamHdr->AddSimpleItem(curOffset + sampSetCk.sampleSetOffsetAddr[i] + 1, 1, L"Vel Limit Low");
-    sampSetParamHdr->AddSimpleItem(curOffset + sampSetCk.sampleSetOffsetAddr[i] + 2, 1, L"Vel Limit High");
-    sampSetParamHdr->AddSimpleItem(curOffset + sampSetCk.sampleSetOffsetAddr[i] + 3, 1, L"Number of Samples");
+                                                             "SampleSet Param");
+    sampSetParamHdr->AddSimpleItem(curOffset + sampSetCk.sampleSetOffsetAddr[i], 1, "Vel Curve");
+    sampSetParamHdr->AddSimpleItem(curOffset + sampSetCk.sampleSetOffsetAddr[i] + 1, 1, "Vel Limit Low");
+    sampSetParamHdr->AddSimpleItem(curOffset + sampSetCk.sampleSetOffsetAddr[i] + 2, 1, "Vel Limit High");
+    sampSetParamHdr->AddSimpleItem(curOffset + sampSetCk.sampleSetOffsetAddr[i] + 3, 1, "Number of Samples");
     for (uint32_t j = 0; j < nSamples; j++)
-      sampSetParamHdr->AddSimpleItem(curOffset + sampSetCk.sampleSetOffsetAddr[i] + 4 + j * 2, 2, L"Sample Index");
+      sampSetParamHdr->AddSimpleItem(curOffset + sampSetCk.sampleSetOffsetAddr[i] + 4 + j * 2, 2, "Sample Index");
   }
 
   // SAMPLE CHUNK
@@ -94,59 +94,59 @@ bool SonyPS2InstrSet::GetHeaderInfo() {
   sampCk.sampleOffsetAddr = new uint32_t[sampCk.maxSampleNumber + 1];
   sampCk.sampleParam = new SampleParam[sampCk.maxSampleNumber + 1];
 
-  VGMHeader *sampCkHdr = AddHeader(curOffset, sampCk.chunkSize, L"Sample Chunk");
-  sampCkHdr->AddSimpleItem(curOffset, 4, L"Creator");
-  sampCkHdr->AddSimpleItem(curOffset + 4, 4, L"Type");
-  sampCkHdr->AddSimpleItem(curOffset + 8, 4, L"Chunk Size");
-  sampCkHdr->AddSimpleItem(curOffset + 12, 4, L"Max Sample Number");
+  VGMHeader *sampCkHdr = AddHeader(curOffset, sampCk.chunkSize, "Sample Chunk");
+  sampCkHdr->AddSimpleItem(curOffset, 4, "Creator");
+  sampCkHdr->AddSimpleItem(curOffset + 4, 4, "Type");
+  sampCkHdr->AddSimpleItem(curOffset + 8, 4, "Chunk Size");
+  sampCkHdr->AddSimpleItem(curOffset + 12, 4, "Max Sample Number");
 
   GetBytes(curOffset + 16, (sampCk.maxSampleNumber + 1) * sizeof(uint32_t), sampCk.sampleOffsetAddr);
   VGMHeader *sampleParamOffsetHdr = sampCkHdr->AddHeader(curOffset + 16,
                                                          (sampCk.maxSampleNumber + 1) * sizeof(uint32_t),
-                                                         L"Sample Param Offsets");
+                                                         "Sample Param Offsets");
   VGMHeader *sampleParamsHdr = sampCkHdr->AddHeader(curOffset + 16 + (sampCk.maxSampleNumber + 1) * sizeof(uint32_t),
                                                     (sampCk.maxSampleNumber + 1) * sizeof(SampleParam),
-                                                    L"Sample Params");
+                                                    "Sample Params");
   for (uint32_t i = 0; i <= sampCk.maxSampleNumber; i++) {
-    sampleParamOffsetHdr->AddSimpleItem(curOffset + 16 + i * sizeof(uint32_t), 4, L"Offset");
+    sampleParamOffsetHdr->AddSimpleItem(curOffset + 16 + i * sizeof(uint32_t), 4, "Offset");
     GetBytes(curOffset + sampCk.sampleOffsetAddr[i], sizeof(SampleParam), sampCk.sampleParam + i);
     VGMHeader *sampleParamHdr = sampleParamsHdr->AddHeader(curOffset + sampCk.sampleOffsetAddr[i],
-                                                           sizeof(SampleParam), L"Sample Param");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i], 2, L"VAG Index");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 2, 1, L"Vel Range Low");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 3, 1, L"Vel Cross Fade");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 4, 1, L"Vel Range High");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 5, 1, L"Vel Follow Pitch");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 6, 1, L"Vel Follow Pitch Center");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 7, 1, L"Vel Follow Pitch Vel Curve");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 8, 1, L"Vel Follow Amp");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 9, 1, L"Vel Follow Amp Center");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 10, 1, L"Vel Follow Amp Vel Curve");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 11, 1, L"Sample Base Note");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 12, 1, L"Sample Detune");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 13, 1, L"Sample Panpot");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 14, 1, L"Sample Group");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 15, 1, L"Sample Priority");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 16, 1, L"Sample Volume");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 17, 1, L"Reserved");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 18, 2, L"Sample ADSR1");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 20, 2, L"Sample ADSR2");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 22, 1, L"Key Follow Attack Rate");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 23, 1, L"Key Follow Attack Rate Center");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 24, 1, L"Key Follow Decay Rate");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 25, 1, L"Key Follow Decay Rate Center");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 26, 1, L"Key Follow Sustain Rate");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 27, 1, L"Key Follow Sustain Rate Center");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 28, 1, L"Key Follow Release Rate");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 29, 1, L"Key Follow Release Rate Center");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 30, 1, L"Key Follow Sustain Level");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 31, 1, L"Key Follow Sustain Level Center");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 32, 2, L"Sample Pitch LFO Delay");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 34, 2, L"Sample Pitch LFO Fade");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 36, 2, L"Sample Amp LFO Delay");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 38, 2, L"Sample Amp LFO Fade");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 40, 1, L"Sample LFO Attributes");
-    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 41, 1, L"Sample SPU Attributes");
+                                                           sizeof(SampleParam), "Sample Param");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i], 2, "VAG Index");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 2, 1, "Vel Range Low");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 3, 1, "Vel Cross Fade");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 4, 1, "Vel Range High");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 5, 1, "Vel Follow Pitch");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 6, 1, "Vel Follow Pitch Center");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 7, 1, "Vel Follow Pitch Vel Curve");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 8, 1, "Vel Follow Amp");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 9, 1, "Vel Follow Amp Center");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 10, 1, "Vel Follow Amp Vel Curve");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 11, 1, "Sample Base Note");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 12, 1, "Sample Detune");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 13, 1, "Sample Panpot");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 14, 1, "Sample Group");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 15, 1, "Sample Priority");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 16, 1, "Sample Volume");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 17, 1, "Reserved");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 18, 2, "Sample ADSR1");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 20, 2, "Sample ADSR2");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 22, 1, "Key Follow Attack Rate");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 23, 1, "Key Follow Attack Rate Center");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 24, 1, "Key Follow Decay Rate");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 25, 1, "Key Follow Decay Rate Center");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 26, 1, "Key Follow Sustain Rate");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 27, 1, "Key Follow Sustain Rate Center");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 28, 1, "Key Follow Release Rate");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 29, 1, "Key Follow Release Rate Center");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 30, 1, "Key Follow Sustain Level");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 31, 1, "Key Follow Sustain Level Center");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 32, 2, "Sample Pitch LFO Delay");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 34, 2, "Sample Pitch LFO Fade");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 36, 2, "Sample Amp LFO Delay");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 38, 2, "Sample Amp LFO Fade");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 40, 1, "Sample LFO Attributes");
+    sampleParamHdr->AddSimpleItem(curOffset + sampCk.sampleOffsetAddr[i] + 41, 1, "Sample SPU Attributes");
   }
 
   // VAGInfo CHUNK
@@ -155,28 +155,28 @@ bool SonyPS2InstrSet::GetHeaderInfo() {
   vagInfoCk.vagInfoOffsetAddr = new uint32_t[vagInfoCk.maxVagInfoNumber + 1];
   vagInfoCk.vagInfoParam = new VAGInfoParam[vagInfoCk.maxVagInfoNumber + 1];
 
-  VGMHeader *vagInfoCkHdr = AddHeader(curOffset, vagInfoCk.chunkSize, L"VAGInfo Chunk");
-  vagInfoCkHdr->AddSimpleItem(curOffset, 4, L"Creator");
-  vagInfoCkHdr->AddSimpleItem(curOffset + 4, 4, L"Type");
-  vagInfoCkHdr->AddSimpleItem(curOffset + 8, 4, L"Chunk Size");
-  vagInfoCkHdr->AddSimpleItem(curOffset + 12, 4, L"Max VAGInfo Number");
+  VGMHeader *vagInfoCkHdr = AddHeader(curOffset, vagInfoCk.chunkSize, "VAGInfo Chunk");
+  vagInfoCkHdr->AddSimpleItem(curOffset, 4, "Creator");
+  vagInfoCkHdr->AddSimpleItem(curOffset + 4, 4, "Type");
+  vagInfoCkHdr->AddSimpleItem(curOffset + 8, 4, "Chunk Size");
+  vagInfoCkHdr->AddSimpleItem(curOffset + 12, 4, "Max VAGInfo Number");
 
   GetBytes(curOffset + 16, (vagInfoCk.maxVagInfoNumber + 1) * sizeof(uint32_t), vagInfoCk.vagInfoOffsetAddr);
   VGMHeader *vagInfoParamOffsetHdr = vagInfoCkHdr->AddHeader(curOffset + 16,
                                                              (vagInfoCk.maxVagInfoNumber + 1) * sizeof(uint32_t),
-                                                             L"VAGInfo Param Offsets");
+                                                             "VAGInfo Param Offsets");
   VGMHeader *vagInfoParamsHdr = vagInfoCkHdr->AddHeader(curOffset + 16 + (vagInfoCk.maxVagInfoNumber + 1) * sizeof(uint32_t),
                                                   (vagInfoCk.maxVagInfoNumber + 1) * sizeof(VAGInfoParam),
-                                                  L"VAGInfo Params");
+                                                  "VAGInfo Params");
   for (uint32_t i = 0; i <= vagInfoCk.maxVagInfoNumber; i++) {
-    vagInfoParamOffsetHdr->AddSimpleItem(curOffset + 16 + i * sizeof(uint32_t), 4, L"Offset");
+    vagInfoParamOffsetHdr->AddSimpleItem(curOffset + 16 + i * sizeof(uint32_t), 4, "Offset");
     GetBytes(curOffset + vagInfoCk.vagInfoOffsetAddr[i], sizeof(VAGInfoParam), vagInfoCk.vagInfoParam + i);
     VGMHeader *vagInfoParamHdr = vagInfoParamsHdr->AddHeader(curOffset + vagInfoCk.vagInfoOffsetAddr[i],
-                                                             sizeof(VAGInfoParam), L"VAGInfo Param");
-    vagInfoParamHdr->AddSimpleItem(curOffset + vagInfoCk.vagInfoOffsetAddr[i], 4, L"VAG Offset Addr");
-    vagInfoParamHdr->AddSimpleItem(curOffset + vagInfoCk.vagInfoOffsetAddr[i] + 4, 2, L"Sampling Rate");
-    vagInfoParamHdr->AddSimpleItem(curOffset + vagInfoCk.vagInfoOffsetAddr[i] + 6, 1, L"Loop Flag");
-    vagInfoParamHdr->AddSimpleItem(curOffset + vagInfoCk.vagInfoOffsetAddr[i] + 7, 1, L"Reserved");
+                                                             sizeof(VAGInfoParam), "VAGInfo Param");
+    vagInfoParamHdr->AddSimpleItem(curOffset + vagInfoCk.vagInfoOffsetAddr[i], 4, "VAG Offset Addr");
+    vagInfoParamHdr->AddSimpleItem(curOffset + vagInfoCk.vagInfoOffsetAddr[i] + 4, 2, "Sampling Rate");
+    vagInfoParamHdr->AddSimpleItem(curOffset + vagInfoCk.vagInfoOffsetAddr[i] + 6, 1, "Loop Flag");
+    vagInfoParamHdr->AddSimpleItem(curOffset + vagInfoCk.vagInfoOffsetAddr[i] + 7, 1, "Reserved");
   }
   return true;
 }
@@ -190,63 +190,63 @@ bool SonyPS2InstrSet::GetInstrPointers() {
   progCk.programOffsetAddr = new uint32_t[progCk.maxProgramNumber + 1];
   progCk.progParamBlock = new SonyPS2Instr::ProgParam[progCk.maxProgramNumber + 1];
 
-  VGMHeader *progCkHdr = AddHeader(curOffset, progCk.chunkSize, L"Program Chunk");
-  progCkHdr->AddSimpleItem(curOffset, 4, L"Creator");
-  progCkHdr->AddSimpleItem(curOffset + 4, 4, L"Type");
-  progCkHdr->AddSimpleItem(curOffset + 8, 4, L"Chunk Size");
-  progCkHdr->AddSimpleItem(curOffset + 12, 4, L"Max Program Number");
+  VGMHeader *progCkHdr = AddHeader(curOffset, progCk.chunkSize, "Program Chunk");
+  progCkHdr->AddSimpleItem(curOffset, 4, "Creator");
+  progCkHdr->AddSimpleItem(curOffset + 4, 4, "Type");
+  progCkHdr->AddSimpleItem(curOffset + 8, 4, "Chunk Size");
+  progCkHdr->AddSimpleItem(curOffset + 12, 4, "Max Program Number");
 
   GetBytes(curOffset + 16, (progCk.maxProgramNumber + 1) * sizeof(uint32_t), progCk.programOffsetAddr);
   VGMHeader *progParamOffsetHdr = progCkHdr->AddHeader(curOffset + 16,
                                                        (progCk.maxProgramNumber + 1) * sizeof(uint32_t),
-                                                       L"Program Param Offsets");
+                                                       "Program Param Offsets");
   VGMHeader *progParamsHdr = progCkHdr->AddHeader(curOffset + 16 + (progCk.maxProgramNumber + 1) * sizeof(uint32_t),
                                                   0/*(progCk.maxProgramNumber+1)*sizeof(SonyPS2Instr::ProgParam)*/,
-                                                  L"Program Params");
+                                                  "Program Params");
 
   this->RemoveContainer(aInstrs);            //Remove the instrument vector as a contained item of the VGMInstr, instead
   progParamsHdr->AddContainer(aInstrs);    //it will be the contained item of the "Program Params" item.  Thus showing
   //up in the treeview appropriately
 
   for (uint32_t i = 0; i <= progCk.maxProgramNumber; i++) {
-    progParamOffsetHdr->AddSimpleItem(curOffset + 16 + i * sizeof(uint32_t), 4, L"Offset");
+    progParamOffsetHdr->AddSimpleItem(curOffset + 16 + i * sizeof(uint32_t), 4, "Offset");
     if (progCk.programOffsetAddr[i] == 0xFFFFFFFF)
       continue;
     GetBytes(curOffset + progCk.programOffsetAddr[i], sizeof(SonyPS2Instr::ProgParam), progCk.progParamBlock + i);
     //VGMHeader* progParamHdr = progParamsHdr->AddHeader(curOffset+progCk.programOffsetAddr[i],
-    //	sizeof(SonyPS2Instr::ProgParam), L"Program Param");
+    //	sizeof(SonyPS2Instr::ProgParam), "Program Param");
 
     SonyPS2Instr *instr = new SonyPS2Instr(this, curOffset + progCk.programOffsetAddr[i],
                                            sizeof(SonyPS2Instr::ProgParam), i / 128, i % 128);
     aInstrs.push_back(instr);
 
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i], 4, L"SplitBlock Addr");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 4, 1, L"Number of SplitBlocks");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 5, 1, L"Size of SplitBlock");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 6, 1, L"Program Volume");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 7, 1, L"Program Panpot");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 8, 1, L"Program Transpose");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 9, 1, L"Program Detune");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 10, 1, L"Key Follow Pan");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 11, 1, L"Key Follow Pan Center");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 12, 1, L"Program Attributes");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 13, 1, L"Reserved");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 14, 1, L"Program Pitch LFO Waveform");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 15, 1, L"Program Amp LFO Waveform");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 16, 1, L"Program Pitch LFO Start Phase");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 17, 1, L"Program Amp LFO Start Phase");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 18, 1, L"Program Pitch LFO Start Phase Random");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 19, 1, L"Program Amp LFO Start Phase Random");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 20, 2, L"Program Pitch LFO Cycle Period (msec)");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 22, 2, L"Program Amp LFO Cycle Period (msec)");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 24, 2, L"Program Pitch LFO Depth (+)");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 26, 2, L"Program Pitch LFO Depth (-)");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 28, 2, L"MIDI Pitch Modulation Max Amplitude (+)");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 30, 2, L"MIDI Pitch Modulation Max Amplitude (-)");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 32, 1, L"Program Amp LFO Depth (+)");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 33, 1, L"Program Amp LFO Depth (-)");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 34, 1, L"MIDI Amp Modulation Max Amplitude (+)");
-    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 35, 1, L"MIDI Amp Modulation Max Amplitude (-)");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i], 4, "SplitBlock Addr");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 4, 1, "Number of SplitBlocks");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 5, 1, "Size of SplitBlock");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 6, 1, "Program Volume");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 7, 1, "Program Panpot");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 8, 1, "Program Transpose");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 9, 1, "Program Detune");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 10, 1, "Key Follow Pan");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 11, 1, "Key Follow Pan Center");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 12, 1, "Program Attributes");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 13, 1, "Reserved");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 14, 1, "Program Pitch LFO Waveform");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 15, 1, "Program Amp LFO Waveform");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 16, 1, "Program Pitch LFO Start Phase");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 17, 1, "Program Amp LFO Start Phase");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 18, 1, "Program Pitch LFO Start Phase Random");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 19, 1, "Program Amp LFO Start Phase Random");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 20, 2, "Program Pitch LFO Cycle Period (msec)");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 22, 2, "Program Amp LFO Cycle Period (msec)");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 24, 2, "Program Pitch LFO Depth (+)");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 26, 2, "Program Pitch LFO Depth (-)");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 28, 2, "MIDI Pitch Modulation Max Amplitude (+)");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 30, 2, "MIDI Pitch Modulation Max Amplitude (-)");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 32, 1, "Program Amp LFO Depth (+)");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 33, 1, "Program Amp LFO Depth (-)");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 34, 1, "MIDI Amp Modulation Max Amplitude (+)");
+    instr->AddSimpleItem(curOffset + progCk.programOffsetAddr[i] + 35, 1, "MIDI Amp Modulation Max Amplitude (-)");
 
     assert(progCk.progParamBlock[i].sizeSplitBlock == 20);    //make sure the size of a split block is indeed 20
     uint8_t nSplits = progCk.progParamBlock[i].nSplit;
@@ -255,28 +255,28 @@ bool SonyPS2InstrSet::GetInstrPointers() {
     instr->splitBlocks = new SonyPS2Instr::SplitBlock[nSplits];
     GetBytes(absSplitBlocksAddr, nSplits * sizeof(SonyPS2Instr::SplitBlock), instr->splitBlocks);
     VGMHeader *splitBlocksHdr = instr->AddHeader(absSplitBlocksAddr,
-                                                 nSplits * sizeof(SonyPS2Instr::SplitBlock), L"Split Blocks");
+                                                 nSplits * sizeof(SonyPS2Instr::SplitBlock), "Split Blocks");
     for (uint8_t j = 0; j < nSplits; j++) {
       uint32_t splitOff = absSplitBlocksAddr + j * sizeof(SonyPS2Instr::SplitBlock);
       VGMHeader *splitBlockHdr = splitBlocksHdr->AddHeader(splitOff,
-                                                           sizeof(SonyPS2Instr::SplitBlock), L"Split Block");
-      splitBlockHdr->AddSimpleItem(splitOff, 2, L"Sample Set Index");
-      splitBlockHdr->AddSimpleItem(splitOff + 2, 1, L"Split Range Low");
-      splitBlockHdr->AddSimpleItem(splitOff + 3, 1, L"Split Cross Fade");
-      splitBlockHdr->AddSimpleItem(splitOff + 4, 1, L"Split Range High");
-      splitBlockHdr->AddSimpleItem(splitOff + 5, 1, L"Split Number");
-      splitBlockHdr->AddSimpleItem(splitOff + 6, 2, L"Split Bend Range Low");
-      splitBlockHdr->AddSimpleItem(splitOff + 8, 2, L"Split Bend Range High");
-      splitBlockHdr->AddSimpleItem(splitOff + 10, 1, L"Key Follow Pitch");
-      splitBlockHdr->AddSimpleItem(splitOff + 11, 1, L"Key Follow Pitch Center");
-      splitBlockHdr->AddSimpleItem(splitOff + 12, 1, L"Key Follow Amp");
-      splitBlockHdr->AddSimpleItem(splitOff + 13, 1, L"Key Follow Amp Center");
-      splitBlockHdr->AddSimpleItem(splitOff + 14, 1, L"Key Follow Pan");
-      splitBlockHdr->AddSimpleItem(splitOff + 15, 1, L"Key Follow Pan Center");
-      splitBlockHdr->AddSimpleItem(splitOff + 16, 1, L"Split Volume");
-      splitBlockHdr->AddSimpleItem(splitOff + 17, 1, L"Split Panpot");
-      splitBlockHdr->AddSimpleItem(splitOff + 18, 1, L"Split Transpose");
-      splitBlockHdr->AddSimpleItem(splitOff + 19, 1, L"Split Detune");
+                                                           sizeof(SonyPS2Instr::SplitBlock), "Split Block");
+      splitBlockHdr->AddSimpleItem(splitOff, 2, "Sample Set Index");
+      splitBlockHdr->AddSimpleItem(splitOff + 2, 1, "Split Range Low");
+      splitBlockHdr->AddSimpleItem(splitOff + 3, 1, "Split Cross Fade");
+      splitBlockHdr->AddSimpleItem(splitOff + 4, 1, "Split Range High");
+      splitBlockHdr->AddSimpleItem(splitOff + 5, 1, "Split Number");
+      splitBlockHdr->AddSimpleItem(splitOff + 6, 2, "Split Bend Range Low");
+      splitBlockHdr->AddSimpleItem(splitOff + 8, 2, "Split Bend Range High");
+      splitBlockHdr->AddSimpleItem(splitOff + 10, 1, "Key Follow Pitch");
+      splitBlockHdr->AddSimpleItem(splitOff + 11, 1, "Key Follow Pitch Center");
+      splitBlockHdr->AddSimpleItem(splitOff + 12, 1, "Key Follow Amp");
+      splitBlockHdr->AddSimpleItem(splitOff + 13, 1, "Key Follow Amp Center");
+      splitBlockHdr->AddSimpleItem(splitOff + 14, 1, "Key Follow Pan");
+      splitBlockHdr->AddSimpleItem(splitOff + 15, 1, "Key Follow Pan Center");
+      splitBlockHdr->AddSimpleItem(splitOff + 16, 1, "Split Volume");
+      splitBlockHdr->AddSimpleItem(splitOff + 17, 1, "Split Panpot");
+      splitBlockHdr->AddSimpleItem(splitOff + 18, 1, "Split Transpose");
+      splitBlockHdr->AddSimpleItem(splitOff + 19, 1, "Split Detune");
     }
   }
 
@@ -298,7 +298,7 @@ SonyPS2Instr::SonyPS2Instr(VGMInstrSet *instrSet,
                            uint32_t length,
                            uint32_t theBank,
                            uint32_t theInstrNum)
-    : VGMInstr(instrSet, offset, length, theBank, theInstrNum, L"Program Param"),
+    : VGMInstr(instrSet, offset, length, theBank, theInstrNum, "Program Param"),
       splitBlocks(0) {
   RemoveContainer(aRgns);
 }
@@ -407,8 +407,8 @@ bool SonyPS2SampColl::GetSampleInfo() {
 
     uint16_t sampleRate = vagInfoParam.vagSampleRate;
 
-    wostringstream name;
-    name << L"Sample " << samples.size();
+    ostringstream name;
+    name << "Sample " << samples.size();
     PSXSamp *samp = new PSXSamp(this, offset, length, offset, length, 1, 16, sampleRate, name.str(), true);
     samples.push_back(samp);
 

--- a/src/main/formats/SonyPS2Scanner.cpp
+++ b/src/main/formats/SonyPS2Scanner.cpp
@@ -66,7 +66,7 @@ void SonyPS2Scanner::SearchForSampColl(RawFile *file) {
   if (nFileLength < 32)
     return;
 
-  if (StringToLower(file->GetExtension()) == L"bd") {
+  if (StringToLower(file->GetExtension()) == "bd") {
     // Hack for incorrectly ripped bd files.  Should ALWAYS start with 16 0x00 bytes (must... suppress... rage)
     // If it doesn't, we'll throw out this file and create a new one with the correct formating
     uint8_t buf[16];

--- a/src/main/formats/SonyPS2Scanner.h
+++ b/src/main/formats/SonyPS2Scanner.h
@@ -5,9 +5,9 @@ class SonyPS2Scanner:
     public VGMScanner {
  public:
   SonyPS2Scanner(void) {
-    USE_EXTENSION(L"sq")
-    USE_EXTENSION(L"hd")
-    USE_EXTENSION(L"bd")
+    USE_EXTENSION("sq")
+    USE_EXTENSION("hd")
+    USE_EXTENSION("bd")
   }
  public:
   ~SonyPS2Scanner(void) {

--- a/src/main/formats/SonyPS2Seq.cpp
+++ b/src/main/formats/SonyPS2Seq.cpp
@@ -21,20 +21,20 @@ SonyPS2Seq::~SonyPS2Seq(void) {
 }
 
 bool SonyPS2Seq::GetHeaderInfo(void) {
-  name() = L"Sony PS2 Seq";
+  name() = "Sony PS2 Seq";
   uint32_t curOffset = offset();
   //read the version chunk
   GetBytes(curOffset, 0x10, &versCk);
-  VGMHeader *versCkHdr = VGMSeq::AddHeader(curOffset, versCk.chunkSize, L"Version Chunk");
-  versCkHdr->AddSimpleItem(curOffset, 4, L"Creator");
-  versCkHdr->AddSimpleItem(curOffset + 4, 4, L"Type");
+  VGMHeader *versCkHdr = VGMSeq::AddHeader(curOffset, versCk.chunkSize, "Version Chunk");
+  versCkHdr->AddSimpleItem(curOffset, 4, "Creator");
+  versCkHdr->AddSimpleItem(curOffset + 4, 4, "Type");
   curOffset += versCk.chunkSize;
 
   //read the header chunk
   GetBytes(curOffset, 0x20, &hdrCk);
-  VGMHeader *hdrCkHdr = VGMSeq::AddHeader(curOffset, hdrCk.chunkSize, L"Header Chunk");
-  hdrCkHdr->AddSimpleItem(curOffset, 4, L"Creator");
-  hdrCkHdr->AddSimpleItem(curOffset + 4, 4, L"Type");
+  VGMHeader *hdrCkHdr = VGMSeq::AddHeader(curOffset, hdrCk.chunkSize, "Header Chunk");
+  hdrCkHdr->AddSimpleItem(curOffset, 4, "Creator");
+  hdrCkHdr->AddSimpleItem(curOffset + 4, 4, "Type");
   curOffset += hdrCk.chunkSize;
   //Now we're at the Midi chunk, which starts with the sig "SCEIMidi" (in 32bit little endian)
   midiChunkSize = GetWord(curOffset + 8);
@@ -123,8 +123,8 @@ bool SonyPS2Seq::ReadEvent(void) {
           break;
 
         case 6 :
-          //AddGenericEvent(beginOffset, curOffset-beginOffset, L"NRPN Data Entry", NULL, BG_CLR_PINK);
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop start number", L"", CLR_LOOP);
+          //AddGenericEvent(beginOffset, curOffset-beginOffset, "NRPN Data Entry", NULL, BG_CLR_PINK);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop start number", "", CLR_LOOP);
           break;
 
         //volume
@@ -144,18 +144,18 @@ bool SonyPS2Seq::ReadEvent(void) {
 
         //0 == endless loop
         case 38 :
-          AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop count", L"", CLR_LOOP);
+          AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop count", "", CLR_LOOP);
           break;
 
         //(0x63) nrpn msb
         case 99 :
           switch (value) {
             case 0 :
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Start", L"", CLR_LOOP);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", CLR_LOOP);
               break;
 
             case 1 :
-              AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", L"", CLR_LOOP);
+              AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", CLR_LOOP);
               break;
           }
           break;
@@ -200,7 +200,7 @@ bool SonyPS2Seq::ReadEvent(void) {
     }
 
     default:
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"UNKNOWN", L"", CLR_UNRECOGNIZED);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", CLR_UNRECOGNIZED);
       return false;
   }
   return true;

--- a/src/main/formats/SquarePS2Seq.cpp
+++ b/src/main/formats/SquarePS2Seq.cpp
@@ -20,13 +20,13 @@ BGMSeq::~BGMSeq(void) {
 }
 
 bool BGMSeq::GetHeaderInfo(void) {
-  VGMHeader *header = AddHeader(dwOffset, 0x20, L"Header");
-  header->AddSimpleItem(dwOffset, 4, L"Signature");
-  header->AddSimpleItem(dwOffset + 0x4, 2, L"ID");
-  header->AddSimpleItem(dwOffset + 0x6, 2, L"Associated WD ID");
-  header->AddSimpleItem(dwOffset + 0x8, 1, L"Number of Tracks");
-  header->AddSimpleItem(dwOffset + 0xE, 2, L"PPQN");
-  header->AddSimpleItem(dwOffset + 0x10, 4, L"File length");
+  VGMHeader *header = AddHeader(dwOffset, 0x20, "Header");
+  header->AddSimpleItem(dwOffset, 4, "Signature");
+  header->AddSimpleItem(dwOffset + 0x4, 2, "ID");
+  header->AddSimpleItem(dwOffset + 0x6, 2, "Associated WD ID");
+  header->AddSimpleItem(dwOffset + 0x8, 1, "Number of Tracks");
+  header->AddSimpleItem(dwOffset + 0xE, 2, "PPQN");
+  header->AddSimpleItem(dwOffset + 0x10, 4, "File length");
 
   nNumTracks = GetByte(dwOffset + 8);
   seqID = GetShort(dwOffset + 4);
@@ -34,10 +34,10 @@ bool BGMSeq::GetHeaderInfo(void) {
   SetPPQN(GetShort(dwOffset + 0xE));
   unLength = GetWord(dwOffset + 0x10);
 
-  wostringstream theName;
-  theName << L"BGM " << seqID;
+  ostringstream theName;
+  theName << "BGM " << seqID;
   if (seqID != assocWDID)
-    theName << L"using WD " << assocWDID;
+    theName << "using WD " << assocWDID;
   name = theName.str();
   return true;
 }
@@ -75,9 +75,9 @@ bool BGMTrack::ReadEvent(void) {
   // address range check for safety
   if (!vgmfile->IsValidOffset(curOffset)) {
     if (readMode== ReadMode::READMODE_ADD_TO_UI) {
-      std::wostringstream message;
-	  message << *vgmfile->GetName() << L": Address out of range. Conversion aborted.";
-      pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_WARN, L"SquarePS2Seq"));
+      std::ostringstream message;
+	  message << *vgmfile->GetName() << ": Address out of range. Conversion aborted.";
+      pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_WARN, "SquarePS2Seq"));
     }
     return false;
   }
@@ -96,7 +96,7 @@ bool BGMTrack::ReadEvent(void) {
       //rest_time += current_delta_time;
       //if (nScanMode == MODE_SCAN)
       //	AddBGMEvent("Loop Begin", ICON_STARTREP, aBGMTracks[cur_track]->pTreeItem, offsetAtDelta, j-offsetAtDelta, BG_CLR_CYAN);
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Begin", L"", CLR_LOOP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Begin", "", CLR_LOOP);
       break;
 
     // Loop end
@@ -105,7 +105,7 @@ bool BGMTrack::ReadEvent(void) {
 //		loop_counter++;
       //if (loop_counter < num_loops)
       //	j = loop_start;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", L"", CLR_LOOP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", CLR_LOOP);
       break;
 
     //end of track?
@@ -170,7 +170,7 @@ bool BGMTrack::ReadEvent(void) {
       break;
 
     case 0x18 :
-      AddNoteOff(beginOffset, curOffset - beginOffset, prevKey, L"Note off (prev key)");
+      AddNoteOff(beginOffset, curOffset - beginOffset, prevKey, "Note off (prev key)");
       prevKey = key;
       break;
 
@@ -252,7 +252,7 @@ bool BGMTrack::ReadEvent(void) {
       break;
 
     default :
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"UNKNOWN", L"", CLR_UNRECOGNIZED);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", CLR_UNRECOGNIZED);
       break;
 
   }

--- a/src/main/formats/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnesInstr.cpp
@@ -13,7 +13,7 @@ SuzukiSnesInstrSet::SuzukiSnesInstrSet(RawFile *file,
                                        uint16_t addrVolumeTable,
                                        uint16_t addrADSRTable,
                                        uint16_t addrTuningTable,
-                                       const std::wstring &name) :
+                                       const std::string &name) :
     VGMInstrSet(SuzukiSnesFormat::name, file, addrSRCNTable, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrSRCNTable(addrSRCNTable),
@@ -76,8 +76,8 @@ bool SuzukiSnesInstrSet::GetInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    std::wostringstream instrName;
-    instrName << L"Instrument " << srcn;
+    std::ostringstream instrName;
+    instrName << "Instrument " << srcn;
     SuzukiSnesInstr *newInstr = new SuzukiSnesInstr(this,
                                                     version,
                                                     instrNum,
@@ -115,7 +115,7 @@ SuzukiSnesInstr::SuzukiSnesInstr(VGMInstrSet *instrSet,
                                  uint16_t addrVolumeTable,
                                  uint16_t addrADSRTable,
                                  uint16_t addrTuningTable,
-                                 const std::wstring &name) :
+                                 const std::string &name) :
     VGMInstr(instrSet, addrSRCNTable, 0, 0, instrNum, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrSRCNTable(addrSRCNTable),
@@ -178,8 +178,8 @@ SuzukiSnesRgn::SuzukiSnesRgn(SuzukiSnesInstr *instr,
   int8_t coarse_tuning = GetByte(addrTuningTable + srcn * 2 + 1);
 
   AddSampNum(srcn, addrSRCNTable + instrNum, 1);
-  AddSimpleItem(addrADSRTable + srcn * 2, 1, L"ADSR1");
-  AddSimpleItem(addrADSRTable + srcn * 2 + 1, 1, L"ADSR2");
+  AddSimpleItem(addrADSRTable + srcn * 2, 1, "ADSR1");
+  AddSimpleItem(addrADSRTable + srcn * 2 + 1, 1, "ADSR2");
   AddFineTune((int16_t) (fine_tuning / 256.0 * 100.0), addrTuningTable + srcn * 2, 1);
   AddUnityKey(69 - coarse_tuning, addrTuningTable + srcn * 2 + 1, 1);
   AddVolume(vol / 256.0, addrVolumeTable + srcn * 2, 1);

--- a/src/main/formats/SuzukiSnesInstr.h
+++ b/src/main/formats/SuzukiSnesInstr.h
@@ -18,7 +18,7 @@ class SuzukiSnesInstrSet:
                      uint16_t addrVolumeTable,
                      uint16_t addrADSRTable,
                      uint16_t addrTuningTable,
-                     const std::wstring &name = L"SuzukiSnesInstrSet");
+                     const std::string &name = "SuzukiSnesInstrSet");
   virtual ~SuzukiSnesInstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -50,7 +50,7 @@ class SuzukiSnesInstr
                   uint16_t addrVolumeTable,
                   uint16_t addrADSRTable,
                   uint16_t addrTuningTable,
-                  const std::wstring &name = L"SuzukiSnesInstr");
+                  const std::string &name = "SuzukiSnesInstr");
   virtual ~SuzukiSnesInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/SuzukiSnesScanner.cpp
+++ b/src/main/formats/SuzukiSnesScanner.cpp
@@ -152,7 +152,7 @@ void SuzukiSnesScanner::Scan(RawFile *file, void *info) {
 
 void SuzukiSnesScanner::SearchForSuzukiSnesFromARAM(RawFile *file) {
   SuzukiSnesVersion version = SUZUKISNES_NONE;
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
 
   // search for note length table
   uint32_t ofsSongLoad;

--- a/src/main/formats/SuzukiSnesScanner.h
+++ b/src/main/formats/SuzukiSnesScanner.h
@@ -8,7 +8,7 @@ class SuzukiSnesScanner:
     public VGMScanner {
  public:
   SuzukiSnesScanner(void) {
-    USE_EXTENSION(L"spc");
+    USE_EXTENSION("spc");
   }
   virtual ~SuzukiSnesScanner(void) {
   }

--- a/src/main/formats/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnesSeq.cpp
@@ -14,7 +14,7 @@ const uint8_t SuzukiSnesSeq::NOTE_DUR_TABLE[13] = {
     0x10, 0x0c, 0x08, 0x06, 0x03
 };
 
-SuzukiSnesSeq::SuzukiSnesSeq(RawFile *file, SuzukiSnesVersion ver, uint32_t seqdataOffset, std::wstring newName)
+SuzukiSnesSeq::SuzukiSnesSeq(RawFile *file, SuzukiSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(SuzukiSnesFormat::name, file, seqdataOffset, 0, newName),
       version(ver) {
   bLoadTickByTick = true;
@@ -51,7 +51,7 @@ bool SuzukiSnesSeq::GetHeaderInfo(void) {
 
       uint8_t firstByte = GetByte(curOffset);
       if (firstByte >= 0x80) {
-        header->AddSimpleItem(curOffset, 1, L"Unknown Items End");
+        header->AddSimpleItem(curOffset, 1, "Unknown Items End");
         curOffset++;
         break;
       }
@@ -67,15 +67,15 @@ bool SuzukiSnesSeq::GetHeaderInfo(void) {
     uint16_t addrTrackStart = GetShort(curOffset);
 
     if (addrTrackStart != 0) {
-      std::wstringstream trackName;
-      trackName << L"Track Pointer " << (trackIndex + 1);
+      std::stringstream trackName;
+      trackName << "Track Pointer " << (trackIndex + 1);
       header->AddSimpleItem(curOffset, 2, trackName.str().c_str());
 
       aTracks.push_back(new SuzukiSnesTrack(this, addrTrackStart));
     }
     else {
       // example: Super Mario RPG - Where Am I Going?
-      header->AddSimpleItem(curOffset, 2, L"NULL");
+      header->AddSimpleItem(curOffset, 2, "NULL");
     }
 
     curOffset += 2;
@@ -225,7 +225,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   SuzukiSnesSeqEventType eventType = (SuzukiSnesSeqEventType) 0;
   std::map<uint8_t, SuzukiSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -235,27 +235,27 @@ bool SuzukiSnesTrack::ReadEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -263,12 +263,12 @@ bool SuzukiSnesTrack::ReadEvent(void) {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -277,13 +277,13 @@ bool SuzukiSnesTrack::ReadEvent(void) {
       uint8_t arg2 = GetByte(curOffset++);
       uint8_t arg3 = GetByte(curOffset++);
       uint8_t arg4 = GetByte(curOffset++);
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(L' ') << std::setw(0)
-          << L"  Arg1: " << (int) arg1
-          << L"  Arg2: " << (int) arg2
-          << L"  Arg3: " << (int) arg3
-          << L"  Arg4: " << (int) arg4;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
+          << std::dec << std::setfill(' ') << std::setw(0)
+          << "  Arg1: " << (int) arg1
+          << "  Arg2: " << (int) arg2
+          << "  Arg3: " << (int) arg3
+          << "  Arg4: " << (int) arg4;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
       break;
     }
 
@@ -312,7 +312,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
       }
       else if (noteIndex == 13) {
         MakePrevDurNoteEnd(GetTime() + dur);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
         AddTime(dur);
       }
       else {
@@ -339,16 +339,16 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_NOP: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
       break;
     }
 
     case EVENT_NOISE_FREQ: {
       uint8_t newNCK = GetByte(curOffset++) & 0x1f;
-      desc << L"Noise Frequency (NCK): " << (int) newNCK;
+      desc << "Noise Frequency (NCK): " << (int) newNCK;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Noise Frequency",
+                      "Noise Frequency",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -358,7 +358,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_NOISE_ON: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Noise On",
+                      "Noise On",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -368,7 +368,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_NOISE_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Noise Off",
+                      "Noise Off",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -378,7 +378,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_PITCH_MOD_ON: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Modulation On",
+                      "Pitch Modulation On",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -388,7 +388,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_PITCH_MOD_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pitch Modulation Off",
+                      "Pitch Modulation Off",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -398,8 +398,8 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_JUMP_TO_SFX_LO: {
       // TODO: EVENT_JUMP_TO_SFX_LO
       uint8_t sfxIndex = GetByte(curOffset++);
-      desc << L"SFX: " << (int) sfxIndex;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Jump to SFX (LOWORD)", desc.str().c_str());
+      desc << "SFX: " << (int) sfxIndex;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Jump to SFX (LOWORD)", desc.str().c_str());
       bContinue = false;
       break;
     }
@@ -407,8 +407,8 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_JUMP_TO_SFX_HI: {
       // TODO: EVENT_JUMP_TO_SFX_HI
       uint8_t sfxIndex = GetByte(curOffset++);
-      desc << L"SFX: " << (int) sfxIndex;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Jump to SFX (HIWORD)", desc.str().c_str());
+      desc << "SFX: " << (int) sfxIndex;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Jump to SFX (HIWORD)", desc.str().c_str());
       bContinue = false;
       break;
     }
@@ -416,8 +416,8 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_CALL_SFX_LO: {
       // TODO: EVENT_CALL_SFX_LO
       uint8_t sfxIndex = GetByte(curOffset++);
-      desc << L"SFX: " << (int) sfxIndex;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Call SFX (LOWORD)", desc.str().c_str());
+      desc << "SFX: " << (int) sfxIndex;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Call SFX (LOWORD)", desc.str().c_str());
       bContinue = false;
       break;
     }
@@ -425,8 +425,8 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_CALL_SFX_HI: {
       // TODO: EVENT_CALL_SFX_HI
       uint8_t sfxIndex = GetByte(curOffset++);
-      desc << L"SFX: " << (int) sfxIndex;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Call SFX (HIWORD)", desc.str().c_str());
+      desc << "SFX: " << (int) sfxIndex;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Call SFX (HIWORD)", desc.str().c_str());
       bContinue = false;
       break;
     }
@@ -463,16 +463,16 @@ bool SuzukiSnesTrack::ReadEvent(void) {
       AddTempoBPM(beginOffset,
                   curOffset - beginOffset,
                   parentSeq->GetTempoInBPM(parentSeq->spcTempo),
-                  L"Tempo (Relative)");
+                  "Tempo (Relative)");
       break;
     }
 
     case EVENT_TIMER1_FREQ: {
       uint8_t newFreq = GetByte(curOffset++);
-      desc << L"Frequency: " << (0.125 * newFreq) << L"ms";
+      desc << "Frequency: " << (0.125 * newFreq) << "ms";
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Timer 1 Frequency",
+                      "Timer 1 Frequency",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_TEMPO);
@@ -481,10 +481,10 @@ bool SuzukiSnesTrack::ReadEvent(void) {
 
     case EVENT_TIMER1_FREQ_REL: {
       int8_t delta = GetByte(curOffset++);
-      desc << L"Frequency Delta: " << (0.125 * delta) << L"ms";
+      desc << "Frequency Delta: " << (0.125 * delta) << "ms";
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Timer 1 Frequency (Relative)",
+                      "Timer 1 Frequency (Relative)",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_TEMPO);
@@ -495,8 +495,8 @@ bool SuzukiSnesTrack::ReadEvent(void) {
       uint8_t count = GetByte(curOffset++);
       int realLoopCount = (count == 0) ? 256 : count;
 
-      desc << L"Loop Count: " << realLoopCount;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      desc << "Loop Count: " << realLoopCount;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
 
       if (loopLevel >= SUZUKISNES_LOOP_LEVEL_MAX) {
         // stack overflow
@@ -511,7 +511,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_LOOP_END: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       if (loopLevel == 0) {
         // stack overflow
@@ -534,7 +534,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_LOOP_BREAK: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Loop Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
 
       if (loopLevel == 0) {
         // stack overflow
@@ -554,7 +554,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
       infiniteLoopPoint = curOffset;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Infinite Loop Point",
+                      "Infinite Loop Point",
                       desc.str().c_str(),
                       CLR_LOOP,
                       ICON_STARTREP);
@@ -564,7 +564,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_ADSR_DEFAULT: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Default ADSR",
+                      "Default ADSR",
                       desc.str().c_str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -573,10 +573,10 @@ bool SuzukiSnesTrack::ReadEvent(void) {
 
     case EVENT_ADSR_AR: {
       uint8_t newAR = GetByte(curOffset++) & 15;
-      desc << L"AR: " << (int) newAR;
+      desc << "AR: " << (int) newAR;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"ADSR Attack Rate",
+                      "ADSR Attack Rate",
                       desc.str().c_str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -585,10 +585,10 @@ bool SuzukiSnesTrack::ReadEvent(void) {
 
     case EVENT_ADSR_DR: {
       uint8_t newDR = GetByte(curOffset++) & 7;
-      desc << L"DR: " << (int) newDR;
+      desc << "DR: " << (int) newDR;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"ADSR Decay Rate",
+                      "ADSR Decay Rate",
                       desc.str().c_str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -597,10 +597,10 @@ bool SuzukiSnesTrack::ReadEvent(void) {
 
     case EVENT_ADSR_SL: {
       uint8_t newSL = GetByte(curOffset++) & 7;
-      desc << L"SL: " << (int) newSL;
+      desc << "SL: " << (int) newSL;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"ADSR Sustain Level",
+                      "ADSR Sustain Level",
                       desc.str().c_str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -609,10 +609,10 @@ bool SuzukiSnesTrack::ReadEvent(void) {
 
     case EVENT_ADSR_SR: {
       uint8_t newSR = GetByte(curOffset++) & 15;
-      desc << L"SR: " << (int) newSR;
+      desc << "SR: " << (int) newSR;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"ADSR Sustain Rate",
+                      "ADSR Sustain Rate",
                       desc.str().c_str(),
                       CLR_ADSR,
                       ICON_CONTROL);
@@ -622,8 +622,8 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_DURATION_RATE: {
       // TODO: save duration rate and apply to note length
       uint8_t newDurRate = GetByte(curOffset++);
-      desc << L"Duration Rate: " << (int) newDurRate;
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Duration Rate", desc.str().c_str(), CLR_DURNOTE);
+      desc << "Duration Rate: " << (int) newDurRate;
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str().c_str(), CLR_DURNOTE);
       break;
     }
 
@@ -635,10 +635,10 @@ bool SuzukiSnesTrack::ReadEvent(void) {
 
     case EVENT_NOISE_FREQ_REL: {
       int8_t delta = GetByte(curOffset++);
-      desc << L"Noise Frequency (NCK) Delta: " << (int) delta;
+      desc << "Noise Frequency (NCK) Delta: " << (int) delta;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Noise Frequency (Relative)",
+                      "Noise Frequency (Relative)",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -655,17 +655,17 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_VOLUME_REL: {
       int8_t delta = GetByte(curOffset++);
       spcVolume = (spcVolume + delta) & 0x7f;
-      AddVol(beginOffset, curOffset - beginOffset, spcVolume, L"Volume (Relative)");
+      AddVol(beginOffset, curOffset - beginOffset, spcVolume, "Volume (Relative)");
       break;
     }
 
     case EVENT_VOLUME_FADE: {
       uint8_t fadeLength = GetByte(curOffset++);
       uint8_t vol = GetByte(curOffset++);
-      desc << L"Fade Length: " << (int) fadeLength << L"  Volume: " << (int) vol;
+      desc << "Fade Length: " << (int) fadeLength << "  Volume: " << (int) vol;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Volume Fade",
+                      "Volume Fade",
                       desc.str().c_str(),
                       CLR_VOLUME,
                       ICON_CONTROL);
@@ -675,10 +675,10 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_PORTAMENTO: {
       uint8_t arg1 = GetByte(curOffset++);
       uint8_t arg2 = GetByte(curOffset++);
-      desc << L"Arg1: " << (int) arg1 << L"  Arg2: " << (int) arg2;
+      desc << "Arg1: " << (int) arg1 << "  Arg2: " << (int) arg2;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Portamento",
+                      "Portamento",
                       desc.str().c_str(),
                       CLR_PORTAMENTO,
                       ICON_CONTROL);
@@ -688,7 +688,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_PORTAMENTO_TOGGLE: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Portamento On/Off",
+                      "Portamento On/Off",
                       desc.str().c_str(),
                       CLR_PORTAMENTO,
                       ICON_CONTROL);
@@ -709,20 +709,20 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_PAN_FADE: {
       uint8_t fadeLength = GetByte(curOffset++);
       uint8_t pan = GetByte(curOffset++);
-      desc << L"Fade Length: " << (int) fadeLength << L"  Pan: " << (int) (pan >> 1);
+      desc << "Fade Length: " << (int) fadeLength << "  Pan: " << (int) (pan >> 1);
 
       // TODO: correct midi pan value, apply volume scale, do pan slide
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Pan Fade", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
       break;
     }
 
     case EVENT_PAN_LFO_ON: {
       uint8_t lfoDepth = GetByte(curOffset++);
       uint8_t lfoRate = GetByte(curOffset++);
-      desc << L"Depth: " << (int) lfoDepth << L"  Rate: " << (int) lfoRate;
+      desc << "Depth: " << (int) lfoDepth << "  Rate: " << (int) lfoRate;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pan LFO",
+                      "Pan LFO",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -732,7 +732,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_PAN_LFO_RESTART: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pan LFO Restart",
+                      "Pan LFO Restart",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -742,7 +742,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_PAN_LFO_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Pan LFO Off",
+                      "Pan LFO Off",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -761,14 +761,14 @@ bool SuzukiSnesTrack::ReadEvent(void) {
       // TODO: fraction part of transpose?
       int8_t newTranspose = GetByte(curOffset++);
       int8_t semitones = newTranspose / 4;
-      AddTranspose(beginOffset, curOffset - beginOffset, transpose + semitones, L"Transpose (Relative)");
+      AddTranspose(beginOffset, curOffset - beginOffset, transpose + semitones, "Transpose (Relative)");
       break;
     }
 
     case EVENT_PERC_ON: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Percussion On",
+                      "Percussion On",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -778,7 +778,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_PERC_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Percussion Off",
+                      "Percussion Off",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -788,10 +788,10 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_VIBRATO_ON: {
       uint8_t lfoDepth = GetByte(curOffset++);
       uint8_t lfoRate = GetByte(curOffset++);
-      desc << L"Depth: " << (int) lfoDepth << L"  Rate: " << (int) lfoRate;
+      desc << "Depth: " << (int) lfoDepth << "  Rate: " << (int) lfoRate;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato",
+                      "Vibrato",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -802,10 +802,10 @@ bool SuzukiSnesTrack::ReadEvent(void) {
       uint8_t lfoDepth = GetByte(curOffset++);
       uint8_t lfoRate = GetByte(curOffset++);
       uint8_t lfoDelay = GetByte(curOffset++);
-      desc << L"Depth: " << (int) lfoDepth << L"  Rate: " << (int) lfoRate << L"  Delay: " << (int) lfoDelay;
+      desc << "Depth: " << (int) lfoDepth << "  Rate: " << (int) lfoRate << "  Delay: " << (int) lfoDelay;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato",
+                      "Vibrato",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -815,7 +815,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_VIBRATO_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Vibrato Off",
+                      "Vibrato Off",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -825,10 +825,10 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_TREMOLO_ON: {
       uint8_t lfoDepth = GetByte(curOffset++);
       uint8_t lfoRate = GetByte(curOffset++);
-      desc << L"Depth: " << (int) lfoDepth << L"  Rate: " << (int) lfoRate;
+      desc << "Depth: " << (int) lfoDepth << "  Rate: " << (int) lfoRate;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Tremolo",
+                      "Tremolo",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -839,10 +839,10 @@ bool SuzukiSnesTrack::ReadEvent(void) {
       uint8_t lfoDepth = GetByte(curOffset++);
       uint8_t lfoRate = GetByte(curOffset++);
       uint8_t lfoDelay = GetByte(curOffset++);
-      desc << L"Depth: " << (int) lfoDepth << L"  Rate: " << (int) lfoRate << L"  Delay: " << (int) lfoDelay;
+      desc << "Depth: " << (int) lfoDepth << "  Rate: " << (int) lfoRate << "  Delay: " << (int) lfoDelay;
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Tremolo",
+                      "Tremolo",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -852,7 +852,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_TREMOLO_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Tremolo Off",
+                      "Tremolo Off",
                       desc.str().c_str(),
                       CLR_MODULATION,
                       ICON_CONTROL);
@@ -862,7 +862,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_SLUR_ON: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Slur On",
+                      "Slur On",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -872,7 +872,7 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     case EVENT_SLUR_OFF: {
       AddGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      L"Slur Off",
+                      "Slur Off",
                       desc.str().c_str(),
                       CLR_CHANGESTATE,
                       ICON_CONTROL);
@@ -880,27 +880,27 @@ bool SuzukiSnesTrack::ReadEvent(void) {
     }
 
     case EVENT_ECHO_ON: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo On", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      AddGenericEvent(beginOffset, curOffset - beginOffset, L"Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      AddGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
       break;
     }
 
     default:
-      desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-      AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str().c_str());
-      pRoot->AddLogItem(new LogItem((std::wstring(L"Unknown Event - ") + desc.str()).c_str(),
+      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+      AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      pRoot->AddLogItem(new LogItem((std::string("Unknown Event - ") + desc.str()).c_str(),
                                     LOG_LEVEL_ERR,
-                                    L"CompileSnesSeq"));
+                                    "CompileSnesSeq"));
       bContinue = false;
       break;
   }
 
-  //wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   return bContinue;

--- a/src/main/formats/SuzukiSnesSeq.h
+++ b/src/main/formats/SuzukiSnesSeq.h
@@ -74,7 +74,7 @@ class SuzukiSnesSeq
     : public VGMSeq {
  public:
   SuzukiSnesSeq
-      (RawFile *file, SuzukiSnesVersion ver, uint32_t seqdataOffset, std::wstring newName = L"Square SUZUKI SNES Seq");
+      (RawFile *file, SuzukiSnesVersion ver, uint32_t seqdataOffset, std::string newName = "Square SUZUKI SNES Seq");
   virtual ~SuzukiSnesSeq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/TamSoftPS1Instr.cpp
+++ b/src/main/formats/TamSoftPS1Instr.cpp
@@ -6,7 +6,7 @@
 // TamSoftPS1InstrSet
 // ******************
 
-TamSoftPS1InstrSet::TamSoftPS1InstrSet(RawFile *file, uint32_t offset, bool ps2, const std::wstring &name) :
+TamSoftPS1InstrSet::TamSoftPS1InstrSet(RawFile *file, uint32_t offset, bool ps2, const std::string &name) :
     VGMInstrSet(TamSoftPS1Format::name, file, offset, 0, name), ps2(ps2) {
 }
 
@@ -37,8 +37,8 @@ bool TamSoftPS1InstrSet::GetInstrPointers() {
       SizeOffsetPair vagLocation(vagOffset - 0x800, PSXSamp::GetSampleLength(rawfile, vagOffset, dwOffset + unLength, vagLoop));
       vagLocations.push_back(vagLocation);
 
-      std::wstringstream instrName;
-      instrName << L"Instrument " << instrNum;
+      std::stringstream instrName;
+      instrName << "Instrument " << instrNum;
       TamSoftPS1Instr *newInstr = new TamSoftPS1Instr(this, instrNum, instrName.str());
       aInstrs.push_back(newInstr);
     }
@@ -61,7 +61,7 @@ bool TamSoftPS1InstrSet::GetInstrPointers() {
 // TamSoftPS1Instr
 // ***************
 
-TamSoftPS1Instr::TamSoftPS1Instr(TamSoftPS1InstrSet *instrSet, uint8_t instrNum, const std::wstring &name) :
+TamSoftPS1Instr::TamSoftPS1Instr(TamSoftPS1InstrSet *instrSet, uint8_t instrNum, const std::string &name) :
     VGMInstr(instrSet, instrSet->dwOffset + 4 * instrNum, 0x400 + 4, 0, instrNum, name) {
 }
 
@@ -71,7 +71,7 @@ TamSoftPS1Instr::~TamSoftPS1Instr() {
 bool TamSoftPS1Instr::LoadInstr() {
   TamSoftPS1InstrSet *parInstrSet = (TamSoftPS1InstrSet *) this->parInstrSet;
 
-  AddSimpleItem(dwOffset, 4, L"Sample Offset");
+  AddSimpleItem(dwOffset, 4, "Sample Offset");
 
   TamSoftPS1Rgn *rgn = new TamSoftPS1Rgn(this, dwOffset + 0x400, parInstrSet->ps2);
   rgn->sampNum = instrNum;
@@ -86,8 +86,8 @@ bool TamSoftPS1Instr::LoadInstr() {
 TamSoftPS1Rgn::TamSoftPS1Rgn(TamSoftPS1Instr *instr, uint32_t offset, bool ps2) :
     VGMRgn(instr, offset, 4) {
   unityKey = TAMSOFTPS1_KEY_OFFSET + 48;
-  AddSimpleItem(offset, 2, L"ADSR1");
-  AddSimpleItem(offset + 2, 2, L"ADSR2");
+  AddSimpleItem(offset, 2, "ADSR1");
+  AddSimpleItem(offset + 2, 2, "ADSR2");
 
   uint16_t adsr1 = GetShort(offset);
   uint16_t adsr2 = GetShort(offset + 2);

--- a/src/main/formats/TamSoftPS1Instr.h
+++ b/src/main/formats/TamSoftPS1Instr.h
@@ -11,7 +11,7 @@
 class TamSoftPS1InstrSet:
     public VGMInstrSet {
  public:
-  TamSoftPS1InstrSet(RawFile *file, uint32_t offset, bool ps2, const std::wstring &name = L"TamSoftPS1InstrSet");
+  TamSoftPS1InstrSet(RawFile *file, uint32_t offset, bool ps2, const std::string &name = "TamSoftPS1InstrSet");
   virtual ~TamSoftPS1InstrSet(void);
 
   virtual bool GetHeaderInfo();
@@ -27,7 +27,7 @@ class TamSoftPS1InstrSet:
 class TamSoftPS1Instr
     : public VGMInstr {
  public:
-  TamSoftPS1Instr(TamSoftPS1InstrSet *instrSet, uint8_t instrNum, const std::wstring &name = L"TamSoftPS1Instr");
+  TamSoftPS1Instr(TamSoftPS1InstrSet *instrSet, uint8_t instrNum, const std::string &name = "TamSoftPS1Instr");
   virtual ~TamSoftPS1Instr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/TamSoftPS1Scanner.cpp
+++ b/src/main/formats/TamSoftPS1Scanner.cpp
@@ -4,10 +4,10 @@
 #include "TamSoftPS1Instr.h"
 
 void TamSoftPS1Scanner::Scan(RawFile *file, void *info) {
-  std::wstring basename(RawFile::removeExtFromPath(file->GetFileName()));
-  std::wstring extension(StringToLower(file->GetExtension()));
+  std::string basename(RawFile::removeExtFromPath(file->GetFileName()));
+  std::string extension(StringToLower(file->GetExtension()));
 
-  if (extension == L"tsq") {
+  if (extension == "tsq") {
     uint8_t numSongs = 0;
     uint32_t seqHeaderBoundaryOffset = 0xffffffff;
     for (numSongs = 0; numSongs < 128; numSongs++) {
@@ -31,8 +31,8 @@ void TamSoftPS1Scanner::Scan(RawFile *file, void *info) {
     }
 
     for (uint8_t songIndex = 0; songIndex < numSongs; songIndex++) {
-      std::wstringstream seqname;
-      seqname << basename << L" (" << songIndex << L")";
+      std::stringstream seqname;
+      seqname << basename << " (" << songIndex << ")";
 
       TamSoftPS1Seq *newSeq = new TamSoftPS1Seq(file, 0, songIndex, seqname.str());
       if (newSeq->LoadVGMFile()) {
@@ -43,9 +43,9 @@ void TamSoftPS1Scanner::Scan(RawFile *file, void *info) {
       }
     }
   }
-  else if (extension == L"tvb" || extension == L"tvb2") {
+  else if (extension == "tvb" || extension == "tvb2") {
     bool ps2 = false;
-    if (extension == L"tvb2") {
+    if (extension == "tvb2") {
       // note: this is not a real extension
       ps2 = true;
     }

--- a/src/main/formats/TamSoftPS1Scanner.h
+++ b/src/main/formats/TamSoftPS1Scanner.h
@@ -5,8 +5,8 @@ class TamSoftPS1Scanner:
     public VGMScanner {
  public:
   TamSoftPS1Scanner(void) {
-    USE_EXTENSION(L"tsq");
-    USE_EXTENSION(L"tvb");
+    USE_EXTENSION("tsq");
+    USE_EXTENSION("tvb");
   }
 
   virtual ~TamSoftPS1Scanner(void) {

--- a/src/main/formats/TamSoftPS1Seq.cpp
+++ b/src/main/formats/TamSoftPS1Seq.cpp
@@ -26,7 +26,7 @@ const uint16_t TamSoftPS1Seq::PITCH_TABLE[73] = {
     0x3FFF,
 };
 
-TamSoftPS1Seq::TamSoftPS1Seq(RawFile *file, uint32_t offset, uint8_t theSong, const std::wstring &name)
+TamSoftPS1Seq::TamSoftPS1Seq(RawFile *file, uint32_t offset, uint8_t theSong, const std::string &name)
     : VGMSeq(TamSoftPS1Format::name, file, offset, 0, name), song(theSong), ps2(false), type(0) {
   bLoadTickByTick = true;
   bUseLinearAmplitudeScale = true;
@@ -59,11 +59,11 @@ bool TamSoftPS1Seq::GetHeaderInfo(void) {
   type = GetShort(dwSongItemOffset);
   uint16_t seqHeaderRelOffset = GetShort(dwSongItemOffset + 2);
 
-  std::wstringstream songTableItemName;
-  songTableItemName << L"Song " << song;
+  std::stringstream songTableItemName;
+  songTableItemName << "Song " << song;
   VGMHeader *songTableItem = AddHeader(dwSongItemOffset, 4, songTableItemName.str());
-  songTableItem->AddSimpleItem(dwSongItemOffset, 2, L"BGM/SFX");
-  songTableItem->AddSimpleItem(dwSongItemOffset + 2, 2, L"Header Offset");
+  songTableItem->AddSimpleItem(dwSongItemOffset, 2, "BGM/SFX");
+  songTableItem->AddSimpleItem(dwSongItemOffset + 2, 2, "Header Offset");
 
   if (seqHeaderRelOffset < dwSongItemOffset + 4) {
     return false;
@@ -111,15 +111,15 @@ bool TamSoftPS1Seq::GetHeaderInfo(void) {
       for (uint8_t trackIndex = 0; trackIndex < maxTracks; trackIndex++) {
         uint32_t dwTrackHeaderOffset = dwHeaderOffset + 4 * trackIndex;
 
-        std::wstringstream trackHeaderName;
-        trackHeaderName << L"Track " << (trackIndex + 1);
+        std::stringstream trackHeaderName;
+        trackHeaderName << "Track " << (trackIndex + 1);
         VGMHeader *trackHeader = seqHeader->AddHeader(dwTrackHeaderOffset, 4, trackHeaderName.str());
 
         uint8_t live = GetByte(dwTrackHeaderOffset);
         uint32_t dwRelTrackOffset = GetShort(dwTrackHeaderOffset + 2);
-        trackHeader->AddSimpleItem(dwTrackHeaderOffset, 1, L"Active/Inactive");
-        trackHeader->AddSimpleItem(dwTrackHeaderOffset + 1, 1, L"Padding");
-        trackHeader->AddSimpleItem(dwTrackHeaderOffset + 2, 2, L"Track Offset");
+        trackHeader->AddSimpleItem(dwTrackHeaderOffset, 1, "Active/Inactive");
+        trackHeader->AddSimpleItem(dwTrackHeaderOffset + 1, 1, "Padding");
+        trackHeader->AddSimpleItem(dwTrackHeaderOffset + 2, 2, "Track Offset");
 
         if (live != 0) {
           if (dwHeaderOffset + dwRelTrackOffset < vgmfile->GetEndOffset()) {
@@ -181,17 +181,17 @@ bool TamSoftPS1Track::ReadEvent(void) {
   uint8_t statusByte = GetByte(curOffset++);
   bool bContinue = true;
 
-  std::wstringstream desc;
+  std::stringstream desc;
 
   if (statusByte >= 0x00 && statusByte <= 0x7f) {
     // if status_byte == 0, it actually sets 0xffffffff to delta-time o_O
-    desc << L"Delta Time: " << statusByte;
-    AddGenericEvent(beginOffset, curOffset - beginOffset, L"Delta Time", desc.str(), CLR_REST);
+    desc << "Delta Time: " << statusByte;
+    AddGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", desc.str(), CLR_REST);
     AddTime(statusByte);
   }
   else if (statusByte >= 0x80 && statusByte <= 0xdf) {
     uint8_t key = statusByte & 0x7f;
-    desc << L"Key: " << key;
+    desc << "Key: " << key;
 
     if (lastNoteKey >= 0) {
       FinalizeAllNotes();
@@ -221,8 +221,8 @@ bool TamSoftPS1Track::ReadEvent(void) {
         double volumeScale;
         uint8_t midiPan = ConvertVolumeBalanceToStdMidiPan(volumeBalanceLeft / 256.0, volumeBalanceRight / 256.0, &volumeScale);
 
-        desc << L"Left Volume: " << volumeBalanceLeft << L"  Right Volume: " << volumeBalanceRight;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Volume Balance", desc.str(), CLR_PAN, ICON_CONTROL);
+        desc << "Left Volume: " << volumeBalanceLeft << "  Right Volume: " << volumeBalanceRight;
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Volume Balance", desc.str(), CLR_PAN, ICON_CONTROL);
         AddPanNoItem(midiPan);
         break;
       }
@@ -236,7 +236,7 @@ bool TamSoftPS1Track::ReadEvent(void) {
       case 0xE3: {
         uint16_t a1 = GetShort(curOffset);
         curOffset += 2;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"NOP", desc.str());
+        AddUnknown(beginOffset, curOffset - beginOffset, "NOP", desc.str());
         break;
       }
 
@@ -244,15 +244,15 @@ bool TamSoftPS1Track::ReadEvent(void) {
         // pitch bend
         uint16_t pitchRegValue = GetShort(curOffset);
         curOffset += 2;
-        desc << L"Pitch: " << pitchRegValue;
+        desc << "Pitch: " << pitchRegValue;
 
         double cents = 0;
         if (lastNoteKey >= 0) {
           cents = PitchScaleToCents((double) pitchRegValue / lastNotePitch);
-          desc << L" (" << cents << L" cents)";
+          desc << " (" << cents << " cents)";
         }
 
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Pitch Bend", desc.str());
+        AddUnknown(beginOffset, curOffset - beginOffset, "Pitch Bend", desc.str());
         break;
       }
 
@@ -260,41 +260,41 @@ bool TamSoftPS1Track::ReadEvent(void) {
         // pitch bend that updates volume/ADSR registers too?
         uint16_t pitchRegValue = GetShort(curOffset);
         curOffset += 2;
-        desc << L"Pitch: " << pitchRegValue;
+        desc << "Pitch: " << pitchRegValue;
 
         double cents = 0;
         if (lastNoteKey >= 0) {
           cents = PitchScaleToCents((double) pitchRegValue / lastNotePitch);
-          desc << L" (" << cents << L" cents)";
+          desc << " (" << cents << " cents)";
         }
 
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Note By Pitch?", desc.str());
+        AddUnknown(beginOffset, curOffset - beginOffset, "Note By Pitch?", desc.str());
         break;
       }
 
       case 0xE6: {
         uint8_t mode = GetByte(curOffset++);
-        desc << L"Reverb Mode: " << mode;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reverb Mode", desc.str(), CLR_REVERB, ICON_CONTROL);
+        desc << "Reverb Mode: " << mode;
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Mode", desc.str(), CLR_REVERB, ICON_CONTROL);
         break;
       }
 
       case 0xE7: {
         uint8_t depth = GetByte(curOffset++);
-        desc << L"Reverb Depth: " << depth;
+        desc << "Reverb Depth: " << depth;
         parentSeq->reverbDepth = depth << 8;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Reverb Depth", desc.str(), CLR_REVERB, ICON_CONTROL);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", desc.str(), CLR_REVERB, ICON_CONTROL);
         break;
       }
 
       case 0xE8: {
         uint8_t midiReverb = roundi(fabs(parentSeq->reverbDepth / 32768.0) * 127.0);
-        AddReverb(beginOffset, curOffset - beginOffset, midiReverb, L"Reverb On");
+        AddReverb(beginOffset, curOffset - beginOffset, midiReverb, "Reverb On");
         break;
       }
 
       case 0xE9: {
-        AddReverb(beginOffset, curOffset - beginOffset, 0, L"Reverb Off");
+        AddReverb(beginOffset, curOffset - beginOffset, 0, "Reverb Off");
         break;
       }
 
@@ -308,14 +308,14 @@ bool TamSoftPS1Track::ReadEvent(void) {
 
       case 0xF0: {
         FinalizeAllNotes();
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Note Off", desc.str(), CLR_NOTEOFF, ICON_NOTE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Note Off", desc.str(), CLR_NOTEOFF, ICON_NOTE);
         break;
       }
 
       case 0xF1: {
         uint16_t a1 = GetByte(curOffset++);
-        desc << L"Arg1: " << a1;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event F1", desc.str());
+        desc << "Arg1: " << a1;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event F1", desc.str());
         break;
       }
 
@@ -324,21 +324,21 @@ bool TamSoftPS1Track::ReadEvent(void) {
         curOffset += 2;
 
         uint32_t dest = curOffset + relOffset;
-        desc << L"Destination: $" << std::hex << std::setfill(L'0') << std::setw(4) << std::uppercase << (int) dest;
+        desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
         uint32_t length = curOffset - beginOffset;
 
         curOffset = dest;
         if (!IsOffsetUsed(dest)) {
-          AddGenericEvent(beginOffset, length, L"Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+          AddGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
         }
         else {
-          bContinue = AddLoopForever(beginOffset, length, L"Jump");
+          bContinue = AddLoopForever(beginOffset, length, "Jump");
         }
         break;
       }
 
       case 0xF9: {
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event F9", desc.str());
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event F9", desc.str());
         break;
       }
 
@@ -348,18 +348,18 @@ bool TamSoftPS1Track::ReadEvent(void) {
         break;
 
       default:
-        desc << L"Event: 0x" << std::hex << std::setfill(L'0') << std::setw(2) << std::uppercase << (int) statusByte;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event", desc.str());
-        pRoot->AddLogItem(new LogItem(std::wstring(L"Unknown Event - ") + desc.str(),
+        desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+        pRoot->AddLogItem(new LogItem(std::string("Unknown Event - ") + desc.str(),
                                       LOG_LEVEL_ERR,
-                                      std::wstring(L"TamSoftPS1Seq")));
+                                      std::string("TamSoftPS1Seq")));
         bContinue = false;
         break;
     }
   }
 
-  //std::wostringstream ssTrace;
-  //ssTrace << L"" << std::hex << std::setfill(L'0') << std::setw(8) << std::uppercase << beginOffset << L": " << std::setw(2) << (int)statusByte  << L" -> " << std::setw(8) << curOffset << std::endl;
+  //std::ostringstream ssTrace;
+  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
   //OutputDebugString(ssTrace.str().c_str());
 
   if (!bContinue) {

--- a/src/main/formats/TamSoftPS1Seq.h
+++ b/src/main/formats/TamSoftPS1Seq.h
@@ -7,7 +7,7 @@
 class TamSoftPS1Seq:
     public VGMSeq {
  public:
-  TamSoftPS1Seq(RawFile *file, uint32_t offset, uint8_t theSong, const std::wstring &name = L"TamSoftPS1Seq");
+  TamSoftPS1Seq(RawFile *file, uint32_t offset, uint8_t theSong, const std::string &name = "TamSoftPS1Seq");
   virtual ~TamSoftPS1Seq(void);
 
   virtual bool GetHeaderInfo(void);

--- a/src/main/formats/TriAcePS1InstrSet.cpp
+++ b/src/main/formats/TriAcePS1InstrSet.cpp
@@ -8,7 +8,7 @@
 // *****************
 
 TriAcePS1InstrSet::TriAcePS1InstrSet(RawFile *file, uint32_t offset)
-    : VGMInstrSet(TriAcePS1Format::name, file, offset, 0, L"TriAce InstrSet") {
+    : VGMInstrSet(TriAcePS1Format::name, file, offset, 0, "TriAce InstrSet") {
 }
 
 TriAcePS1InstrSet::~TriAcePS1InstrSet(void) {
@@ -23,9 +23,9 @@ TriAcePS1InstrSet::~TriAcePS1InstrSet(void) {
 //==============================================================
 bool TriAcePS1InstrSet::GetHeaderInfo() {
   VGMHeader *header = AddHeader(dwOffset, sizeof(TriAcePS1InstrSet::_InstrHeader));    //1,Sep.2009 revise
-  header->AddSimpleItem(dwOffset, 4, L"InstrSet Size");
-  header->AddSimpleItem(dwOffset + 4, 2, L"Instr Section Size");
-  //header->AddSimpleItem(dwOffset+6, 1, L"Number of Instruments");
+  header->AddSimpleItem(dwOffset, 4, "InstrSet Size");
+  header->AddSimpleItem(dwOffset + 4, 2, "Instr Section Size");
+  //header->AddSimpleItem(dwOffset+6, 1, "Number of Instruments");
 
   //-----------------------
   //1,Sep.2009 revise		to do こうしたい。
@@ -61,11 +61,11 @@ bool TriAcePS1InstrSet::GetInstrPointers() {
     TriAcePS1Instr *newInstr = new TriAcePS1Instr(this, i, 0, 0, 0);
     aInstrs.push_back(newInstr);
     GetBytes(i, sizeof(TriAcePS1Instr::InstrInfo), &newInstr->instrinfo);
-    newInstr->AddSimpleItem(i + 0, sizeof(short), L"Instrument Number");            //1,Sep.2009 revise
-    newInstr->AddSimpleItem(i + 2, sizeof(short), L"ADSR1");                        //1,Sep.2009 revise
-    newInstr->AddSimpleItem(i + 4, sizeof(short), L"ADSR2");                        //1,Sep.2009 revise
+    newInstr->AddSimpleItem(i + 0, sizeof(short), "Instrument Number");            //1,Sep.2009 revise
+    newInstr->AddSimpleItem(i + 2, sizeof(short), "ADSR1");                        //1,Sep.2009 revise
+    newInstr->AddSimpleItem(i + 4, sizeof(short), "ADSR2");                        //1,Sep.2009 revise
     newInstr->AddUnknownItem(i + 6, sizeof(char));                                  //1,Sep.2009 revise
-    newInstr->AddSimpleItem(i + 7, sizeof(char), L"Number of Rgns");                //1,Sep.2009 revise
+    newInstr->AddSimpleItem(i + 7, sizeof(char), "Number of Rgns");                //1,Sep.2009 revise
     i += sizeof(TriAcePS1Instr::RgnInfo) * (newInstr->instrinfo.numRgns);
   }
   return true;
@@ -121,19 +121,19 @@ bool TriAcePS1Instr::LoadInstr() {
     rgn->AddKeyHigh(rgninfo->note_range_high, rgn->dwOffset + 1);
     rgn->AddVelLow(rgninfo->vel_range_low, rgn->dwOffset + 2);
     rgn->AddVelHigh(rgninfo->vel_range_high, rgn->dwOffset + 3);
-    rgn->AddSimpleItem(rgn->dwOffset + 4, 4, L"Sample Offset");
+    rgn->AddSimpleItem(rgn->dwOffset + 4, 4, "Sample Offset");
     rgn->sampOffset = rgninfo->sampOffset; //+ ((VGMInstrSet*)this->vgmfile)->sampColl->dwOffset;
-    rgn->AddSimpleItem(rgn->dwOffset + 8, 4, L"Sample Loop Point");
+    rgn->AddSimpleItem(rgn->dwOffset + 8, 4, "Sample Loop Point");
     //rgn->loop.loopStatus = (rgninfo->loopOffset != rgninfo->sampOffset) && (rgninfo->loopOffset != 0);
     rgn->loop.loopStart = rgninfo->loopOffset;
-    rgn->AddSimpleItem(rgn->dwOffset + 12, 1, L"Attenuation");
+    rgn->AddSimpleItem(rgn->dwOffset + 12, 1, "Attenuation");
     rgn->AddUnityKey((int8_t) 0x3B - rgninfo->pitchTuneSemitones,
                      rgn->dwOffset + 13);  //You would think it would be 0x3C (middle c)
-    rgn->AddSimpleItem(rgn->dwOffset + 14, 1, L"Pitch Fine Tune");
+    rgn->AddSimpleItem(rgn->dwOffset + 14, 1, "Pitch Fine Tune");
     const int kTuningOffset = 22; // approx. 21.500638 from pitch table (0x10be vs 0x1000)
     rgn->fineTune = (short)((double)rgninfo->pitchTuneFine / 64.0 * 100) - kTuningOffset;
     rgn->sampCollPtr = ((VGMInstrSet *) this->vgmfile)->sampColl;
-    rgn->AddSimpleItem(rgn->dwOffset + 15, 5, L"Unknown values");
+    rgn->AddSimpleItem(rgn->dwOffset + 15, 5, "Unknown values");
 
 
     PSXConvADSR(rgn, instrinfo.ADSR1, instrinfo.ADSR2, false);

--- a/src/main/formats/TriAcePS1Scanner.cpp
+++ b/src/main/formats/TriAcePS1Scanner.cpp
@@ -69,7 +69,7 @@ void TriAcePS1Scanner::SearchForSLZSeq(RawFile *file) {
     if (!instrsets.size())
       return;
 
-    std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+    std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
     VGMColl *coll = new VGMColl(name);
     coll->UseSeq(seq);
     for (uint32_t i = 0; i < instrsets.size(); i++)
@@ -199,7 +199,7 @@ TriAcePS1Seq *TriAcePS1Scanner::TriAceSLZDecompress(RawFile *file, uint32_t cfOf
     }
   }
   if (ufOff > ufSize)
-    pRoot->AddLogItem(new LogItem(std::wstring(L"ufOff > ufSize"), LOG_LEVEL_ERR, L"SNSFFile"));
+    pRoot->AddLogItem(new LogItem(std::string("ufOff > ufSize"), LOG_LEVEL_ERR, "SNSFFile"));
 
   //If we had to use DEFAULT_UFSIZE because the uncompressed file size was not given (Valkyrie Profile),
   //then create a new buffer of the correct size now that we know it, and delete the old one.
@@ -209,13 +209,13 @@ TriAcePS1Seq *TriAcePS1Scanner::TriAceSLZDecompress(RawFile *file, uint32_t cfOf
     delete[] uf;
     uf = newUF;
   }
-  //pRoot->UI_WriteBufferToFile(L"uncomp.raw", uf, ufOff);
+  //pRoot->UI_WriteBufferToFile("uncomp.raw", uf, ufOff);
 
   //Create the new virtual file, and analyze the sequence
-  std::wstring name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
+  std::string name = file->tag.HasTitle() ? file->tag.title : RawFile::removeExtFromPath(file->GetFileName());
   VirtFile *newVirtFile = newVirtFile = new VirtFile(uf,
                                                      ufOff,
-                                                     name + std::wstring(L" Sequence"),
+                                                     name + std::string(" Sequence"),
                                                      file->GetParRawFileFullPath().c_str());
 
   TriAcePS1Seq *newSeq = new TriAcePS1Seq(newVirtFile, 0, name);

--- a/src/main/formats/TriAcePS1Seq.cpp
+++ b/src/main/formats/TriAcePS1Seq.cpp
@@ -11,7 +11,7 @@ DECLARE_FORMAT(TriAcePS1);
 // TriAcePS1Seq
 // ************
 
-TriAcePS1Seq::TriAcePS1Seq(RawFile *file, uint32_t offset, const std::wstring &name)
+TriAcePS1Seq::TriAcePS1Seq(RawFile *file, uint32_t offset, const std::string &name)
     : VGMSeq(TriAcePS1Format::name, file, offset, 0, name) {
   AddContainer<TriAcePS1ScorePattern>(aScorePatterns);
   UseLinearAmplitudeScale();
@@ -28,10 +28,10 @@ bool TriAcePS1Seq::GetHeaderInfo(void) {
   SetPPQN(0x30);
 
   header = AddHeader(dwOffset, 0xD5);
-  header->AddSimpleItem(dwOffset + 2, 2, L"Size");
-  header->AddSimpleItem(dwOffset + 0xB, 4, L"Song title");
-  header->AddSimpleItem(dwOffset + 0xF, 1, L"BPM");
-  header->AddSimpleItem(dwOffset + 0x10, 2, L"Time Signature");
+  header->AddSimpleItem(dwOffset + 2, 2, "Size");
+  header->AddSimpleItem(dwOffset + 0xB, 4, "Song title");
+  header->AddSimpleItem(dwOffset + 0xF, 1, "BPM");
+  header->AddSimpleItem(dwOffset + 0x10, 2, "Time Signature");
 
   unLength = GetShort(dwOffset + 2);
   AlwaysWriteInitialTempo(GetByte(dwOffset + 0xF));
@@ -39,7 +39,7 @@ bool TriAcePS1Seq::GetHeaderInfo(void) {
 }
 
 bool TriAcePS1Seq::GetTrackPointers(void) {
-  VGMHeader *TrkInfoHeader = header->AddHeader(dwOffset + 0x16, 6 * 32, L"Track Info Blocks");
+  VGMHeader *TrkInfoHeader = header->AddHeader(dwOffset + 0x16, 6 * 32, "Track Info Blocks");
 
 
   GetBytes(dwOffset + 0x16, 6 * 32, &TrkInfos);
@@ -47,7 +47,7 @@ bool TriAcePS1Seq::GetTrackPointers(void) {
     if (TrkInfos[i].trkOffset != 0) {
       aTracks.push_back(new TriAcePS1Track(this, TrkInfos[i].trkOffset, 0));
 
-      VGMHeader *TrkInfoBlock = TrkInfoHeader->AddHeader(dwOffset + 0x16 + 6 * i, 6, L"Track Info");
+      VGMHeader *TrkInfoBlock = TrkInfoHeader->AddHeader(dwOffset + 0x16 + 6 * i, 6, "Track Info");
     }
   return true;
 }
@@ -80,7 +80,7 @@ void TriAcePS1Track::LoadTrackMainLoop(uint32_t stopOffset, int32_t stopTime) {
     uint32_t endOffset = ReadScorePattern(scorePatternOffset);
     if (seq->curScorePattern)
       seq->curScorePattern->unLength = endOffset - seq->curScorePattern->dwOffset;
-    AddSimpleItem(scorePatternPtrOffset, 2, L"Score Pattern Ptr");
+    AddSimpleItem(scorePatternPtrOffset, 2, "Score Pattern Ptr");
     scorePatternPtrOffset += 2;
     scorePatternOffset = GetShort(scorePatternPtrOffset);
   }
@@ -118,7 +118,7 @@ bool TriAcePS1Track::ReadEvent(void) {
   else
     switch (status_byte) {
       case 0x80 :
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Score Pattern End", L"", CLR_TRACKEND);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Score Pattern End", "", CLR_TRACKEND);
         return false;
 
       //unknown
@@ -200,19 +200,19 @@ bool TriAcePS1Track::ReadEvent(void) {
       case 0x8A : {
         event_dur = GetByte(curOffset++);
         uint8_t val = GetByte(curOffset++);
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event (tempo?)");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event (tempo?)");
         break;
       }
 
       //Dal Segno: start point
       case 0x8D :
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Dal Segno: start point", L"", CLR_UNKNOWN);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Dal Segno: start point", "", CLR_UNKNOWN);
         break;
 
       //Dal Segno: end point
       case 0x8E :
         curOffset++;
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Dal Segno: end point", L"", CLR_UNKNOWN);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Dal Segno: end point", "", CLR_UNKNOWN);
         break;
 
       //rest
@@ -254,7 +254,7 @@ bool TriAcePS1Track::ReadEvent(void) {
       case 0x95 :
         event_dur = GetByte(curOffset++);
         curOffset++;
-        AddUnknown(beginOffset, curOffset - beginOffset, L"Unknown Event  (Tie?)");
+        AddUnknown(beginOffset, curOffset - beginOffset, "Unknown Event  (Tie?)");
         break;
 
       //Pitch Bend Range
@@ -297,7 +297,7 @@ bool TriAcePS1Track::ReadEvent(void) {
       case 0x9E :
         impliedNoteDur = GetByte(curOffset++);
         impliedVelocity = GetByte(curOffset++);
-        AddGenericEvent(beginOffset, curOffset - beginOffset, L"Imply Note Params", L"", CLR_CHANGESTATE);
+        AddGenericEvent(beginOffset, curOffset - beginOffset, "Imply Note Params", "", CLR_CHANGESTATE);
         break;
 
       default :

--- a/src/main/formats/TriAcePS1Seq.h
+++ b/src/main/formats/TriAcePS1Seq.h
@@ -15,7 +15,7 @@ class TriAcePS1Seq:
   } TrkInfo;
 
 
-  TriAcePS1Seq(RawFile *file, uint32_t offset, const std::wstring &name = std::wstring(L"TriAce Seq"));
+  TriAcePS1Seq(RawFile *file, uint32_t offset, const std::string &name = std::string("TriAce Seq"));
   virtual ~TriAcePS1Seq(void);
 
   virtual bool GetHeaderInfo(void);
@@ -34,7 +34,7 @@ class TriAcePS1ScorePattern
     : public VGMContainerItem {
  public:
   TriAcePS1ScorePattern(TriAcePS1Seq *parentSeq, uint32_t offset)
-      : VGMContainerItem(parentSeq, offset, 0, L"Score Pattern") { }
+      : VGMContainerItem(parentSeq, offset, 0, "Score Pattern") { }
 };
 
 

--- a/src/main/formats/Vab.cpp
+++ b/src/main/formats/Vab.cpp
@@ -22,22 +22,22 @@ bool Vab::GetHeaderInfo() {
     return false;
   }
 
-  name = L"VAB";
+  name = "VAB";
 
-  VGMHeader *vabHdr = AddHeader(dwOffset, 0x20, L"VAB Header");
-  vabHdr->AddSimpleItem(dwOffset + 0x00, 4, L"ID");
-  vabHdr->AddSimpleItem(dwOffset + 0x04, 4, L"Version");
-  vabHdr->AddSimpleItem(dwOffset + 0x08, 4, L"VAB ID");
-  vabHdr->AddSimpleItem(dwOffset + 0x0c, 4, L"Total Size");
-  vabHdr->AddSimpleItem(dwOffset + 0x10, 2, L"Reserved");
-  vabHdr->AddSimpleItem(dwOffset + 0x12, 2, L"Number of Programs");
-  vabHdr->AddSimpleItem(dwOffset + 0x14, 2, L"Number of Tones");
-  vabHdr->AddSimpleItem(dwOffset + 0x16, 2, L"Number of VAGs");
-  vabHdr->AddSimpleItem(dwOffset + 0x18, 1, L"Master Volume");
-  vabHdr->AddSimpleItem(dwOffset + 0x19, 1, L"Master Pan");
-  vabHdr->AddSimpleItem(dwOffset + 0x1a, 1, L"Bank Attributes 1");
-  vabHdr->AddSimpleItem(dwOffset + 0x1b, 1, L"Bank Attributes 2");
-  vabHdr->AddSimpleItem(dwOffset + 0x1c, 4, L"Reserved");
+  VGMHeader *vabHdr = AddHeader(dwOffset, 0x20, "VAB Header");
+  vabHdr->AddSimpleItem(dwOffset + 0x00, 4, "ID");
+  vabHdr->AddSimpleItem(dwOffset + 0x04, 4, "Version");
+  vabHdr->AddSimpleItem(dwOffset + 0x08, 4, "VAB ID");
+  vabHdr->AddSimpleItem(dwOffset + 0x0c, 4, "Total Size");
+  vabHdr->AddSimpleItem(dwOffset + 0x10, 2, "Reserved");
+  vabHdr->AddSimpleItem(dwOffset + 0x12, 2, "Number of Programs");
+  vabHdr->AddSimpleItem(dwOffset + 0x14, 2, "Number of Tones");
+  vabHdr->AddSimpleItem(dwOffset + 0x16, 2, "Number of VAGs");
+  vabHdr->AddSimpleItem(dwOffset + 0x18, 1, "Master Volume");
+  vabHdr->AddSimpleItem(dwOffset + 0x19, 1, "Master Pan");
+  vabHdr->AddSimpleItem(dwOffset + 0x1a, 1, "Bank Attributes 1");
+  vabHdr->AddSimpleItem(dwOffset + 0x1b, 1, "Bank Attributes 2");
+  vabHdr->AddSimpleItem(dwOffset + 0x1c, 4, "Reserved");
 
   GetBytes(dwOffset, 0x20, &hdr);
 
@@ -57,19 +57,19 @@ bool Vab::GetInstrPointers() {
 
   uint32_t offVAGOffsets = offToneAttrs + (32 * 16 * numPrograms);
 
-  VGMHeader *progsHdr = AddHeader(offProgs, 16 * 128, L"Program Table");
-  VGMHeader *toneAttrsHdr = AddHeader(offToneAttrs, 32 * 16, L"Tone Attributes Table");
+  VGMHeader *progsHdr = AddHeader(offProgs, 16 * 128, "Program Table");
+  VGMHeader *toneAttrsHdr = AddHeader(offToneAttrs, 32 * 16, "Tone Attributes Table");
 
   if (numPrograms > 128) {
-    std::wstringstream message;
-    message << L"Too many programs (" << numPrograms << L")  Offset: 0x" << std::hex << dwOffset;
-    pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, L"VAB"));
+    std::stringstream message;
+    message << "Too many programs (" << numPrograms << ")  Offset: 0x" << std::hex << dwOffset;
+    pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, "VAB"));
     return false;
   }
   if (numVAGs > 255) {
-    std::wstringstream message;
-    message << L"Too many VAGs (" << numVAGs << L")  Offset: 0x" << std::hex << dwOffset;
-    pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, L"VAB"));
+    std::stringstream message;
+    message << "Too many VAGs (" << numVAGs << ")  Offset: 0x" << std::hex << dwOffset;
+    pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, "VAB"));
     return false;
   }
 
@@ -93,25 +93,25 @@ bool Vab::GetInstrPointers() {
 
     uint8_t numTonesPerInstr = GetByte(offCurrProg);
     if (numTonesPerInstr > 32) {
-      wchar_t log[512];
-      swprintf(log, 512, L"Too many tones (%u) in Program #%u.", numTonesPerInstr, progIndex);
-      pRoot->AddLogItem(new LogItem(log, LOG_LEVEL_WARN, L"Vab"));
+      char log[512];
+      snprintf(log, 512, "Too many tones (%u) in Program #%u.", numTonesPerInstr, progIndex);
+      pRoot->AddLogItem(new LogItem(log, LOG_LEVEL_WARN, "Vab"));
     }
     else if (numTonesPerInstr != 0) {
       VabInstr *newInstr = new VabInstr(this, offCurrToneAttrs, 0x20 * 16, 0, progIndex);
       aInstrs.push_back(newInstr);
       GetBytes(offCurrProg, 0x10, &newInstr->attr);
 
-      VGMHeader *hdr = progsHdr->AddHeader(offCurrProg, 0x10, L"Program");
-      hdr->AddSimpleItem(offCurrProg + 0x00, 1, L"Number of Tones");
-      hdr->AddSimpleItem(offCurrProg + 0x01, 1, L"Volume");
-      hdr->AddSimpleItem(offCurrProg + 0x02, 1, L"Priority");
-      hdr->AddSimpleItem(offCurrProg + 0x03, 1, L"Mode");
-      hdr->AddSimpleItem(offCurrProg + 0x04, 1, L"Pan");
-      hdr->AddSimpleItem(offCurrProg + 0x05, 1, L"Reserved");
-      hdr->AddSimpleItem(offCurrProg + 0x06, 2, L"Attribute");
-      hdr->AddSimpleItem(offCurrProg + 0x08, 4, L"Reserved");
-      hdr->AddSimpleItem(offCurrProg + 0x0c, 4, L"Reserved");
+      VGMHeader *hdr = progsHdr->AddHeader(offCurrProg, 0x10, "Program");
+      hdr->AddSimpleItem(offCurrProg + 0x00, 1, "Number of Tones");
+      hdr->AddSimpleItem(offCurrProg + 0x01, 1, "Volume");
+      hdr->AddSimpleItem(offCurrProg + 0x02, 1, "Priority");
+      hdr->AddSimpleItem(offCurrProg + 0x03, 1, "Mode");
+      hdr->AddSimpleItem(offCurrProg + 0x04, 1, "Pan");
+      hdr->AddSimpleItem(offCurrProg + 0x05, 1, "Reserved");
+      hdr->AddSimpleItem(offCurrProg + 0x06, 2, "Attribute");
+      hdr->AddSimpleItem(offCurrProg + 0x08, 4, "Reserved");
+      hdr->AddSimpleItem(offCurrProg + 0x0c, 4, "Reserved");
 
       newInstr->masterVol = GetByte(offCurrProg + 0x01);
 
@@ -122,10 +122,10 @@ bool Vab::GetInstrPointers() {
   }
 
   if ((offVAGOffsets + 2 * 256) <= nEndOffset) {
-    wchar_t name[256];
+    char name[256];
     std::vector<SizeOffsetPair> vagLocations;
     uint32_t totalVAGSize = 0;
-    VGMHeader *vagOffsetHdr = AddHeader(offVAGOffsets, 2 * 256, L"VAG Pointer Table");
+    VGMHeader *vagOffsetHdr = AddHeader(offVAGOffsets, 2 * 256, "VAG Pointer Table");
 
     uint32_t vagStartOffset = offVAGOffsets + 2 * 256;
     uint32_t vagOffset = vagStartOffset;
@@ -133,7 +133,7 @@ bool Vab::GetInstrPointers() {
     for (uint32_t i = 0; i < numVAGs; i++) {
       uint32_t vagSize = GetShort(offVAGOffsets + i * 2) * 8;
 
-      swprintf(name, 256, L"VAG Size /8 #%u", i);
+      snprintf(name, 256, "VAG Size /8 #%u", i);
       vagOffsetHdr->AddSimpleItem(offVAGOffsets + i * 2, 2, name);
 
       if (vagOffset + vagSize <= nEndOffset) {
@@ -141,9 +141,9 @@ bool Vab::GetInstrPointers() {
         totalVAGSize += vagSize;
       }
       else {
-        wchar_t log[512];
-        swprintf(log, 512, L"VAG #%u pointer (offset=0x%08X, size=%u) is invalid.", i, vagOffset, vagSize);
-        pRoot->AddLogItem(new LogItem(log, LOG_LEVEL_WARN, L"Vab"));
+        char log[512];
+        snprintf(log, 512, "VAG #%u pointer (offset=0x%08X, size=%u) is invalid.", i, vagOffset, vagSize);
+        pRoot->AddLogItem(new LogItem(log, LOG_LEVEL_WARN, "Vab"));
       }
 
       vagOffset += vagSize;
@@ -181,7 +181,7 @@ VabInstr::VabInstr(VGMInstrSet *instrSet,
                    uint32_t length,
                    uint32_t theBank,
                    uint32_t theInstrNum,
-                   const wstring &name)
+                   const string &name)
     : VGMInstr(instrSet, offset, length, theBank, theInstrNum, name),
       masterVol(127) {
 }
@@ -221,39 +221,39 @@ bool VabRgn::LoadRgn() {
   unLength = 0x20;
   GetBytes(dwOffset, 0x20, &attr);
 
-  AddGeneralItem(dwOffset, 1, L"Priority");
-  AddGeneralItem(dwOffset + 1, 1, L"Mode (use reverb?)");
+  AddGeneralItem(dwOffset, 1, "Priority");
+  AddGeneralItem(dwOffset + 1, 1, "Mode (use reverb?)");
   AddVolume((GetByte(dwOffset + 2) * instr->masterVol) / (127.0 * 127.0), dwOffset + 2, 1);
   AddPan(GetByte(dwOffset + 3), dwOffset + 3);
   AddUnityKey(GetByte(dwOffset + 4), dwOffset + 4);
-  AddGeneralItem(dwOffset + 5, 1, L"Pitch Tune");
+  AddGeneralItem(dwOffset + 5, 1, "Pitch Tune");
   AddKeyLow(GetByte(dwOffset + 6), dwOffset + 6);
   AddKeyHigh(GetByte(dwOffset + 7), dwOffset + 7);
-  AddGeneralItem(dwOffset + 8, 1, L"Vibrato Width");
-  AddGeneralItem(dwOffset + 9, 1, L"Vibrato Time");
-  AddGeneralItem(dwOffset + 10, 1, L"Portamento Width");
-  AddGeneralItem(dwOffset + 11, 1, L"Portamento Holding Time");
-  AddGeneralItem(dwOffset + 12, 1, L"Pitch Bend Min");
-  AddGeneralItem(dwOffset + 13, 1, L"Pitch Bend Max");
-  AddGeneralItem(dwOffset + 14, 1, L"Reserved");
-  AddGeneralItem(dwOffset + 15, 1, L"Reserved");
-  AddGeneralItem(dwOffset + 16, 2, L"ADSR1");
-  AddGeneralItem(dwOffset + 18, 2, L"ADSR2");
-  AddGeneralItem(dwOffset + 20, 2, L"Parent Program");
+  AddGeneralItem(dwOffset + 8, 1, "Vibrato Width");
+  AddGeneralItem(dwOffset + 9, 1, "Vibrato Time");
+  AddGeneralItem(dwOffset + 10, 1, "Portamento Width");
+  AddGeneralItem(dwOffset + 11, 1, "Portamento Holding Time");
+  AddGeneralItem(dwOffset + 12, 1, "Pitch Bend Min");
+  AddGeneralItem(dwOffset + 13, 1, "Pitch Bend Max");
+  AddGeneralItem(dwOffset + 14, 1, "Reserved");
+  AddGeneralItem(dwOffset + 15, 1, "Reserved");
+  AddGeneralItem(dwOffset + 16, 2, "ADSR1");
+  AddGeneralItem(dwOffset + 18, 2, "ADSR2");
+  AddGeneralItem(dwOffset + 20, 2, "Parent Program");
   AddSampNum(GetShort(dwOffset + 22) - 1, dwOffset + 22, 2);
-  AddGeneralItem(dwOffset + 24, 2, L"Reserved");
-  AddGeneralItem(dwOffset + 26, 2, L"Reserved");
-  AddGeneralItem(dwOffset + 28, 2, L"Reserved");
-  AddGeneralItem(dwOffset + 30, 2, L"Reserved");
+  AddGeneralItem(dwOffset + 24, 2, "Reserved");
+  AddGeneralItem(dwOffset + 26, 2, "Reserved");
+  AddGeneralItem(dwOffset + 28, 2, "Reserved");
+  AddGeneralItem(dwOffset + 30, 2, "Reserved");
   ADSR1 = attr.adsr1;
   ADSR2 = attr.adsr2;
   if ((int) sampNum < 0)
     sampNum = 0;
 
   if (keyLow > keyHigh) {
-    std::wstringstream message;
-    message << L"Low Key (" << keyLow << L") is higher than High Key (" << keyHigh << L")  Offset: 0x" << std::hex << dwOffset;
-    pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, L"VAB (VabRgn)"));
+    std::stringstream message;
+    message << "Low Key (" << keyLow << ") is higher than High Key (" << keyHigh << ")  Offset: 0x" << std::hex << dwOffset;
+    pRoot->AddLogItem(new LogItem(message.str(), LOG_LEVEL_ERR, "VAB (VabRgn)"));
     return false;
   }
 

--- a/src/main/formats/Vab.h
+++ b/src/main/formats/Vab.h
@@ -127,7 +127,7 @@ class VabInstr
            uint32_t length,
            uint32_t theBank,
            uint32_t theInstrNum,
-           const std::wstring &name = L"Instrument");
+           const std::string &name = "Instrument");
   virtual ~VabInstr(void);
 
   virtual bool LoadInstr();

--- a/src/main/formats/WD.cpp
+++ b/src/main/formats/WD.cpp
@@ -21,11 +21,11 @@ WDInstrSet::~WDInstrSet(void) {
 
 
 bool WDInstrSet::GetHeaderInfo() {
-  VGMHeader *header = AddHeader(dwOffset, 0x10, L"Header");
-  header->AddSimpleItem(dwOffset + 0x2, 2, L"ID");
-  header->AddSimpleItem(dwOffset + 0x4, 4, L"Sample Section Size");
-  header->AddSimpleItem(dwOffset + 0x8, 4, L"Number of Instruments");
-  header->AddSimpleItem(dwOffset + 0xC, 4, L"Number of Regions");
+  VGMHeader *header = AddHeader(dwOffset, 0x10, "Header");
+  header->AddSimpleItem(dwOffset + 0x2, 2, "ID");
+  header->AddSimpleItem(dwOffset + 0x4, 4, "Sample Section Size");
+  header->AddSimpleItem(dwOffset + 0x8, 4, "Number of Instruments");
+  header->AddSimpleItem(dwOffset + 0xC, 4, "Number of Regions");
 
   id = GetShort(0x2 + dwOffset);
   dwSampSectSize = GetWord(0x4 + dwOffset);
@@ -35,8 +35,8 @@ bool WDInstrSet::GetHeaderInfo() {
   if (dwSampSectSize < 0x40)    //Some songs in the Bouncer have bizarre values here
     dwSampSectSize = 0;
 
-  wostringstream theName;
-  theName << L"WD " << id;
+  ostringstream theName;
+  theName << "WD " << id;
   name = theName.str();
 
   uint32_t sampCollOff = dwOffset + GetWord(dwOffset + 0x20) + (dwTotalRegions * 0x20);
@@ -65,8 +65,8 @@ bool WDInstrSet::GetInstrPointers() {
       instrLength = GetWord(j + ((i + 1) * 4)) - GetWord(j + (i * 4));
     else
       instrLength = sampColl->dwOffset - (GetWord(j + (i * 4)) + dwOffset);
-    wostringstream name;
-    name << L"Instrument " << i;
+    ostringstream name;
+    name << "Instrument " << i;
     WDInstr *newWDInstr = new WDInstr(this, dwOffset + GetWord(j + (i * 4)), instrLength, 0, i, name.str());//strStr);
     aInstrs.push_back(newWDInstr);
   }
@@ -83,7 +83,7 @@ WDInstr::WDInstr(VGMInstrSet *instrSet,
                  uint32_t length,
                  uint32_t theBank,
                  uint32_t theInstrNum,
-                 const wstring name)
+                 const string name)
     : VGMInstr(instrSet, offset, length, theBank, theInstrNum, name, defaultWDReverbPercent) {
 }
 
@@ -92,7 +92,7 @@ WDInstr::~WDInstr(void) {
 
 
 bool WDInstr::LoadInstr() {
-  wostringstream strStr;
+  ostringstream strStr;
   uint32_t j = 0;
   long startAddress = 0;
   bool notSampleStart = false;
@@ -108,19 +108,19 @@ bool WDInstr::LoadInstr() {
     WDRgn *rgn = new WDRgn(this, k * 0x20 + dwOffset);
     aRgns.push_back(rgn);
 
-    rgn->AddSimpleItem(k * 0x20 + dwOffset, 1, L"Stereo Region Flag");
-    rgn->AddSimpleItem(k * 0x20 + 1 + dwOffset, 1, L"First/Last Region Flags");
-    rgn->AddSimpleItem(k * 0x20 + 2 + dwOffset, 2, L"Unknown Flag");
-    rgn->AddSimpleItem(k * 0x20 + 0x4 + dwOffset, 4, L"Sample Offset");
-    rgn->AddSimpleItem(k * 0x20 + 0x8 + dwOffset, 4, L"Loop Start");
-    rgn->AddSimpleItem(k * 0x20 + 0xC + dwOffset, 2, L"ADSR1");
-    rgn->AddSimpleItem(k * 0x20 + 0xE + dwOffset, 2, L"ADSR2");
-    rgn->AddSimpleItem(k * 0x20 + 0x12 + dwOffset, 1, L"Finetune");
-    rgn->AddSimpleItem(k * 0x20 + 0x13 + dwOffset, 1, L"UnityKey");
-    rgn->AddSimpleItem(k * 0x20 + 0x14 + dwOffset, 1, L"Key High");
-    rgn->AddSimpleItem(k * 0x20 + 0x15 + dwOffset, 1, L"Velocity High");
-    rgn->AddSimpleItem(k * 0x20 + 0x16 + dwOffset, 1, L"Attenuation");
-    rgn->AddSimpleItem(k * 0x20 + 0x17 + dwOffset, 1, L"Pan");
+    rgn->AddSimpleItem(k * 0x20 + dwOffset, 1, "Stereo Region Flag");
+    rgn->AddSimpleItem(k * 0x20 + 1 + dwOffset, 1, "First/Last Region Flags");
+    rgn->AddSimpleItem(k * 0x20 + 2 + dwOffset, 2, "Unknown Flag");
+    rgn->AddSimpleItem(k * 0x20 + 0x4 + dwOffset, 4, "Sample Offset");
+    rgn->AddSimpleItem(k * 0x20 + 0x8 + dwOffset, 4, "Loop Start");
+    rgn->AddSimpleItem(k * 0x20 + 0xC + dwOffset, 2, "ADSR1");
+    rgn->AddSimpleItem(k * 0x20 + 0xE + dwOffset, 2, "ADSR2");
+    rgn->AddSimpleItem(k * 0x20 + 0x12 + dwOffset, 1, "Finetune");
+    rgn->AddSimpleItem(k * 0x20 + 0x13 + dwOffset, 1, "UnityKey");
+    rgn->AddSimpleItem(k * 0x20 + 0x14 + dwOffset, 1, "Key High");
+    rgn->AddSimpleItem(k * 0x20 + 0x15 + dwOffset, 1, "Velocity High");
+    rgn->AddSimpleItem(k * 0x20 + 0x16 + dwOffset, 1, "Attenuation");
+    rgn->AddSimpleItem(k * 0x20 + 0x17 + dwOffset, 1, "Pan");
 
     rgn->bStereoRegion = GetByte(k * 0x20 + dwOffset) & 0x1;
     rgn->bUnknownFlag2 = GetByte(k * 0x20 + 2 + dwOffset) & 0x1;

--- a/src/main/formats/WD.h
+++ b/src/main/formats/WD.h
@@ -64,7 +64,7 @@ class WDInstr
           uint32_t length,
           uint32_t theBank,
           uint32_t theInstrNum,
-          std::wstring name);
+          std::string name);
   virtual ~WDInstr(void);
   virtual bool LoadInstr();
 

--- a/src/main/loaders/GSFLoader.cpp
+++ b/src/main/loaders/GSFLoader.cpp
@@ -8,7 +8,7 @@ using namespace std;
 #define GSF_VERSION    0x22
 #define GSF_MAX_ROM_SIZE    0x2000000
 
-wchar_t *GetFileWithBase(const wchar_t *f, const wchar_t *newfile);
+char* GetFileWithBase(const char* f, const char* newfile);
 
 GSFLoader::GSFLoader(void) {
 }
@@ -22,21 +22,21 @@ PostLoadCommand GSFLoader::Apply(RawFile *file) {
   if (memcmp(sig, "PSF", 3) == 0) {
     uint8_t version = sig[3];
     if (version == GSF_VERSION) {
-      const wchar_t *complaint;
+      const char* complaint;
       size_t exebufsize = GSF_MAX_ROM_SIZE;
       uint8_t *exebuf = NULL;
       //memset(exebuf, 0, exebufsize);
 
       complaint = psf_read_exe(file, exebuf, exebufsize);
       if (complaint) {
-        pRoot->AddLogItem(new LogItem(std::wstring(complaint), LOG_LEVEL_ERR, L"GSFLoader"));
+        pRoot->AddLogItem(new LogItem(std::string(complaint), LOG_LEVEL_ERR, "GSFLoader"));
         delete[] exebuf;
         return KEEP_IT;
       }
-      //pRoot->UI_WriteBufferToFile(L"uncomp.gba", exebuf, exebufsize);
+      //pRoot->UI_WriteBufferToFile("uncomp.gba", exebuf, exebufsize);
 
-      wstring str = file->GetFileName();
-      pRoot->CreateVirtFile(exebuf, (uint32_t) exebufsize, str.data(), L"", file->tag);
+      string str = file->GetFileName();
+      pRoot->CreateVirtFile(exebuf, (uint32_t) exebufsize, str.data(), "", file->tag);
       return DELETE_IT;
     }
   }
@@ -57,7 +57,7 @@ PostLoadCommand GSFLoader::Apply(RawFile *file) {
 **
 ** Returns the error message, or NULL on success
 */
-const wchar_t *GSFLoader::psf_read_exe(
+const char* GSFLoader::psf_read_exe(
     RawFile *file,
     unsigned char *&exebuffer,
     size_t &exebuffersize
@@ -67,7 +67,7 @@ const wchar_t *GSFLoader::psf_read_exe(
     return psf.GetError();
 
   // search exclusively for _lib tag, and if found, perform a recursive load
-  const wchar_t *psflibError = load_psf_libs(psf, file, exebuffer, exebuffersize);
+  const char* psflibError = load_psf_libs(psf, file, exebuffer, exebuffersize);
   if (psflibError != NULL)
     return psflibError;
 
@@ -81,40 +81,40 @@ const wchar_t *GSFLoader::psf_read_exe(
   uint32_t gsfRomSize = gsfExeHeadSeg->GetWord(0x08);
   delete gsfExeHeadSeg;
   if (gsfRomRegion != 0x08000000)
-    return L"GSF ROM offset points to unsupported region. (multi-boot GSF is not supported yet)";
+    return "GSF ROM offset points to unsupported region. (multi-boot GSF is not supported yet)";
   if (gsfRomStart + gsfRomSize > exebuffersize || (exebuffer == NULL && exebuffersize == 0))
-    return L"GSF ROM section start and/or size values are corrupt.";
+    return "GSF ROM section start and/or size values are corrupt.";
 
   if (exebuffer == NULL) {
     exebuffersize = gsfRomStart + gsfRomSize;
     exebuffer = new uint8_t[exebuffersize];
     if (exebuffer == NULL) {
-      return L"GSF ROM memory allocation error.";
+      return "GSF ROM memory allocation error.";
     }
     memset(exebuffer, 0, exebuffersize);
   }
 
   if (!psf.ReadExe(exebuffer + gsfRomStart, gsfRomSize, 0x0c))
-    return L"Decompression failed";
+    return "Decompression failed";
 
   // set tags to RawFile
   if (psf.tags.count("title") != 0) {
-    file->tag.title = string2wstring(psf.tags["title"]);
+    file->tag.title = psf.tags["title"];
   }
   if (psf.tags.count("artist") != 0) {
-    file->tag.artist = string2wstring(psf.tags["artist"]);
+    file->tag.artist = psf.tags["artist"];
   }
   if (psf.tags.count("game") != 0) {
-    file->tag.album = string2wstring(psf.tags["game"]);
+    file->tag.album = psf.tags["game"];
   }
   if (psf.tags.count("comment") != 0) {
-    file->tag.comment = string2wstring(psf.tags["comment"]);
+    file->tag.comment = psf.tags["comment"];
   }
 
   return NULL;
 }
 
-const wchar_t *GSFLoader::load_psf_libs(PSFFile &psf, RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize) {
+const char* GSFLoader::load_psf_libs(PSFFile &psf, RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize) {
   char libTagName[16];
   int libIndex = 1;
   while (true) {
@@ -127,19 +127,15 @@ const wchar_t *GSFLoader::load_psf_libs(PSFFile &psf, RawFile *file, unsigned ch
     if (itLibTag == psf.tags.end())
       break;
 
-    wchar_t tempfn[PATH_MAX] = {0};
-    mbstowcs(tempfn, itLibTag->second.c_str(), itLibTag->second.size());
-
-    wchar_t *fullPath;
-    fullPath = GetFileWithBase(file->GetFullPath(), tempfn);
+    auto fullPath = GetFileWithBase(file->GetFullPath().c_str(), itLibTag->second.c_str());
 
     // TODO: Make sure to limit recursion to avoid crashing.
     RawFile *newRawFile = new RawFile(fullPath);
-    const wchar_t *psflibError = NULL;
+    const char* psflibError = NULL;
     if (newRawFile->open(fullPath))
       psflibError = psf_read_exe(newRawFile, exebuffer, exebuffersize);
     else
-      psflibError = L"Unable to open lib file.";
+      psflibError = "Unable to open lib file.";
     delete fullPath;
     delete newRawFile;
 

--- a/src/main/loaders/GSFLoader.h
+++ b/src/main/loaders/GSFLoader.h
@@ -10,7 +10,7 @@ class GSFLoader:
   virtual ~GSFLoader(void);
 
   virtual PostLoadCommand Apply(RawFile *theFile);
-  const wchar_t *psf_read_exe(RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
+  const char* psf_read_exe(RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
  private:
-  const wchar_t *load_psf_libs(PSFFile &psf, RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
+  const char* load_psf_libs(PSFFile &psf, RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
 };

--- a/src/main/loaders/MAMELoader.cpp
+++ b/src/main/loaders/MAMELoader.cpp
@@ -47,10 +47,9 @@ MAMELoader::~MAMELoader() {
 }
 
 int MAMELoader::LoadXML() {
-  const wstring xmlFilePath = pRoot->UI_GetResourceDirPath() + L"mame_roms.xml";
-  string xmlFilePathString = wstring2string(xmlFilePath);
+  const string xmlFilePath = pRoot->UI_GetResourceDirPath() + "mame_roms.xml";
 
-  TiXmlDocument doc(xmlFilePathString);
+  TiXmlDocument doc(xmlFilePath);
   if (!doc.LoadFile())        //if loading the xml file fails
   {
     return 1;
@@ -152,11 +151,10 @@ int MAMELoader::LoadRomGroupEntry(TiXmlElement *romgroupElmt, MAMEGame *gameentr
 PostLoadCommand MAMELoader::Apply(RawFile *file) {
   if (!bLoadedXml)
     return KEEP_IT;
-  if (file->GetExtension() != L"zip")
+  if (file->GetExtension() != "zip")
     return KEEP_IT;
 
-  wstring fullfilename_w = file->GetFileName();
-  string fullfilename = wstring2string(fullfilename_w);
+  string fullfilename = file->GetFileName();
   size_t endoffilename = fullfilename.rfind('.');
   if (endoffilename == string::npos)
     return KEEP_IT;             // no '.' found in filename, so don't do anything
@@ -176,9 +174,9 @@ PostLoadCommand MAMELoader::Apply(RawFile *file) {
     return KEEP_IT;
 
   //try to open up the game zip
-  wstring fullpath = file->GetFullPath();
-  string test = wstring2string(fullpath);
-  unzFile cur_file = unzOpen(wstring2string(fullpath).c_str());
+  string fullpath = file->GetFullPath();
+  string test = fullpath;
+  unzFile cur_file = unzOpen(fullpath.c_str());
   if (!cur_file) {
     return KEEP_IT;
   }
@@ -316,7 +314,7 @@ VirtFile *MAMELoader::LoadRomGroup(MAMERomGroup *entry, const string &format, un
                                      swap_key2,
                                      addr_key,
                                      xor_key);
-      //pRoot->UI_WriteBufferToFile(L"opcodesdump", decrypt, destFileSize);
+      //pRoot->UI_WriteBufferToFile("opcodesdump", decrypt, destFileSize);
       delete[] decrypt;
     }
     else if (entry->encryption == "cps3") {
@@ -332,18 +330,18 @@ VirtFile *MAMELoader::LoadRomGroup(MAMERomGroup *entry, const string &format, un
         CPS3Decrypt::cps3_decode((uint32_t *)destFile, (uint32_t *)destFile, key1, key2,
                                  destFileSize);
       }
-//      wostringstream strstream;
-//      strstream << L"romgroup  - " << entry->type.c_str();
+//      ostringstream strstream;
+//      strstream << "romgroup  - " << entry->type.c_str();
 //      pRoot->UI_WriteBufferToFile(strstream.str(), destFile, destFileSize);
     }
   }
 
   //static int num = 0;
-  //wostringstream	fn;
-  //fn << L"romgroup " << num++;
+  //ostringstream	fn;
+  //fn << "romgroup " << num++;
   //pRoot->UI_WriteBufferToFile(fn.str().c_str(), destFile, destFileSize);
-  wostringstream strstream;
-  strstream << L"romgroup  - " << entry->type.c_str();
+  ostringstream strstream;
+  strstream << "romgroup  - " << entry->type.c_str();
   VirtFile *newVirtFile = new VirtFile(destFile, destFileSize, strstream.str());
   newVirtFile->DontUseLoaders();
   newVirtFile->DontUseScanners();

--- a/src/main/loaders/NCSFLoader.cpp
+++ b/src/main/loaders/NCSFLoader.cpp
@@ -8,7 +8,7 @@ using namespace std;
 #define NCSF_VERSION    0x25
 #define NCSF_MAX_ROM_SIZE    0x10000000
 
-wchar_t *GetFileWithBase(const wchar_t *f, const wchar_t *newfile);
+char* GetFileWithBase(const char* f, const char* newfile);
 
 NCSFLoader::NCSFLoader(void) {
 }
@@ -22,21 +22,21 @@ PostLoadCommand NCSFLoader::Apply(RawFile *file) {
   if (memcmp(sig, "PSF", 3) == 0) {
     uint8_t version = sig[3];
     if (version == NCSF_VERSION) {
-      const wchar_t *complaint;
+      const char* complaint;
       size_t exebufsize = NCSF_MAX_ROM_SIZE;
       uint8_t *exebuf = NULL;
       //memset(exebuf, 0, exebufsize);
 
       complaint = psf_read_exe(file, exebuf, exebufsize);
       if (complaint) {
-        pRoot->AddLogItem(new LogItem(std::wstring(complaint), LOG_LEVEL_ERR, L"NCSFLoader"));
+        pRoot->AddLogItem(new LogItem(std::string(complaint), LOG_LEVEL_ERR, "NCSFLoader"));
         delete[] exebuf;
         return KEEP_IT;
       }
-      //pRoot->UI_WriteBufferToFile(L"uncomp.sdat", exebuf, exebufsize);
+      //pRoot->UI_WriteBufferToFile("uncomp.sdat", exebuf, exebufsize);
 
-      wstring str = file->GetFileName();
-      pRoot->CreateVirtFile(exebuf, (uint32_t) exebufsize, str.data(), L"", file->tag);
+      string str = file->GetFileName();
+      pRoot->CreateVirtFile(exebuf, (uint32_t) exebufsize, str.data(), "", file->tag);
       return DELETE_IT;
     }
   }
@@ -57,7 +57,7 @@ PostLoadCommand NCSFLoader::Apply(RawFile *file) {
 **
 ** Returns the error message, or NULL on success
 */
-const wchar_t *NCSFLoader::psf_read_exe(
+const char* NCSFLoader::psf_read_exe(
     RawFile *file,
     unsigned char *&exebuffer,
     size_t &exebuffersize
@@ -67,7 +67,7 @@ const wchar_t *NCSFLoader::psf_read_exe(
     return psf.GetError();
 
   // search exclusively for _lib tag, and if found, perform a recursive load
-  const wchar_t *psflibError = load_psf_libs(psf, file, exebuffer, exebuffersize);
+  const char* psflibError = load_psf_libs(psf, file, exebuffer, exebuffersize);
   if (psflibError != NULL)
     return psflibError;
 
@@ -79,38 +79,38 @@ const wchar_t *NCSFLoader::psf_read_exe(
   uint32_t ncsfRomSize = ncsfExeHeadSeg->GetWord(0x08);
   delete ncsfExeHeadSeg;
   if (ncsfRomStart + ncsfRomSize > exebuffersize || (exebuffer == NULL && exebuffersize == 0))
-    return L"NCSF ROM section start and/or size values are likely corrupt.";
+    return "NCSF ROM section start and/or size values are likely corrupt.";
 
   if (exebuffer == NULL) {
     exebuffersize = ncsfRomStart + ncsfRomSize;
     exebuffer = new uint8_t[exebuffersize];
     if (exebuffer == NULL) {
-      return L"NCSF ROM memory allocation error.";
+      return "NCSF ROM memory allocation error.";
     }
     memset(exebuffer, 0, exebuffersize);
   }
 
   if (!psf.ReadExe(exebuffer + ncsfRomStart, ncsfRomSize, 0))
-    return L"Decompression failed";
+    return "Decompression failed";
 
   // set tags to RawFile
   if (psf.tags.count("title") != 0) {
-    file->tag.title = string2wstring(psf.tags["title"]);
+    file->tag.title = psf.tags["title"];
   }
   if (psf.tags.count("artist") != 0) {
-    file->tag.artist = string2wstring(psf.tags["artist"]);
+    file->tag.artist = psf.tags["artist"];
   }
   if (psf.tags.count("game") != 0) {
-    file->tag.album = string2wstring(psf.tags["game"]);
+    file->tag.album = psf.tags["game"];
   }
   if (psf.tags.count("comment") != 0) {
-    file->tag.comment = string2wstring(psf.tags["comment"]);
+    file->tag.comment = psf.tags["comment"];
   }
 
   return NULL;
 }
 
-const wchar_t *NCSFLoader::load_psf_libs(PSFFile &psf,
+const char* NCSFLoader::load_psf_libs(PSFFile &psf,
                                          RawFile *file,
                                          unsigned char *&exebuffer,
                                          size_t &exebuffersize) {
@@ -126,19 +126,15 @@ const wchar_t *NCSFLoader::load_psf_libs(PSFFile &psf,
     if (itLibTag == psf.tags.end())
       break;
 
-    wchar_t tempfn[PATH_MAX] = {0};
-    mbstowcs(tempfn, itLibTag->second.c_str(), itLibTag->second.size());
-
-    wchar_t *fullPath;
-    fullPath = GetFileWithBase(file->GetFullPath(), tempfn);
+    auto fullPath = GetFileWithBase(file->GetFullPath().c_str(), itLibTag->second.c_str());
 
     // TODO: Make sure to limit recursion to avoid crashing.
     RawFile *newRawFile = new RawFile(fullPath);
-    const wchar_t *psflibError = NULL;
+    const char* psflibError = NULL;
     if (newRawFile->open(fullPath))
       psflibError = psf_read_exe(newRawFile, exebuffer, exebuffersize);
     else
-      psflibError = L"Unable to open lib file.";
+      psflibError = "Unable to open lib file.";
     delete fullPath;
     delete newRawFile;
 

--- a/src/main/loaders/NCSFLoader.h
+++ b/src/main/loaders/NCSFLoader.h
@@ -10,7 +10,7 @@ class NCSFLoader:
   virtual ~NCSFLoader(void);
 
   virtual PostLoadCommand Apply(RawFile *theFile);
-  const wchar_t *psf_read_exe(RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
+  const char* psf_read_exe(RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
  private:
-  const wchar_t *load_psf_libs(PSFFile &psf, RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
+  const char* load_psf_libs(PSFFile &psf, RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
 };

--- a/src/main/loaders/NDS2SFLoader.cpp
+++ b/src/main/loaders/NDS2SFLoader.cpp
@@ -8,7 +8,7 @@ using namespace std;
 #define NDS2SF_VERSION    0x24
 #define NDS2SF_MAX_ROM_SIZE    0x10000000
 
-wchar_t *GetFileWithBase(const wchar_t *f, const wchar_t *newfile);
+char* GetFileWithBase(const char* f, const char* newfile);
 
 NDS2SFLoader::NDS2SFLoader(void) {
 }
@@ -22,21 +22,21 @@ PostLoadCommand NDS2SFLoader::Apply(RawFile *file) {
   if (memcmp(sig, "PSF", 3) == 0) {
     uint8_t version = sig[3];
     if (version == NDS2SF_VERSION) {
-      const wchar_t *complaint;
+      const char* complaint;
       size_t exebufsize = NDS2SF_MAX_ROM_SIZE;
       uint8_t *exebuf = NULL;
       //memset(exebuf, 0, exebufsize);
 
       complaint = psf_read_exe(file, exebuf, exebufsize);
       if (complaint) {
-        pRoot->AddLogItem(new LogItem(std::wstring(complaint), LOG_LEVEL_ERR, L"NDS2SFLoader"));
+        pRoot->AddLogItem(new LogItem(std::string(complaint), LOG_LEVEL_ERR, "NDS2SFLoader"));
         delete[] exebuf;
         return KEEP_IT;
       }
-      //pRoot->UI_WriteBufferToFile(L"uncomp.nds", exebuf, exebufsize);
+      //pRoot->UI_WriteBufferToFile("uncomp.nds", exebuf, exebufsize);
 
-      wstring str = file->GetFileName();
-      pRoot->CreateVirtFile(exebuf, (uint32_t) exebufsize, str.data(), L"", file->tag);
+      string str = file->GetFileName();
+      pRoot->CreateVirtFile(exebuf, (uint32_t) exebufsize, str.data(), "", file->tag);
       return DELETE_IT;
     }
   }
@@ -57,7 +57,7 @@ PostLoadCommand NDS2SFLoader::Apply(RawFile *file) {
 **
 ** Returns the error message, or NULL on success
 */
-const wchar_t *NDS2SFLoader::psf_read_exe(
+const char* NDS2SFLoader::psf_read_exe(
     RawFile *file,
     unsigned char *&exebuffer,
     size_t &exebuffersize
@@ -67,7 +67,7 @@ const wchar_t *NDS2SFLoader::psf_read_exe(
     return psf.GetError();
 
   // search exclusively for _lib tag, and if found, perform a recursive load
-  const wchar_t *psflibError = load_psf_libs(psf, file, exebuffer, exebuffersize);
+  const char* psflibError = load_psf_libs(psf, file, exebuffer, exebuffersize);
   if (psflibError != NULL)
     return psflibError;
 
@@ -79,38 +79,38 @@ const wchar_t *NDS2SFLoader::psf_read_exe(
   uint32_t nds2sfRomSize = nds2sfExeHeadSeg->GetWord(0x04);
   delete nds2sfExeHeadSeg;
   if (nds2sfRomStart + nds2sfRomSize > exebuffersize || (exebuffer == NULL && exebuffersize == 0))
-    return L"2SF ROM section start and/or size values are likely corrupt.";
+    return "2SF ROM section start and/or size values are likely corrupt.";
 
   if (exebuffer == NULL) {
     exebuffersize = nds2sfRomStart + nds2sfRomSize;
     exebuffer = new uint8_t[exebuffersize];
     if (exebuffer == NULL) {
-      return L"2SF ROM memory allocation error.";
+      return "2SF ROM memory allocation error.";
     }
     memset(exebuffer, 0, exebuffersize);
   }
 
   if (!psf.ReadExe(exebuffer + nds2sfRomStart, nds2sfRomSize, 0x08))
-    return L"Decompression failed";
+    return "Decompression failed";
 
   // set tags to RawFile
   if (psf.tags.count("title") != 0) {
-    file->tag.title = string2wstring(psf.tags["title"]);
+    file->tag.title = psf.tags["title"];
   }
   if (psf.tags.count("artist") != 0) {
-    file->tag.artist = string2wstring(psf.tags["artist"]);
+    file->tag.artist = psf.tags["artist"];
   }
   if (psf.tags.count("game") != 0) {
-    file->tag.album = string2wstring(psf.tags["game"]);
+    file->tag.album = psf.tags["game"];
   }
   if (psf.tags.count("comment") != 0) {
-    file->tag.comment = string2wstring(psf.tags["comment"]);
+    file->tag.comment = psf.tags["comment"];
   }
 
   return NULL;
 }
 
-const wchar_t *NDS2SFLoader::load_psf_libs(PSFFile &psf,
+const char* NDS2SFLoader::load_psf_libs(PSFFile &psf,
                                            RawFile *file,
                                            unsigned char *&exebuffer,
                                            size_t &exebuffersize) {
@@ -126,19 +126,17 @@ const wchar_t *NDS2SFLoader::load_psf_libs(PSFFile &psf,
     if (itLibTag == psf.tags.end())
       break;
 
-    wchar_t tempfn[PATH_MAX] = {0};
-    mbstowcs(tempfn, itLibTag->second.c_str(), itLibTag->second.size());
+    const char* tempfn = itLibTag->second.c_str();
 
-    wchar_t *fullPath;
-    fullPath = GetFileWithBase(file->GetFullPath(), tempfn);
+    const char* fullPath = GetFileWithBase(file->GetFullPath().c_str(), tempfn);
 
     // TODO: Make sure to limit recursion to avoid crashing.
     RawFile *newRawFile = new RawFile(fullPath);
-    const wchar_t *psflibError = NULL;
+    const char* psflibError = NULL;
     if (newRawFile->open(fullPath))
       psflibError = psf_read_exe(newRawFile, exebuffer, exebuffersize);
     else
-      psflibError = L"Unable to open lib file.";
+      psflibError = "Unable to open lib file.";
     delete fullPath;
     delete newRawFile;
 

--- a/src/main/loaders/NDS2SFLoader.h
+++ b/src/main/loaders/NDS2SFLoader.h
@@ -10,7 +10,7 @@ class NDS2SFLoader:
   virtual ~NDS2SFLoader(void);
 
   virtual PostLoadCommand Apply(RawFile *theFile);
-  const wchar_t *psf_read_exe(RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
+  const char* psf_read_exe(RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
  private:
-  const wchar_t *load_psf_libs(PSFFile &psf, RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
+  const char* load_psf_libs(PSFFile &psf, RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
 };

--- a/src/main/loaders/PSF1Loader.h
+++ b/src/main/loaders/PSF1Loader.h
@@ -10,7 +10,7 @@ class PSF1Loader:
   virtual ~PSF1Loader(void);
 
   virtual PostLoadCommand Apply(RawFile *theFile);
-  const wchar_t *psf_read_exe(RawFile *file, unsigned char *exebuffer, unsigned exebuffersize);
+  const char* psf_read_exe(RawFile *file, unsigned char *exebuffer, unsigned exebuffersize);
  private:
-  const wchar_t *load_psf_libs(PSFFile &psf, RawFile *file, unsigned char *exebuffer, unsigned exebuffersize);
+  const char* load_psf_libs(PSFFile &psf, RawFile *file, unsigned char *exebuffer, unsigned exebuffersize);
 };

--- a/src/main/loaders/PSF2Loader.cpp
+++ b/src/main/loaders/PSF2Loader.cpp
@@ -60,7 +60,7 @@ int PSF2Loader::psf2_decompress_block(
   blocks = new uint8[numblocks * 4];
 
   if (!blocks) {
-    pRoot->AddLogItem(new LogItem(std::wstring(L"Out of Memory"), LOG_LEVEL_ERR, L"PSF2Loader"));
+    pRoot->AddLogItem(new LogItem(std::string("Out of Memory"), LOG_LEVEL_ERR, "PSF2Loader"));
     return -1;
   }
 
@@ -69,7 +69,7 @@ int PSF2Loader::psf2_decompress_block(
   zblock = new uint8[current_block];
 
   if (!zblock) {
-    pRoot->AddLogItem(new LogItem(std::wstring(L"Out of Memory"), LOG_LEVEL_ERR, L"PSF2Loader"));
+    pRoot->AddLogItem(new LogItem(std::string("Out of Memory"), LOG_LEVEL_ERR, "PSF2Loader"));
     delete[] blocks;
     return -1;
   }
@@ -81,7 +81,7 @@ int PSF2Loader::psf2_decompress_block(
 
   destlen = blocksize;
   if (uncompress(decompressedblock, &destlen, zblock, current_block) != Z_OK) {
-    pRoot->AddLogItem(new LogItem(std::wstring(L"Decompression failed"), LOG_LEVEL_ERR, L"PSF2Loader"));
+    pRoot->AddLogItem(new LogItem(std::string("Decompression failed"), LOG_LEVEL_ERR, "PSF2Loader"));
     delete[] zblock;
     delete[] blocks;
     return -1;
@@ -96,8 +96,7 @@ int PSF2Loader::psf2_decompress_block(
 int PSF2Loader::psf2unpack(RawFile *file, unsigned long fileoffset, unsigned long dircount) {
   unsigned int i, j, k;
 
-  wchar_t wfilename[37];
-  unsigned char filename[37];
+  char filename[37];
   unsigned long offset = 0;
   unsigned long filesize = 0;
   unsigned long buffersize = 0;
@@ -120,7 +119,7 @@ int PSF2Loader::psf2unpack(RawFile *file, unsigned long fileoffset, unsigned lon
 
       r = psf2unpack(file, offset + 0x14, filesize);
       if (r) {
-        pRoot->AddLogItem(new LogItem(std::wstring(L"Directory decompression failed"), LOG_LEVEL_ERR, L"PSF2Loader"));
+        pRoot->AddLogItem(new LogItem(std::string("Directory decompression failed"), LOG_LEVEL_ERR, "PSF2Loader"));
         return -1;
       }
     }
@@ -133,7 +132,7 @@ int PSF2Loader::psf2unpack(RawFile *file, unsigned long fileoffset, unsigned lon
 
       dblock = new uint8[buffersize];
       if (!dblock) {
-        pRoot->AddLogItem(new LogItem(std::wstring(L"Out of Memory"), LOG_LEVEL_ERR, L"PSF2Loader"));
+        pRoot->AddLogItem(new LogItem(std::string("Out of Memory"), LOG_LEVEL_ERR, "PSF2Loader"));
         return -1;
       }
 
@@ -153,11 +152,9 @@ int PSF2Loader::psf2unpack(RawFile *file, unsigned long fileoffset, unsigned lon
           memcpy(newdataBuf + k, dblock, filesize);
           k += filesize;
         }
-
       }
 
-      mbstowcs(wfilename, (const char *) filename, sizeof(filename) / sizeof(filename[0]));
-      pRoot->CreateVirtFile(newdataBuf, actualFileSize, wfilename, file->GetFullPath());
+      pRoot->CreateVirtFile(newdataBuf, actualFileSize, filename, file->GetFullPath());
       delete[] dblock;
     }
   }

--- a/src/main/loaders/SNSFLoader.cpp
+++ b/src/main/loaders/SNSFLoader.cpp
@@ -8,7 +8,7 @@ using namespace std;
 #define SNSF_VERSION    0x23
 #define SNSF_MAX_ROM_SIZE    0x600000
 
-wchar_t *GetFileWithBase(const wchar_t *f, const wchar_t *newfile);
+char* GetFileWithBase(const char* f, const char* newfile);
 
 SNSFLoader::SNSFLoader(void) {
 }
@@ -22,21 +22,21 @@ PostLoadCommand SNSFLoader::Apply(RawFile *file) {
   if (memcmp(sig, "PSF", 3) == 0) {
     uint8_t version = sig[3];
     if (version == SNSF_VERSION) {
-      const wchar_t *complaint;
+      const char* complaint;
       size_t exebufsize = SNSF_MAX_ROM_SIZE;
       uint8_t *exebuf = NULL;
       //memset(exebuf, 0, exebufsize);
 
       complaint = psf_read_exe(file, exebuf, exebufsize);
       if (complaint) {
-        pRoot->AddLogItem(new LogItem(std::wstring(complaint), LOG_LEVEL_ERR, L"SNSFFile"));
+        pRoot->AddLogItem(new LogItem(std::string(complaint), LOG_LEVEL_ERR, "SNSFFile"));
         delete[] exebuf;
         return KEEP_IT;
       }
-      //pRoot->UI_WriteBufferToFile(L"uncomp.smc", exebuf, exebufsize);
+      //pRoot->UI_WriteBufferToFile("uncomp.smc", exebuf, exebufsize);
 
-      wstring str = file->GetFileName();
-      pRoot->CreateVirtFile(exebuf, (uint32_t) exebufsize, str.data(), L"", file->tag);
+      string str = file->GetFileName();
+      pRoot->CreateVirtFile(exebuf, (uint32_t) exebufsize, str.data(), "", file->tag);
       return DELETE_IT;
     }
   }
@@ -57,17 +57,17 @@ PostLoadCommand SNSFLoader::Apply(RawFile *file) {
 **
 ** Returns the error message, or NULL on success
 */
-const wchar_t *SNSFLoader::psf_read_exe(
-    RawFile *file,
-    unsigned char *&exebuffer,
-    size_t &exebuffersize
+const char* SNSFLoader::psf_read_exe(
+    RawFile* file,
+    unsigned char*& exebuffer,
+    size_t& exebuffersize
 ) {
   uint32_t base_offset = 0;
   bool base_set = false;
   return psf_read_exe_sub(file, exebuffer, exebuffersize, base_offset, base_set);
 }
 
-const wchar_t *SNSFLoader::psf_read_exe_sub(
+const char* SNSFLoader::psf_read_exe_sub(
     RawFile *file,
     unsigned char *&exebuffer,
     size_t &exebuffersize,
@@ -79,7 +79,7 @@ const wchar_t *SNSFLoader::psf_read_exe_sub(
     return psf.GetError();
 
   // search exclusively for _lib tag, and if found, perform a recursive load
-  const wchar_t *psflibError = load_psf_libs(psf, file, exebuffer, exebuffersize, base_offset, base_set);
+  const char* psflibError = load_psf_libs(psf, file, exebuffer, exebuffersize, base_offset, base_set);
   if (psflibError != NULL)
     return psflibError;
 
@@ -100,43 +100,43 @@ const wchar_t *SNSFLoader::psf_read_exe_sub(
   }
 
   if (snsfRomStart + snsfRomSize > exebuffersize || (exebuffer == NULL && exebuffersize == 0))
-    return L"SNSF ROM section start and/or size values are likely corrupt.";
+    return "SNSF ROM section start and/or size values are likely corrupt.";
 
   if (exebuffer == NULL) {
     exebuffersize = snsfRomStart + snsfRomSize;
     exebuffer = new uint8_t[exebuffersize];
     if (exebuffer == NULL) {
-      return L"SNSF ROM memory allocation error.";
+      return "SNSF ROM memory allocation error.";
     }
     memset(exebuffer, 0, exebuffersize);
   }
 
   if (!psf.ReadExe(exebuffer + snsfRomStart, snsfRomSize, 0x08))
-    return L"Decompression failed";
+    return "Decompression failed";
 
   // set tags to RawFile
   if (psf.tags.count("title") != 0) {
-    file->tag.title = string2wstring(psf.tags["title"]);
+    file->tag.title = psf.tags["title"];
   }
   if (psf.tags.count("artist") != 0) {
-    file->tag.artist = string2wstring(psf.tags["artist"]);
+    file->tag.artist = psf.tags["artist"];
   }
   if (psf.tags.count("game") != 0) {
-    file->tag.album = string2wstring(psf.tags["game"]);
+    file->tag.album = psf.tags["game"];
   }
   if (psf.tags.count("comment") != 0) {
-    file->tag.comment = string2wstring(psf.tags["comment"]);
+    file->tag.comment = psf.tags["comment"];
   }
 
   return NULL;
 }
 
-const wchar_t *SNSFLoader::load_psf_libs(PSFFile &psf,
-                                         RawFile *file,
-                                         unsigned char *&exebuffer,
-                                         size_t &exebuffersize,
-                                         uint32_t &base_offset,
-                                         bool &base_set) {
+const char* SNSFLoader::load_psf_libs(PSFFile &psf,
+                                      RawFile *file,
+                                      unsigned char *&exebuffer,
+                                      size_t &exebuffersize,
+                                      uint32_t &base_offset,
+                                      bool &base_set) {
   char libTagName[16];
   int libIndex = 1;
   while (true) {
@@ -149,19 +149,17 @@ const wchar_t *SNSFLoader::load_psf_libs(PSFFile &psf,
     if (itLibTag == psf.tags.end())
       break;
 
-    wchar_t tempfn[PATH_MAX] = {0};
-    mbstowcs(tempfn, itLibTag->second.c_str(), itLibTag->second.size());
+    auto tempfn = itLibTag->second.c_str();
 
-    wchar_t *fullPath;
-    fullPath = GetFileWithBase(file->GetFullPath(), tempfn);
+    char* fullPath = GetFileWithBase(file->GetFullPath().c_str(), tempfn);
 
     // TODO: Make sure to limit recursion to avoid crashing.
     RawFile *newRawFile = new RawFile(fullPath);
-    const wchar_t *psflibError = NULL;
+    const char* psflibError = NULL;
     if (newRawFile->open(fullPath))
       psflibError = psf_read_exe_sub(newRawFile, exebuffer, exebuffersize, base_offset, base_set);
     else
-      psflibError = L"Unable to open lib file.";
+      psflibError = "Unable to open lib file.";
     delete fullPath;
     delete newRawFile;
 

--- a/src/main/loaders/SNSFLoader.h
+++ b/src/main/loaders/SNSFLoader.h
@@ -10,11 +10,11 @@ class SNSFLoader:
   virtual ~SNSFLoader(void);
 
   virtual PostLoadCommand Apply(RawFile *theFile);
-  const wchar_t *psf_read_exe(RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
+  const char* psf_read_exe(RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize);
  private:
-  const wchar_t *psf_read_exe_sub
+  const char* psf_read_exe_sub
       (RawFile *file, unsigned char *&exebuffer, size_t &exebuffersize, uint32_t &base_offset, bool &base_set);
-  const wchar_t *load_psf_libs(PSFFile &psf,
+  const char* load_psf_libs(PSFFile &psf,
                                RawFile *file,
                                unsigned char *&exebuffer,
                                size_t &exebuffersize,

--- a/src/main/loaders/SPCLoader.cpp
+++ b/src/main/loaders/SPCLoader.cpp
@@ -25,7 +25,7 @@ PostLoadCommand SPCLoader::Apply(RawFile *file) {
   VirtFile *spcFile = new VirtFile(spcData, 0x10000, file->GetFileName());
 
   std::vector<uint8_t> dsp(file->buf.data + 0x10100, file->buf.data + 0x10100 + 0x80);
-  spcFile->tag.binaries[L"dsp"] = dsp;
+  spcFile->tag.binaries["dsp"] = dsp;
 
   // Parse [ID666](http://vspcplay.raphnet.net/spc_file_format.txt) if available.
   if (file->GetByte(0x23) == 0x1a) {
@@ -34,24 +34,24 @@ PostLoadCommand SPCLoader::Apply(RawFile *file) {
     file->GetBytes(0x2e, 32, s);
     s[32] = '\0';
     std::string s_str = s;
-    spcFile->tag.title = string2wstring(s_str);
+    spcFile->tag.title = s_str;
 
     file->GetBytes(0x4e, 32, s);
     s[32] = '\0';
     s_str = s;
-    spcFile->tag.album = string2wstring(s_str);
+    spcFile->tag.album = s_str;
 
     file->GetBytes(0x7e, 32, s);
     s[32] = '\0';
     s_str = s;
-    spcFile->tag.comment = string2wstring(s_str);
+    spcFile->tag.comment = s_str;
 
     if (file->GetByte(0xd2) < 0x30) {
       // binary format
       file->GetBytes(0xb0, 32, s);
       s[32] = '\0';
       s_str = s;
-      spcFile->tag.artist = string2wstring(s_str);
+      spcFile->tag.artist = s_str;
 
       spcFile->tag.length = (double) (file->GetWord(0xa9) & 0xffffff);
     }
@@ -60,7 +60,7 @@ PostLoadCommand SPCLoader::Apply(RawFile *file) {
       file->GetBytes(0xb1, 32, s);
       s[32] = '\0';
       s_str = s;
-      spcFile->tag.artist = string2wstring(s_str);
+      spcFile->tag.artist = s_str;
 
       file->GetBytes(0xa9, 3, s);
       s[3] = '\0';
@@ -102,7 +102,7 @@ PostLoadCommand SPCLoader::Apply(RawFile *file) {
           case 1: {
             // String (data contains null character)
             std::string s_str = std::string((char *) (file->buf.data + xid6_offset + 4), xid6_length - 1);
-            std::wstring xid6_string = string2wstring(s_str);
+            std::string xid6_string = s_str;
             switch (xid6_id) {
               case 1:
                 // Song name

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -42,9 +42,9 @@ bool CLIVGMRoot::MakeOutputDir() {
   return true;
 }
 
-bool CLIVGMRoot::OpenRawFile(const wstring &filename) {
-  wstring fname = filename;
-  cout << "Loading " << wstring2string(fname) << endl;
+bool CLIVGMRoot::OpenRawFile(const string &filename) {
+  string fname = filename;
+  cout << "Loading " << fname << endl;
   return VGMRoot::OpenRawFile(filename);
 }
 
@@ -61,9 +61,9 @@ bool CLIVGMRoot::Init() {
   size_t inputFileCtr = 0;
   size_t numColls = 0;
   // map for deconflicting identical collection names using input filenames
-  map<wstring, vector<pair<size_t, fs::path>>> collNameMap {};
+  map<string, vector<pair<size_t, fs::path>>> collNameMap {};
   for (fs::path infile : inputFiles) {
-    if (!OpenRawFile(infile.wstring())) {  // file not found
+    if (!OpenRawFile(infile.string())) {  // file not found
       return false;
     }
     UpdateCollections();
@@ -74,7 +74,7 @@ bool CLIVGMRoot::Init() {
     else {
       for(size_t i = numColls; i < GetNumCollections(); ++i) {
         VGMColl* coll = vVGMColl[i];
-        wstring collName = *coll->GetName();
+        string collName = *coll->GetName();
         auto it = collNameMap.find(collName);
         pair<size_t, fs::path> p = make_pair(i, infile);
         if (it == collNameMap.end()) {
@@ -123,7 +123,7 @@ bool CLIVGMRoot::Init() {
             baseNameIdx[baseName] = idx;
           }
           // update collection name to be unique
-          wstring newCollName = collNameIt->first + string2wstring(suffix);
+          string newCollName = collNameIt->first + suffix;
           vVGMColl[p.first]->SetName(&newCollName);
         }
       }
@@ -138,35 +138,35 @@ bool CLIVGMRoot::Init() {
 bool CLIVGMRoot::ExportAllCollections() {
   bool success = true;
   for (VGMColl* coll : vVGMColl) {
-    wstring collName = *coll->GetName();
+    string collName = *coll->GetName();
     success &= ExportCollection(coll);
   }
   return success;
 }
 
 bool CLIVGMRoot::ExportCollection(VGMColl* coll) {
-    wstring collName = *coll->GetName();
-    cout << "Exporting: " << wstring2string(collName) << endl;
+    string collName = *coll->GetName();
+    cout << "Exporting: " << collName << endl;
     return SaveMidi(coll) & SaveSF2(coll) & SaveDLS(coll);
 }
 
 bool CLIVGMRoot::SaveMidi(VGMColl* coll) {
   if (coll->seq != nullptr) {
-    wstring collName = *coll->GetName();
-    wstring filepath = UI_GetSaveFilePath(collName, L"mid");
+    string collName = *coll->GetName();
+    string filepath = UI_GetSaveFilePath(collName, "mid");
     if (!coll->seq->SaveAsMidi(filepath)) {
-      pRoot->AddLogItem(new LogItem(std::wstring(L"Failed to save MIDI file"),
-        LOG_LEVEL_ERR, L"VGMColl"));
+      pRoot->AddLogItem(new LogItem(std::string("Failed to save MIDI file"),
+        LOG_LEVEL_ERR, "VGMColl"));
       return false;
     }
-    cout << "\t" + wstring2string(filepath) << endl;
+    cout << "\t" + filepath << endl;
   }
   return true;
 }
 
 bool CLIVGMRoot::SaveSF2(VGMColl* coll) {
-  wstring collName = *coll->GetName();
-  wstring filepath = UI_GetSaveFilePath(collName, L"sf2");
+  string collName = *coll->GetName();
+  string filepath = UI_GetSaveFilePath(collName, "sf2");
   SF2File *sf2file = coll->CreateSF2File();
   bool success = false;
   if (sf2file != nullptr) {
@@ -176,18 +176,18 @@ bool CLIVGMRoot::SaveSF2(VGMColl* coll) {
     delete sf2file;
   }
   if (success) {
-    cout << "\t" + wstring2string(filepath) << endl;
+    cout << "\t" + filepath << endl;
   }
   else {
-    pRoot->AddLogItem(new LogItem(std::wstring(L"Failed to save SF2 file"),
-      LOG_LEVEL_ERR, L"VGMColl"));
+    pRoot->AddLogItem(new LogItem(std::string("Failed to save SF2 file"),
+      LOG_LEVEL_ERR, "VGMColl"));
   }
   return success;
 }
 
 bool CLIVGMRoot::SaveDLS(VGMColl* coll) {
-  wstring collName = *coll->GetName();
-  wstring filepath = UI_GetSaveFilePath(collName, L"dls");
+  string collName = *coll->GetName();
+  string filepath = UI_GetSaveFilePath(collName, "dls");
   DLSFile dlsfile;
   bool success = false;
   if (coll->CreateDLSFile(dlsfile)) {
@@ -196,11 +196,11 @@ bool CLIVGMRoot::SaveDLS(VGMColl* coll) {
     }
   }
   if (success) {
-    cout << "\t" + wstring2string(filepath) << endl;
+    cout << "\t" + filepath << endl;
   }
   else {
-    pRoot->AddLogItem(new LogItem(std::wstring(L"Failed to save DLS file"),
-      LOG_LEVEL_ERR, L"VGMColl"));
+    pRoot->AddLogItem(new LogItem(std::string("Failed to save DLS file"),
+      LOG_LEVEL_ERR, "VGMColl"));
   }
   return success;
 }
@@ -211,9 +211,9 @@ void CLIVGMRoot::UI_SetRootPtr(VGMRoot** theRoot) {
 
 void CLIVGMRoot::UI_AddLogItem(LogItem* theLog) {
   if (theLog->GetLogLevel() <= LOG_LEVEL_WARN) {
-    wstring source = theLog->GetSource();
-    wstring text = theLog->GetText();
-    cerr << "[" << wstring2string(source) << "]" << wstring2string(text) << endl;
+    string source = theLog->GetSource();
+    string text = theLog->GetText();
+    cerr << "[" << source << "]" << text << endl;
   }
 }
 
@@ -228,15 +228,15 @@ void CLIVGMRoot::UpdateCollections() {
 }
 
 
-wstring CLIVGMRoot::UI_GetOpenFilePath(const wstring& suggestedFilename, const wstring& extension) {
-  return L"Placeholder";
+string CLIVGMRoot::UI_GetOpenFilePath(const string& suggestedFilename, const string& extension) {
+  return "Placeholder";
 }
 
-wstring CLIVGMRoot::UI_GetSaveFilePath(const wstring& suggestedFilename, const wstring& extension) {
-  fs::path savePath = outputDir / fs::path(ConvertToSafeFileName(suggestedFilename) + L"." + extension);
-  return savePath.wstring();
+string CLIVGMRoot::UI_GetSaveFilePath(const string& suggestedFilename, const string& extension) {
+  fs::path savePath = outputDir / fs::path(ConvertToSafeFileName(suggestedFilename) + "." + extension);
+  return savePath.string();
 }
 
-wstring CLIVGMRoot::UI_GetSaveDirPath(const std::wstring& suggestedDir) {
-  return this->outputDir.wstring();
+string CLIVGMRoot::UI_GetSaveDirPath(const std::string& suggestedDir) {
+  return this->outputDir.string();
 }

--- a/src/ui/cli/CLIVGMRoot.h
+++ b/src/ui/cli/CLIVGMRoot.h
@@ -36,7 +36,7 @@ public:
 
   bool SaveDLS(VGMColl *coll);
 
-  virtual bool OpenRawFile(const wstring &filename);
+  virtual bool OpenRawFile(const string &filename);
 
   virtual bool Init();
 
@@ -48,13 +48,13 @@ public:
 
   virtual void UpdateCollections();
 
-  virtual wstring UI_GetOpenFilePath(const wstring& suggestedFilename = L"",
-                                          const wstring& extension = L"");
+  virtual string UI_GetOpenFilePath(const string& suggestedFilename = "",
+                                          const string& extension = "");
 
-  virtual wstring UI_GetSaveFilePath(const wstring& suggestedFilename,
-                                          const wstring& extension = L"");
+  virtual string UI_GetSaveFilePath(const string& suggestedFilename,
+                                          const string& extension = "");
 
-  virtual wstring UI_GetSaveDirPath(const wstring& suggestedDir = L"");
+  virtual string UI_GetSaveDirPath(const string& suggestedDir = "");
 
   set<fs::path> inputFiles = {};
   fs::path outputDir = fs::path(".");

--- a/src/ui/qt/Logger.cpp
+++ b/src/ui/qt/Logger.cpp
@@ -86,7 +86,7 @@ void Logger::push(const LogItem *item) {
   }
 
   logger_textarea->appendHtml(QStringLiteral("<font color=%2>[%1] %3</font>")
-                                  .arg(QString::fromStdWString(item->GetSource()),
+                                  .arg(QString::fromStdString(item->GetSource()),
                                        QString(log_colors[static_cast<int>(item->GetLogLevel())]),
-                                       QString::fromStdWString(item->GetText())));
+                                       QString::fromStdString(item->GetText())));
 }

--- a/src/ui/qt/MainWindow.cpp
+++ b/src/ui/qt/MainWindow.cpp
@@ -45,8 +45,8 @@ MainWindow::MainWindow() : QMainWindow(nullptr) {
                         .arg(qVersion())
                         .arg(VGMTRANS_REVISION)
                         .arg(VGMTRANS_BRANCH)
-                        .toStdWString();
-  qtVGMRoot.UI_AddLogItem(new LogItem(infostring, LOG_LEVEL_INFO, L"VGMTransQt"));
+                        .toStdString();
+  qtVGMRoot.UI_AddLogItem(new LogItem(infostring, LOG_LEVEL_INFO, "VGMTransQt"));
 }
 
 void MainWindow::createElements() {
@@ -182,5 +182,5 @@ void MainWindow::openFileInternal(QString filename) {
     }
   }
 
-  qtVGMRoot.OpenRawFile(filename.toStdWString());
+  qtVGMRoot.OpenRawFile(filename.toStdString());
 }

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -84,7 +84,7 @@ QListWidget *ManualCollectionDialog::makeSequenceList() {
   for (auto seq : seqs) {
     auto seq_item = new QListWidgetItem(widget);
     seq_item->setData(Qt::UserRole, QVariant::fromValue((void *)seq));
-    widget->setItemWidget(seq_item, new QRadioButton(QString::fromStdWString(*seq->GetName())));
+    widget->setItemWidget(seq_item, new QRadioButton(QString::fromStdString(*seq->GetName())));
   }
 
   return widget;
@@ -100,7 +100,7 @@ QListWidget *ManualCollectionDialog::makeInstrumentSetList() {
   for (auto seq : seqs) {
     auto seq_item = new QListWidgetItem(widget);
     seq_item->setData(Qt::UserRole, QVariant::fromValue((void *)seq));
-    widget->setItemWidget(seq_item, new QCheckBox(QString::fromStdWString(*seq->GetName())));
+    widget->setItemWidget(seq_item, new QCheckBox(QString::fromStdString(*seq->GetName())));
   }
 
   return widget;
@@ -116,14 +116,14 @@ QListWidget *ManualCollectionDialog::makeSampleCollectionList() {
   for (auto seq : seqs) {
     auto seq_item = new QListWidgetItem(widget);
     seq_item->setData(Qt::UserRole, QVariant::fromValue((void *)seq));
-    widget->setItemWidget(seq_item, new QCheckBox(QString::fromStdWString(*seq->GetName())));
+    widget->setItemWidget(seq_item, new QCheckBox(QString::fromStdString(*seq->GetName())));
   }
 
   return widget;
 }
 
 void ManualCollectionDialog::createCollection() {
-  auto coll = new VGMColl(m_name_field->text().toStdWString());
+  auto coll = new VGMColl(m_name_field->text().toStdString());
 
   VGMSeq *chosen_seq = nullptr;
   for (int i = 0; i < m_seq_list->count(); i++) {

--- a/src/ui/qt/MenuBar.cpp
+++ b/src/ui/qt/MenuBar.cpp
@@ -49,10 +49,10 @@ void MenuBar::appendOptionsMenu(const QList<QDockWidget *> &dockWidgets) {
     } else if (text == "MMA") {
       ConversionOptions::the().SetBankSelectStyle(BankSelectStyle::MMA);
       pRoot->UI_AddLogItem(
-          new LogItem(L"MMA style (CC0 * 128 + CC32) bank select was chosen and "
-                      L"it will be used for bank select events in generated MIDIs. This "
-                      L"will cause in-program playback to sound incorrect!",
-                      LOG_LEVEL_WARN, L"VGMTransQt"));
+          new LogItem("MMA style (CC0 * 128 + CC32) bank select was chosen and "
+                      "it will be used for bank select events in generated MIDIs. This "
+                      "will cause in-program playback to sound incorrect!",
+                      LOG_LEVEL_WARN, "VGMTransQt"));
     }
   });
 

--- a/src/ui/qt/QtVGMRoot.cpp
+++ b/src/ui/qt/QtVGMRoot.cpp
@@ -13,15 +13,15 @@
 
 QtVGMRoot qtVGMRoot;
 
-const std::wstring QtVGMRoot::UI_GetResourceDirPath() {
+const std::string QtVGMRoot::UI_GetResourceDirPath() {
 #if defined(Q_OS_WIN)
-  return (QApplication::applicationDirPath() + "/").toStdWString();
+  return (QApplication::applicationDirPath() + "/").toStdString();
 #elif defined(Q_OS_OSX)
-  return (QApplication::applicationDirPath() + "/../Resources/").toStdWString();
+  return (QApplication::applicationDirPath() + "/../Resources/").toStdString();
 #elif defined(Q_OS_LINUX)
-  return (QApplication::applicationDirPath() + "/").toStdWString();
+  return (QApplication::applicationDirPath() + "/").toStdString();
 #else
-  return (QApplication::applicationDirPath() + "/").toStdWString();
+  return (QApplication::applicationDirPath() + "/").toStdString();
 #endif
 }
 
@@ -94,33 +94,33 @@ void QtVGMRoot::UI_EndRemoveVGMFiles() {
   this->UI_EndedRemovingVGMFiles();
 }
 
-void QtVGMRoot::UI_AddItem(VGMItem* item, VGMItem* parent, const std::wstring& itemName,
+void QtVGMRoot::UI_AddItem(VGMItem* item, VGMItem* parent, const std::string& itemName,
                            void* UI_specific) {
   auto treeview = static_cast<VGMFileTreeView*>(UI_specific);
   treeview->addVGMItem(item, parent, itemName);
 }
 
-std::wstring QtVGMRoot::UI_GetOpenFilePath(const std::wstring&, const std::wstring&) {
-  std::wstring path = L"Placeholder";
+std::string QtVGMRoot::UI_GetOpenFilePath(const std::string&, const std::string&) {
+  std::string path = "Placeholder";
   return path;
 }
 
-std::wstring QtVGMRoot::UI_GetSaveFilePath(const std::wstring& suggested_filename,
-                                           const std::wstring& extension) {
+std::string QtVGMRoot::UI_GetSaveFilePath(const std::string& suggested_filename,
+                                           const std::string& extension) {
   static auto selected_dir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
   QFileDialog dialog(QApplication::activeWindow());
   dialog.setFileMode(QFileDialog::AnyFile);
-  dialog.selectFile(QString::fromStdWString(suggested_filename));
+  dialog.selectFile(QString::fromStdString(suggested_filename));
   dialog.setDirectory(selected_dir);
   dialog.setAcceptMode(QFileDialog::AcceptSave);
 
-  if (extension == L"mid") {
+  if (extension == "mid") {
     dialog.setDefaultSuffix("mid");
     dialog.setNameFilter("Standard MIDI (*.mid)");
-  } else if (extension == L"dls") {
+  } else if (extension == "dls") {
     dialog.setDefaultSuffix("dls");
     dialog.setNameFilter("Downloadable Sound (*.dls)");
-  } else if (extension == L"sf2") {
+  } else if (extension == "sf2") {
     dialog.setDefaultSuffix("sf2");
     dialog.setNameFilter("SoundFont\u00AE 2 (*.sf2)");
   } else {
@@ -129,13 +129,13 @@ std::wstring QtVGMRoot::UI_GetSaveFilePath(const std::wstring& suggested_filenam
 
   if (dialog.exec()) {
     selected_dir = dialog.directory().absolutePath();
-    return dialog.selectedFiles().at(0).toStdWString();
+    return dialog.selectedFiles().at(0).toStdString();
   } else {
     return {};
   }
 }
 
-std::wstring QtVGMRoot::UI_GetSaveDirPath(const std::wstring&) {
+std::string QtVGMRoot::UI_GetSaveDirPath(const std::string&) {
   static auto selected_dir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
   QFileDialog dialog(QApplication::activeWindow());
   dialog.setFileMode(QFileDialog::FileMode::Directory);
@@ -144,7 +144,7 @@ std::wstring QtVGMRoot::UI_GetSaveDirPath(const std::wstring&) {
 
   if (dialog.exec()) {
     selected_dir = dialog.directory().absolutePath();
-    return dialog.selectedFiles().at(0).toStdWString();
+    return dialog.selectedFiles().at(0).toStdString();
   } else {
     return {};
   }

--- a/src/ui/qt/QtVGMRoot.h
+++ b/src/ui/qt/QtVGMRoot.h
@@ -15,7 +15,7 @@ class QtVGMRoot final : public QObject, public VGMRoot {
 public:
   ~QtVGMRoot() override = default;
 
-  const std::wstring UI_GetResourceDirPath();
+  const std::string UI_GetResourceDirPath();
   void UI_SetRootPtr(VGMRoot** theRoot) override;
   void UI_PreExit() override;
   void UI_Exit() override;
@@ -36,13 +36,13 @@ public:
   void UI_RemoveVGMColl(VGMColl* targColl) override;
   void UI_BeginRemoveVGMFiles() override;
   void UI_EndRemoveVGMFiles() override;
-  void UI_AddItem(VGMItem* item, VGMItem* parent, const std::wstring& itemName,
+  void UI_AddItem(VGMItem* item, VGMItem* parent, const std::string& itemName,
                   void* UI_specific) override;
-  std::wstring UI_GetOpenFilePath(const std::wstring& suggestedFilename = L"",
-                                          const std::wstring& extension = L"") override;
-  std::wstring UI_GetSaveFilePath(const std::wstring& suggestedFilename,
-                                          const std::wstring& extension = L"") override;
-  std::wstring UI_GetSaveDirPath(const std::wstring& suggestedDir = L"") override;
+  std::string UI_GetOpenFilePath(const std::string& suggestedFilename = "",
+                                          const std::string& extension = "") override;
+  std::string UI_GetSaveFilePath(const std::string& suggestedFilename,
+                                          const std::string& extension = "") override;
+  std::string UI_GetSaveDirPath(const std::string& suggestedDir = "") override;
 
 private:
   int rawFileLoadRecurseStack = 0;

--- a/src/ui/qt/SequencePlayer.cpp
+++ b/src/ui/qt/SequencePlayer.cpp
@@ -84,8 +84,8 @@ SequencePlayer::SequencePlayer() {
   BASS_Init(-1, 44100, 0, nullptr, nullptr);
   if (BASS_ErrorGetCode() != BASS_OK) {
     pRoot->AddLogItem(new LogItem(
-        L"Failed to initialize audio device. Collection playback will not be available.",
-        LOG_LEVEL_ERR, L"SequencePlayer"));
+        "Failed to initialize audio device. Collection playback will not be available.",
+        LOG_LEVEL_ERR, "SequencePlayer"));
     return;
   }
 
@@ -161,16 +161,16 @@ bool SequencePlayer::playCollection(VGMColl *coll) {
 
   VGMSeq *seq = coll->GetSeq();
   if (!seq) {
-    pRoot->AddLogItem(new LogItem(L"Failed to play collection as it lacks sequence data.",
-                                  LOG_LEVEL_ERR, L"SequencePlayer"));
+    pRoot->AddLogItem(new LogItem("Failed to play collection as it lacks sequence data.",
+                                  LOG_LEVEL_ERR, "SequencePlayer"));
     return false;
   }
 
   SF2File *sf2 = coll->CreateSF2File();
   if (!sf2) {
     pRoot->AddLogItem(
-        new LogItem(L"Failed to play collection as a soundfont file could not be produced.",
-                    LOG_LEVEL_ERR, L"SequencePlayer"));
+        new LogItem("Failed to play collection as a soundfont file could not be produced.",
+                    LOG_LEVEL_ERR, "SequencePlayer"));
     return false;
   }
 
@@ -182,9 +182,9 @@ bool SequencePlayer::playCollection(VGMColl *coll) {
   HSOUNDFONT sf2_handle =
       BASS_MIDI_FontInitUser(&memory_file_callbacks, sf2_data_blob, BASS_MIDI_FONT_XGDRUMS);
   if (BASS_ErrorGetCode() != BASS_OK) {
-    pRoot->AddLogItem(new LogItem(L"Could not load soundfont. Maybe the system is running out of "
-                                  L"memory or the sountfont was too large?",
-                                  LOG_LEVEL_ERR, L"SequencePlayer"));
+    pRoot->AddLogItem(new LogItem("Could not load soundfont. Maybe the system is running out of "
+                                  "memory or the sountfont was too large?",
+                                  LOG_LEVEL_ERR, "SequencePlayer"));
     return false;
   }
 
@@ -197,7 +197,7 @@ bool SequencePlayer::playCollection(VGMColl *coll) {
   if (BASS_ErrorGetCode() != BASS_OK) {
     BASS_MIDI_FontFree(sf2_handle);
 
-    pRoot->AddLogItem(new LogItem(L"Failed reading MIDI data", LOG_LEVEL_ERR, L"SequencePlayer"));
+    pRoot->AddLogItem(new LogItem("Failed reading MIDI data", LOG_LEVEL_ERR, "SequencePlayer"));
     return false;
   }
 
@@ -212,7 +212,7 @@ bool SequencePlayer::playCollection(VGMColl *coll) {
     BASS_StreamFree(midi_stream);
 
     pRoot->AddLogItem(
-        new LogItem(L"Could not assign soundfont to MIDI data", LOG_LEVEL_ERR, L"SequencePlayer"));
+        new LogItem("Could not assign soundfont to MIDI data", LOG_LEVEL_ERR, "SequencePlayer"));
     return false;
   }
 
@@ -234,7 +234,7 @@ bool SequencePlayer::playCollection(VGMColl *coll) {
   m_active_vgmcoll = coll;
   m_active_stream = midi_stream;
   m_loaded_sf = sf2_handle;
-  m_song_title = QString::fromStdWString(*m_active_vgmcoll->GetName());
+  m_song_title = QString::fromStdString(*m_active_vgmcoll->GetName());
   toggle();
 
   return true;

--- a/src/ui/qt/osdepend.cpp
+++ b/src/ui/qt/osdepend.cpp
@@ -2,12 +2,12 @@
 
 #include "osdepend.h"
 
-void Alert(const wchar_t *fmt, ...)
+void Alert(const char* fmt, ...)
 {
 
 }
 
-void LogDebug(const wchar_t *fmt, ...)
+void LogDebug(const char* fmt, ...)
 {
 
 }

--- a/src/ui/qt/osdepend.h
+++ b/src/ui/qt/osdepend.h
@@ -1,7 +1,7 @@
 #ifndef OSDEPEND_H
 #define OSDEPEND_H
 
-void Alert(const wchar_t *fmt, ...);
-void LogDebug(const wchar_t *fmt, ...);
+void Alert(const char* fmt, ...);
+void LogDebug(const char* fmt, ...);
 
 #endif // OSDEPEND_H

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -176,7 +176,7 @@ bool HexView::event(QEvent *e) {
 
     VGMItem* item = vgmfile->GetItemFromOffset(offset, false);
     if (item) {
-      auto description = QString::fromStdWString(item->GetDescription());
+      auto description = QString::fromStdString(item->GetDescription());
       if (!description.isEmpty()) {
         QToolTip::showText(helpevent->globalPos(), description, this);
       }

--- a/src/ui/qt/workarea/RawFileListView.cpp
+++ b/src/ui/qt/workarea/RawFileListView.cpp
@@ -77,7 +77,7 @@ QVariant RawFileListViewModel::data(const QModelIndex &index, int role) const {
   switch (index.column()) {
     case Property::Name: {
       if (role == Qt::DisplayRole) {
-        return QString::fromWCharArray(qtVGMRoot.vRawFile[index.row()]->GetFileName());
+        return QString::fromStdString(qtVGMRoot.vRawFile[index.row()]->GetFileName());
       } else if (role == Qt::DecorationRole) {
         static QIcon fileicon(":/images/file.svg");
         return fileicon;
@@ -128,7 +128,7 @@ RawFileListView::RawFileListView(QWidget *parent) : QTableView(parent) {
     QModelIndexList list = sm->selectedRows();
     for (auto &index : list) {
       auto rawfile = qtVGMRoot.vRawFile[index.row()];
-      std::wstring filepath = pRoot->UI_GetSaveFilePath(L"");
+      std::string filepath = pRoot->UI_GetSaveFilePath("");
       if (!filepath.empty()) {
         /* todo: free function in VGMExport */
         rawfile->OnSaveAsRaw();

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -58,7 +58,7 @@ int VGMCollListViewModel::rowCount(const QModelIndex &) const {
 
 QVariant VGMCollListViewModel::data(const QModelIndex &index, int role) const {
   if (role == Qt::DisplayRole || role == Qt::EditRole) {
-    return QString::fromStdWString(*qtVGMRoot.vVGMColl[index.row()]->GetName());
+    return QString::fromStdString(*qtVGMRoot.vVGMColl[index.row()]->GetName());
   } else if (role == Qt::DecorationRole) {
     return VGMCollIcon();
   }
@@ -87,7 +87,7 @@ void VGMCollNameEditor::setEditorData(QWidget *editor, const QModelIndex &index)
 void VGMCollNameEditor::setModelData(QWidget *editor, QAbstractItemModel *model,
                                      const QModelIndex &index) const {
   auto *line_edit = qobject_cast<QLineEdit *>(editor);
-  auto new_name = line_edit->text().toStdWString();
+  auto new_name = line_edit->text().toStdString();
   qtVGMRoot.vVGMColl[index.row()]->SetName(&new_name);
   model->dataChanged(index, index);
 }

--- a/src/ui/qt/workarea/VGMCollView.cpp
+++ b/src/ui/qt/workarea/VGMCollView.cpp
@@ -44,7 +44,7 @@ QVariant VGMCollViewModel::data(const QModelIndex &index, int role) const {
   }
 
   if (role == Qt::DisplayRole) {
-    return QString::fromStdWString(*file->GetName());
+    return QString::fromStdString(*file->GetName());
   } else if (role == Qt::DecorationRole) {
     return iconForFileType(file->GetFileType());
   }
@@ -123,7 +123,7 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
       m_collection_title->setText("No collection selected");
     } else {
       m_collection_title->setText(
-          QString::fromStdWString(*qtVGMRoot.vVGMColl[index.row()]->GetName()));
+          QString::fromStdString(*qtVGMRoot.vVGMColl[index.row()]->GetName()));
       m_collection_title->setReadOnly(false);
       commit_rename->setEnabled(true);
     }
@@ -136,7 +136,7 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
       return;
     }
 
-    auto title = m_collection_title->text().toStdWString();
+    auto title = m_collection_title->text().toStdString();
     /* This makes a copy, no worries */
     qtVGMRoot.vVGMColl[model_index.row()]->SetName(&title);
 

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -34,7 +34,7 @@ QVariant VGMFileListModel::data(const QModelIndex &index, int role) const {
   switch (index.column()) {
     case Property::Name: {
       if (role == Qt::DisplayRole) {
-        return QString::fromStdWString(*vgmfile->GetName());
+        return QString::fromStdString(*vgmfile->GetName());
       } else if (role == Qt::DecorationRole) {
         return iconForFileType(vgmfile->GetFileType());
       }

--- a/src/ui/qt/workarea/VGMFileTreeView.cpp
+++ b/src/ui/qt/workarea/VGMFileTreeView.cpp
@@ -107,8 +107,8 @@ int VGMFileTreeView::getSortedIndex(QTreeWidgetItem* parent, VGMTreeItem* item) 
 }
 
 
-void VGMFileTreeView::addVGMItem(VGMItem *item, VGMItem *parent, const std::wstring &name) {
-  auto item_name = QString::fromStdWString(name);
+void VGMFileTreeView::addVGMItem(VGMItem *item, VGMItem *parent, const std::string &name) {
+  auto item_name = QString::fromStdString(name);
   auto tree_item = new VGMTreeItem(item_name, item, nullptr, parent);
   if (name == item->GetDescription()) {
     tree_item->setText(0, QString{"<b>%1</b><br>Offset: 0x%2 | Length: 0x%3"}
@@ -118,12 +118,12 @@ void VGMFileTreeView::addVGMItem(VGMItem *item, VGMItem *parent, const std::wstr
   } else {
     tree_item->setText(0, QString{"<b>%1</b><br>%2<br>Offset: 0x%3 | Length: 0x%4"}
                               .arg(item_name)
-                              .arg(QString::fromStdWString(item->GetDescription()))
+                              .arg(QString::fromStdString(item->GetDescription()))
                               .arg(item->dwOffset, 1, 16)
                               .arg(item->unLength, 1, 16));
   }
   tree_item->setIcon(0, iconForItemType(item->GetIcon()));
-  tree_item->setToolTip(0, QString::fromStdWString(item->GetDescription()));
+  tree_item->setToolTip(0, QString::fromStdString(item->GetDescription()));
 
   if (parent != parent_cached) {
     parent_cached = parent;

--- a/src/ui/qt/workarea/VGMFileTreeView.h
+++ b/src/ui/qt/workarea/VGMFileTreeView.h
@@ -54,7 +54,7 @@ public:
   void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
   void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
 
-  void addVGMItem(VGMItem *item, VGMItem *parent, const std::wstring &name);
+  void addVGMItem(VGMItem *item, VGMItem *parent, const std::string &name);
   auto getTreeWidgetItem(VGMItem *vgm_item) { return m_items.at(vgm_item); };
 
 private:

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -20,7 +20,7 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
     : QMdiSubWindow(), m_vgmfile(vgmfile), m_hexview(new HexView(vgmfile)) {
   m_splitter = new QSplitter(Qt::Horizontal, this);
 
-  setWindowTitle(QString::fromStdWString(*m_vgmfile->GetName()));
+  setWindowTitle(QString::fromStdString(*m_vgmfile->GetName()));
   setWindowIcon(iconForFileType(m_vgmfile->GetFileType()));
   setAttribute(Qt::WA_DeleteOnClose);
 


### PR DESCRIPTION
This replaces every `wchar_t`, every `wstring`, every `wostream`, every L""/L'' literal and every function call related to wide chars with their plain jane `char` equivalent. Some unnecessary conversion calls are removed.

I did not go through and clean up all of the string handling code. There is surely plenty of bad string-related code in here, but now it's at least all working with string/char instead of a gross mix of wide chars and normal chars.

## Motivation and Context
We don't need wide chars. They're gross. Get rid of  them.

## How Has This Been Tested?
Tested on MacOS and Windows 10.

Loaded psf, psf2, spc, 2sf, gsf files, including instances of "minixsf" files that recursively load another file. Tested saving various formats to disk. Tested adding unicode characters to the path of files being loaded. No issues.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
