### PR TITLE
Fix mdi window bug, add unified vgm file selection behavior

### DIFF
--- a/src/main/VGMColl.cpp
+++ b/src/main/VGMColl.cpp
@@ -611,3 +611,24 @@ bool VGMColl::OnSaveAllSF2() {
   }
   return true;
 }
+
+// A helper lambda function to search a vector of VGMFile* for the file
+template<typename T>
+bool contains(const std::vector<T*>& vec, const VGMFile* file) {
+  return std::any_of(vec.begin(), vec.end(), [file](const VGMFile* elem) {
+    return elem == file;
+  });
+}
+
+bool VGMColl::containsVGMFile(const VGMFile* file) const {
+  // First, check if the file matches the seq property directly
+  if (seq == file) {
+    return true;
+  }
+
+  // Then, check in the vectors if the file is present
+  if (contains(instrsets, file) || contains(sampcolls, file) || contains(miscfiles, file)) {
+    return true;
+  }
+  return false;
+}

--- a/src/main/VGMColl.cpp
+++ b/src/main/VGMColl.cpp
@@ -612,7 +612,7 @@ bool VGMColl::OnSaveAllSF2() {
   return true;
 }
 
-// A helper lambda function to search a vector of VGMFile* for the file
+// A helper lambda function to search for a file in a vector of VGMFile*
 template<typename T>
 bool contains(const std::vector<T*>& vec, const VGMFile* file) {
   return std::any_of(vec.begin(), vec.end(), [file](const VGMFile* elem) {
@@ -626,7 +626,7 @@ bool VGMColl::containsVGMFile(const VGMFile* file) const {
     return true;
   }
 
-  // Then, check in the vectors if the file is present
+  // Then, check if the file is present in any of the file vectors
   if (contains(instrsets, file) || contains(sampcolls, file) || contains(miscfiles, file)) {
     return true;
   }

--- a/src/main/VGMColl.h
+++ b/src/main/VGMColl.h
@@ -37,6 +37,8 @@ class VGMColl
   bool OnSaveAllDLS();
   bool OnSaveAllSF2();
 
+  bool containsVGMFile(const VGMFile*) const;
+
   VGMSeq *seq;
   std::vector<VGMInstrSet *> instrsets;
   std::vector<VGMSampColl *> sampcolls;

--- a/src/ui/qt/workarea/MdiArea.h
+++ b/src/ui/qt/workarea/MdiArea.h
@@ -31,8 +31,17 @@ public:
 
   void newView(VGMFile *file);
   void removeView(VGMFile *file);
+  void focusView(VGMFile *file, QWidget *caller);
+
+signals:
+  void vgmFileSelected(VGMFile *file);
+
+public slots:
+  void onSubWindowActivated(QMdiSubWindow *window);
 
 private:
   MdiArea(QWidget *parent = nullptr);
-  std::unordered_map<VGMFile *, QMdiSubWindow *> m_registered_views;
+  void ensureMaximizedSubWindow(QMdiSubWindow *window);
+  std::unordered_map<VGMFile *, QMdiSubWindow *> fileToWindowMap;
+  std::unordered_map<QMdiSubWindow *, VGMFile *> windowToFileMap;
 };

--- a/src/ui/qt/workarea/VGMCollView.cpp
+++ b/src/ui/qt/workarea/VGMCollView.cpp
@@ -154,7 +154,7 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
   m_listview->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
   connect(m_listview, &QListView::doubleClicked, this, &VGMCollView::doubleClickedSlot);
-  connect(m_listview->selectionModel(), &QItemSelectionModel::currentChanged, this, &VGMCollView::handleSelectionChanged);
+  connect(m_listview->selectionModel(), &QItemSelectionModel::selectionChanged, this, &VGMCollView::handleSelectionChanged);
   connect(MdiArea::the(), &MdiArea::vgmFileSelected, this, &VGMCollView::selectRowForVGMFile);
 
 
@@ -196,14 +196,20 @@ void VGMCollView::doubleClickedSlot(QModelIndex index) {
   MdiArea::the()->newView(file_to_open);
 }
 
-void VGMCollView::handleSelectionChanged(const QModelIndex &current, const QModelIndex &previous) {
-  Q_UNUSED(previous);
+void VGMCollView::handleSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected) {
+  Q_UNUSED(deselected);
 
-  if (current.isValid()) {
-    auto index = vgmCollViewModel->index(current.row());
-    VGMFile* file = vgmCollViewModel->fileFromIndex(index);
-    MdiArea::the()->focusView(file, this);
-  }
+  if (selected.indexes().isEmpty())
+    return;
+
+  QModelIndex firstSelectedIndex = selected.indexes().first();
+
+  if (!firstSelectedIndex.isValid())
+    return;
+
+  auto index = vgmCollViewModel->index(firstSelectedIndex.row());
+  VGMFile* file = vgmCollViewModel->fileFromIndex(index);
+  MdiArea::the()->focusView(file, this);
 }
 
 void VGMCollView::selectRowForVGMFile(VGMFile *file) {

--- a/src/ui/qt/workarea/VGMCollView.h
+++ b/src/ui/qt/workarea/VGMCollView.h
@@ -9,8 +9,8 @@
 #include <QAbstractListModel>
 #include <QGroupBox>
 #include <QItemSelectionModel>
+#include "VGMColl.h"
 
-class VGMColl;
 class VGMFile;
 class QLabel;
 class QListView;
@@ -25,6 +25,8 @@ public:
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
 
   [[nodiscard]] VGMFile *fileFromIndex(QModelIndex index) const;
+  [[nodiscard]] QModelIndex indexFromFile(VGMFile* file) const;
+  bool containsVGMFile(VGMFile* file);
 
 public slots:
   void handleNewCollSelected(QModelIndex modelIndex);
@@ -38,10 +40,13 @@ class VGMCollView : public QGroupBox {
 public:
   VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent = 0);
 
-public slots:
+private slots:
   void doubleClickedSlot(QModelIndex);
+  void handleSelectionChanged(const QModelIndex &current, const QModelIndex &previous);
+  void selectRowForVGMFile(VGMFile *file);
 
 private:
+  VGMCollViewModel *vgmCollViewModel;
   QLineEdit *m_collection_title;
   QListView *m_listview;
   QLabel *m_title;

--- a/src/ui/qt/workarea/VGMCollView.h
+++ b/src/ui/qt/workarea/VGMCollView.h
@@ -42,7 +42,7 @@ public:
 
 private slots:
   void doubleClickedSlot(QModelIndex);
-  void handleSelectionChanged(const QModelIndex &current, const QModelIndex &previous);
+  void handleSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
   void selectRowForVGMFile(VGMFile *file);
 
 private:

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -144,7 +144,7 @@ VGMFileListView::VGMFileListView(QWidget *parent) : QTableView(parent) {
   connect(this, &QAbstractItemView::customContextMenuRequested, this, &VGMFileListView::itemMenu);
   connect(this, &QAbstractItemView::doubleClicked, this, &VGMFileListView::requestVGMFileView);
   connect( MdiArea::the(), &MdiArea::vgmFileSelected, this, &VGMFileListView::selectRowForVGMFile);
-  connect(selectionModel(), &QItemSelectionModel::currentChanged, this, &VGMFileListView::handleSelectionChanged);
+  connect(selectionModel(), &QItemSelectionModel::selectionChanged, this, &VGMFileListView::handleSelectionChanged);
 }
 
 void VGMFileListView::onHeaderSectionResized(int index, int oldSize, int newSize) {
@@ -235,13 +235,18 @@ void VGMFileListView::requestVGMFileView(QModelIndex index) {
   MdiArea::the()->newView(qtVGMRoot.vVGMFile[index.row()]);
 }
 
-void VGMFileListView::handleSelectionChanged(const QModelIndex &current, const QModelIndex &previous) {
-  Q_UNUSED(previous);
+void VGMFileListView::handleSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected) {
+  Q_UNUSED(deselected);
 
-  if (current.isValid()) {
-    VGMFile* file = qtVGMRoot.vVGMFile[current.row()];
-    MdiArea::the()->focusView(file, this);
-  }
+  if (selected.indexes().isEmpty())
+    return;
+
+  QModelIndex firstSelectedIndex = selected.indexes().first();
+  if (!firstSelectedIndex.isValid())
+    return;
+
+  VGMFile* file = qtVGMRoot.vVGMFile[firstSelectedIndex.row()];
+  MdiArea::the()->focusView(file, this);
 }
 
 void VGMFileListView::selectRowForVGMFile(VGMFile *file) {

--- a/src/ui/qt/workarea/VGMFileListView.h
+++ b/src/ui/qt/workarea/VGMFileListView.h
@@ -43,6 +43,7 @@ class VGMFileListView final : public QTableView {
    public slots:
     void requestVGMFileView(QModelIndex index);
     void removeVGMFile(VGMFile *file);
+    void selectRowForVGMFile(VGMFile *file);
 
    protected:
     void scrollContentsBy(int dx, int dy) override;
@@ -50,6 +51,7 @@ class VGMFileListView final : public QTableView {
 
    private slots:
     void onHeaderSectionResized(int index, int oldSize, int newSize);
+    void handleSelectionChanged(const QModelIndex &current, const QModelIndex &previous);
 
    private:
     void keyPressEvent(QKeyEvent *input) override;

--- a/src/ui/qt/workarea/VGMFileListView.h
+++ b/src/ui/qt/workarea/VGMFileListView.h
@@ -51,7 +51,7 @@ class VGMFileListView final : public QTableView {
 
    private slots:
     void onHeaderSectionResized(int index, int oldSize, int newSize);
-    void handleSelectionChanged(const QModelIndex &current, const QModelIndex &previous);
+    void handleSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 
    private:
     void keyPressEvent(QKeyEvent *input) override;


### PR DESCRIPTION
**Update: I discovered that this PR is vulnerable to a separate dangling pointer bug that can cause a crash. It's fixed here: #447**

## Description

I would have split this into two PRs, but there's overlap.

1) There's a bug whereby closing an MDI window causes every other open MDI window to become windowed instead of maximized. To fix this, I've added a new ensureMaximizedSubWindow() function that gets called every time the subWindowActivated signal is fired by MdiArea.

2) The WTL version had a UI behavior whereby selecting a file in the vgm file list or focusing its MDI window caused both to be selected/focused. I've added this behavior back in and extended it to the VGMCollView. 

## How Has This Been Tested?
Thorough clicking and clacking.

## Screenshots (if appropriate):
The MDI window bug. Closing a window often results in something like this:
<img width="865" alt="image" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/a28d9198-47f0-4fb7-aa72-109712b70899">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
