### PR TITLE
Small fixes / cleanup for Root and CLIVGMRoot

### DIFF
--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -132,6 +132,8 @@ bool VGMRoot::CloseRawFile(RawFile *targFile) {
     // will be invalidated. Therefore, we can't simply erase using the iterator, but instead we
     // search for the RawFile to be deleted and erase if found.
     vRawFile.erase(std::remove(vRawFile.begin(), vRawFile.end(), targFile), vRawFile.end());
+
+    UI_CloseRawFile(targFile);
   } else {
     L_WARN("Requested deletion for RawFile but it was not found");
     return false;

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -33,7 +33,7 @@ public:
   VGMRoot() = default;
   virtual ~VGMRoot() = default;
 
-  bool Init();
+  virtual bool Init();
   virtual bool OpenRawFile(const std::string &filename);
   bool CreateVirtFile(uint8_t *databuf, uint32_t fileSize, const std::string &filename,
                       const std::string &parRawFileFullPath = "", VGMTag tag = VGMTag());
@@ -47,9 +47,8 @@ public:
 
   virtual const std::string UI_GetResourceDirPath();
   virtual void UI_SetRootPtr(VGMRoot **theRoot) = 0;
-  virtual void UI_PreExit() {}
-  virtual void UI_Exit() = 0;
   virtual void UI_AddRawFile(RawFile *) {}
+  virtual void UI_CloseRawFile(RawFile *targFile) {}
 
   virtual void UI_OnBeginLoadRawFile() {}
   virtual void UI_OnEndLoadRawFile() {}

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -231,11 +231,6 @@ void CLIVGMRoot::UpdateCollections() {
   vVGMFile.clear();
 }
 
-
-string CLIVGMRoot::UI_GetOpenFilePath(const string& suggestedFilename, const string& extension) {
-  return "Placeholder";
-}
-
 string CLIVGMRoot::UI_GetSaveFilePath(const string& suggestedFilename, const string& extension) {
   fs::path savePath = outputDir / fs::path(ConvertToSafeFileName(suggestedFilename) + "." + extension);
   return savePath.string();

--- a/src/ui/cli/CLIVGMRoot.h
+++ b/src/ui/cli/CLIVGMRoot.h
@@ -40,21 +40,16 @@ public:
 
   bool OpenRawFile(const std::string &filename) override;
 
-  virtual bool Init();
+  bool Init() override;
 
-  virtual void UI_SetRootPtr(VGMRoot** theRoot);
+  void UI_SetRootPtr(VGMRoot** theRoot) override;
 
-  virtual void UI_Exit() {}
-
-  virtual void UI_Log(LogItem* theLog);
+  void UI_Log(LogItem* theLog) override;
 
   virtual void UpdateCollections();
 
-  virtual std::string UI_GetOpenFilePath(const std::string& suggestedFilename = "",
-                                          const std::string& extension = "");
-
-  virtual std::string UI_GetSaveFilePath(const std::string& suggestedFilename,
-                                          const std::string& extension = "");
+  std::string UI_GetSaveFilePath(const std::string& suggestedFilename,
+                                 const std::string& extension = "") override;
 
   virtual std::string UI_GetSaveDirPath(const std::string& suggestedDir = "");
 

--- a/src/ui/qt/QtVGMRoot.cpp
+++ b/src/ui/qt/QtVGMRoot.cpp
@@ -29,12 +29,6 @@ void QtVGMRoot::UI_SetRootPtr(VGMRoot** theRoot) {
   *theRoot = &qtVGMRoot;
 }
 
-void QtVGMRoot::UI_PreExit() {
-}
-
-void QtVGMRoot::UI_Exit() {
-}
-
 void QtVGMRoot::UI_AddRawFile(RawFile*) {
   this->UI_AddedRawFile();
 }

--- a/src/ui/qt/QtVGMRoot.h
+++ b/src/ui/qt/QtVGMRoot.h
@@ -17,8 +17,6 @@ public:
 
   const std::string UI_GetResourceDirPath() override;
   void UI_SetRootPtr(VGMRoot** theRoot) override;
-  void UI_PreExit() override;
-  void UI_Exit() override;
   void UI_AddRawFile(RawFile* newFile) override;
   void UI_CloseRawFile(RawFile* targFile);
 


### PR DESCRIPTION
- remove Root::UIExit() and Root::UI_PreExit()
- re-add UI_CloseRawFile() and call it in Root::CloseRawFile()
- remove unused CLIVGMRoot::UI_GetOpenFilePath() and CLIVGMRoot::UI_Exit()
- make Root::Init() virtual, since it's overridden by the CLIVGMRoot class