### PR TITLE
Add SnappingSplitter for HexView

### DIFF
--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -74,6 +74,8 @@ add_executable(
   util/UIHelpers.h
   widgets/MarqueeLabel.cpp
   widgets/MarqueeLabel.h
+  widgets/SnappingSplitter.cpp
+  widgets/SnappingSplitter.h
   widgets/TableView.cpp
   widgets/TableView.h
   widgets/TitleBar.cpp

--- a/src/ui/qt/widgets/SnappingSplitter.cpp
+++ b/src/ui/qt/widgets/SnappingSplitter.cpp
@@ -1,0 +1,82 @@
+/*
+* VGMTrans (c) 2002-2024
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+ */
+
+#pragma once
+
+#include "SnappingSplitter.h"
+#include <QMouseEvent>
+
+SnappingSplitter::SnappingSplitter(Qt::Orientation orientation, QWidget* parent)
+    : QSplitter(orientation, parent) {
+  connect(this, &SnappingSplitter::splitterMoved, this, &SnappingSplitter::onSplitterMoved);
+}
+
+void SnappingSplitter::onSplitterMoved() {
+  printf("splitterMoved\n");
+  enforceConfigurations();
+  state = saveState();
+}
+
+void SnappingSplitter::resizeEvent(QResizeEvent* event) {
+  QSplitter::resizeEvent(event);
+  restoreState(state);
+  enforceConfigurationsOnResize();
+}
+
+void SnappingSplitter::enforceConfigurations() {
+  for (const CollapseRange& range : collapseRanges) {
+    QList<int> sizes = this->sizes();
+
+    int halfway = range.upperBound + (range.lowerBound - range.upperBound) / 2;
+    if (sizes[range.index] <= range.upperBound && sizes[range.index] > range.lowerBound) {
+      if (sizes[range.index] > halfway) {
+        // Hold the size at upperBound until halfway point is crossed
+        setSizesToUpperBound(range.index, range.upperBound);
+      } else if (sizes[range.index] <= halfway) {
+        // Collapse when halfway point is crossed
+        setSizesToLowerBound(range.index, range.lowerBound);
+      }
+    }
+  }
+}
+
+// On a resize event, we immediately collapse when the size is in range, because minimum
+// width settings on the other view may otherwise force sizing within the collapsed range
+void SnappingSplitter::enforceConfigurationsOnResize() {
+  for (const CollapseRange& range : collapseRanges) {
+    QList<int> sizes = this->sizes();
+
+    if (sizes[range.index] < range.upperBound && sizes[range.index] > range.lowerBound) {
+        setSizesToLowerBound(range.index, range.lowerBound);
+    }
+  }
+}
+
+void SnappingSplitter::setSizesToUpperBound(int index, int threshold) {
+  QList<int> newSizes = this->sizes();
+  newSizes[index] = threshold;
+  newSizes[!index] = this->size().width() - threshold - this->handleWidth();
+  this->setSizes(newSizes);
+}
+
+void SnappingSplitter::setSizesToLowerBound(int index, int collapsePoint) {
+  QList<int> newSizes = this->sizes();
+  newSizes[index] = collapsePoint;
+  newSizes[!index] = this->size().width() - collapsePoint - this->handleWidth();
+  this->setSizes(newSizes);
+}
+
+void SnappingSplitter::addCollapseRange(int index, int lowerBound, int upperBound) {
+  collapseRanges.append({index, lowerBound, upperBound});
+}
+
+void SnappingSplitter::clearCollapseRanges() {
+  collapseRanges.clear();
+}
+
+void SnappingSplitter::persistState() {
+  state = saveState();
+}

--- a/src/ui/qt/widgets/SnappingSplitter.cpp
+++ b/src/ui/qt/widgets/SnappingSplitter.cpp
@@ -7,8 +7,6 @@
 #pragma once
 
 #include "SnappingSplitter.h"
-#include <QMouseEvent>
-#include <QScrollArea>
 
 SnappingSplitter::SnappingSplitter(Qt::Orientation orientation, QWidget* parent)
     : QSplitter(orientation, parent) {
@@ -16,23 +14,14 @@ SnappingSplitter::SnappingSplitter(Qt::Orientation orientation, QWidget* parent)
 }
 
 void SnappingSplitter::onSplitterMoved() {
-  printf("splitterMoved\n");
   enforceSnapRanges();
-  state = saveState();
   persistState();
 }
 
 void SnappingSplitter::resizeEvent(QResizeEvent* event) {
-//  QSplitter::resizeEvent(event);
-//  if (bDoRestore) {
-    restoreState(state);
-    bDoRestore = false;
-//  }
-//  printf("sizes[0]: %d\n", sizes()[0]);
-
-    if (!enforceSnapRangesOnResize()) {
-      forceWidgetWidth(0);
-    }
+  QSplitter::resizeEvent(event);
+  restoreState(state);
+  enforceSnapRangesOnResize();
 }
 
 void SnappingSplitter::enforceSnapRanges() {
@@ -54,17 +43,14 @@ void SnappingSplitter::enforceSnapRanges() {
 
 // On a resize event, we immediately collapse when the size is in range, because minimum
 // width settings on the other view may otherwise force sizing within the collapsed range
-bool SnappingSplitter::enforceSnapRangesOnResize() {
+void SnappingSplitter::enforceSnapRangesOnResize() {
   for (const SnapRange& range : snapRanges) {
     QList<int> sizes = this->sizes();
 
-//    printf("%d   %d  %d\n", sizes[range.index], range.lowerBound, range.upperBound);
     if (sizes[range.index] < range.upperBound && sizes[range.index] > range.lowerBound) {
         setSizesToLowerBound(range.index, range.lowerBound);
-        return true;
     }
   }
-  return false;
 }
 
 void SnappingSplitter::setSizesToUpperBound(int index, int threshold) {
@@ -72,7 +58,6 @@ void SnappingSplitter::setSizesToUpperBound(int index, int threshold) {
   newSizes[index] = threshold;
   newSizes[!index] = this->size().width() - threshold - this->handleWidth();
   this->setSizes(newSizes);
-  forceWidgetWidth(index);
 }
 
 void SnappingSplitter:: setSizesToLowerBound(int index, int collapsePoint) {
@@ -80,17 +65,6 @@ void SnappingSplitter:: setSizesToLowerBound(int index, int collapsePoint) {
   newSizes[index] = collapsePoint;
   newSizes[!index] = this->size().width() - collapsePoint - this->handleWidth();
   this->setSizes(newSizes);
-  forceWidgetWidth(index);
-}
-
-void SnappingSplitter::forceWidgetWidth(int index) {
-//  int size = sizes()[index];
-//  auto maybeScrollArea = dynamic_cast<QScrollArea*>(widget(index));
-//  if (maybeScrollArea) {
-//    maybeScrollArea->widget()->setFixedWidth(size);
-//  } else {
-//    widget(index)->setFixedWidth(size);
-//  }
 }
 
 void SnappingSplitter::addSnapRange(int index, int lowerBound, int upperBound) {
@@ -103,5 +77,4 @@ void SnappingSplitter::clearSnapRanges() {
 
 void SnappingSplitter::persistState() {
   state = saveState();
-  bDoRestore = true;
 }

--- a/src/ui/qt/widgets/SnappingSplitter.h
+++ b/src/ui/qt/widgets/SnappingSplitter.h
@@ -12,24 +12,22 @@
 
 class QMouseEvent;
 
-// A CollapseRange will prevent the splitter from setting the size of the view to any value between
-// the upper and lower bound, instead snapping to the closest bound when mouse is within the range.
-struct CollapseRange {
+// A SnapRange prevents the splitter from setting the size of the view to any value between the
+// upper and lower bound, instead snapping to the closest bound when mouse is within the range.
+struct SnapRange {
   int index;          // Index of the widget this behavior should apply to (0 or 1)
   int lowerBound;     // Lower bound for snapping
   int upperBound;     // Upper bound for snapping
 };
 
 class SnappingSplitter : public QSplitter {
-  QList<CollapseRange> collapseRanges;
-
 public:
-  SnappingSplitter(Qt::Orientation orientation, QWidget* parent = nullptr);
+  explicit SnappingSplitter(Qt::Orientation orientation, QWidget* parent = nullptr);
 
-  void enforceConfigurations();
-  void enforceConfigurationsOnResize();
-  void addCollapseRange(int index, int lowerBound, int upperBound);
-  void clearCollapseRanges();
+  void enforceSnapRanges();
+  bool enforceSnapRangesOnResize();
+  void addSnapRange(int index, int lowerBound, int upperBound);
+  void clearSnapRanges();
 
   void persistState();
   QByteArray state;
@@ -39,4 +37,9 @@ protected:
   void resizeEvent(QResizeEvent* event) override;
   void setSizesToUpperBound(int index, int threshold);
   void setSizesToLowerBound(int index, int threshold);
+  void forceWidgetWidth(int index);
+
+private:
+  QList<SnapRange> snapRanges;
+  bool bDoRestore = false;
 };

--- a/src/ui/qt/widgets/SnappingSplitter.h
+++ b/src/ui/qt/widgets/SnappingSplitter.h
@@ -1,0 +1,42 @@
+/*
+* VGMTrans (c) 2002-2024
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+ */
+
+#pragma once
+
+#include <QSplitter>
+#include <QSplitterHandle>
+#include <QList>
+
+class QMouseEvent;
+
+// A CollapseRange will prevent the splitter from setting the size of the view to any value between
+// the upper and lower bound, instead snapping to the closest bound when mouse is within the range.
+struct CollapseRange {
+  int index;          // Index of the widget this behavior should apply to (0 or 1)
+  int lowerBound;     // Lower bound for snapping
+  int upperBound;     // Upper bound for snapping
+};
+
+class SnappingSplitter : public QSplitter {
+  QList<CollapseRange> collapseRanges;
+
+public:
+  SnappingSplitter(Qt::Orientation orientation, QWidget* parent = nullptr);
+
+  void enforceConfigurations();
+  void enforceConfigurationsOnResize();
+  void addCollapseRange(int index, int lowerBound, int upperBound);
+  void clearCollapseRanges();
+
+  void persistState();
+  QByteArray state;
+
+protected:
+  void onSplitterMoved();
+  void resizeEvent(QResizeEvent* event) override;
+  void setSizesToUpperBound(int index, int threshold);
+  void setSizesToLowerBound(int index, int threshold);
+};

--- a/src/ui/qt/widgets/SnappingSplitter.h
+++ b/src/ui/qt/widgets/SnappingSplitter.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <QSplitter>
-#include <QSplitterHandle>
 #include <QList>
 
 class QMouseEvent;
@@ -25,7 +24,7 @@ public:
   explicit SnappingSplitter(Qt::Orientation orientation, QWidget* parent = nullptr);
 
   void enforceSnapRanges();
-  bool enforceSnapRangesOnResize();
+  void enforceSnapRangesOnResize();
   void addSnapRange(int index, int lowerBound, int upperBound);
   void clearSnapRanges();
 
@@ -37,9 +36,7 @@ protected:
   void resizeEvent(QResizeEvent* event) override;
   void setSizesToUpperBound(int index, int threshold);
   void setSizesToLowerBound(int index, int threshold);
-  void forceWidgetWidth(int index);
 
 private:
   QList<SnapRange> snapRanges;
-  bool bDoRestore = false;
 };

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -183,9 +183,8 @@ void HexView::setSelectedItem(VGMItem *item) {
 }
 
 void HexView::resizeOverlays(int height) {
-  int x = hexXOffset() - (charWidth/2);
   overlay->setGeometry(
-      x,
+      hexXOffset() - (charWidth/2),
       overlay->y(),
       ((BYTES_PER_LINE * 3 + HEX_TO_ASCII_SPACING_CHARS + BYTES_PER_LINE) * charWidth) + charWidth/2,
       height
@@ -231,8 +230,6 @@ void HexView::changeEvent(QEvent *event) {
           if (event->type() == QEvent::Resize) {
             QScrollArea* scrollArea = getContainingScrollArea(this);
 
-            printf("scrollArea->width: %d\n", scrollArea->width());
-
             int scrollAreaWidth = scrollArea->width();
             int scrollAreaHeight = scrollArea->height();
 
@@ -259,9 +256,6 @@ void HexView::changeEvent(QEvent *event) {
               drawSelectedItem();
               redrawOverlay();
             }
-
-            printf("scrollArea->width: %d  scrollArea->viewport()->width() %d  width(): %d\n",
-                   scrollArea->width(), scrollArea->viewport()->width(), QWidget::width());
 
             // For optimization, we hide/show the selection view on scroll based on whether it's in viewport, but
             // scroll events don't trigger on resize, and the user could expand the viewport so that it's in view

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -103,6 +103,12 @@ int HexView::getVirtualWidth() const {
   return (numChars * charWidth) + SELECTION_PADDING;
 }
 
+int HexView::getVirtualWidthSansAscii() const {
+  const int numChars = NUM_ADDRESS_NIBBLES + ADDRESS_SPACING_CHARS + (BYTES_PER_LINE * 3) +
+                       (HEX_TO_ASCII_SPACING_CHARS / 2);
+  return (numChars * charWidth) + SELECTION_PADDING;
+}
+
 int HexView::getTotalLines() {
   return (vgmfile->unLength + BYTES_PER_LINE - 1) / BYTES_PER_LINE;
 }

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -21,6 +21,7 @@ public:
   void setSelectedItem(VGMItem* item);
   void setFont(QFont& font);
   int getVirtualWidth() const;
+  int getVirtualWidthSansAscii() const;
 
 protected:
   bool event(QEvent *event) override;

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -22,6 +22,10 @@ public:
   void setFont(QFont& font);
   int getVirtualWidth() const;
   int getVirtualWidthSansAscii() const;
+  int getVirtualWidthSansAsciiAndAddress() const;
+  int getViewportWidth() const;
+  int getViewportWidthSansAscii() const;
+  int getViewportWidthSansAsciiAndAddress() const;
 
 protected:
   bool event(QEvent *event) override;
@@ -36,6 +40,7 @@ protected:
   void mouseDoubleClickEvent(QMouseEvent* event) override;
 
 private:
+  int hexXOffset();
   int getVirtualHeight();
   int getTotalLines();
   int getOffsetFromPoint(QPoint pos);
@@ -76,6 +81,9 @@ private:
   int lineHeight;
   bool addressAsHex = true;
   bool isDragging = false;
+  bool showOffset = true;
+  int prevWidth = 0;
+  int prevHeight = 0;
 
   QCache<int, QPixmap> lineCache;
   QGraphicsOpacityEffect* overlayOpacityEffect = nullptr;

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -39,8 +39,7 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
   m_splitter->setStretchFactor(0, 0);
   m_splitter->setStretchFactor(1, 1);
   m_splitter->persistState();
-  m_splitter->addSnapRange(0, hexViewWidthSansAsciiAndAddress(), hexViewWidthSansAscii());
-  m_splitter->addSnapRange(0, hexViewWidthSansAscii(), hexViewWidth());
+  resetSnapRanges();
   m_hexScrollArea->setMaximumWidth(hexViewWidth());
   m_treeview->setMinimumWidth(treeViewMinimumWidth);
 
@@ -69,6 +68,12 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
   });
 
   setWidget(m_splitter);
+}
+
+void VGMFileView::resetSnapRanges() {
+  m_splitter->clearSnapRanges();
+  m_splitter->addSnapRange(0, hexViewWidthSansAsciiAndAddress(), hexViewWidthSansAscii());
+  m_splitter->addSnapRange(0, hexViewWidthSansAscii(), hexViewWidth());
 }
 
 int VGMFileView::hexViewWidth() {
@@ -110,9 +115,7 @@ void VGMFileView::updateHexViewFont(qreal sizeIncrement) {
   int fullWidthAfterResize = hexViewWidth();
   int widthChange = fullWidthAfterResize - fullWidthBeforeResize;
   int newWidth = actualWidthBeforeResize + static_cast<int>(round(static_cast<float>(widthChange) * percentHexViewVisible));
-  m_splitter->clearSnapRanges();
-  m_splitter->addSnapRange(0, hexViewWidthSansAsciiAndAddress(), hexViewWidthSansAscii());
-  m_splitter->addSnapRange(0, hexViewWidthSansAscii(), hexViewWidth());
+  resetSnapRanges();
   m_splitter->setSizes(QList<int>{newWidth, treeViewMinimumWidth});
   m_splitter->persistState();
 }

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -14,6 +14,7 @@
 #include "HexView.h"
 #include "VGMFileTreeView.h"
 #include "MdiArea.h"
+#include "SnappingSplitter.h"
 #include "Helpers.h"
 
 VGMFileView::VGMFileView(VGMFile *vgmfile)

--- a/src/ui/qt/workarea/VGMFileView.h
+++ b/src/ui/qt/workarea/VGMFileView.h
@@ -6,10 +6,8 @@
 
 #pragma once
 #include <QMdiSubWindow>
-#include <QSplitter>
-#include <QBuffer>
-#include "SnappingSplitter.h"
 
+class SnappingSplitter;
 class VGMFile;
 class HexView;
 class VGMFileTreeView;
@@ -23,7 +21,6 @@ public:
   explicit VGMFileView(VGMFile *vgmFile);
 
 private:
-//  static constexpr int hexViewPadding = 15;  // Extra horizontal padding for view's max width
   static constexpr int treeViewMinimumWidth = 220;
 
   void closeEvent(QCloseEvent *closeEvent) override;

--- a/src/ui/qt/workarea/VGMFileView.h
+++ b/src/ui/qt/workarea/VGMFileView.h
@@ -23,12 +23,13 @@ public:
   explicit VGMFileView(VGMFile *vgmFile);
 
 private:
-  static constexpr int hexViewPadding = 15;  // Extra horizontal padding for view's max width
-  static constexpr int treeViewMinimumWidth = 200;
+//  static constexpr int hexViewPadding = 15;  // Extra horizontal padding for view's max width
+  static constexpr int treeViewMinimumWidth = 220;
 
   void closeEvent(QCloseEvent *closeEvent) override;
   int hexViewWidth();
   int hexViewWidthSansAscii();
+  int hexViewWidthSansAsciiAndAddress();
   void updateHexViewFont(qreal sizeIncrement);
 
   VGMFileTreeView* m_treeview{};

--- a/src/ui/qt/workarea/VGMFileView.h
+++ b/src/ui/qt/workarea/VGMFileView.h
@@ -8,6 +8,7 @@
 #include <QMdiSubWindow>
 #include <QSplitter>
 #include <QBuffer>
+#include "SnappingSplitter.h"
 
 class VGMFile;
 class HexView;
@@ -23,17 +24,18 @@ public:
 
 private:
   static constexpr int hexViewPadding = 15;  // Extra horizontal padding for view's max width
-  static constexpr int treeViewMinimumWidth = 235;
+  static constexpr int treeViewMinimumWidth = 200;
 
   void closeEvent(QCloseEvent *closeEvent) override;
   int hexViewWidth();
+  int hexViewWidthSansAscii();
   void updateHexViewFont(qreal sizeIncrement);
 
   VGMFileTreeView* m_treeview{};
   VGMFile* m_vgmfile{};
   QScrollArea* m_hexScrollArea;
   HexView* m_hexview{};
-  QSplitter* m_splitter;
+  SnappingSplitter* m_splitter;
 
 public slots:
   void onSelectionChange(VGMItem* item);

--- a/src/ui/qt/workarea/VGMFileView.h
+++ b/src/ui/qt/workarea/VGMFileView.h
@@ -23,6 +23,7 @@ public:
 private:
   static constexpr int treeViewMinimumWidth = 220;
 
+  void resetSnapRanges();
   void closeEvent(QCloseEvent *closeEvent) override;
   int hexViewWidth();
   int hexViewWidthSansAscii();


### PR DESCRIPTION
## Description
This adds a new QSplitter subclass to which you can apply "SnapRanges" - upper and lower bounds which the splitter will snap to, preventing sizing to any value in between. It's basically the same behavior as when a QSplitter nears collapse of one of its views.

The use case is to improve how the HexView responds to window resizing and manual splitter resizing.

Relatedly, I've added logic for HexView to hide the address prefix when it cannot fit on the screen.

## Motivation and Context
Making the HexView sizing less awkward.

## How Has This Been Tested?
Tested on Windows and MacOS.

## Screenshots (if appropriate):

https://github.com/vgmtrans/vgmtrans/assets/1659535/829430c9-4e37-47a9-be64-949849675f3c


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
