### PR TITLE
Remove a couple MacOS specific fixes for VGMFileTreeView 

### DIFF
--- a/src/ui/qt/workarea/VGMFileTreeView.cpp
+++ b/src/ui/qt/workarea/VGMFileTreeView.cpp
@@ -88,24 +88,9 @@ void VGMFileTreeView::focusInEvent(QFocusEvent* event) {
 }
 
 void VGMFileTreeView::currentChanged(const QModelIndex &current, const QModelIndex &previous) {
-  // On MacOS, there is a peculiar accessibility-related bug that causes an exception to be thrown here. It causes
-  // multiple problems, including issues with tree item selection and a second MDI window not appearing. With no
-  // good fix, for now we bypass QTreeView::currentChanged.
-#ifdef Q_OS_MAC
-  QAbstractItemView::currentChanged(current, previous);
-#else
   QTreeView::currentChanged(current, previous);
-#endif
 
   updateStatusBar();
-}
-
-void VGMFileTreeView::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) {
-#ifdef Q_OS_MAC
-  QAbstractItemView::selectionChanged(selected, deselected);
-#else
-  QTreeView::selectionChanged(selected, deselected);
-#endif
 }
 
 void VGMFileTreeView::mousePressEvent(QMouseEvent *event) {

--- a/src/ui/qt/workarea/VGMFileTreeView.h
+++ b/src/ui/qt/workarea/VGMFileTreeView.h
@@ -57,7 +57,6 @@ public:
 protected:
   void focusInEvent(QFocusEvent* event) override;
   void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
-  void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
   void mousePressEvent(QMouseEvent *event) override;
   void mouseDoubleClickEvent(QMouseEvent *event) override;
   void keyPressEvent(QKeyEvent *event) override;


### PR DESCRIPTION
The app is running fine on MacOS without these quirk fixes. Fixed by Qt6? Other code changes? No idea.