### PR TITLE
Fix a Windows bug causing new subwindows to flash

### DIFF
--- a/src/ui/qt/workarea/MdiArea.cpp
+++ b/src/ui/qt/workarea/MdiArea.cpp
@@ -43,7 +43,7 @@ void MdiArea::newView(VGMFile *file) {
     auto tab = addSubWindow(vgmfile_view, Qt::SubWindow);
     fileToWindowMap.insert(std::make_pair(file, tab));
     windowToFileMap.insert(std::make_pair(tab, file));
-    tab->show();
+    tab->showMaximized();
   }
 }
 

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -30,7 +30,6 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
   m_hexScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   m_hexScrollArea->setWidgetResizable(true);
   m_hexScrollArea->setWidget(m_hexview);
-  m_hexScrollArea->show();
 
   m_splitter->addWidget(m_hexScrollArea);
   m_splitter->addWidget(m_treeview);


### PR DESCRIPTION
## Description
There is a Windows-specific bug that occurs when a VGMFile is opened into the MdiArea. A new window will flash and then disappear before the sub window is created.

The culprit is an unnecessary call to `m_hexScrollArea->show()` in `VGMFileView.cpp`.

I've removed this call, and I've also changed the call in MdiArea from `tab->show()` to `tab->showMaximized()`. While this change isn't necessary for the window to display maximized, it seems more reflective of our intentions. I'm confused why windows are appearing maximized even when we call `tab->show()`. Unfortunately, this change doesn't obviate the need for my last fix with `ensureMaximizedSubWindow()`.

## How Has This Been Tested?
Tested on Windows 10

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
