### PR TITLE
Change collection list double-click behavior to play/pause

### DIFF
--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -102,12 +102,14 @@ VGMCollListView::VGMCollListView(QWidget *parent) : QListView(parent) {
   setItemDelegate(new VGMCollNameEditor);
 
   setContextMenuPolicy(Qt::CustomContextMenu);
-  setSelectionMode(QAbstractItemView::ExtendedSelection);
-  setEditTriggers(QAbstractItemView::DoubleClicked);
+  setSelectionMode(QAbstractItemView::SingleSelection);
+  setEditTriggers(QAbstractItemView::NoEditTriggers);
   setResizeMode(QListView::Adjust);
   setIconSize(QSize(16, 16));
   setWrapping(true);
 
+  connect(this, &QListView::doubleClicked, this,
+          &VGMCollListView::handlePlaybackRequest);
   connect(this, &QAbstractItemView::customContextMenuRequested, this,
           &VGMCollListView::collectionMenu);
   connect(model, &VGMCollListViewModel::dataChanged, [=]() {


### PR DESCRIPTION
## Description
Currently, double clicking a collection puts the collection name into an edit mode. I don't think this provides much value to the user.

I can think of two more-helpful responses to a double click:
1) play/pause the sequence player for the clicked collection
2) open up the hex view for the associated sequence file of the clicked collection

I went with 1.

I also changed the selection behavior to only allow selection of one collection at a time, since that is the paradigm we use with the VGMCollView (to the left of the VGMCollListView).

## How Has This Been Tested?
Played around with it. Haven't been able to break it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
