### PR TITLE
Add SPC2Loader

### DIFF
--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -16,6 +16,7 @@
 #include "NDS2SFLoader.h"
 #include "NCSFLoader.h"
 #include "SPCLoader.h"
+#include "SPC2Loader.h"
 #include "RSNLoader.h"
 #include "MAMELoader.h"
 
@@ -73,6 +74,7 @@ bool VGMRoot::Init(void) {
   AddLoader<NDS2SFLoader>();
   AddLoader<NCSFLoader>();
   AddLoader<SPCLoader>();
+  AddLoader<SPC2Loader>();
   AddLoader<RSNLoader>();
   AddLoader<MAMELoader>();
 

--- a/src/main/loaders/SPC2Loader.cpp
+++ b/src/main/loaders/SPC2Loader.cpp
@@ -1,0 +1,92 @@
+/*
+* VGMTrans (c) 2002-2023
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+ */
+
+#include "common.h"
+#include "SPC2Loader.h"
+#include "Root.h"
+
+using namespace std;
+
+// SPC2 file specs available here: http://blog.kevtris.org/blogfiles/spc2_file_specification_v1.txt
+
+PostLoadCommand SPC2Loader::Apply(RawFile *file) {
+  // Constants
+  const size_t HEADER_SIZE = 16;
+  const size_t SPC_DATA_BLOCK_SIZE = 1024;
+  const size_t RAM_BLOCK_SIZE = 256;
+  const size_t SPC_HEADER_SIZE = 256;
+  const size_t SPC_RAM_SIZE = 65536;
+  const size_t SPC_FILE_SIZE = SPC_HEADER_SIZE + SPC_RAM_SIZE + 128; // 256 byte header + 64KB RAM + 128 bytes DSP Registers
+
+  const size_t SPC_FILENAME_OFFSET = 992;
+  const size_t SPC_FILENAME_SIZE = 28;
+
+  // File size sanity check. Max ram block size is 16MB, and we'll add a generous 1MB for everything else.
+  if (file->size() > (65536*256) + (1024*1024)) {
+    return KEEP_IT;
+  }
+
+  // Read header
+  uint8_t header[HEADER_SIZE];
+  file->GetBytes(0, HEADER_SIZE, header);
+
+  // Check for header signature. Support major revision 1.
+  if (memcmp(header, "KSPC\x01", 5) != 0) {
+    return KEEP_IT;
+  }
+
+  // Extract number of SPCs
+  uint16_t numSPCs = header[7] | (header[8] << 8);
+
+  // Iterate over each SPC data block
+  for (uint16_t i = 0; i < numSPCs; ++i) {
+    // Read SPC data block
+    uint8_t spcDataBlock[SPC_DATA_BLOCK_SIZE];
+    size_t spcBlockOffset = HEADER_SIZE + (i * SPC_DATA_BLOCK_SIZE);
+    file->GetBytes(spcBlockOffset, SPC_DATA_BLOCK_SIZE, spcDataBlock);
+
+    // Reconstruct the SPC file's RAM
+    auto *spcFile = new uint8_t[SPC_FILE_SIZE];
+    memset(spcFile, 0, SPC_FILE_SIZE);
+
+    // Extract spc file name
+    // Find the length of the string up to the first null byte or 28 characters, whichever comes first
+    const char* dataStart = reinterpret_cast<char*>(spcDataBlock + SPC_FILENAME_OFFSET);
+    size_t length = std::find(dataStart, dataStart + SPC_FILENAME_SIZE, '\0') - dataStart;
+    std::string originalSpcFilename(dataStart, length);
+    originalSpcFilename += ".spc";
+
+    // Construct SPC file header
+    const char* headerTitle = "SNES-SPC700 Sound File Data v0.30\x1A\x1A";
+    std::memcpy(spcFile, headerTitle, std::strlen(headerTitle)); // Copy header title
+
+    // Copy SPC700 registers from SPC2 file to SPC header
+    std::memcpy(spcFile + 0x25, spcDataBlock + 704, 9); // Copy PC, A, X, Y, PSW, SP
+
+    // Copy the id666 tags
+    std::memcpy(spcFile + 0x2E, spcDataBlock + 768, 224);
+
+    // Reconstruct the SPC file's RAM
+    for (int j = 0; j < 256; ++j) {
+      uint16_t blockIndex = spcDataBlock[j * 2] | (spcDataBlock[j * 2 + 1] << 8);
+      uint8_t ramBlock[RAM_BLOCK_SIZE];
+      size_t ramBlockOffset = 16 + (numSPCs * SPC_DATA_BLOCK_SIZE) + (blockIndex * RAM_BLOCK_SIZE);
+      file->GetBytes(ramBlockOffset, RAM_BLOCK_SIZE, ramBlock);
+      std::copy(ramBlock, ramBlock + RAM_BLOCK_SIZE, spcFile + SPC_HEADER_SIZE + (j * RAM_BLOCK_SIZE));
+    }
+
+    // Add DSP Registers
+    std::copy(spcDataBlock + 512, spcDataBlock + 640, spcFile + SPC_HEADER_SIZE + SPC_RAM_SIZE);
+
+    // Save the reconstructed SPC file
+    if (!pRoot->CreateVirtFile(spcFile, SPC_FILE_SIZE, originalSpcFilename, "", file->tag)) {
+      pRoot->AddLogItem(new LogItem((std::string("Failed to save SPC file: ") + originalSpcFilename.c_str()),
+                                    LOG_LEVEL_ERR,
+                                    "SPC2Loader"));
+    }
+  }
+  return DELETE_IT;
+}

--- a/src/main/loaders/SPC2Loader.h
+++ b/src/main/loaders/SPC2Loader.h
@@ -1,0 +1,19 @@
+/*
+* VGMTrans (c) 2002-2023
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+*/
+
+#pragma once
+
+#include "Loader.h"
+
+class SPC2Loader:
+    public VGMLoader {
+public:
+  SPC2Loader(void) = default;
+public:
+  virtual ~SPC2Loader(void) = default;
+  virtual PostLoadCommand Apply(RawFile *theFile);
+};
+


### PR DESCRIPTION
This adds a loader for the SPC2 format (.sp2), another archive format for spc files. This format's distinction is its ability to decompress individual files without having to decompress the entire archive at once, not that this matters for our purposes.

## How Has This Been Tested?
Ran it on MacOS.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
