### PR TITLE
Fix VGMCollView not updating its model immediately after VGMColl deletion

### DIFF
--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -41,7 +41,7 @@ class VGMRoot {
   void AddVGMFile(VGMFile *theFile);
   void RemoveVGMFile(VGMFile *theFile, bool bRemoveFromRaw = true);
   void AddVGMColl(VGMColl *theColl);
-  void RemoveVGMColl(VGMColl *theFile);
+  void RemoveVGMColl(VGMColl *theColl);
   void AddLogItem(LogItem *theLog);
   void AddScanner(const std::string &formatname);
 

--- a/src/ui/qt/QtVGMRoot.cpp
+++ b/src/ui/qt/QtVGMRoot.cpp
@@ -82,10 +82,6 @@ void QtVGMRoot::UI_AddVGMColl(VGMColl*) {
   this->UI_AddedVGMColl();
 }
 
-void QtVGMRoot::UI_RemoveVGMColl(VGMColl*) {
-  this->UI_RemovedVGMColl();
-}
-
 void QtVGMRoot::UI_BeginRemoveVGMFiles() {
   this->UI_BeganRemovingVGMFiles();
 }

--- a/src/ui/qt/QtVGMRoot.h
+++ b/src/ui/qt/QtVGMRoot.h
@@ -33,7 +33,6 @@ public:
   void UI_AddVGMSampColl(VGMSampColl* theSampColl) override;
   void UI_AddVGMMisc(VGMMiscFile* theMiscFile) override;
   void UI_AddVGMColl(VGMColl* theColl) override;
-  void UI_RemoveVGMColl(VGMColl* targColl) override;
   void UI_BeginRemoveVGMFiles() override;
   void UI_EndRemoveVGMFiles() override;
   void UI_AddItem(VGMItem* item, VGMItem* parent, const std::string& itemName,
@@ -57,6 +56,7 @@ signals:
   void UI_AddedVGMFile();
   void UI_AddedVGMColl();
   void UI_RemovedVGMColl();
+  void UI_RemoveVGMColl(VGMColl* targColl) override;
   void UI_RemoveVGMFile(VGMFile* targFile) override;
   void UI_AddLogItem(LogItem* theLog) override;
 };

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -45,7 +45,7 @@ VGMCollListViewModel::VGMCollListViewModel(QObject *parent) : QAbstractListModel
             if (!resettingModel)
               dataChanged(index(0, 0), index(rowCount() - 1, 0));
           });
-  connect(&qtVGMRoot, &QtVGMRoot::UI_RemovedVGMColl,
+  connect(&qtVGMRoot, &QtVGMRoot::UI_RemoveVGMColl,
           [=]() {
             if (!resettingModel)
               dataChanged(index(0, 0), index(rowCount() - 1, 0));

--- a/src/ui/qt/workarea/VGMCollView.cpp
+++ b/src/ui/qt/workarea/VGMCollView.cpp
@@ -125,6 +125,14 @@ bool VGMCollViewModel::containsVGMFile(VGMFile* file) {
   return m_coll->containsVGMFile(file);
 }
 
+void VGMCollViewModel::removeVGMColl(VGMColl* coll) {
+  if (m_coll != coll)
+    return;
+
+  // Select an invalid index to clear the view
+  handleNewCollSelected(QModelIndex());
+}
+
 
 VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
     : QGroupBox("Selected collection", parent) {
@@ -153,6 +161,7 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
   m_listview->setSelectionRectVisible(true);
   m_listview->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
+  connect(&qtVGMRoot, &QtVGMRoot::UI_RemoveVGMColl, this, &VGMCollView::removeVGMColl);
   connect(m_listview, &QListView::doubleClicked, this, &VGMCollView::doubleClickedSlot);
   connect(m_listview->selectionModel(), &QItemSelectionModel::selectionChanged, this, &VGMCollView::handleSelectionChanged);
   connect(MdiArea::the(), &MdiArea::vgmFileSelected, this, &VGMCollView::selectRowForVGMFile);
@@ -189,6 +198,14 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
   });
 
   setLayout(layout);
+}
+
+void VGMCollView::removeVGMColl(VGMColl *coll) {
+  if (vgmCollViewModel->m_coll != coll)
+    return;
+
+  m_collection_title->setText("No collection selected");
+  vgmCollViewModel->removeVGMColl(coll);
 }
 
 void VGMCollView::doubleClickedSlot(QModelIndex index) {

--- a/src/ui/qt/workarea/VGMCollView.h
+++ b/src/ui/qt/workarea/VGMCollView.h
@@ -30,8 +30,9 @@ public:
 
 public slots:
   void handleNewCollSelected(QModelIndex modelIndex);
+  void removeVGMColl(VGMColl* coll);
 
-private:
+public:
   VGMColl *m_coll;
 };
 
@@ -41,6 +42,7 @@ public:
   VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent = 0);
 
 private slots:
+  void removeVGMColl(VGMColl *coll);
   void doubleClickedSlot(QModelIndex);
   void handleSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
   void selectRowForVGMFile(VGMFile *file);


### PR DESCRIPTION
## Description
Turns out there is a crashing bug in #446. The issue is a dangling pointer in VGMCollViewModel that #446 accesses. When a user deletes a collection, VGMCollViewModel does not check if the deleted collection is the one pointed to by its m_coll property.

In #446, if the user selects a collection, then deletes it by removing any of its files, then attempts to open the MDI window of any file, the VGMCollViewModel::containsVGMFile() may cause a crash when it dereferences m_coll.

This fixes the bug by handling the UI_RemoveVGMColl() callback in VGMCollView to check if the removed collection is selected. If so, it updates the model accordingly. Yes, we should probably be using smart pointers here and everywhere.

Note that I removed `UI_RemovedVGMColl()` and upgraded `UI_RemoveVGMColl(VGMColl*)` to a signal in its place.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
