### PR TITLE
VGMFileTreeView behavior tweaks

### DIFF
--- a/src/ui/qt/workarea/VGMFileTreeView.cpp
+++ b/src/ui/qt/workarea/VGMFileTreeView.cpp
@@ -61,52 +61,6 @@ VGMFileTreeView::VGMFileTreeView(VGMFile *file, QWidget *parent) : QTreeWidget(p
   setItemDelegate(new VGMTreeDisplayItem());
 }
 
-// Override the focusInEvent to prevent item selection upon focus
-//void VGMFileTreeView::focusInEvent(QFocusEvent* event) {
-//
-//}
-//
-//void VGMFileTreeView::currentChanged(const QModelIndex &current, const QModelIndex &previous) {
-//  // On MacOS, there is a peculiar accessibility-related bug that causes an exception to be thrown here. It causes
-//  // multiple problems, including issues with tree item selection and a second MDI window not appearing. With no
-//  // good fix, for now we bypass QTreeView::currentChanged.
-//#ifdef Q_OS_MAC
-//  QAbstractItemView::currentChanged(current, previous);
-//#else
-//  QTreeView::currentChanged(current, previous);
-//#endif
-//}
-//
-//void VGMFileTreeView::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) {
-//#ifdef Q_OS_MAC
-//  QAbstractItemView::selectionChanged(selected, deselected);
-//#else
-//  QTreeView::selectionChanged(selected, deselected);
-//#endif
-//}
-
-// Find the index to insert a child item, sorted by offset, using binary search
-int VGMFileTreeView::getSortedIndex(QTreeWidgetItem* parent, VGMTreeItem* item) {
-  int newOffset = item->item_offset();
-  int left = 0;
-  int right = parent->childCount() - 1;
-
-  while (left <= right) {
-    int mid = left + (right - left) / 2;
-    VGMTreeItem* childItem = static_cast<VGMTreeItem*>(parent->child(mid));
-
-    if (childItem->item_offset() == newOffset) {
-      return mid;
-    } else if (childItem->item_offset() < newOffset) {
-      left = mid + 1;
-    } else {
-      right = mid - 1;
-    }
-  }
-  return left;
-}
-
-
 void VGMFileTreeView::addVGMItem(VGMItem *item, VGMItem *parent, const std::string &name) {
   auto item_name = QString::fromStdString(name);
   auto tree_item = new VGMTreeItem(item_name, item, nullptr, parent);
@@ -187,16 +141,38 @@ void VGMFileTreeView::mouseDoubleClickEvent(QMouseEvent *event) {
 }
 
 void VGMFileTreeView::keyPressEvent(QKeyEvent *event) {
-
-  // On left arrow key press, collapse and select parent item if possible
   if (event->key() == Qt::Key_Left) {
     QTreeWidgetItem *current = currentItem();
-    if (current && current->parent()) {
+
+    // If the item has a parent and is not expanded, move to the parent
+    if (current && current->parent() && !isExpanded(indexFromItem(current))) {
       QTreeWidgetItem *parent = current->parent();
-      collapseItem(parent);
       setCurrentItem(parent);
       return;
     }
   }
+
+  // Call base class keyPressEvent for other keys and unhandled cases
   QTreeWidget::keyPressEvent(event);
+}
+
+// Find the index to insert a child item, sorted by offset, using binary search
+int VGMFileTreeView::getSortedIndex(QTreeWidgetItem* parent, VGMTreeItem* item) {
+  int newOffset = item->item_offset();
+  int left = 0;
+  int right = parent->childCount() - 1;
+
+  while (left <= right) {
+    int mid = left + (right - left) / 2;
+    VGMTreeItem* childItem = static_cast<VGMTreeItem*>(parent->child(mid));
+
+    if (childItem->item_offset() == newOffset) {
+      return mid;
+    } else if (childItem->item_offset() < newOffset) {
+      left = mid + 1;
+    } else {
+      right = mid - 1;
+    }
+  }
+  return left;
 }

--- a/src/ui/qt/workarea/VGMFileTreeView.cpp
+++ b/src/ui/qt/workarea/VGMFileTreeView.cpp
@@ -62,28 +62,28 @@ VGMFileTreeView::VGMFileTreeView(VGMFile *file, QWidget *parent) : QTreeWidget(p
 }
 
 // Override the focusInEvent to prevent item selection upon focus
-void VGMFileTreeView::focusInEvent(QFocusEvent* event) {
-
-}
-
-void VGMFileTreeView::currentChanged(const QModelIndex &current, const QModelIndex &previous) {
-  // On MacOS, there is a peculiar accessibility-related bug that causes an exception to be thrown here. It causes
-  // multiple problems, including issues with tree item selection and a second MDI window not appearing. With no
-  // good fix, for now we bypass QTreeView::currentChanged.
-#ifdef Q_OS_MAC
-  QAbstractItemView::currentChanged(current, previous);
-#else
-  QTreeView::currentChanged(current, previous);
-#endif
-}
-
-void VGMFileTreeView::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) {
-#ifdef Q_OS_MAC
-  QAbstractItemView::selectionChanged(selected, deselected);
-#else
-  QTreeView::selectionChanged(selected, deselected);
-#endif
-}
+//void VGMFileTreeView::focusInEvent(QFocusEvent* event) {
+//
+//}
+//
+//void VGMFileTreeView::currentChanged(const QModelIndex &current, const QModelIndex &previous) {
+//  // On MacOS, there is a peculiar accessibility-related bug that causes an exception to be thrown here. It causes
+//  // multiple problems, including issues with tree item selection and a second MDI window not appearing. With no
+//  // good fix, for now we bypass QTreeView::currentChanged.
+//#ifdef Q_OS_MAC
+//  QAbstractItemView::currentChanged(current, previous);
+//#else
+//  QTreeView::currentChanged(current, previous);
+//#endif
+//}
+//
+//void VGMFileTreeView::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) {
+//#ifdef Q_OS_MAC
+//  QAbstractItemView::selectionChanged(selected, deselected);
+//#else
+//  QTreeView::selectionChanged(selected, deselected);
+//#endif
+//}
 
 // Find the index to insert a child item, sorted by offset, using binary search
 int VGMFileTreeView::getSortedIndex(QTreeWidgetItem* parent, VGMTreeItem* item) {
@@ -134,4 +134,69 @@ void VGMFileTreeView::addVGMItem(VGMItem *item, VGMItem *parent, const std::stri
   parent_item_cached->insertChild(insertIndex, tree_item);
   m_items[item] = tree_item;
   tree_item->setData(0, Qt::UserRole, QVariant::fromValue((void *)item));
+}
+
+// Override the focusInEvent to prevent item selection upon focus
+void VGMFileTreeView::focusInEvent(QFocusEvent* event) {
+
+}
+
+void VGMFileTreeView::currentChanged(const QModelIndex &current, const QModelIndex &previous) {
+  // On MacOS, there is a peculiar accessibility-related bug that causes an exception to be thrown here. It causes
+  // multiple problems, including issues with tree item selection and a second MDI window not appearing. With no
+  // good fix, for now we bypass QTreeView::currentChanged.
+#ifdef Q_OS_MAC
+  QAbstractItemView::currentChanged(current, previous);
+#else
+  QTreeView::currentChanged(current, previous);
+#endif
+}
+
+void VGMFileTreeView::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) {
+#ifdef Q_OS_MAC
+  QAbstractItemView::selectionChanged(selected, deselected);
+#else
+  QTreeView::selectionChanged(selected, deselected);
+#endif
+}
+
+void VGMFileTreeView::mousePressEvent(QMouseEvent *event) {
+  // Get the item at the current mouse position
+  QTreeWidgetItem *itemAtPoint = itemAt(event->pos());
+
+  // If the item at the mouse position is already selected
+  if (itemAtPoint && itemAtPoint->isSelected()) {
+    clearSelection();
+    setCurrentItem(nullptr);
+  } else {
+    QTreeWidget::mousePressEvent(event);
+  }
+}
+
+void VGMFileTreeView::mouseDoubleClickEvent(QMouseEvent *event) {
+  QTreeWidgetItem *itemAtPoint = itemAt(event->pos());
+
+  // Check if the item is expandable/contractible
+  if (itemAtPoint && itemAtPoint->childCount() > 0) {
+    // If it's expandable, forward the event to the default behavior
+    QTreeWidget::mouseDoubleClickEvent(event);
+  } else {
+    // If not, treat the second click like a normal mousePressEvent
+    mousePressEvent(event);
+  }
+}
+
+void VGMFileTreeView::keyPressEvent(QKeyEvent *event) {
+
+  // On left arrow key press, collapse and select parent item if possible
+  if (event->key() == Qt::Key_Left) {
+    QTreeWidgetItem *current = currentItem();
+    if (current && current->parent()) {
+      QTreeWidgetItem *parent = current->parent();
+      collapseItem(parent);
+      setCurrentItem(parent);
+      return;
+    }
+  }
+  QTreeWidget::keyPressEvent(event);
 }

--- a/src/ui/qt/workarea/VGMFileTreeView.h
+++ b/src/ui/qt/workarea/VGMFileTreeView.h
@@ -50,12 +50,16 @@ public:
   explicit VGMFileTreeView(VGMFile *vgmfile, QWidget *parent = nullptr);
   ~VGMFileTreeView() override = default;
 
+  void addVGMItem(VGMItem *item, VGMItem *parent, const std::string &name);
+  auto getTreeWidgetItem(VGMItem *vgm_item) { return m_items.at(vgm_item); };
+
+protected:
   void focusInEvent(QFocusEvent* event) override;
   void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
   void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
-
-  void addVGMItem(VGMItem *item, VGMItem *parent, const std::string &name);
-  auto getTreeWidgetItem(VGMItem *vgm_item) { return m_items.at(vgm_item); };
+  void mousePressEvent(QMouseEvent *event) override;
+  void mouseDoubleClickEvent(QMouseEvent *event) override;
+  void keyPressEvent(QKeyEvent *event) override;
 
 private:
   int getSortedIndex(QTreeWidgetItem* parent, VGMTreeItem* item);

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -48,6 +48,7 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
   connect(m_treeview, &VGMFileTreeView::currentItemChanged,
           [&](QTreeWidgetItem *item, QTreeWidgetItem *) {
             if (item == nullptr) {
+              // If the VGMFileTreeView deselected, then so should the HexView
               onSelectionChange(nullptr);
               return;
             }

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -48,6 +48,7 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
   connect(m_treeview, &VGMFileTreeView::currentItemChanged,
           [&](QTreeWidgetItem *item, QTreeWidgetItem *) {
             if (item == nullptr) {
+              onSelectionChange(nullptr);
               return;
             }
             auto vgmitem = static_cast<VGMItem *>(item->data(0, Qt::UserRole).value<void *>());


### PR DESCRIPTION
Refines some of the key and mouse event handling in the VGMFileTreeView.

## Description
This adds handlers for keyPressEvent, mousePressEvent, and mouseDoubleClickEvent.

On the keypress side, I've added logic so that a left arrow key will change the selected item to the parent, so long as the current item is not expanded. This is a common convention across operating systems.

On the mouse event side, I've made it so that clicking an already selected item will deselect it. This is to provide parity with the HexView behavior, where clicking an item will both select and deselect it. Because clicking quickly registers as a double click and overrides the regular click handler, I added the same logic to the double click handler.

Also, I moved but did not edit the addVGMItem() method to be consistent with its order in the header.

## How Has This Been Tested?
Tested on MacOS.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
