### PR TITLE
Collection list polish

### DIFF
--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -71,7 +71,7 @@ Qt::ItemFlags VGMCollListViewModel::flags(const QModelIndex &index) const {
     return Qt::ItemIsEnabled;
   }
 
-  return QAbstractListModel::flags(index) | Qt::ItemIsEditable;
+  return QAbstractListModel::flags(index);
 }
 
 /*
@@ -103,10 +103,15 @@ VGMCollListView::VGMCollListView(QWidget *parent) : QListView(parent) {
 
   setContextMenuPolicy(Qt::CustomContextMenu);
   setSelectionMode(QAbstractItemView::ExtendedSelection);
-  setEditTriggers(QAbstractItemView::NoEditTriggers);
   setResizeMode(QListView::Adjust);
   setIconSize(QSize(16, 16));
   setWrapping(true);
+
+#ifdef Q_OS_MAC
+  // On MacOS, a wrapping QListView gives unwanted padding to the scrollbar. This compensates.
+  int scrollBarThickness = style()->pixelMetric(QStyle::PM_ScrollBarExtent);
+  setStyleSheet(QString("QListView {padding: -%1px;}").arg(scrollBarThickness / 2));
+#endif
 
   connect(this, &QListView::doubleClicked, this,
           &VGMCollListView::handlePlaybackRequest);

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -110,7 +110,9 @@ VGMCollListView::VGMCollListView(QWidget *parent) : QListView(parent) {
 #ifdef Q_OS_MAC
   // On MacOS, a wrapping QListView gives unwanted padding to the scrollbar. This compensates.
   int scrollBarThickness = style()->pixelMetric(QStyle::PM_ScrollBarExtent);
-  setStyleSheet(QString("QListView {padding: -%1px;}").arg(scrollBarThickness / 2));
+  QMargins margins = viewportMargins();
+  margins.setBottom(margins.bottom() - scrollBarThickness);
+  setViewportMargins(margins);
 #endif
 
   connect(this, &QListView::doubleClicked, this,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Just a couple small changes:

- First, it turns out the unwanted name editing behavior in the collection list view is due to setting the `ItemIsEditable` flag, so I removed it.
- Second, on MacOS, the collection list is reserving space for the horizontal scrollbar when it shouldn't. I fixed this. This is probably a Qt bug affecting wrapping QListViews that scroll horizontally, since Qt otherwise behaves in the standard fashion of not reserving space for MacOS's disappearing scrollbars. 

## How Has This Been Tested?
Run on MacOS Sonoma.

## Screenshots (if appropriate):

Minimum height required to show 6 rows:

Before
<img width="281" alt="image" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/4833c608-c424-45fa-a39d-78da7565521c">


After
<img width="275" alt="image" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/34a901fe-2490-4aa2-b1cf-4da8241ca446">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
