### PR TITLE
License disclosure stuff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,8 @@ jobs:
             -appimage -extra-plugins=platforms/,platformthemes/ \
             -qmake=/usr/lib/qt6/bin/qmake6 \
             -verbose=10
+          mkdir -p appdir/usr/share/licenses/VGMTrans
+          cp ../LICENSE/LICENSE appdir/usr/share/licenses/VGMTrans/
           mv VGMTrans*.AppImage VGMTrans.AppImage
       - name: "Upload artifact"
         uses: actions/upload-artifact@v3

--- a/LICENSE/LICENSE
+++ b/LICENSE/LICENSE
@@ -1,6 +1,12 @@
+VGMTrans is released under the zlib/libpng license. This distribution
+incorporates code from various projects, each governed by its respective
+license. Full license details can be found in the source distribution's
+LICENSE directory or within the binary application's About dialog under
+the License tab.
+
 The zlib/libpng License
 
-VGMTrans Copyright (c) 2002-2023 The VGMTrans Team
+VGMTrans Copyright (c) 2002-2024 The VGMTrans Team
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages

--- a/LICENSE/LICENSE_oki_adpcm_state
+++ b/LICENSE/LICENSE_oki_adpcm_state
@@ -1,0 +1,38 @@
+Emulation of the OKI MSM6295 DAC is provided by the oki_adpcm_state
+class, which is adopted from the MAME project with gratitude. It is
+licensed under the BSD-3-Clause. The copyright holders are
+Andrew Gardner and Aaron Giles.
+
+The original code is available at:
+https://github.com/mamedev/mame/blob/master/src/devices/sound/okiadpcm.cpp
+
+The BSD-3-Clause license begins below.
+
+--------------------------------------------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/ui/qt/About.h
+++ b/src/ui/qt/About.h
@@ -8,7 +8,16 @@
 
 #include <QDialog>
 
+class QTabWidget;
+
 class About final : public QDialog {
    public:
     explicit About(QWidget *parent = nullptr);
+
+   private:
+    void setupInfoTab(QWidget* tab);
+    void setupLicensesTab(QWidget* tab);
+    void loadLicenses(QMap<QString, QString>& licenses);
+
+    QTabWidget* tabs{};
 };

--- a/src/ui/qt/resources/resources.qrc
+++ b/src/ui/qt/resources/resources.qrc
@@ -1,5 +1,6 @@
 <!DOCTYPE RCC><RCC version="1.0">
 <qresource>
+  <file>vgmtrans.png</file>
   <file>fonts/Roboto_Mono/RobotoMono-VariableFont_wght.ttf</file>
   <file>images/open_file.svg</file>
   <file>images/player_play.svg</file>
@@ -21,6 +22,7 @@
   <file>images/binary.svg</file>
   <file>images/rest.svg</file>
   <file>images/tempo.svg</file>
-  <file>vgmtrans.png</file>
+  <file alias="legal/VGMTrans">../../../../LICENSE/LICENSE</file>
+  <file alias="legal/oki_adpcm_state">../../../../LICENSE/LICENSE_oki_adpcm_state</file>
 </qresource>
 </RCC>


### PR DESCRIPTION
This adds a bit of structure for adding third party licenses to our repo and the app.

- I added a LICENSE directory that stores our license and the licenses of external source code.
- I added a preface to our LICENSE which acknowledge the use of external source code and directs readers to the LICENSES directory and About dialog.
- I added a new License tab to the About dialog that provides a simple interface for browsing licenses.

To add a new third-party license, simply put the license in the LICENSES directory and add an entry for the file in resources.qrc with an alias of "legal/\<name that should appear in About Dialog\>".

## How Has This Been Tested?
Tested on MacOS. Will test on Windows/Linux.

## Screenshots (if appropriate):
<img width="779" alt="image" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/577483ec-56ff-46b9-a9d4-0962f6ac4895">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
