### PR TITLE
Prevent SnappingSplitter from snapping to non-target size

### DIFF
--- a/src/ui/qt/widgets/SnappingSplitter.h
+++ b/src/ui/qt/widgets/SnappingSplitter.h
@@ -32,10 +32,13 @@ public:
   QByteArray state;
 
 protected:
+  enum Bound: bool {
+    Upper = true,
+    Lower = false
+  };
   void onSplitterMoved();
   void resizeEvent(QResizeEvent* event) override;
-  void setSizesToUpperBound(int index, int threshold);
-  void setSizesToLowerBound(int index, int threshold);
+  void setSizesToBound(Bound bound, const SnapRange& range);
 
 private:
   QList<SnapRange> snapRanges;

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -248,9 +248,11 @@ void HexView::changeEvent(QEvent *event) {
             prevWidth = scrollAreaWidth;
 
             bool prevShowOffset = showOffset;
+            bool prevShouldDrawAscii = shouldDrawAscii;
             showOffset = scrollAreaWidth > getViewportWidthSansAsciiAndAddress();
+            shouldDrawAscii = scrollAreaWidth > getViewportWidthSansAscii();
 
-            if (prevShowOffset != showOffset) {
+            if (prevShowOffset != showOffset || prevShouldDrawAscii != shouldDrawAscii) {
               prevSelectedItem = nullptr;
               lineCache.clear();
               drawSelectedItem();
@@ -339,10 +341,13 @@ bool HexView::handleOverlayPaintEvent(QObject* obj, QEvent* event) {
     painter.fillRect(QRect(0, 0, BYTES_PER_LINE * 3 * charWidth, overlay->height()),
                      QColor(0, 0, 0, 100));
 
-    painter.fillRect(QRect(((BYTES_PER_LINE * 3) + HEX_TO_ASCII_SPACING_CHARS) * charWidth + (charWidth / 2),
-                           0,
-                           BYTES_PER_LINE * charWidth, overlay->height()),
-                           QColor(0, 0, 0, 100));
+    if (shouldDrawAscii) {
+      painter.fillRect(
+          QRect(((BYTES_PER_LINE * 3) + HEX_TO_ASCII_SPACING_CHARS) * charWidth + (charWidth / 2),
+                0,
+                BYTES_PER_LINE * charWidth, overlay->height()),
+          QColor(0, 0, 0, 100));
+    }
 
     return true;
   }
@@ -570,6 +575,8 @@ void HexView::translateAndPrintAscii(
     QColor bgColor,
     QColor textColor
 ) {
+  if (!shouldDrawAscii)
+    return;
   painter.save();
   painter.translate(((BYTES_PER_LINE * 3) + HEX_TO_ASCII_SPACING_CHARS + offset) * charWidth, 0);
   printAscii(painter, data, length, bgColor, textColor);

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -82,6 +82,7 @@ private:
   bool addressAsHex = true;
   bool isDragging = false;
   bool showOffset = true;
+  bool shouldDrawAscii = true;
   int prevWidth = 0;
   int prevHeight = 0;
 


### PR DESCRIPTION
Also, update HexView to only draw ASCII when it's visible.

## Description
Depending on the size of the window, the SnappingSplitter may snap to an upper bound but actually fall short of its size target. This is due to minimum size constraints - the view on the opposite side of the splitter can only shrink to its minimum size, which may not be enough to accommodate.

The new logic checks the actual size after the snap and reverts if the target size wasn't realized.

## How Has This Been Tested?
Run on MacOS

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
