### PR TITLE
Add CPS1 sampled playback

### DIFF
--- a/bin/mame_roms.xml
+++ b/bin/mame_roms.xml
@@ -27,6 +27,10 @@
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>rt_9.12b</rom>
         </romgroup>
+        <romgroup type="oki6295" load_method="append">
+            <rom>rt_18.11c</rom>
+            <rom>rt_19.12c</rom>
+        </romgroup>
     </game>
     <game name="armwar" format="CPS" fmt_version="1.05a">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000" samp_table_length="0x6E0">
@@ -60,6 +64,10 @@
     <game name="cawing" format="CPS" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>ca_9.12b</rom>
+        </romgroup>
+        <romgroup type="oki6295" load_method="append">
+            <rom>ca_18.11c</rom>
+            <rom>ca_19.12c</rom>
         </romgroup>
     </game>
     <game name="captcomm" format="CPS" fmt_version="CPS1_4.25">
@@ -500,10 +508,18 @@
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>sf2_9.12a</rom>
         </romgroup>
+        <romgroup type="oki6295" load_method="append">
+            <rom>sf2_18.11c</rom>
+            <rom>sf2_19.12c</rom>
+        </romgroup>
     </game>
     <game name="sf2ce" format="CPS" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>s92_09.11a</rom>
+        </romgroup>
+        <romgroup type="oki6295" load_method="append">
+            <rom>s92_18.11c</rom>
+            <rom>s92_19.12c</rom>
         </romgroup>
     </game>
     <game name="sf2hf" format="CPS" fmt_version="CPS1_4.25">

--- a/src/main/ScaleConversion.cpp
+++ b/src/main/ScaleConversion.cpp
@@ -117,6 +117,11 @@ uint8_t ConvertPercentAmpToStdMidiVal(double percent) {
   return roundi(127.0 * sqrt(percent));
 }
 
