### PR TITLE
Move CPS1 logic into separate files. Look away from the mess

### DIFF
--- a/bin/mame_roms.xml
+++ b/bin/mame_roms.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" ?>
 <romlist ver="1">
-    <game name="1941" format="CPS" fmt_version="CPS1_2.00">
+    <game name="1941" format="CPS1" fmt_version="CPS1_2.00">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1000" >
             <rom>41_9.12b</rom>
         </romgroup>
     </game>
-    <game name="1944" format="CPS" fmt_version="1.80">
+    <game name="1944" format="CPS2" fmt_version="1.80">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3C05" num_instr_banks="9" samp_table="0x6000" artic_table="0x8000">
             <rom>nff.01</rom>
         </romgroup>
@@ -14,7 +14,7 @@
             <rom>nff.12m</rom>
         </romgroup>
     </game>
-    <game name="19xx" format="CPS" fmt_version="1.05">
+    <game name="19xx" format="CPS2" fmt_version="1.05">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>19x.01</rom>
         </romgroup>
@@ -23,7 +23,7 @@
             <rom>19x.12m</rom>
         </romgroup>
     </game>
-    <game name="3wonders" format="CPS" fmt_version="CPS1_4.25">
+    <game name="3wonders" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>rt_9.12b</rom>
         </romgroup>
@@ -32,7 +32,7 @@
             <rom>rt_19.12c</rom>
         </romgroup>
     </game>
-    <game name="armwar" format="CPS" fmt_version="1.05a">
+    <game name="armwar" format="CPS2" fmt_version="1.05a">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000" samp_table_length="0x6E0">
             <rom>pwg.01</rom>
             <rom>pwg.02</rom>
