### PR TITLE
Add Settings service, add "Show Details" button to VGMFileTreeView

### DIFF
--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -64,6 +64,8 @@ add_executable(
   main_ui.cpp
   services/MenuManager.cpp
   services/MenuManager.h
+  services/Settings.cpp
+  services/Settings.h
   services/NotificationCenter.cpp
   services/NotificationCenter.h
   services/commands/SaveCommands.h

--- a/src/ui/qt/main_ui.cpp
+++ b/src/ui/qt/main_ui.cpp
@@ -15,6 +15,7 @@
 
 int main(int argc, char *argv[]) {
   QCoreApplication::setOrganizationName("VGMTrans");
+  QCoreApplication::setOrganizationDomain("vgmtrans.com");
   QCoreApplication::setApplicationName("VGMTrans");
 
   QApplication app(argc, argv);

--- a/src/ui/qt/services/NotificationCenter.h
+++ b/src/ui/qt/services/NotificationCenter.h
@@ -33,10 +33,14 @@ public:
   void updateStatusForItem(VGMItem* item);
   void selectVGMFile(VGMFile* vgmfile, QWidget* caller);
 
+  void vgmfiletree_setShowDetails(bool showDetails) { emit vgmfiletree_showDetailsChanged(showDetails); }
+
 private:
   explicit NotificationCenter(QObject *parent = nullptr);
 
 signals:
   void statusUpdated(const QString& name, const QString& description, const QIcon* icon, int offset, int size);
   void vgmFileSelected(VGMFile *file, QWidget* caller);
+
+  void vgmfiletree_showDetailsChanged(bool showDetails);
 };

--- a/src/ui/qt/services/Settings.cpp
+++ b/src/ui/qt/services/Settings.cpp
@@ -1,0 +1,31 @@
+/*
+* VGMTrans (c) 2002-2024
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+ */
+
+#include "Settings.h"
+#include "NotificationCenter.h"
+
+SettingsGroup::SettingsGroup(Settings* parent) : parent(parent), settings(parent->settings) {
+}
+
+Settings::Settings(QObject *parent) :
+      VGMFileTreeView(this)
+{
+}
+
+void Settings::VGMFileTreeViewSettings::setShowDetails(bool showDetails) {
+  settings.beginGroup("VGMFileTreeView");
+  settings.setValue("showDetails", showDetails);
+  settings.endGroup();
+  NotificationCenter::the()->vgmfiletree_setShowDetails(showDetails);
+}
+
+bool Settings::VGMFileTreeViewSettings::showDetails() {
+  settings.beginGroup("VGMFileTreeView");
+  bool showDetails = settings.value("showDetails", false).toBool();
+  settings.endGroup();
+
+  return showDetails;
+}

--- a/src/ui/qt/services/Settings.h
+++ b/src/ui/qt/services/Settings.h
@@ -1,0 +1,47 @@
+/*
+* VGMTrans (c) 2002-2024
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+*/
+
+#pragma once
+
+#include <QObject>
+#include <QSettings>
+
+class Settings;
+
+struct SettingsGroup {
+  SettingsGroup(Settings* parent);
+  Settings* parent;
+  QSettings& settings;
+};
+
+class Settings : public QObject {
+  Q_OBJECT
+  friend struct SettingsGroup;
+
+public:
+  static auto the() {
+    static Settings* instance = new Settings();
+    return instance;
+  }
+
+  Settings(const Settings&) = delete;
+  Settings&operator=(const Settings&) = delete;
+  Settings(Settings&&) = delete;
+  Settings&operator=(Settings&&) = delete;
+
+  struct VGMFileTreeViewSettings : public SettingsGroup {
+    VGMFileTreeViewSettings(Settings* parent): SettingsGroup(parent) {}
+
+    bool showDetails();
+    void setShowDetails(bool);
+  };
+  VGMFileTreeViewSettings VGMFileTreeView;
+
+private:
+  explicit Settings(QObject *parent = nullptr);
+  QSettings settings;
+};
+

--- a/src/ui/qt/util/Metrics.h
+++ b/src/ui/qt/util/Metrics.h
@@ -7,7 +7,8 @@
 #pragma once
 
 namespace Size {
-  constexpr int VTab = 30;      // Tab Height
+  constexpr int VTab = 30;            // Tab Height
+  constexpr int HeaderCheckbox = 11;  // Width/Height of checkbox appearing in a QHeaderView
 }
 
 namespace Margin {

--- a/src/ui/qt/widgets/TableView.cpp
+++ b/src/ui/qt/widgets/TableView.cpp
@@ -8,7 +8,7 @@
 #include <QHeaderView>
 
 TableView::TableView(QWidget *parent) : QTableView(parent) {
-  setAlternatingRowColors(true);
+  setAlternatingRowColors(false);
   setShowGrid(false);
   setSortingEnabled(false);
   setContextMenuPolicy(Qt::CustomContextMenu);

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -119,7 +119,6 @@ VGMFileListView::VGMFileListView(QWidget *parent) : TableView(parent) {
   connect(&qtVGMRoot, &QtVGMRoot::UI_RemoveVGMFile, this, &VGMFileListView::removeVGMFile);
   connect(this, &QAbstractItemView::customContextMenuRequested, this, &VGMFileListView::itemMenu);
   connect(this, &QAbstractItemView::doubleClicked, this, &VGMFileListView::requestVGMFileView);
-//  connect(MdiArea::the(), &MdiArea::vgmFileSelected, this, &VGMFileListView::selectRowForVGMFile);
   connect(NotificationCenter::the(), &NotificationCenter::vgmFileSelected, this, &VGMFileListView::onVGMFileSelected);
 }
 

--- a/src/ui/qt/workarea/VGMFileTreeView.cpp
+++ b/src/ui/qt/workarea/VGMFileTreeView.cpp
@@ -45,6 +45,13 @@ VMGFileTreeHeaderView::VMGFileTreeHeaderView(Qt::Orientation orientation, QWidge
 void VMGFileTreeHeaderView::showEvent(QShowEvent *event) {
   QFont headerFont = font();
   headerFont.setPointSize(headerFont.pointSize()-1);
+#ifdef Q_OS_MAC
+  // Hide the splitter that appears on the far right of the header. Oddly, setting border-right
+  // does not work, but setting border-top seems to reset the appearance altogether and remove the
+  // splitter. The margin and padding settings here get us back to the default appearance.
+  setStyleSheet("QHeaderView::section { border-top: 0px solid white; margin-left: 4px; padding-bottom: -1px; padding-top: -3px; }");
+  resizeSection(0, width());
+#endif
   detailsCheckBox->setFont(headerFont);
 
   QHeaderView::showEvent(event);
@@ -54,7 +61,7 @@ void VMGFileTreeHeaderView::resizeEvent(QResizeEvent *event) {
   QHeaderView::resizeEvent(event);
 
   // Resize the first and only section to 1 pixel beyond the width to hide the column splitter
-  resizeSection(0, width() + 1);
+  resizeSection(0, width());
   detailsCheckBox->move(width() - detailsCheckBox->width() - 10,
                     (height() - detailsCheckBox->height()) / 2);
 }
@@ -205,12 +212,6 @@ void VGMFileTreeView::mouseDoubleClickEvent(QMouseEvent *event) {
     // If not, treat the second click like a normal mousePressEvent
     mousePressEvent(event);
   }
-}
-
-void VGMFileTreeView::scrollContentsBy(int dx, int dy) {
-  // Call the base class implementation with dx set to 0 to disable horizontal scrolling
-  // We disable horizontal scrolling so that we can hide the header column splitter
-  QTreeWidget::scrollContentsBy(0, dy);
 }
 
 void VGMFileTreeView::keyPressEvent(QKeyEvent *event) {

--- a/src/ui/qt/workarea/VGMFileTreeView.h
+++ b/src/ui/qt/workarea/VGMFileTreeView.h
@@ -92,7 +92,6 @@ protected:
   void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
   void mousePressEvent(QMouseEvent *event) override;
   void mouseDoubleClickEvent(QMouseEvent *event) override;
-  void scrollContentsBy(int dx, int dy) override;
   void keyPressEvent(QKeyEvent *event) override;
 
 private:

--- a/src/ui/qt/workarea/VGMFileTreeView.h
+++ b/src/ui/qt/workarea/VGMFileTreeView.h
@@ -10,11 +10,35 @@
 #include <QTreeWidgetItem>
 #include <QObject>
 #include <QStyledItemDelegate>
+#include <QHeaderView>
 #include <unordered_map>
 #include <utility>
-#include <VGMFile.h>
+#include "VGMFile.h"
 
 class VGMFile;
+class QCheckBox;
+
+// ***********************************
+// VMGFileTreeHeaderView
+// ***********************************
+
+class VMGFileTreeHeaderView : public QHeaderView {
+  Q_OBJECT
+
+public:
+  VMGFileTreeHeaderView(Qt::Orientation orientation, QWidget *parent = nullptr, bool showDetails = false);
+
+private:
+  QCheckBox* detailsCheckBox;
+  void resizeEvent(QResizeEvent *event);
+  void showEvent(QShowEvent *event);
+  void onShowDetailsChanged(bool showDetails);
+  void toggleShowDetails();
+};
+
+// ***********************************
+// VGMTreeItem
+// ***********************************
 
 class VGMTreeItem : public QTreeWidgetItem {
   static constexpr auto ItemType = QTreeWidgetItem::UserType + 1;
@@ -36,6 +60,10 @@ private:
   VGMItem *m_parent = nullptr;
 };
 
+// ***********************************
+// VGMTreeDisplayItem
+// ***********************************
+
 class VGMTreeDisplayItem : public QStyledItemDelegate {
   Q_OBJECT
 public:
@@ -43,6 +71,10 @@ public:
              const QModelIndex &index) const override;
   QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 };
+
+// ***********************************
+// VGMFileTreeView
+// ***********************************
 
 class VGMFileTreeView : public QTreeWidget {
   Q_OBJECT
@@ -60,11 +92,16 @@ protected:
   void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
   void mousePressEvent(QMouseEvent *event) override;
   void mouseDoubleClickEvent(QMouseEvent *event) override;
+  void scrollContentsBy(int dx, int dy) override;
   void keyPressEvent(QKeyEvent *event) override;
 
 private:
   int getSortedIndex(QTreeWidgetItem* parent, VGMTreeItem* item);
+  void setItemText(VGMItem* item, VGMTreeItem* treeItem);
+  void onShowDetailsChanged(bool showDetails);
+  void updateItemTextRecursively(QTreeWidgetItem* item);
 
+  bool showDetails = false;
   QTreeWidgetItem *parent_item_cached{};
   VGMItem *parent_cached{};
   std::unordered_map<VGMItem*, QTreeWidgetItem*> m_items{};


### PR DESCRIPTION
## Description
Two additions here:

### Settings Service,
First, is the introduction of a `Settings` class, a singleton that accesses QSettings ~~and emits signals when settings have been changed~~ (⚠️ Update: I'm now routing through NotificationCenter as I believe it's more intuitive). I'm attempting to use nested structures to group the settings and make code more readable. For example, the first component of the app to use Settings is the VGMFileTreeView, so I've added a nested struct called VGMFileTreeViewSettings with an instance that is simply the class name: VGMFileTreeView. Thus, the following lines access the showDetails setting:

`Settings::the()->VGMFileTreeView.showDetails()`
`Settings::the()->VGMFileTreeView.setShowDetails()`

~~QObject signals have some limitations. They cannot be static, and they cannot be used within nested classes or structs. Therefore, I had to declare them within the Settings scope. Because of this, I prefixed the name of the signal with the group: `VGMFileTreeView_showDetailsChanged()`.~~ 
⚠️ Update: As mentioned, the signals are now routed through NotificationCenter. They still use prefixes.

Let me know if you have idea on this. I'm sure this isn't perfect.

### Show Details button
Second, as mentioned in the status bar PR, I went ahead and added a checkbox button to the VGMFileTreeView header to enable/disable the more detailed tree view items. I've linked this to the Settings service so that it will persist across app runs and between sub windows, so you don't have to keep checking the box.

## How Has This Been Tested?
I ran this on MacOS, Windows and Ubuntu. Settings successfully persist across app runs, and updates other sub windows when the checkbox is activated/deactivated on one of them.

## Screenshots (if appropriate):
MacOS
<img width="310" alt="Screenshot 2024-04-23 at 12 42 13 AM" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/e4ac12e4-d650-4a76-b2c3-2a179b303ebb"><img width="317" alt="Screenshot 2024-04-23 at 12 41 58 AM" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/60866367-7b9b-4108-b161-6846d629bf1f">

Windows
<img width="234" alt="Capture2" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/5b4b1a97-5aa0-4cdb-8b50-1baccfec5006"><img width="230" alt="Capture" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/b6e04c2e-fa89-4aa5-a7ff-d8d3179367f0">

Ubuntu
<img width="417" alt="image" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/3042bf32-da5d-4cf4-bcb2-01d79c1dfb8d"><img width="420" alt="image" src="https://github.com/vgmtrans/vgmtrans/assets/1659535/918ecc02-f072-40cf-8bc5-632fc8b3e9aa">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