+// db attenuation is expressed as a positive value. So, a reduction of 3.2db is expressed as 3.2, not -3.2.
+uint8_t ConvertDBAttenuationToStdMidiVal(double dbAtten) {
+  return roundi(pow(10, -dbAtten / 40.0));
+}
+
 double ConvertLogScaleValToAtten(double percent) {
   if (percent == 0)
     return 100.0;        // assume 0 is -100.0db attenuation

--- a/src/main/ScaleConversion.h
+++ b/src/main/ScaleConversion.h
@@ -4,6 +4,7 @@ double LinAmpDecayTimeToLinDBDecayTime(double secondsToFullAtten, int linearVolu
 
 uint8_t Convert7bitPercentVolValToStdMidiVal(uint8_t percentVal);
 uint8_t ConvertPercentAmpToStdMidiVal(double percent);
+uint8_t ConvertDBAttenuationToStdMidiVal(double dbAtten);
 double ConvertLogScaleValToAtten(double percent);
 double ConvertPercentAmplitudeToAttenDB(double percent);
 double ConvertPercentAmplitudeToAttenDB_SF2(double percent);

--- a/src/main/formats/CPSFormat.h
+++ b/src/main/formats/CPSFormat.h
@@ -1,9 +1,15 @@
 #pragma once
 #include "Format.h"
-#include "Root.h"
 #include "VGMColl.h"
 #include "CPSScanner.h"
 
+enum CPSSynth {
+  QSOUND,
+  OKIM6295,
+  YM2151
+};
+
+constexpr int CPS1_OKIMSM6295_SAMPLE_RATE = 7576; // 1Mhz / 132, rounded
 
 BEGIN_FORMAT(CPS)
   USING_SCANNER(CPSScanner)

--- a/src/main/formats/CPSInstr.cpp
+++ b/src/main/formats/CPSInstr.cpp
@@ -4,6 +4,7 @@
 #include "ScaleConversion.h"
 #include "CPSFormat.h"
 #include "CPSInstr.h"
+#include "OkiAdpcm.h"
 
 using namespace std;
 
@@ -173,9 +174,45 @@ bool CPS3SampleInfoTable::LoadMain() {
   return true;
 }
 
-// **************
+// ******************
+// CPS1SampleInstrSet
+// ******************
+
+CPS1SampleInstrSet::CPS1SampleInstrSet(RawFile *file,
+                                       CPSFormatVer version,
+                                       uint32_t offset,
+                                       std::string &name)
+    : VGMInstrSet(CPSFormat::name, file, offset, 0, name),
+          fmt_version(version) {
+}
+
+CPS1SampleInstrSet::~CPS1SampleInstrSet(void) {
+}
+
+bool CPS1SampleInstrSet::GetInstrPointers() {
+  for (int i = 0; i < 128; ++i) {
+    auto offset = dwOffset + (i * 4);
+    if (!(GetByte(offset) & 0x80)) {
+      break;
+    }
+    std::ostringstream ss;
+    ss << "Instrument " << i;
+    string name = ss.str();
+    VGMInstr* instr = new VGMInstr(this, offset, 4, 0, i, name);
+    VGMRgn* rgn = new VGMRgn(instr, offset);
+    instr->unLength = 4;
+    rgn->unLength = 4;
+    // subtract 1 to account for the first OKIM6295 sample ptr always being null
+    rgn->sampNum = GetByte(offset+1) - 1;
+    instr->aRgns.push_back(rgn);
+    aInstrs.push_back(instr);
+  }
+  return true;
+}
+
+// ***********
 // CPSInstrSet
-// **************
+// ***********
 
 CPSInstrSet::CPSInstrSet(RawFile *file,
                          CPSFormatVer version,
@@ -475,6 +512,66 @@ bool CPSInstr::LoadInstr() {
 
     rgn->SetUnityKey(((CPSInstrSet *) parInstrSet)->sampInfoTable->infos[rgn->sampNum].unity_key);
     aRgns.push_back(rgn);
+  }
+  return true;
+}
+
+
+// **************
+// CPS1SampColl
+// **************
+
+CPS1SampColl::CPS1SampColl(RawFile *file,
+                           CPS1SampleInstrSet *theinstrset,
+                           uint32_t offset,
+                           uint32_t length,
+                           string name)
+    : VGMSampColl(CPSFormat::name, file, offset, length, name),
+      instrset(theinstrset) {
+}
+
+
+bool CPS1SampColl::GetHeaderInfo() {
+  auto header = AddHeader(8, 0x400-8, "Sample Pointers");
+
+  int i = 1;
+  for (int offset = 8; offset < 0x400; offset += 8) {
+    if (GetWord(offset) == 0xFFFFFFFF) {
+      break;
+    }
+    ostringstream startStream;
+    startStream << "Sample " << i << " Start";
+    auto startStr = startStream.str();
+    ostringstream endStream;
+    endStream << "Sample " << i++ << " End";
+    auto endStr = endStream.str();
+
+    header->AddSimpleItem(offset, 3, startStr);
+    header->AddSimpleItem(offset+3, 3, endStr);
+  }
+  return true;
+}
+
+bool CPS1SampColl::GetSampleInfo() {
+  constexpr int PTR_SIZE = 3;
+
+  int i = 1;
+  for (int offset = 8; offset < 0x400; offset += 8) {
+    auto sampAddr = GetShort(offset);
+    if (sampAddr == 0xFFFF) {
+      break;
+    }
+    auto begin = GetWordBE(offset) >> 8;
+    auto end = GetWordBE(offset+PTR_SIZE) >> 8;
+
+    ostringstream name;
+    name << "Sample " << i++;
+
+    auto sample = new DailogicAdpcmSamp(this, begin, end-begin, CPS1_OKIMSM6295_SAMPLE_RATE, name.str());
+    sample->SetWaveType(WT_PCM16);
+    sample->SetLoopStatus(false);
+    sample->unityKey = 0x3C;
+    samples.push_back(sample);
   }
   return true;
 }

--- a/src/main/formats/CPSInstr.h
+++ b/src/main/formats/CPSInstr.h
@@ -200,6 +200,26 @@ public:
   virtual bool LoadMain();
 };
 
+// ******************
+// CPS1SampleInstrSet
+// ******************
+
+class CPS1SampleInstrSet
+    : public VGMInstrSet {
+public:
+  CPS1SampleInstrSet(RawFile *file,
+               CPSFormatVer fmt_version,
+               uint32_t offset,
+               std::string &name);
+  virtual ~CPS1SampleInstrSet(void);
+
+  virtual bool GetInstrPointers();
+
+public:
+  CPSFormatVer fmt_version;
+  CPSSampleInfoTable *sampInfoTable;
+};
+
 // **************
 // CPSInstrSet
 // **************
@@ -256,6 +276,22 @@ protected:
   int nNumRegions;
 };
 