@@ -42,7 +42,7 @@
             <rom>pwg.12m</rom>`
         </romgroup>
     </game>
-    <game name="avsp" format="CPS" fmt_version="1.04">
+    <game name="avsp" format="CPS2" fmt_version="1.04">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>avp.01</rom>
         </romgroup>
@@ -51,7 +51,7 @@
             <rom>avp.12m</rom>
         </romgroup>
     </game>
-    <game name="batcir" format="CPS" fmt_version="1.16b">
+    <game name="batcir" format="CPS2" fmt_version="1.16b">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x4004" num_instr_banks="2" samp_table="0x5008">
             <rom>btc.01</rom>
             <rom>btc.02</rom>
@@ -61,7 +61,7 @@
             <rom>btc.12m</rom>
         </romgroup>
     </game>
-    <game name="cawing" format="CPS" fmt_version="CPS1_4.25">
+    <game name="cawing" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>ca_9.12b</rom>
         </romgroup>
@@ -70,12 +70,12 @@
             <rom>ca_19.12c</rom>
         </romgroup>
     </game>
-    <game name="captcomm" format="CPS" fmt_version="CPS1_4.25">
+    <game name="captcomm" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>cc_09.11a</rom>
         </romgroup>
     </game>
-    <game name="choko" format="CPS" fmt_version="1.80">
+    <game name="choko" format="CPS2" fmt_version="1.80">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3C05" num_instr_banks="2" samp_table="0x3D95" artic_table="0x40BD">
             <rom>tko.01</rom>
         </romgroup>
@@ -84,7 +84,7 @@
             <rom>tkoj5_b.simm5</rom>
         </romgroup>
     </game>
-    <game name="csclub" format="CPS" fmt_version="1.30">
+    <game name="csclub" format="CPS2" fmt_version="1.30">
         <romgroup type="audiocpu" load_method="append" seq_table="0x7005" instr_table_ptrs="0x3b04" num_instr_banks="16" samp_table="0x5000" artic_table="0x6000">
             <rom>csc.01</rom>
         </romgroup>
@@ -99,12 +99,12 @@
             <rom>csc.58</rom>
         </romgroup>
     </game>
-    <game name="cworld2j" format="CPS" fmt_version="CPS1_4.25">
+    <game name="cworld2j" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>q5_23.13b</rom>
         </romgroup>
     </game>
-    <game name="cybots" format="CPS" fmt_version="1.05a">
+    <game name="cybots" format="CPS2" fmt_version="1.05a">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000" samp_table_length="0x868">
             <rom>cyb.01</rom>
             <rom>cyb.02</rom>
@@ -114,7 +114,7 @@
             <rom>cyb.12m</rom>
         </romgroup>
     </game>
-    <game name="ddsom" format="CPS" fmt_version="1.15">
+    <game name="ddsom" format="CPS2" fmt_version="1.15">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x39E9" num_instr_banks="2" samp_table="0x49E9">
             <rom>dd2.01</rom>
             <rom>dd2.02</rom>
@@ -124,7 +124,7 @@
             <rom>dd2.12m</rom>
         </romgroup>
     </game>
-    <game name="ddtod" format="CPS" fmt_version="1.04">
+    <game name="ddtod" format="CPS2" fmt_version="1.04">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>dad.01</rom>
         </romgroup>
@@ -133,7 +133,7 @@
             <rom>dad.12m</rom>
         </romgroup>
     </game>
-    <game name="dimahoou" format="CPS" fmt_version="1.80">
+    <game name="dimahoou" format="CPS2" fmt_version="1.80">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3C05" num_instr_banks="5" samp_table="0x6000" artic_table="0x8000">
             <rom>gmd.01</rom>
             <rom>gmd.02</rom>
@@ -143,7 +143,7 @@
             <rom>gmd.12m</rom>
         </romgroup>
     </game>
-    <game name="dino" format="CPS" fmt_version="1.00">
+    <game name="dino" format="CPS2" fmt_version="1.00">
         <romgroup type="audiocpu" load_method="append" encryption="kabuki" kabuki_swap_key1="0x76543210" kabuki_swap_key2="0x24601357" kabuki_addr_key="0x4343" kabuki_xor_key="0x43" seq_table="0x8005" instr_table="0x6E62" num_instr_banks="1" samp_table="0x6A82" samp_table_length="0x3E0">
             <rom>cd_q.5k</rom>
         </romgroup>
@@ -154,7 +154,7 @@
             <rom>cd-q4.4k</rom>
         </romgroup>
     </game>
-    <game name="dstlk" format="CPS" fmt_version="1.05">
+    <game name="dstlk" format="CPS2" fmt_version="1.05">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" seq_table_length="0xAC4" instr_table="0x7000" num_instr_banks="1" samp_table="0x8000">
             <rom>vam.01</rom>
             <rom>vam.02</rom>
@@ -164,7 +164,7 @@
             <rom>vam.12m</rom>
         </romgroup>
     </game>
-    <game name="ecofghtr" format="CPS" fmt_version="1.04">
+    <game name="ecofghtr" format="CPS2" fmt_version="1.04">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>uec.01</rom>
         </romgroup>
@@ -179,12 +179,12 @@
             <rom>e02-14.33</rom>
         </romgroup>
     </game>
-    <game name="ffight" format="CPS" fmt_version="CPS1_2.00ff">
+    <game name="ffight" format="CPS1" fmt_version="CPS1_2.00ff">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1000">
             <rom>ff_09.12b</rom>
         </romgroup>
     </game>
-    <game name="gigawing" format="CPS" fmt_version="1.40">
+    <game name="gigawing" format="CPS2" fmt_version="1.40">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3C05" num_instr_banks="6" samp_table="0x6000" artic_table="0x8000">
             <rom>ggw.01</rom>
         </romgroup>
@@ -193,7 +193,7 @@
             <rom>ggw.12m</rom>
         </romgroup>
     </game>
-    <game name="hsf2" format="CPS" fmt_version="1.06b">
+    <game name="hsf2" format="CPS2" fmt_version="1.06b">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>hs2.01</rom>
             <rom>hs2.02</rom>
@@ -202,7 +202,7 @@
             <rom>hs2.11m</rom>
         </romgroup>
     </game>
-    <game name="jojo" format="CPS" fmt_version="CPS3">
+    <game name="jojo" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0x02203ee3" key2="0x01301972" seq_table="0x760008" samp_table="0x75c000" samp_table_length="0x2480" instr_table_ptrs="0x758000" num_instr_banks="2">
             <rom>jojon/jojo-simm1.0</rom>
             <rom>jojon/jojo-simm1.1</rom>
@@ -214,7 +214,7 @@
             <rom>jojon/jojo-simm3.1</rom>
         </romgroup>
     </game>
-    <game name="jojon" format="CPS" fmt_version="CPS3">
+    <game name="jojon" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0x02203ee3" key2="0x01301972" seq_table="0x760008" samp_table="0x75c000" samp_table_length="0x2480" instr_table_ptrs="0x758000" num_instr_banks="2">
             <rom>jojo-simm1.0</rom>
             <rom>jojo-simm1.1</rom>
@@ -226,7 +226,7 @@
             <rom>jojo-simm3.1</rom>
         </romgroup>
     </game>
-    <game name="jojoba" format="CPS" fmt_version="CPS3">
+    <game name="jojoba" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0x23323ee3" key2="0x03021972" seq_table="0x760008" samp_table="0x75c000" samp_table_length="0x2480" instr_table_ptrs="0x758000" num_instr_banks="2">
             <rom>jojoban/jojoba-simm1.0</rom>
             <rom>jojoban/jojoba-simm1.1</rom>
@@ -238,7 +238,7 @@
             <rom>jojoban/jojoba-simm3.1</rom>
         </romgroup>
     </game>
-        <game name="jojoban" format="CPS" fmt_version="CPS3">
+        <game name="jojoban" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0x23323ee3" key2="0x03021972" seq_table="0x760008" samp_table="0x75c000" samp_table_length="0x2480" instr_table_ptrs="0x758000" num_instr_banks="2">
             <rom>jojoba-simm1.0</rom>
             <rom>jojoba-simm1.1</rom>
@@ -250,7 +250,7 @@
             <rom>jojoba-simm3.1</rom>
         </romgroup>
     </game>
-    <game name="jyangoku" format="CPS" fmt_version="1.80">
+    <game name="jyangoku" format="CPS2" fmt_version="1.80">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3EF4" num_instr_banks="3" samp_table="0x40B8" artic_table="0x4428">
             <rom>maj_01.1a</rom>
         </romgroup>
@@ -259,22 +259,22 @@
             <rom>maj5_b.simm5</rom>
         </romgroup>
     </game>
-    <game name="kenseim" format="CPS" fmt_version="CPS1_4.25">
+    <game name="kenseim" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>knm_09.12a</rom>
         </romgroup>
     </game>
-    <game name="knights" format="CPS" fmt_version="CPS1_4.25">
+    <game name="knights" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>kr_09.11a</rom>
         </romgroup>
     </game>
-    <game name="kod" format="CPS" fmt_version="CPS1_4.25">
+    <game name="kod" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>kd_9.12a</rom>
         </romgroup>
     </game>
-    <game name="mmatrix" format="CPS" fmt_version="1.80">
+    <game name="mmatrix" format="CPS2" fmt_version="1.80">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3C05" num_instr_banks="9" samp_table="0x6000" samp_table_length="0x828" artic_table="0x8000">
             <rom>mmx.01</rom>
         </romgroup>
@@ -283,12 +283,12 @@
             <rom>mmx.12m</rom>
         </romgroup>
     </game>
-    <game name="megaman" format="CPS" fmt_version="CPS1_5.02">
+    <game name="megaman" format="CPS1" fmt_version="CPS1_5.02">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1C80" >
             <rom>rcm_09.11a</rom>
         </romgroup>
     </game>
-    <game name="megaman2" format="CPS" fmt_version="1.15c">
+    <game name="megaman2" format="CPS2" fmt_version="1.15c">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x4000" num_instr_banks="2" samp_table="0x5000">
             <rom>rm2.01a</rom>
             <rom>rm2.02</rom>
@@ -298,12 +298,12 @@
             <rom>rm2.12m</rom>
         </romgroup>
     </game>
-    <game name="mercs" format="CPS" fmt_version="CPS1_2.00">
+    <game name="mercs" format="CPS1" fmt_version="CPS1_2.00">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1000">
             <rom>so2_09.12b</rom>
         </romgroup>
     </game>
-    <game name="mmancp2u" format="CPS" fmt_version="1.05a">
+    <game name="mmancp2u" format="CPS2" fmt_version="1.05a">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>rcm.01</rom>
         </romgroup>
@@ -318,7 +318,7 @@
             <rom>rcm.58</rom>
         </romgroup>
     </game>
-    <game name="mpang" format="CPS" fmt_version="1.80">
+    <game name="mpang" format="CPS2" fmt_version="1.80">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3C05" num_instr_banks="3" samp_table="0x3FBF" artic_table="0x45E7">
             <rom>mpn.01</rom>
         </romgroup>
@@ -327,7 +327,7 @@
             <rom>mpn-simm.05b</rom>
         </romgroup>
     </game>
-    <game name="msh" format="CPS" fmt_version="1.05">
+    <game name="msh" format="CPS2" fmt_version="1.05">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>msh.01</rom>
             <rom>msh.02</rom>
@@ -337,7 +337,7 @@
             <rom>msh.12m</rom>
         </romgroup>
     </game>
-    <game name="mshvsf" format="CPS" fmt_version="1.31">
+    <game name="mshvsf" format="CPS2" fmt_version="1.31">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3C05" num_instr_banks="28" samp_table="0x6000" samp_table_length="0x1B48" artic_table="0x8000">
             <rom>mvs.01</rom>
             <rom>mvs.02</rom>
@@ -347,17 +347,17 @@
             <rom>mvs.12m</rom>
         </romgroup>
     </game>
-    <game name="msword" format="CPS" fmt_version="CPS1_3.50">
+    <game name="msword" format="CPS1" fmt_version="CPS1_3.50">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1000" >
             <rom>ms_09.12b</rom>
         </romgroup>
     </game>
-    <game name="mtwins" format="CPS" fmt_version="CPS1_4.25">
+    <game name="mtwins" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>ch_09.12b</rom>
         </romgroup>
     </game>
-    <game name="mvsc" format="CPS" fmt_version="1.30">
+    <game name="mvsc" format="CPS2" fmt_version="1.30">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3B04" num_instr_banks="16" samp_table="0x5000" artic_table="0x8000">
             <rom>mvc.01</rom>
             <rom>mvc.02</rom>
@@ -367,12 +367,12 @@
             <rom>mvc.12m</rom>
         </romgroup>
     </game>
-    <game name="nemo" format="CPS" fmt_version="CPS1_4.25">
+    <game name="nemo" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>nme_09.12b</rom>
         </romgroup>
     </game>
-    <game name="nwarr" format="CPS" fmt_version="1.05a">
+    <game name="nwarr" format="CPS2" fmt_version="1.05a">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000" samp_table_length="0x8E8">
             <rom>vph.01</rom>
             <rom>vph.02</rom>
@@ -382,12 +382,12 @@
             <rom>vph.12m</rom>
         </romgroup>
     </game>
-    <game name="pang3" format="CPS" fmt_version="CPS1_5.00">
+    <game name="pang3" format="CPS1" fmt_version="CPS1_5.00">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1C80" >
             <rom>pa3_11.11f</rom>
         </romgroup>
     </game>
-    <game name="plsmaswd" format="CPS" fmt_version="2.10">
+    <game name="plsmaswd" format="CPS2" fmt_version="2.10">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9008" instr_table_ptrs="0x3FF4" num_instr_banks="3" samp_table="0x6000" samp_table_length="0x480" artic_table="0x8000">
             <rom>sg2_02.2e</rom>
             <rom>sg2_03.3e</rom>
@@ -396,12 +396,12 @@
             <rom>sg2-01m.3a</rom>
         </romgroup>
     </game>
-    <game name="pnickj" format="CPS" fmt_version="CPS1_4.25">
+    <game name="pnickj" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>pnij_17.13b</rom>
         </romgroup>
     </game>
-    <game name="progear" format="CPS" fmt_version="1.80">
+    <game name="progear" format="CPS2" fmt_version="1.80">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3C05" num_instr_banks="4" samp_table="0x6000" artic_table="0x8000">
             <rom>pga.01</rom>
         </romgroup>
@@ -412,7 +412,7 @@
             <rom>pga-simm.06b</rom>
         </romgroup>
     </game>
-    <game name="punisher" format="CPS" fmt_version="1.01">
+    <game name="punisher" format="CPS2" fmt_version="1.01">
         <romgroup type="audiocpu" load_method="append" encryption="kabuki" kabuki_swap_key1="0x67452103" kabuki_swap_key2="0x75316024" kabuki_addr_key="0x2222" kabuki_xor_key="0x22" seq_table="0x8005" instr_table="0x6F75" num_instr_banks="2" samp_table="0x6A9D" samp_table_length="0x4D8">
             <rom>ps_q.5k</rom>
         </romgroup>
@@ -423,7 +423,7 @@
             <rom>ps-q4.4k</rom>
         </romgroup>
     </game>
-    <game name="pzloop2" format="CPS" fmt_version="1.80">
+    <game name="pzloop2" format="CPS2" fmt_version="1.80">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3C05" num_instr_banks="2" samp_table="0x3F5D" artic_table="0x45A5">
             <rom>pl2.01</rom>
         </romgroup>
@@ -432,12 +432,12 @@
             <rom>pl2-simm.05b</rom>
         </romgroup>
     </game>
-    <game name="qad" format="CPS" fmt_version="CPS1_4.25">
+    <game name="qad" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>qd_23.13b</rom>
         </romgroup>
     </game>
-    <game name="qndream" format="CPS" fmt_version="1.16b">
+    <game name="qndream" format="CPS2" fmt_version="1.16b">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x4004" num_instr_banks="15" samp_table="0x5062">
             <rom>tqz.01</rom>
         </romgroup>
@@ -446,12 +446,12 @@
             <rom>tqz.12m</rom>
         </romgroup>
     </game>
-    <game name="qtono2j" format="CPS" fmt_version="CPS1_5.00">
+    <game name="qtono2j" format="CPS1" fmt_version="CPS1_5.00">
         <romgroup type="audiocpu" load_method="append" seq_table="0x13C0" >
             <rom>tn2j_09.12a</rom>
         </romgroup>
     </game>
-    <game name="redearth" format="CPS" fmt_version="CPS3">
+    <game name="redearth" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0x9e300ab1" key2="0xa175b82c" seq_table="0xbc198" samp_table="0xb83ec" samp_table_length="0x1690" instr_table_ptrs="0xb9a7c" num_instr_banks="2">
             <rom>redearthn/redearth-simm1.0</rom>
             <rom>redearthn/redearth-simm1.1</rom>
@@ -463,7 +463,7 @@
             <rom>redearthn/redearth-simm3.1</rom>
         </romgroup>
     </game>
-        <game name="redearthn" format="CPS" fmt_version="CPS3">
+        <game name="redearthn" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0x9e300ab1" key2="0xa175b82c" seq_table="0xbc198" samp_table="0xb83ec" samp_table_length="0x1690" instr_table_ptrs="0xb9a7c" num_instr_banks="2">
             <rom>redearth-simm1.0</rom>
             <rom>redearth-simm1.1</rom>
@@ -475,7 +475,7 @@
             <rom>redearth-simm3.1</rom>
         </romgroup>
     </game>
-    <game name="ringdest" format="CPS" fmt_version="1.05a">
+    <game name="ringdest" format="CPS2" fmt_version="1.05a">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>smb.01</rom>
             <rom>smb.02</rom>
@@ -485,7 +485,7 @@
             <rom>smb.12m</rom>
         </romgroup>
     </game>
-    <game name="rvschool" format="CPS"  fmt_version="2.10">
+    <game name="rvschool" format="CPS2"  fmt_version="2.10">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9008" instr_table_ptrs="0x7079" num_instr_banks="2" samp_table="0x733D" samp_table_length="0x468" artic_table="0x77A5">
             <rom>jst_02.2e</rom>
             <rom>jst_03.3e</rom>
@@ -504,7 +504,7 @@
             <rom>521-a13.7g</rom>
         </romgroup>
     </game>
-    <game name="sf2" format="CPS" fmt_version="CPS1_4.25">
+    <game name="sf2" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>sf2_9.12a</rom>
         </romgroup>
@@ -513,7 +513,7 @@
             <rom>sf2_19.12c</rom>
         </romgroup>
     </game>
-    <game name="sf2ce" format="CPS" fmt_version="CPS1_4.25">
+    <game name="sf2ce" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>s92_09.11a</rom>
         </romgroup>
@@ -522,12 +522,12 @@
             <rom>s92_19.12c</rom>
         </romgroup>
     </game>
-    <game name="sf2hf" format="CPS" fmt_version="CPS1_4.25">
+    <game name="sf2hf" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>s92_09.11a</rom>
         </romgroup>
     </game>
-    <game name="sfa" format="CPS" fmt_version="1.05a">
+    <game name="sfa" format="CPS2" fmt_version="1.05a">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>sfz.01</rom>
             <rom>sfz.02</rom>
@@ -537,7 +537,7 @@
             <rom>sfz.12m</rom>
         </romgroup>
     </game>
-    <game name="sfa2" format="CPS" fmt_version="1.05c">
+    <game name="sfa2" format="CPS2" fmt_version="1.05c">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>sz2.01a</rom>
             <rom>sz2.02a</rom>
@@ -547,7 +547,7 @@
             <rom>sz2.12m</rom>
         </romgroup>
     </game>
-    <game name="sfz2al" format="CPS" fmt_version="1.05c">
+    <game name="sfz2al" format="CPS2" fmt_version="1.05c">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>sza.01</rom>
             <rom>sza.02</rom>
@@ -557,7 +557,7 @@
             <rom>sza.12m</rom>
         </romgroup>
     </game>
-    <game name="sfa3" format="CPS" fmt_version="1.71">
+    <game name="sfa3" format="CPS2" fmt_version="1.71">
         <romgroup type="audiocpu" load_method="append" seq_table="0x8C05" instr_table_ptrs="0x3C05" num_instr_banks="16" samp_table="0x6000" samp_table_length="0x1A30" artic_table="0x8000">
             <rom>sz3.01</rom>
             <rom>sz3.02</rom>
@@ -567,7 +567,7 @@
             <rom>sz3.12m</rom>
         </romgroup>
     </game>
-    <game name="sfex" format="CPS" fmt_version="2.00">
+    <game name="sfex" format="CPS2" fmt_version="2.00">
         <romgroup type="audiocpu" load_method="append" seq_table="0x6004" seq_table_length="0x58" instr_table_ptrs="0x39F4" num_instr_banks="6" samp_table="0x4638">
             <rom>sfe_02.2e</rom>
             <rom>sfe_03.3e</rom>
@@ -576,7 +576,7 @@
             <rom>sfe-01m.3b</rom>
         </romgroup>
     </game>
-    <game name="sfexp" format="CPS" fmt_version="2.00">
+    <game name="sfexp" format="CPS2" fmt_version="2.00">
         <romgroup type="audiocpu" load_method="append" seq_table="0x6004" seq_table_length="0x58" instr_table_ptrs="0x39F4" num_instr_banks="6" samp_table="0x4638">
             <rom>sfe_02.2e</rom>
             <rom>sfe_03.3e</rom>
@@ -585,7 +585,7 @@
             <rom>sfe-01m.3b</rom>
         </romgroup>
     </game>
-    <game name="sfiii" format="CPS" fmt_version="CPS3">
+    <game name="sfiii" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0xb5fe053e" key2="0xfc03925a" seq_table="0x3865cc" samp_table="0x3829FC" samp_table_length="0x1750" instr_table_ptrs="0x38414C" num_instr_banks="2">
             <rom>sfiiin/sfiii-simm1.0</rom>
             <rom>sfiiin/sfiii-simm1.1</rom>
@@ -597,7 +597,7 @@
             <rom>sfiiin/sfiii-simm3.1</rom>
         </romgroup>
     </game>
-    <game name="sfiiin" format="CPS" fmt_version="CPS3">
+    <game name="sfiiin" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0xb5fe053e" key2="0xfc03925a" seq_table="0x3865cc" samp_table="0x3829FC" samp_table_length="0x1750" instr_table_ptrs="0x38414C" num_instr_banks="2">
             <rom>sfiii-simm1.0</rom>
             <rom>sfiii-simm1.1</rom>
@@ -609,7 +609,7 @@
             <rom>sfiii-simm3.1</rom>
         </romgroup>
     </game>
-    <game name="sfiii2" format="CPS" fmt_version="CPS3">
+    <game name="sfiii2" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0x00000000" key2="0x00000000" seq_table="0x52c29C" samp_table="0x5271b0" samp_table_length="0x2300" instr_table_ptrs="0x5294b0" num_instr_banks="2">
             <rom>sfiii2n/sfiii2-simm1.0</rom>
             <rom>sfiii2n/sfiii2-simm1.1</rom>
@@ -621,7 +621,7 @@
             <rom>sfiii2n/sfiii2-simm3.1</rom>
         </romgroup>
     </game>
-    <game name="sfiii2n" format="CPS" fmt_version="CPS3">
+    <game name="sfiii2n" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0x00000000" key2="0x00000000" seq_table="0x52c29C" samp_table="0x5271b0" samp_table_length="0x2300" instr_table_ptrs="0x5294b0" num_instr_banks="2">
             <rom>sfiii2-simm1.0</rom>
             <rom>sfiii2-simm1.1</rom>
@@ -633,7 +633,7 @@
             <rom>sfiii2-simm3.1</rom>
         </romgroup>
     </game>
-    <game name="sfiii3" format="CPS" fmt_version="CPS3">
+    <game name="sfiii3" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0xa55432b4" key2="0x0c129981" seq_table="0x78f008" samp_table="0x78C000" samp_table_length="0x2DD0" instr_table_ptrs="0x788000" num_instr_banks="16">
             <rom>sfiii3n/sfiii3-simm1.0</rom>
             <rom>sfiii3n/sfiii3-simm1.1</rom>
@@ -645,7 +645,7 @@
             <rom>sfiii3n/sfiii3-simm3.1</rom>
         </romgroup>
     </game>
-    <game name="sfiii3n" format="CPS" fmt_version="CPS3">
+    <game name="sfiii3n" format="CPS2" fmt_version="CPS3">
         <romgroup type="audiocpu" load_method="deinterlace" encryption="cps3" key1="0xa55432b4" key2="0x0c129981" seq_table="0x78f008" samp_table="0x78C000" samp_table_length="0x2DD0" instr_table_ptrs="0x788000" num_instr_banks="16">
             <rom>sfiii3-simm1.0</rom>
             <rom>sfiii3-simm1.1</rom>
@@ -657,7 +657,7 @@
             <rom>sfiii3-simm3.1</rom>
         </romgroup>
     </game>
-    <game name="sgemf" format="CPS" fmt_version="1.30">
+    <game name="sgemf" format="CPS2" fmt_version="1.30">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3B04" num_instr_banks="16" samp_table="0x5000" artic_table="0x8000">
             <rom>pcf.01</rom>
             <rom>pcf.02</rom>
@@ -667,7 +667,7 @@
             <rom>pcf.12m</rom>
         </romgroup>
     </game>
-    <game name="slammast" format="CPS" fmt_version="1.01">
+    <game name="slammast" format="CPS2" fmt_version="1.01">
         <romgroup type="audiocpu" load_method="append" encryption="kabuki" kabuki_swap_key1="0x54321076" kabuki_swap_key2="0x65432107" kabuki_addr_key="0x3131" kabuki_xor_key="0x19" seq_table="0x8005" instr_table="0x72DA" num_instr_banks="1" samp_table="0x6AF2" samp_table_length="0x7E8">
             <rom>mb_qa.5k</rom>
         </romgroup>
@@ -682,7 +682,7 @@
             <rom>mb-q8.4m</rom>
         </romgroup>
     </game>
-    <game name="spf2t" format="CPS" fmt_version="2.01b">
+    <game name="spf2t" format="CPS2" fmt_version="2.01b">
         <romgroup type="audiocpu" load_method="append" seq_table="0x6004" instr_table_ptrs="0x3FE4" num_instr_banks="14" samp_table="0x4F78">
             <rom>pzf.01</rom>
             <rom>pzf.02</rom>
@@ -692,7 +692,7 @@
             <rom>pzf.12m</rom>
         </romgroup>
     </game>
-    <game name="ssf2" format="CPS" fmt_version="1.03">
+    <game name="ssf2" format="CPS2" fmt_version="1.03">
         <romgroup type="audiocpu" load_method="append" seq_table="0x7C15" instr_table="0x6C00" num_instr_banks="1" samp_table="0x7410">
             <rom>ssf-01a</rom>
         </romgroup>
@@ -707,7 +707,7 @@
             <rom>ssf.q08</rom>
         </romgroup>
     </game>
-    <game name="ssf2t" format="CPS" fmt_version="1.04">
+    <game name="ssf2t" format="CPS2" fmt_version="1.04">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000">
             <rom>sfx.01</rom>
             <rom>sfx.02</rom>
@@ -717,7 +717,7 @@
             <rom>sfx.12m</rom>
         </romgroup>
     </game>
-    <game name="starglad" format="CPS" fmt_version="2.01b">
+    <game name="starglad" format="CPS2" fmt_version="2.01b">
         <romgroup type="audiocpu" load_method="append" seq_table="0x6008" instr_table_ptrs="0x3EF4" num_instr_banks="6" samp_table="0x4700">
             <rom>ps1_02a.2e</rom>
             <rom>ps1_03a.3e</rom>
@@ -726,7 +726,7 @@
             <rom>ps1-01m.3b</rom>
         </romgroup>
     </game>
-    <game name="strider2" format="CPS"  fmt_version="2.10">
+    <game name="strider2" format="CPS2"  fmt_version="2.10">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9008" instr_table_ptrs="0x7079" num_instr_banks="2" samp_table="0x7145" samp_table_length="0x168" artic_table="0x72AD">>
             <rom>hr2_02.2e</rom>
         </romgroup>
@@ -734,7 +734,7 @@
             <rom>hr2-01m.3a</rom>
         </romgroup>
     </game>
-    <game name="techromn" format="CPS" fmt_version="2.11">
+    <game name="techromn" format="CPS2" fmt_version="2.11">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9008" instr_table_ptrs="0x3EF4" num_instr_banks="3" samp_table="0x430c" samp_table_length="0x6E8" artic_table="0x49f4">
             <rom>kio_02.2e</rom>
             <rom>kio_03.3e</rom>
@@ -743,7 +743,7 @@
             <rom>kio-01m.3a</rom>
         </romgroup>
     </game>
-    <game name="ts2" format="CPS" fmt_version="1.05">
+    <game name="ts2" format="CPS2" fmt_version="1.05">
         <romgroup type="audiocpu" load_method="append" seq_table="0x4809" instr_table="0x3847" num_instr_banks="1" samp_table="0x4047" samp_table_length="0x2E0">
             <rom>ts2_02.2e</rom>
         </romgroup>
@@ -751,12 +751,12 @@
             <rom>ts2-01m.3b</rom>
         </romgroup>
     </game>
-    <game name="varth" format="CPS" fmt_version="CPS1_4.25">
+    <game name="varth" format="CPS1" fmt_version="CPS1_4.25">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>va_09.12b</rom>
         </romgroup>
     </game>
-    <game name="vhunt2" format="CPS" fmt_version="1.30">
+    <game name="vhunt2" format="CPS2" fmt_version="1.30">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3B04" num_instr_banks="8" samp_table="0x46E0" artic_table="0x59A8">
             <rom>vh2.01</rom>
             <rom>vh2.02</rom>
@@ -766,7 +766,7 @@
             <rom>vh2.12m</rom>
         </romgroup>
     </game>
-    <game name="vsav" format="CPS" fmt_version="1.30">
+    <game name="vsav" format="CPS2" fmt_version="1.30">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3B04" num_instr_banks="7" samp_table="0x45FA" samp_table_length="0x1420" artic_table="0x5A1A">
             <rom>vm3.01</rom>
             <rom>vm3.02</rom>
@@ -776,7 +776,7 @@
             <rom>vm3.12m</rom>
         </romgroup>
     </game>
-    <game name="vsav2" format="CPS" fmt_version="1.30">
+    <game name="vsav2" format="CPS2" fmt_version="1.30">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3B04" num_instr_banks="8" samp_table="0x4798" samp_table_length="0x1440" artic_table="0x5BD8">
             <rom>vs2.01</rom>
             <rom>vs2.02</rom>
@@ -786,7 +786,7 @@
             <rom>vs2.12m</rom>
         </romgroup>
     </game>
-    <game name="wof" format="CPS" fmt_version="1.00">
+    <game name="wof" format="CPS2" fmt_version="1.00">
         <romgroup type="audiocpu" load_method="append" encryption="kabuki" kabuki_swap_key1="0x01234567" kabuki_swap_key2="0x54163072" kabuki_addr_key="0x5151" kabuki_xor_key="0x51" seq_table="0x8005" instr_table="0x6DDA" num_instr_banks="1" samp_table="0x6A82" samp_table_length="0x358">
             <rom>tk2_qa.rom</rom>
         </romgroup>
@@ -797,7 +797,7 @@
             <rom>tk2_q4.rom</rom>
         </romgroup>
     </game>
-    <game name="xmcota" format="CPS" fmt_version="1.05">
+    <game name="xmcota" format="CPS2" fmt_version="1.05">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" seq_table_length="0xC50" instr_table="0x7000" num_instr_banks="2" samp_table="0x8000" samp_table_length="0x978">
             <rom>xmn.01a</rom>
             <rom>xmn.02a</rom>
@@ -807,7 +807,7 @@
             <rom>xmn.12m</rom>
         </romgroup>
     </game>
-    <game name="xmvsf" format="CPS" fmt_version="1.16">
+    <game name="xmvsf" format="CPS2" fmt_version="1.16">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x4004" num_instr_banks="21" samp_table="0x54F6" samp_table_length="0xE20">
             <rom>xvs.01</rom>
             <rom>xvs.02</rom>

--- a/src/main/formats/CPS1Instr.cpp
+++ b/src/main/formats/CPS1Instr.cpp
@@ -1,0 +1,98 @@
+#include "CPS1Instr.h"
+#include "CPS2Format.h"
+#include "VGMRgn.h"
+#include "OkiAdpcm.h"
+
+// ******************
+// CPS1SampleInstrSet
+// ******************
+
+CPS1SampleInstrSet::CPS1SampleInstrSet(RawFile *file,
+                                       CPSFormatVer version,
+                                       uint32_t offset,
+                                       std::string &name)
+    : VGMInstrSet(CPS1Format::name, file, offset, 0, name),
+      fmt_version(version) {
+}
+
+CPS1SampleInstrSet::~CPS1SampleInstrSet(void) {
+}
+
+bool CPS1SampleInstrSet::GetInstrPointers() {
+  for (int i = 0; i < 128; ++i) {
+    auto offset = dwOffset + (i * 4);
+    if (!(GetByte(offset) & 0x80)) {
+      break;
+    }
+    std::ostringstream ss;
+    ss << "Instrument " << i;
+    string name = ss.str();
+    VGMInstr* instr = new VGMInstr(this, offset, 4, 0, i, name);
+    VGMRgn* rgn = new VGMRgn(instr, offset);
+    instr->unLength = 4;
+    rgn->unLength = 4;
+    // subtract 1 to account for the first OKIM6295 sample ptr always being null
+    rgn->sampNum = GetByte(offset+1) - 1;
+    instr->aRgns.push_back(rgn);
+    aInstrs.push_back(instr);
+  }
+  return true;
+}
+
+// **************
+// CPS1SampColl
+// **************
+
+CPS1SampColl::CPS1SampColl(RawFile *file,
+                           CPS1SampleInstrSet *theinstrset,
+                           uint32_t offset,
+                           uint32_t length,
+                           string name)
+    : VGMSampColl(CPS1Format::name, file, offset, length, name),
+      instrset(theinstrset) {
+}
+
+
+bool CPS1SampColl::GetHeaderInfo() {
+  auto header = AddHeader(8, 0x400-8, "Sample Pointers");
+
+  int i = 1;
+  for (int offset = 8; offset < 0x400; offset += 8) {
+    if (GetWord(offset) == 0xFFFFFFFF) {
+      break;
+    }
+    ostringstream startStream;
+    startStream << "Sample " << i << " Start";
+    auto startStr = startStream.str();
+    ostringstream endStream;
+    endStream << "Sample " << i++ << " End";
+    auto endStr = endStream.str();
+
+    header->AddSimpleItem(offset, 3, startStr);
+    header->AddSimpleItem(offset+3, 3, endStr);
+  }
+  return true;
+}
+
+bool CPS1SampColl::GetSampleInfo() {
+  constexpr int PTR_SIZE = 3;
+
+  int i = 1;
+  for (int offset = 8; offset < 0x400; offset += 8) {
+    auto sampAddr = GetShort(offset);
+    if (sampAddr == 0xFFFF) {
+      break;
+    }
+    auto begin = GetWordBE(offset) >> 8;
+    auto end = GetWordBE(offset+PTR_SIZE) >> 8;
+
+    ostringstream name;
+    name << "Sample " << i++;
+    auto sample = new DialogicAdpcmSamp(this, begin, end-begin, CPS1_OKIMSM6295_SAMPLE_RATE, name.str());
+    sample->SetWaveType(WT_PCM16);
+    sample->SetLoopStatus(false);
+    sample->unityKey = 0x3C;
+    samples.push_back(sample);
+  }
+  return true;
+}

--- a/src/main/formats/CPS1Instr.h
+++ b/src/main/formats/CPS1Instr.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "VGMInstrSet.h"
+#include "CPS1Scanner.h"
+#include "VGMSampColl.h"
+
+// ******************
+// CPS1SampleInstrSet
+// ******************
+
+class CPS1SampleInstrSet
+    : public VGMInstrSet {
+public:
+  CPS1SampleInstrSet(RawFile *file,
+                     CPSFormatVer fmt_version,
+                     uint32_t offset,
+                     std::string &name);
+  virtual ~CPS1SampleInstrSet(void);
+
+  virtual bool GetInstrPointers();
+
+public:
+  CPSFormatVer fmt_version;
+};
+
+// **************
+// CPS1SampColl
+// **************
+
+class CPS1SampColl
+    : public VGMSampColl {
+public:
+  CPS1SampColl(RawFile *file, CPS1SampleInstrSet *instrset, uint32_t offset,
+               uint32_t length = 0, std::string name = std::string("CPS1 Sample Collection"));
+  virtual bool GetHeaderInfo();
+  virtual bool GetSampleInfo();
+
+private:
+  vector<VGMItem*> samplePointers;
+  CPS1SampleInstrSet *instrset;
+};

--- a/src/main/formats/CPS1Scanner.cpp
+++ b/src/main/formats/CPS1Scanner.cpp
@@ -1,0 +1,161 @@
+#include "pch.h"
+#include "Root.h"
+#include "CPS1Scanner.h"
+#include "CPSSeq.h"
+#include "CPS1Instr.h"
+#include "MAMELoader.h"
+#include "VGMMiscFile.h"
+
+using namespace std;
+
+class CPS1SampleInstrSet;
+
+void CPS1Scanner::Scan(RawFile *file, void *info) {
+  MAMEGame *gameentry = (MAMEGame *) info;
+  CPSFormatVer fmt_ver = GetVersionEnum(gameentry->fmt_version_str);
+
+  if (fmt_ver == VER_UNDEFINED) {
+    string alert = "XML entry uses an undefined format version: " + gameentry->fmt_version_str;
+    pRoot->AddLogItem(new LogItem(alert, LOG_LEVEL_ERR, "CPS1Scanner"));
+    return;
+  }
+
+  switch (fmt_ver) {
+    case VER_CPS1_200:
+    case VER_CPS1_200ff:
+    case VER_CPS1_350:
+    case VER_CPS1_425:
+    case VER_CPS1_500:
+    case VER_CPS1_502:
+      LoadCPS1(gameentry, fmt_ver);
+      break;
+    default:
+      break;
+  }
+}
+
+void CPS1Scanner::LoadCPS1(MAMEGame *gameentry, CPSFormatVer fmt_ver) {
+  CPS1SampleInstrSet *instrset = nullptr;
+  CPS1SampColl *sampcoll = nullptr;
+
+  MAMERomGroup* seqRomGroupEntry = gameentry->GetRomGroupOfType("audiocpu");
+  if (!seqRomGroupEntry)
+    return;
+  uint32_t seq_table_offset;
+  uint32_t seq_table_length;
+  if (!seqRomGroupEntry->file ||
+      !seqRomGroupEntry->GetHexAttribute("seq_table", &seq_table_offset))
+    return;
+
+  if (fmt_ver == VER_UNDEFINED) {
+    string alert = "XML entry uses an undefined QSound version: " + gameentry->fmt_version_str;
+    pRoot->AddLogItem(new LogItem(alert, LOG_LEVEL_ERR, "CPS1Scanner"));
+    return;
+  }
+
+  RawFile *programFile = seqRomGroupEntry->file;
+
+  MAMERomGroup* sampsRomGroupEntry = gameentry->GetRomGroupOfType("oki6295");
+  if (sampsRomGroupEntry && sampsRomGroupEntry->file) {
+    uint32_t instrTablePtrOffset = 4;
+    uint32_t instr_table_offset = programFile->GetShortBE(seq_table_offset + instrTablePtrOffset);
+
+    RawFile *samplesFile = sampsRomGroupEntry->file;
+
+    ostringstream name;
+    name.str("");
+    name << gameentry->name.c_str() << " oki msm6295 instrument set";
+    auto instrset_name = name.str();
+    name.str("");
+    name << gameentry->name.c_str() << " sample collection";
+    auto sampcoll_name = name.str();
+
+    instrset = new CPS1SampleInstrSet(programFile,
+                                      fmt_ver,
+                                      instr_table_offset,
+                                      instrset_name);
+    if (!instrset->LoadVGMFile()) {
+      delete instrset;
+      instrset = NULL;
+    }
+
+    sampcoll = new CPS1SampColl(samplesFile, instrset, 0, samplesFile->size(), sampcoll_name);
+    if (!sampcoll->LoadVGMFile()) {
+      delete sampcoll;
+      sampcoll = NULL;
+    }
+  }
+
+  string seq_table_name;
+  ostringstream name;
+
+  name.str("");
+  name << gameentry->name.c_str() << " sequence pointer table";
+  seq_table_name = name.str();
+
+  uint8_t ptrsStart;
+  const uint8_t ptrSize = 2;
+
+  switch (fmt_ver) {
+    case VER_CPS1_500: ptrsStart = 2; break;
+    case VER_CPS1_200ff: ptrsStart = 3; break;
+    default: ptrsStart = 4;
+  }
+
+  switch (fmt_ver) {
+    case VER_CPS1_200:
+    case VER_CPS1_200ff:
+    case VER_CPS1_350:
+    case VER_CPS1_425:
+    case VER_CPS1_500:
+      seq_table_length = (uint32_t) (programFile->GetByte(seq_table_offset) * 2) + ptrsStart;
+      break;
+    case VER_CPS1_502:
+      seq_table_length = (uint32_t) (programFile->GetShortBE(seq_table_offset) * 2) + ptrsStart;
+      break;
+  }
+
+  unsigned int k = 0;
+  uint32_t seqPointer = 0;
+
+  // Add SeqTable as Miscfile
+  VGMMiscFile *seqTable = new VGMMiscFile(CPS1Format::name, seqRomGroupEntry->file, seq_table_offset, seq_table_length, seq_table_name);
+  if (!seqTable->LoadVGMFile()) {
+    delete seqTable;
+    seqTable = NULL;
+  }
+
+  int seqNum = 0;
+  for (k = ptrsStart; (seq_table_length == 0 || k < seq_table_length); k += ptrSize) {
+
+    seqPointer = programFile->GetShortBE(seq_table_offset + k);
+
+    if (seqPointer == 0) {
+      continue;
+    }
+
+    seqTable->AddSimpleItem(seq_table_offset + k, ptrSize, "Sequence Pointer");
+
+    name.str("");
+    name << gameentry->name.c_str() << " seq " << seqNum;
+    string seqName = name.str();
+    CPSSeq *newSeq = new CPSSeq(programFile, seqPointer, fmt_ver, seqName);
+
+    if (!newSeq->LoadVGMFile()) {
+      delete newSeq;
+      continue;
+    }
+
+    name.str("");
+    name << gameentry->name.c_str() << " song " << seqNum++;
+    VGMColl* coll = new VGMColl(name.str());
+
+    coll->UseSeq(newSeq);
+    coll->AddInstrSet(instrset);
+    coll->AddSampColl(sampcoll);
+    if (!coll->Load()) {
+      delete coll;
+    }
+  }
+}
+

--- a/src/main/formats/CPS1Scanner.h
+++ b/src/main/formats/CPS1Scanner.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "Scanner.h"
+#include "CPS2Scanner.h"
+
+struct MAMEGame;
+
+class CPS1Scanner:
+    public VGMScanner {
+public:
+  virtual void Scan(RawFile* file, void *info = 0);
+private:
+  void LoadCPS1(MAMEGame* gameentry, CPSFormatVer fmt_ver);
+};

--- a/src/main/formats/CPS2Format.h
+++ b/src/main/formats/CPS2Format.h
@@ -1,7 +1,8 @@
 #pragma once
 #include "Format.h"
 #include "VGMColl.h"
-#include "CPSScanner.h"
+#include "CPS2Scanner.h"
+#include "CPS1Scanner.h"
 
 enum CPSSynth {
   QSOUND,
@@ -11,6 +12,10 @@ enum CPSSynth {
 
 constexpr int CPS1_OKIMSM6295_SAMPLE_RATE = 7576; // 1Mhz / 132, rounded
 
-BEGIN_FORMAT(CPS)
-  USING_SCANNER(CPSScanner)
+BEGIN_FORMAT(CPS1)
+  USING_SCANNER(CPS1Scanner)
+END_FORMAT()
+
+BEGIN_FORMAT(CPS2)
+  USING_SCANNER(CPS2Scanner)
 END_FORMAT()

--- a/src/main/formats/CPS2Instr.h
+++ b/src/main/formats/CPS2Instr.h
@@ -3,7 +3,7 @@
 #include "VGMSampColl.h"
 #include "VGMMiscFile.h"
 
-class CPSInstr;
+class CPS2Instr;
 
 enum CPSFormatVer: uint8_t;
 
@@ -200,41 +200,20 @@ public:
   virtual bool LoadMain();
 };
 
-// ******************
-// CPS1SampleInstrSet
-// ******************
-
-class CPS1SampleInstrSet
-    : public VGMInstrSet {
-public:
-  CPS1SampleInstrSet(RawFile *file,
-               CPSFormatVer fmt_version,
-               uint32_t offset,
-               std::string &name);
-  virtual ~CPS1SampleInstrSet(void);
-
-  virtual bool GetInstrPointers();
-
-public:
-  CPSFormatVer fmt_version;
-  CPSSampleInfoTable *sampInfoTable;
-};
-
 // **************
-// CPSInstrSet
+// CPS2InstrSet
 // **************
 
-class CPSInstrSet
-    : public VGMInstrSet {
+class CPS2InstrSet : public VGMInstrSet {
 public:
-  CPSInstrSet(RawFile *file,
+  CPS2InstrSet(RawFile *file,
               CPSFormatVer fmt_version,
               uint32_t offset,
               int numInstrBanks,
               CPSSampleInfoTable *sampInfoTable,
               CPSArticTable *articTable,
               std::string &name);
-  virtual ~CPSInstrSet(void);
+  virtual ~CPS2InstrSet(void);
 
   virtual bool GetHeaderInfo();
   virtual bool GetInstrPointers();
@@ -248,22 +227,21 @@ public:
 
 
 // ***********
-// CPSInstr
+// CPS2Instr
 // ***********
 
-class CPSInstr
-    : public VGMInstr {
+class CPS2Instr : public VGMInstr {
 public:
-  CPSInstr(VGMInstrSet *instrSet,
+  CPS2Instr(VGMInstrSet *instrSet,
            uint32_t offset,
            uint32_t length,
            uint32_t theBank,
            uint32_t theInstrNum,
            std::string &name);
-  virtual ~CPSInstr(void);
+  virtual ~CPS2Instr(void);
   virtual bool LoadInstr();
 protected:
-  CPSFormatVer GetFormatVer() { return ((CPSInstrSet *) parInstrSet)->fmt_version; }
+  CPSFormatVer GetFormatVer() { return ((CPS2InstrSet *) parInstrSet)->fmt_version; }
 
 protected:
   uint8_t attack_rate;
@@ -277,35 +255,18 @@ protected:
 };
 
 // **************
-// CPS1SampColl
+// CPS2SampColl
 // **************
 
-class CPS1SampColl
+class CPS2SampColl
     : public VGMSampColl {
 public:
-  CPS1SampColl(RawFile *file, CPS1SampleInstrSet *instrset, uint32_t offset,
-              uint32_t length = 0, std::string name = std::string("CPS1 Sample Collection"));
-  virtual bool GetHeaderInfo();
-  virtual bool GetSampleInfo();
-
-private:
-  vector<VGMItem*> samplePointers;
-  CPS1SampleInstrSet *instrset;
-};
-
-// **************
-// CPSSampColl
-// **************
-
-class CPSSampColl
-    : public VGMSampColl {
-public:
-  CPSSampColl(RawFile *file, CPSInstrSet *instrset, CPSSampleInfoTable *sampinfotable, uint32_t offset,
+  CPS2SampColl(RawFile *file, CPS2InstrSet *instrset, CPSSampleInfoTable *sampinfotable, uint32_t offset,
               uint32_t length = 0, std::string name = std::string("QSound Sample Collection"));
   virtual bool GetHeaderInfo();
   virtual bool GetSampleInfo();
 
 private:
-  CPSInstrSet *instrset;
+  CPS2InstrSet *instrset;
   CPSSampleInfoTable *sampInfoTable;
 };

--- a/src/main/formats/CPS2Scanner.h
+++ b/src/main/formats/CPS2Scanner.h
@@ -1,10 +1,6 @@
 #pragma once
 #include "Scanner.h"
 
-class CPSInstrSet;
-class CPSSampColl;
-class CPSSampleInfoTable;
-class CPSArticTable;
 struct MAMEGame;
 
 enum CPSFormatVer: uint8_t {
@@ -39,11 +35,12 @@ enum CPSFormatVer: uint8_t {
   VER_CPS3
 };
 
-class CPSScanner:
+CPSFormatVer GetVersionEnum(string &versionStr);
+
+class CPS2Scanner :
     public VGMScanner {
 public:
-  virtual void Scan(RawFile *file, void *info = 0);
-private:
-  void LoadCPS1(MAMEGame *gameentry);
-  CPSFormatVer GetVersionEnum(std::string &versionStr);
+  virtual void Scan(RawFile* file, void *info = 0);
 };
+
+

--- a/src/main/formats/CPSSeq.cpp
+++ b/src/main/formats/CPSSeq.cpp
@@ -2,11 +2,12 @@
 #include "CPSSeq.h"
 #include "CPSTrackV1.h"
 #include "CPSTrackV2.h"
-#include "CPSInstr.h"
+#include "CPS2Instr.h"
 #include "ScaleConversion.h"
 #include "SeqEvent.h"
 
-DECLARE_FORMAT(CPS);
+DECLARE_FORMAT(CPS1);
+DECLARE_FORMAT(CPS2);
 
 
 // ******
@@ -14,7 +15,7 @@ DECLARE_FORMAT(CPS);
 // ******
 
 CPSSeq::CPSSeq(RawFile *file, uint32_t offset, CPSFormatVer fmtVersion, string &name)
-    : VGMSeq(CPSFormat::name, file, offset, 0, name),
+    : VGMSeq(CPS2Format::name, file, offset, 0, name),
       fmt_version(fmtVersion) {
   HasMonophonicTracks();
   AlwaysWriteInitialVol(127);

--- a/src/main/formats/CPSSeq.h
+++ b/src/main/formats/CPSSeq.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "VGMSeq.h"
 #include "SeqTrack.h"
-#include "CPSFormat.h"
+#include "CPS2Format.h"
 
 enum CPSFormatVer: uint8_t;
 

--- a/src/main/formats/CPSTrackV1.h
+++ b/src/main/formats/CPSTrackV1.h
@@ -2,7 +2,7 @@
 #include "VGMSeq.h"
 #include "SeqTrack.h"
 #include "CPSSeq.h"
-#include "CPSFormat.h"
+#include "CPS2Format.h"
 
 enum CPSFormatVer: uint8_t;
 

--- a/src/main/formats/OkiAdpcm.cpp
+++ b/src/main/formats/OkiAdpcm.cpp
@@ -127,30 +127,30 @@ void oki_adpcm_state::compute_tables()
 
 
 //  *****************
-//  DailogicAdpcmSamp
+//  DialogicAdpcmSamp
 //  *****************
 
-oki_adpcm_state DailogicAdpcmSamp::okiAdpcmState;
+oki_adpcm_state DialogicAdpcmSamp::okiAdpcmState;
 
-DailogicAdpcmSamp::DailogicAdpcmSamp(
+DialogicAdpcmSamp::DialogicAdpcmSamp(
     VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t theRate, string name
   )
     : VGMSamp(sampColl, offset, length, offset, length, 1, 16, theRate, name) {
 
 }
 
-DailogicAdpcmSamp::~DailogicAdpcmSamp() {
+DialogicAdpcmSamp::~DialogicAdpcmSamp() {
 }
 
-double DailogicAdpcmSamp::GetCompressionRatio() {
+double DialogicAdpcmSamp::GetCompressionRatio() {
   return (16.0 / 4); // 4 bit samples converted up to 16 bit samples
 }
 
-void DailogicAdpcmSamp::ConvertToStdWave(uint8_t *buf) {
+void DialogicAdpcmSamp::ConvertToStdWave(uint8_t *buf) {
 
   auto* uncompBuf = reinterpret_cast<int16_t*>(buf);
 
-  DailogicAdpcmSamp::okiAdpcmState.reset();
+  DialogicAdpcmSamp::okiAdpcmState.reset();
 
   int sampleNum = 0;
   for (uint32_t off = dwOffset; off < (dwOffset + unLength); ++off) {
@@ -158,7 +158,7 @@ void DailogicAdpcmSamp::ConvertToStdWave(uint8_t *buf) {
 
     for (int n = 0; n < 2; ++n) {
       uint8_t nibble = byte >> (((n & 1) << 2) ^ 4);
-      int16_t sample = DailogicAdpcmSamp::okiAdpcmState.clock(nibble);
+      int16_t sample = DialogicAdpcmSamp::okiAdpcmState.clock(nibble);
       uncompBuf[sampleNum++] = sample;
     }
   }

--- a/src/main/formats/OkiAdpcm.h
+++ b/src/main/formats/OkiAdpcm.h
@@ -42,14 +42,14 @@ private:
   static bool s_tables_computed;
 };
 
-class DailogicAdpcmSamp
+class DialogicAdpcmSamp
     : public VGMSamp {
 public:
 
-  DailogicAdpcmSamp(
+  DialogicAdpcmSamp(
       VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t theRate, string name
   );
-  virtual ~DailogicAdpcmSamp(void);
+  virtual ~DialogicAdpcmSamp(void);
 
   virtual double GetCompressionRatio();
   virtual void ConvertToStdWave(uint8_t *buf);


### PR DESCRIPTION
Note that this PR is basing on top of the previous "okiadpcm" branch PR.

Adding sampled playback for CPS1 expanded the already bloated CPSScanner.cpp and CPSInstr.cpp files. Since the logic for CPS1 is unique, I've moved it into respective CPS1Scanner.cpp and CPS1Instr.cpp files and added a "CPS1" Format.

This leaves us in an awkward spot, as we would have both a "CPS1" format and a "CPS" format, not to mention a CPS1Scanner and a CPSScanner. Thus I've renamed the CPS format to CPS2, CPSScanner to CPS2Scanner and CPSinstr to CPS2Instr. Unfortunately, "CPS2" is partly a misnomer here as both files and formats cover CPS2/CPS3 and some ZN-1/ZN-2 games. Further muddying the waters, CPSSeq, at least for now, is still used by all formats above, and the CPSTrackV1/V2 classes do not align cleanly with any CPS version (there is a CPS2 game that uses the CPS3 sequence structure).

I throw my hands up in the air. I think eliminating the bloat is probably a net improvement.

## How Has This Been Tested?
Tested that CPS1/2/3 games are all loading and playing as expected.
