### PR TITLE
Add enter and return key behavior for list views

### DIFF
--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -173,16 +173,14 @@ void VGMCollListView::collectionMenu(const QPoint &pos) {
 
 void VGMCollListView::keyPressEvent(QKeyEvent *e) {
   switch (e->key()) {
-    case Qt::Key_Space: {
+    case Qt::Key_Enter:
+    case Qt::Key_Return:
+    case Qt::Key_Space:
       handlePlaybackRequest();
       break;
-    }
-
-    case Qt::Key_Escape: {
+    case Qt::Key_Escape:
       handleStopRequest();
       break;
-    }
-
     default:
       QListView::keyPressEvent(e);
   }

--- a/src/ui/qt/workarea/VGMCollView.cpp
+++ b/src/ui/qt/workarea/VGMCollView.cpp
@@ -206,8 +206,10 @@ void VGMCollView::keyPressEvent(QKeyEvent *e) {
     case Qt::Key_Enter:
     case Qt::Key_Return: {
       QModelIndex currentIndex = m_listview->currentIndex();
-      auto model = qobject_cast<VGMCollViewModel *>(m_listview->model());
-      MdiArea::the()->newView(model->fileFromIndex(currentIndex));
+      if (currentIndex.isValid()) {
+        auto model = qobject_cast<VGMCollViewModel *>(m_listview->model());
+        MdiArea::the()->newView(model->fileFromIndex(currentIndex));
+      }
       break;
     }
     default:

--- a/src/ui/qt/workarea/VGMCollView.cpp
+++ b/src/ui/qt/workarea/VGMCollView.cpp
@@ -11,6 +11,7 @@
 #include <QListView>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QKeyEvent>
 
 #include <VGMFile.h>
 #include <VGMInstrSet.h>
@@ -198,6 +199,20 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
   });
 
   setLayout(layout);
+}
+
+void VGMCollView::keyPressEvent(QKeyEvent *e) {
+  switch (e->key()) {
+    case Qt::Key_Enter:
+    case Qt::Key_Return: {
+      QModelIndex currentIndex = m_listview->currentIndex();
+      auto model = qobject_cast<VGMCollViewModel *>(m_listview->model());
+      MdiArea::the()->newView(model->fileFromIndex(currentIndex));
+      break;
+    }
+    default:
+      QGroupBox::keyPressEvent(e);
+  }
 }
 
 void VGMCollView::removeVGMColl(VGMColl *coll) {

--- a/src/ui/qt/workarea/VGMCollView.h
+++ b/src/ui/qt/workarea/VGMCollView.h
@@ -41,6 +41,9 @@ class VGMCollView : public QGroupBox {
 public:
   VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent = 0);
 
+private:
+  void keyPressEvent(QKeyEvent *e) override;
+
 private slots:
   void removeVGMColl(VGMColl *coll);
   void doubleClickedSlot(QModelIndex);

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -145,6 +145,10 @@ void VGMFileListView::itemMenu(const QPoint &pos) {
 
 void VGMFileListView::keyPressEvent(QKeyEvent *input) {
   switch (input->key()) {
+    case Qt::Key_Enter:
+    case Qt::Key_Return:
+      requestVGMFileView(currentIndex());
+      break;
     case Qt::Key_Delete:
     case Qt::Key_Backspace: {
       if (!selectionModel()->hasSelection())

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -147,7 +147,8 @@ void VGMFileListView::keyPressEvent(QKeyEvent *input) {
   switch (input->key()) {
     case Qt::Key_Enter:
     case Qt::Key_Return:
-      requestVGMFileView(currentIndex());
+      if (currentIndex().isValid())
+        requestVGMFileView(currentIndex());
       break;
     case Qt::Key_Delete:
     case Qt::Key_Backspace: {


### PR DESCRIPTION
## Description
This adds keypress handling for the enter and return keys (which it treats the same). In the file list view and the collection view, these keys open the current file just a double click would. In the collection list view, it toggles playback just like the space bar does.

## Motivation and Context
Getting the app to conform to standard UI input behavior.

## How Has This Been Tested?
Tested on Mac.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