+// **************
+// CPS1SampColl
+// **************
+
+class CPS1SampColl
+    : public VGMSampColl {
+public:
+  CPS1SampColl(RawFile *file, CPS1SampleInstrSet *instrset, uint32_t offset,
+              uint32_t length = 0, std::string name = std::string("CPS1 Sample Collection"));
+  virtual bool GetHeaderInfo();
+  virtual bool GetSampleInfo();
+
+private:
+  vector<VGMItem*> samplePointers;
+  CPS1SampleInstrSet *instrset;
+};
 
 // **************
 // CPSSampColl

--- a/src/main/formats/CPSSeq.cpp
+++ b/src/main/formats/CPSSeq.cpp
@@ -65,7 +65,7 @@ bool CPSSeq::GetTrackPointers(void) {
       case VER_CPS1_200ff:
       case VER_CPS1_350:
       case VER_CPS1_425:
-        newTrack = new CPSTrackV1(this, offset);
+        newTrack = new CPSTrackV1(this, i < 8 ? CPSSynth::YM2151 : CPSSynth::OKIM6295, offset);
         break;
       case VER_200:
       case VER_201B:
@@ -75,7 +75,7 @@ bool CPSSeq::GetTrackPointers(void) {
         newTrack = new CPSTrackV2(this, offset + dwOffset);
         break;
       default:
-        newTrack = new CPSTrackV1(this, offset + dwOffset);
+        newTrack = new CPSTrackV1(this, CPSSynth::QSOUND, offset + dwOffset);
     }
     aTracks.push_back(newTrack);
     header->AddSimpleItem(dwOffset + 1 + (i * 2), 2, "Track Pointer");

--- a/src/main/formats/CPSTrackV1.h
+++ b/src/main/formats/CPSTrackV1.h
@@ -2,13 +2,14 @@
 #include "VGMSeq.h"
 #include "SeqTrack.h"
 #include "CPSSeq.h"
+#include "CPSFormat.h"
 
 enum CPSFormatVer: uint8_t;
 
 class CPSTrackV1
     : public SeqTrack {
 public:
-  CPSTrackV1(CPSSeq *parentSeq, long offset = 0, long length = 0);
+  CPSTrackV1(CPSSeq *parentSeq, CPSSynth channelSynth, long offset = 0, long length = 0);
   virtual void ResetVars();
   virtual void AddInitialMidiEvents(int trackNum);
   virtual bool ReadEvent(void);
@@ -17,6 +18,7 @@ private:
   CPSFormatVer GetVersion() { return ((CPSSeq *) this->parentSeq)->fmt_version; }
   void CalculateAndAddPortamentoTimeNoItem(int8_t noteDistance);
 
+  CPSSynth channelSynth;
   bool bPrevNoteTie;
   uint8_t prevTieNote;
   uint8_t curDeltaTable;

--- a/src/main/formats/OkiAdpcm.cpp
+++ b/src/main/formats/OkiAdpcm.cpp
@@ -1,0 +1,161 @@
+// The oki_adpcm_state code comes from the MAME project. It is shared under the BSD-3-Clause license.
+// The original code is available at: https://github.com/mamedev/mame/blob/a5579831cae73eb13c01b10d74666ee41a217887/src/devices/sound/okiadpcm.cpp
+// The copyright holders are Andrew Gardner and Aaron Giles.
+
+#include "OkiAdpcm.h"
+
+//**************************************************************************
+//  ADPCM STATE HELPER
+//**************************************************************************
+
+// ADPCM state and tables
+bool oki_adpcm_state::s_tables_computed = false;
+const int8_t oki_adpcm_state::s_index_shift[8] = { -1, -1, -1, -1, 2, 4, 6, 8 };
+int oki_adpcm_state::s_diff_lookup[49*16];
+
+//-------------------------------------------------
+//  reset - reset the ADPCM state
+//-------------------------------------------------
+
+void oki_adpcm_state::reset()
+{
+  // reset the signal/step
+  m_signal = m_loop_signal = 0;
+  m_step = m_loop_step = 0;
+  m_saved = false;
+}
+
+
+//-------------------------------------------------
+//  clock - decode single nibble and update
+//  ADPCM output
+//-------------------------------------------------
+
+int16_t oki_adpcm_state::clock(uint8_t nibble)
+{
+  // update the signal
+  m_signal += s_diff_lookup[m_step * 16 + (nibble & 15)];
+
+  // clamp to the maximum
+  if (m_signal > 2047)
+    m_signal = 2047;
+  else if (m_signal < -2048)
+    m_signal = -2048;
+
+  // adjust the step size and clamp
+  m_step += s_index_shift[nibble & 7];
+  if (m_step > 48)
+    m_step = 48;
+  else if (m_step < 0)
+    m_step = 0;
+
+  // return the signal
+  return m_signal;
+}
+
+
+//-------------------------------------------------
+//  save - save current ADPCM state to buffer
+//-------------------------------------------------
+
+void oki_adpcm_state::save()
+{
+  if (!m_saved)
+  {
+    m_loop_signal = m_signal;
+    m_loop_step = m_step;
+    m_saved = true;
+  }
+}
+
+
+//-------------------------------------------------
+//  restore - restore previous ADPCM state
+//  from buffer
+//-------------------------------------------------
+
+void oki_adpcm_state::restore()
+{
+  m_signal = m_loop_signal;
+  m_step = m_loop_step;
+}
+
+
+//-------------------------------------------------
+//  compute_tables - precompute tables for faster
+//  sound generation
+//-------------------------------------------------
+
+void oki_adpcm_state::compute_tables()
+{
+  // skip if we already did it
+  if (s_tables_computed)
+    return;
+  s_tables_computed = true;
+
+  // nibble to bit map
+  static const int8_t nbl2bit[16][4] =
+      {
+          { 1, 0, 0, 0}, { 1, 0, 0, 1}, { 1, 0, 1, 0}, { 1, 0, 1, 1},
+          { 1, 1, 0, 0}, { 1, 1, 0, 1}, { 1, 1, 1, 0}, { 1, 1, 1, 1},
+          {-1, 0, 0, 0}, {-1, 0, 0, 1}, {-1, 0, 1, 0}, {-1, 0, 1, 1},
+          {-1, 1, 0, 0}, {-1, 1, 0, 1}, {-1, 1, 1, 0}, {-1, 1, 1, 1}
+      };
+
+  // loop over all possible steps
+  for (int step = 0; step <= 48; step++)
+  {
+    // compute the step value
+    int stepval = floor(16.0 * pow(11.0 / 10.0, (double)step));
+
+    // loop over all nibbles and compute the difference
+    for (int nib = 0; nib < 16; nib++)
+    {
+      s_diff_lookup[step*16 + nib] = nbl2bit[nib][0] *
+                                       (stepval * nbl2bit[nib][1] +
+                                        stepval/2 * nbl2bit[nib][2] +
+                                        stepval/4 * nbl2bit[nib][3] +
+                                        stepval/8);
+    }
+  }
+}
+
+
+
+//  *****************
+//  DailogicAdpcmSamp
+//  *****************
+
+oki_adpcm_state DailogicAdpcmSamp::okiAdpcmState;
+
+DailogicAdpcmSamp::DailogicAdpcmSamp(
+    VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t theRate, string name
+  )
+    : VGMSamp(sampColl, offset, length, offset, length, 1, 16, theRate, name) {
+
+}
+
+DailogicAdpcmSamp::~DailogicAdpcmSamp() {
+}
+
+double DailogicAdpcmSamp::GetCompressionRatio() {
+  return (16.0 / 4); // 4 bit samples converted up to 16 bit samples
+}
+
+void DailogicAdpcmSamp::ConvertToStdWave(uint8_t *buf) {
+
+  auto* uncompBuf = reinterpret_cast<int16_t*>(buf);
+
+  DailogicAdpcmSamp::okiAdpcmState.reset();
+
+  int sampleNum = 0;
+  for (uint32_t off = dwOffset; off < (dwOffset + unLength); ++off) {
+    uint8_t byte = GetByte(off);
+
+    for (int n = 0; n < 2; ++n) {
+      uint8_t nibble = byte >> (((n & 1) << 2) ^ 4);
+      int16_t sample = DailogicAdpcmSamp::okiAdpcmState.clock(nibble);
+      uncompBuf[sampleNum++] = sample;
+    }
+  }
+}

--- a/src/main/formats/OkiAdpcm.cpp
+++ b/src/main/formats/OkiAdpcm.cpp
@@ -1,6 +1,10 @@
-// The oki_adpcm_state code comes from the MAME project. It is shared under the BSD-3-Clause license.
-// The original code is available at: https://github.com/mamedev/mame/blob/a5579831cae73eb13c01b10d74666ee41a217887/src/devices/sound/okiadpcm.cpp
-// The copyright holders are Andrew Gardner and Aaron Giles.
+// Emulation of the OKI MSM6295 DAC is provided by the oki_adpcm_state
+// class, which is adopted from the MAME project with gratitude. It is
+// licensed under the BSD-3-Clause. The copyright holders are
+// Andrew Gardner and Aaron Giles.
+//
+// The original code is available at:
+//  https://github.com/mamedev/mame/blob/master/src/devices/sound/okiadpcm.cpp
 
 #include "OkiAdpcm.h"
 

--- a/src/main/formats/OkiAdpcm.h
+++ b/src/main/formats/OkiAdpcm.h
@@ -1,0 +1,55 @@
+// The oki_adpcm_state code comes from the MAME project. It is shared under the BSD-3-Clause license.
+// The original code is available at: https://github.com/mamedev/mame/blob/a5579831cae73eb13c01b10d74666ee41a217887/src/devices/sound/okiadpcm.cpp
+// The copyright holders are Andrew Gardner and Aaron Giles.
+
+#pragma once
+
+#include "common.h"
+#include "VGMSamp.h"
+
+class VGMSampColl;
+class VGMInstrSet;
+
+// ======================> oki_adpcm_state
+
+// Internal ADPCM state, used by external ADPCM generators with compatible specs to the OKIM 6295.
+class oki_adpcm_state
+{
+public:
+  oki_adpcm_state() { compute_tables(); reset(); }
+
+  void reset();
+  int16_t clock(uint8_t nibble);
+  int16_t output() { return m_signal; }
+  void save();
+  void restore();
+
+  int32_t   m_signal;
+  int32_t   m_step;
+  int32_t   m_loop_signal;
+  int32_t   m_loop_step;
+  bool      m_saved;
+
+private:
+  static const int8_t s_index_shift[8];
+  static int s_diff_lookup[49*16];
+
+  static void compute_tables();
+  static bool s_tables_computed;
+};
+
+class DailogicAdpcmSamp
+    : public VGMSamp {
+public:
+
+  DailogicAdpcmSamp(
+      VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t theRate, string name
+  );
+  virtual ~DailogicAdpcmSamp(void);
+
+  virtual double GetCompressionRatio();
+  virtual void ConvertToStdWave(uint8_t *buf);
+
+private:
+  static oki_adpcm_state okiAdpcmState;
+};

--- a/src/main/formats/OkiAdpcm.h
+++ b/src/main/formats/OkiAdpcm.h
@@ -1,6 +1,10 @@
-// The oki_adpcm_state code comes from the MAME project. It is shared under the BSD-3-Clause license.
-// The original code is available at: https://github.com/mamedev/mame/blob/a5579831cae73eb13c01b10d74666ee41a217887/src/devices/sound/okiadpcm.cpp
-// The copyright holders are Andrew Gardner and Aaron Giles.
+// Emulation of the OKI MSM6295 DAC is provided by the oki_adpcm_state
+// class, which is adopted from the MAME project with gratitude. It is
+// licensed under the BSD-3-Clause. The copyright holders are
+// Andrew Gardner and Aaron Giles.
+//
+// The original code is available at:
+//  https://github.com/mamedev/mame/blob/master/src/devices/sound/okiadpcm.h
 
 #pragma once
 

--- a/src/main/formats/PSXSPU.h
+++ b/src/main/formats/PSXSPU.h
@@ -396,8 +396,6 @@ class PSXSamp
 
 
  public:
-  VGMInstrSet *parentInstrSet;
-
   bool bSetLoopOnConversion;
   uint32_t dwCompSize;
   uint32_t dwUncompSize;


### PR DESCRIPTION
This adds the CPS1SampleInstrSet and CPS1SampColl classes, which support the OKI MSM6295 sound chip used by CPS1.

The OKI MSM6295 provides 4 channels of 4-bit ADPCM audio. I've added the MAME code for decoding the specific ADPCM format. This chip can change the channel volume but not the pitch. As such, it is used primarily for percussion instruments and sound effects.

## Motivation and Context
This is a precursor to adding support for the FM synthesis chip via a new JUCE-based virtual instrument plugin. I'm working on that project (which I've dubbed "ymmy") in parallel.

## How Has This Been Tested?
CPS1/2/3 sets still load and playback without issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
