### PR TITLE
Root file iteration cleanup

### DIFF
--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -147,7 +147,7 @@ void VGMRoot::AddVGMFile(
 
 // Removes a VGMFile from the interface.  The UI_RemoveVGMFile will handle the
 // interface-specific stuff
-void VGMRoot::RemoveVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file, bool bRemoveRawFile) {
+void VGMRoot::RemoveVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file, bool bRemoveEmptyRawFile) {
   auto targFile = variantToVGMFile(file);
   // First we should call the format's onClose handler in case it needs to use
   // the RawFile before we close it (FilenameMatcher, for ex)
@@ -169,7 +169,7 @@ void VGMRoot::RemoveVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
     RemoveVGMColl(targFile->assocColls.back());
   }
 
-  if (bRemoveRawFile) {
+  if (bRemoveEmptyRawFile) {
     const auto rawFile = targFile->GetRawFile();
     rawFile->RemoveContainedVGMFile(file);
     if (rawFile->containedVGMFiles().empty()) {

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -40,7 +40,7 @@ public:
   bool SetupNewRawFile(RawFile* newRawFile);
   bool CloseRawFile(RawFile *targFile);
   void AddVGMFile(VGMFileVariant file);
-  void RemoveVGMFile(VGMFileVariant file, bool bRemoveRawFile = true);
+  void RemoveVGMFile(VGMFileVariant file, bool bRemoveEmptyRawFile = true);
   void AddVGMColl(VGMColl *theColl);
   void RemoveVGMColl(VGMColl *theFile);
   void Log(LogItem *theLog);

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -40,7 +40,7 @@ public:
   bool SetupNewRawFile(RawFile* newRawFile);
   bool CloseRawFile(RawFile *targFile);
   void AddVGMFile(VGMFileVariant file);
-  void RemoveVGMFile(VGMFileVariant file, bool bRemoveFromRaw = true);
+  void RemoveVGMFile(VGMFileVariant file, bool bRemoveRawFile = true);
   void AddVGMColl(VGMColl *theColl);
   void RemoveVGMColl(VGMColl *theFile);
   void Log(LogItem *theLog);

--- a/src/main/io/RawFile.cpp
+++ b/src/main/io/RawFile.cpp
@@ -18,8 +18,8 @@ void RawFile::AddContainedVGMFile(std::shared_ptr<std::variant<VGMSeq *, VGMInst
 }
 
 void RawFile::RemoveContainedVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> vgmfile) {
-    auto iter =
-        std::find_if(m_vgmfiles.begin(), m_vgmfiles.end(), [vgmfile](auto file) { return *file == vgmfile; });
+    auto iter = std::find_if(m_vgmfiles.begin(), m_vgmfiles.end(),
+      [vgmfile](auto file) { return *file == vgmfile; });
     if (iter != m_vgmfiles.end())
         m_vgmfiles.erase(iter);
     else {

--- a/src/ui/qt/workarea/RawFileListView.cpp
+++ b/src/ui/qt/workarea/RawFileListView.cpp
@@ -3,10 +3,10 @@
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
  */
+#include <ranges>
 
 #include <QKeyEvent>
 #include <QMenu>
-#include <QHeaderView>
 #include "RawFileListView.h"
 #include "RawFile.h"
 #include "VGMFile.h"
@@ -53,12 +53,10 @@ void RawFileListViewModel::AddRawFile() {
 
 void RawFileListViewModel::RemoveRawFile() {
   int position = static_cast<int>(qtVGMRoot.vRawFile.size()) - 1;
-  if (position < 0) {
-    return;
+  if (position >= 0) {
+    beginRemoveRows(QModelIndex(), position, position);
+    endRemoveRows();
   }
-
-  beginRemoveRows(QModelIndex(), position, position);
-  endRemoveRows();
 }
 
 QVariant RawFileListViewModel::headerData(int column, Qt::Orientation orientation, int role) const {
@@ -173,8 +171,8 @@ void RawFileListView::deleteRawFiles() {
     return;
 
   QModelIndexList list = selectionModel()->selectedRows();
-  for (auto it = list.rbegin(); it != list.rend(); ++it) {
-    auto rawfile = qtVGMRoot.vRawFile[it->row()];
+  for (auto & idx : std::ranges::reverse_view(list)) {
+    const auto rawfile = qtVGMRoot.vRawFile[idx.row()];
     qtVGMRoot.CloseRawFile(rawfile);
   }
   clearSelection();

--- a/src/ui/qt/workarea/RawFileListView.cpp
+++ b/src/ui/qt/workarea/RawFileListView.cpp
@@ -56,6 +56,9 @@ void RawFileListViewModel::RemoveRawFile() {
   if (position >= 0) {
     beginRemoveRows(QModelIndex(), position, position);
     endRemoveRows();
+  } else {
+    // hack to refresh the view when deleting the last column
+    dataChanged(index(0, 0), index(0, 0));
   }
 }
 

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -4,6 +4,8 @@
  * refer to the included LICENSE.txt file
  */
 
+#include <ranges>
+
 #include <QHeaderView>
 
 #include "VGMFileListView.h"
@@ -159,8 +161,8 @@ void VGMFileListView::keyPressEvent(QKeyEvent *input) {
 
       QModelIndexList list = selectionModel()->selectedRows();
       pRoot->UI_BeginRemoveVGMFiles();
-      for (auto it = list.rbegin(); it != list.rend(); ++it) {
-        qtVGMRoot.RemoveVGMFile(qtVGMRoot.vVGMFile[it->row()]);
+      for (auto & idx : std::ranges::reverse_view(list)) {
+        qtVGMRoot.RemoveVGMFile(qtVGMRoot.vVGMFile[idx.row()], true);
       }
       pRoot->UI_EndRemoveVGMFiles();
 


### PR DESCRIPTION
Replaced some iterator based loops with range-based loops. Also a small hack fix for RawFileListView not redrawing upon deleting the last RawFile.

Note that I fixed a bug in the last PR where I didn't pass a flag to RemoveVGMFile() from CloseRawFile(), which could result in an unwanted recursive CloseRawFile() call. The weird workaround I had is no longer necessary, hence the simplification in Root.cpp.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
