### PR TITLE
Respecting compiler warnings, part 1

### DIFF
--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -57,8 +57,8 @@ bool VGMRoot::OpenRawFile(const std::string &filename) {
 }
 
 /* Creates a new file backed by RAM */
-bool VGMRoot::CreateVirtFile(uint8_t *databuf, uint32_t fileSize, const std::string &filename,
-                             const std::string &parRawFileFullPath, VGMTag tag) {
+bool VGMRoot::CreateVirtFile(const uint8_t *databuf, uint32_t fileSize, const std::string& filename,
+                             const std::string &parRawFileFullPath, const VGMTag& tag) {
     assert(fileSize != 0);
 
     auto newVirtFile = new VirtFile(databuf, fileSize, filename,
@@ -118,7 +118,7 @@ bool VGMRoot::CloseRawFile(RawFile *targFile) {
     return false;
   }
 
-  auto file = std::find(vRawFile.begin(), vRawFile.end(), targFile);
+  auto file = std::ranges::find(vRawFile, targFile);
   if (file != vRawFile.end()) {
     auto &vgmfiles = (*file)->containedVGMFiles();
     UI_BeginRemoveVGMFiles();
@@ -151,12 +151,11 @@ void VGMRoot::RemoveVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
   auto targFile = variantToVGMFile(file);
   // First we should call the format's onClose handler in case it needs to use
   // the RawFile before we close it (FilenameMatcher, for ex)
-  Format *fmt = targFile->GetFormat();
-  if (fmt) {
+  if (Format *fmt = targFile->GetFormat()) {
     fmt->OnCloseFile(file);
   }
 
-  auto iter = std::find(vVGMFile.begin(), vVGMFile.end(), file);
+  auto iter = std::ranges::find(vVGMFile, file);
 
   if (iter != vVGMFile.end()) {
     UI_RemoveVGMFile(targFile);
@@ -185,7 +184,7 @@ void VGMRoot::AddVGMColl(VGMColl *theColl) {
 }
 
 void VGMRoot::RemoveVGMColl(VGMColl *targColl) {
-  auto iter = find(vVGMColl.begin(), vVGMColl.end(), targColl);
+  auto iter = std::ranges::find(vVGMColl, targColl);
   if (iter != vVGMColl.end())
     vVGMColl.erase(iter);
   else
@@ -214,7 +213,7 @@ void VGMRoot::UI_AddVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
 
 // Given a pointer to a buffer of data, size, and a filename, this function writes the data
 // into a file on the filesystem.
-bool VGMRoot::UI_WriteBufferToFile(const std::string &filepath, uint8_t *buf, uint32_t size) {
+bool VGMRoot::UI_WriteBufferToFile(const std::string &filepath, uint8_t *buf, size_t size) {
     std::ofstream outfile(filepath, std::ios::out | std::ios::trunc | std::ios::binary);
 
     if (!outfile.is_open()) {
@@ -232,6 +231,6 @@ void VGMRoot::Log(LogItem *theLog) {
   UI_Log(theLog);
 }
 
-const std::string VGMRoot::UI_GetResourceDirPath() {
+std::string VGMRoot::UI_GetResourceDirPath() {
   return std::string(std::filesystem::current_path().generic_string());
 }

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -35,8 +35,8 @@ public:
 
   virtual bool Init();
   virtual bool OpenRawFile(const std::string &filename);
-  bool CreateVirtFile(uint8_t *databuf, uint32_t fileSize, const std::string &filename,
-                      const std::string &parRawFileFullPath = "", VGMTag tag = VGMTag());
+  bool CreateVirtFile(const uint8_t* databuf, uint32_t fileSize, const std::string& filename,
+                      const std::string& parRawFileFullPath = "", const VGMTag& tag = VGMTag());
   bool SetupNewRawFile(RawFile* newRawFile);
   bool CloseRawFile(RawFile *targFile);
   void AddVGMFile(VGMFileVariant file);
@@ -45,10 +45,10 @@ public:
   void RemoveVGMColl(VGMColl *theFile);
   void Log(LogItem *theLog);
 
-  virtual const std::string UI_GetResourceDirPath();
+  virtual std::string UI_GetResourceDirPath();
   virtual void UI_SetRootPtr(VGMRoot **theRoot) = 0;
   virtual void UI_AddRawFile(RawFile *) {}
-  virtual void UI_CloseRawFile(RawFile *targFile) {}
+  virtual void UI_CloseRawFile(RawFile *) {}
 
   virtual void UI_OnBeginLoadRawFile() {}
   virtual void UI_OnEndLoadRawFile() {}
@@ -61,14 +61,14 @@ public:
   virtual void UI_RemoveVGMFile(VGMFile *) {}
   virtual void UI_BeginRemoveVGMFiles() {}
   virtual void UI_EndRemoveVGMFiles() {}
-  virtual void UI_Log(LogItem *theLog) { }
+  virtual void UI_Log(LogItem *) { }
 
   virtual void UI_RemoveVGMColl(VGMColl *) {}
   virtual void UI_AddItem(VGMItem *, VGMItem *, const std::string &, void *) {}
   virtual std::string UI_GetSaveFilePath(const std::string &suggestedFilename,
                                          const std::string &extension = "") = 0;
   virtual std::string UI_GetSaveDirPath(const std::string &suggestedDir = "") = 0;
-  virtual bool UI_WriteBufferToFile(const std::string &filepath, uint8_t *buf, uint32_t size);
+  virtual bool UI_WriteBufferToFile(const std::string &filepath, uint8_t *buf, size_t size);
 
   std::vector<RawFile *> vRawFile;
   std::vector<VGMColl *> vVGMColl;

--- a/src/main/components/ExtensionDiscriminator.cpp
+++ b/src/main/components/ExtensionDiscriminator.cpp
@@ -3,6 +3,7 @@
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
  */
+#include "common.h"
 #include "ExtensionDiscriminator.h"
 
 ExtensionDiscriminator::ExtensionDiscriminator() {
@@ -12,12 +13,12 @@ ExtensionDiscriminator::~ExtensionDiscriminator() {
 }
 
 
-int ExtensionDiscriminator::AddExtensionScannerAssoc(std::string extension, VGMScanner *scanner) {
+int ExtensionDiscriminator::AddExtensionScannerAssoc(const std::string& extension, VGMScanner *scanner) {
   mScannerExt[extension].push_back(scanner);
   return true;
 }
 
-std::list<VGMScanner *> *ExtensionDiscriminator::GetScannerList(std::string extension) {
+std::list<VGMScanner *> *ExtensionDiscriminator::GetScannerList(const std::string& extension) {
   std::map<std::string, std::list<VGMScanner *> >::iterator iter = mScannerExt.find(StringToLower(extension));
   if (iter == mScannerExt.end())
     return NULL;

--- a/src/main/components/ExtensionDiscriminator.h
+++ b/src/main/components/ExtensionDiscriminator.h
@@ -5,7 +5,6 @@
  */
 #pragma once
 
-#include "common.h"
 #include <list>
 #include <map>
 
@@ -16,8 +15,8 @@ class ExtensionDiscriminator {
   ExtensionDiscriminator();
   ~ExtensionDiscriminator();
 
-  int AddExtensionScannerAssoc(std::string extension, VGMScanner *);
-  std::list<VGMScanner *> *GetScannerList(std::string extension);
+  int AddExtensionScannerAssoc(const std::string& extension, VGMScanner *);
+  std::list<VGMScanner *> *GetScannerList(const std::string& extension);
 
   std::map<std::string, std::list<VGMScanner *> > mScannerExt;
   static ExtensionDiscriminator &instance() {

--- a/src/main/components/FileLoader.cpp
+++ b/src/main/components/FileLoader.cpp
@@ -1,18 +1,19 @@
 #include "FileLoader.h"
 
 #include <algorithm>
+#include <ranges>
 
 std::vector<RawFile*> FileLoader::results() {
-    std::vector<RawFile*> res;
+  std::vector<RawFile*> res;
 
-    if (!m_res.empty()) {
-        std::move(std::begin(m_res), std::end(m_res), std::back_inserter(res));
-        m_res.clear();
-    }
+  if (!m_res.empty()) {
+    std::ranges::move(m_res, std::back_inserter(res));
+    m_res.clear();
+  }
 
-    return res;
+  return res;
 }
 
 void FileLoader::enqueue(RawFile* file) {
-    m_res.emplace_back(file);
+  m_res.emplace_back(file);
 }

--- a/src/main/components/FileLoader.h
+++ b/src/main/components/FileLoader.h
@@ -2,7 +2,6 @@
 
 #include <deque>
 #include <vector>
-#include <memory>
 
 #include "RawFile.h"
 

--- a/src/main/components/Matcher.cpp
+++ b/src/main/components/Matcher.cpp
@@ -65,7 +65,7 @@ bool FilegroupMatcher::OnNewSampColl(VGMSampColl *sampcoll) {
 }
 
 bool FilegroupMatcher::OnCloseSeq(VGMSeq *seq) {
-  auto iterator = std::find(seqs.begin(), seqs.end(), seq);
+  auto iterator = std::ranges::find(seqs, seq);
   if (iterator != seqs.end()) {
     seqs.erase(iterator);
   }
@@ -73,7 +73,7 @@ bool FilegroupMatcher::OnCloseSeq(VGMSeq *seq) {
 }
 
 bool FilegroupMatcher::OnCloseInstrSet(VGMInstrSet *instrset) {
-  auto iterator = std::find(instrsets.begin(), instrsets.end(), instrset);
+  auto iterator = std::ranges::find(instrsets, instrset);
   if (iterator != instrsets.end()) {
     instrsets.erase(iterator);
   }
@@ -81,7 +81,7 @@ bool FilegroupMatcher::OnCloseInstrSet(VGMInstrSet *instrset) {
 }
 
 bool FilegroupMatcher::OnCloseSampColl(VGMSampColl *sampcoll) {
-  auto iterator = std::find(sampcolls.begin(), sampcolls.end(), sampcoll);
+  auto iterator = std::ranges::find(sampcolls, sampcoll);
   if (iterator != sampcolls.end()) {
     sampcolls.erase(iterator);
   }
@@ -104,7 +104,7 @@ void FilegroupMatcher::MakeCollection(VGMInstrSet *instrset, VGMSampColl *sampco
   else {
     VGMColl *coll = fmt->NewCollection();
     coll->SetName(instrset->GetName());
-    coll->UseSeq(NULL);
+    coll->UseSeq(nullptr);
     coll->AddInstrSet(instrset);
     coll->AddSampColl(sampcoll);
     if (!coll->Load()) {

--- a/src/main/components/Matcher.h
+++ b/src/main/components/Matcher.h
@@ -7,14 +7,14 @@
 #pragma once
 #include <variant>
 #include <map>
-#include <vector>
 #include "Format.h"
 
-class VGMMiscFile;
 #include "VGMSeq.h"
 #include "VGMInstrSet.h"
 #include "VGMSampColl.h"
 #include "VGMColl.h"
+
+class VGMMiscFile;
 
 // *******
 // Matcher
@@ -67,12 +67,10 @@ class SimpleMatcher : public Matcher {
 
     seqs.insert(std::pair<IdType, VGMSeq *>(id, seq));
 
-    VGMInstrSet *matchingInstrSet = nullptr;
-    matchingInstrSet = instrsets[id];
-    if (matchingInstrSet) {
+
+    if (VGMInstrSet* matchingInstrSet = instrsets[id]) {
       if (bRequiresSampColl) {
-        VGMSampColl *matchingSampColl = sampcolls[id];
-        if (matchingSampColl) {
+        if (VGMSampColl *matchingSampColl = sampcolls[id]) {
           VGMColl *coll = fmt->NewCollection();
           if (!coll)
             return false;
@@ -111,7 +109,7 @@ class SimpleMatcher : public Matcher {
       return false;
     instrsets[id] = instrset;
 
-    VGMSampColl *matchingSampColl;
+    VGMSampColl *matchingSampColl = nullptr;
     if (bRequiresSampColl) {
       matchingSampColl = sampcolls[id];
       if (matchingSampColl && matchingSampColl->bLoadOnInstrSetMatch) {
@@ -355,8 +353,8 @@ class FilegroupMatcher : public Matcher {
   bool OnCloseInstrSet(VGMInstrSet *instrset) override;
   bool OnCloseSampColl(VGMSampColl *sampcoll) override;
 
+  bool MakeCollectionsForFile(VGMFile *file) override;
   virtual void MakeCollection(VGMInstrSet *instrset, VGMSampColl *sampcoll);
-  virtual bool MakeCollectionsForFile(VGMFile *file);
 
   virtual void LookForMatch();
 

--- a/src/main/components/PSFFile.cpp
+++ b/src/main/components/PSFFile.cpp
@@ -6,9 +6,6 @@
 
 #include "PSFFile.h"
 
-#include <exception>
-#include <algorithm>
-
 #include "util/decompression.h"
 #include "io/RawFile.h"
 
@@ -44,7 +41,7 @@ PSFFile::PSFFile(const RawFile &file) {
         auto exe_begin = file.begin() + 16 + reservedarea_size;
 
         if (m_exe_CRC !=
-            crc32(crc32(0L, Z_NULL, 0), reinterpret_cast<const Bytef *>(exe_begin), exe_size)) {
+            crc32(crc32(0L, nullptr, 0), reinterpret_cast<const Bytef *>(exe_begin), exe_size)) {
             throw std::runtime_error("CRC32 mismatch, data is corrupt");
         }
 
@@ -97,13 +94,13 @@ void PSFFile::parseTags(std::span<const char> tag_section) {
         // All characters 0x01-0x20 are considered whitespace.
         // (There must be no null (0x00) characters.)
         while (name_token_end > name_token && *(name_token_end - 1) <= 0x20)
-            name_token_end--;
+            --name_token_end;
         while (value_token_end > value_token && *(value_token_end - 1) <= 0x20)
-            value_token_end--;
+            --value_token_end;
         while (name_token < name_token_end && *(name_token) <= 0x20)
-            name_token++;
+            ++name_token;
         while (value_token < value_token_end && *(value_token) <= 0x20)
-            value_token++;
+            ++value_token;
 
         // Read variable=value as string.
         std::string name(tag_section.data() + std::distance(std::begin(tag_section), name_token),

--- a/src/main/components/Scanner.cpp
+++ b/src/main/components/Scanner.cpp
@@ -4,7 +4,6 @@
  * refer to the included LICENSE.txt file
  */
 #include "Scanner.h"
-#include "Root.h"
 
 VGMScanner::VGMScanner() {
 }

--- a/src/main/components/Scanner.h
+++ b/src/main/components/Scanner.h
@@ -4,7 +4,6 @@
  * refer to the included LICENSE.txt file
  */
 #pragma once
-#include "ExtensionDiscriminator.h"
 
 class RawFile;
 
@@ -20,6 +19,6 @@ class VGMScanner {
 
   virtual bool Init();
   //virtual bool UseExtension() {return true;}
-  void InitiateScan(RawFile *file, void *offset = 0);
-  virtual void Scan(RawFile *file, void *offset = 0) = 0;
+  void InitiateScan(RawFile *file, void *offset = nullptr);
+  virtual void Scan(RawFile *file, void *offset = nullptr) = 0;
 };

--- a/src/main/components/ScannerManager.h
+++ b/src/main/components/ScannerManager.h
@@ -5,54 +5,53 @@
 #include <algorithm>
 #include <functional>
 #include <memory>
-#include <type_traits>
 #include <initializer_list>
 
 class VGMScanner;
 using scannerSpawner = std::function<std::shared_ptr<VGMScanner>()>;
 
 class ScannerManager final {
-   public:
-    static ScannerManager &get() {
-        static ScannerManager instance;
-        return instance;
+ public:
+  static ScannerManager &get() {
+    static ScannerManager instance;
+    return instance;
+  }
+
+  ScannerManager(const ScannerManager &) = delete;
+  ScannerManager &operator=(const ScannerManager &) = delete;
+  ScannerManager(ScannerManager &&) = delete;
+  ScannerManager &operator=(ScannerManager &&) = delete;
+
+  void add(const char *scanner_name, scannerSpawner gen) {
+    m_generators.emplace(scanner_name, std::move(gen));
+  }
+
+  void add_extension_binding(const char *ext, scannerSpawner gen) {
+    m_generators_ext[ext].emplace_back(std::move(gen));
+  }
+
+  std::vector<std::shared_ptr<VGMScanner>> scanners() const {
+    std::vector<std::shared_ptr<VGMScanner>> tmp(m_generators.size());
+    std::ranges::transform(m_generators, tmp.begin(), [](auto pair) { return pair.second(); });
+
+    return tmp;
+  }
+
+  std::vector<std::shared_ptr<VGMScanner>> scanners_with_extension(const std::string& ext) const {
+    std::vector<std::shared_ptr<VGMScanner>> tmp;
+    if (auto vec = m_generators_ext.find(ext); vec != m_generators_ext.end()) {
+      tmp.resize(vec->second.size());
+      std::ranges::transform(vec->second, tmp.begin(), [](auto spawner) { return spawner(); });
     }
 
-    void add(const char *scanner_name, scannerSpawner gen) {
-        m_generators.emplace(scanner_name, std::move(gen));
-    }
+    return tmp;
+  }
 
-    void add_extension_binding(const char *ext, scannerSpawner gen) {
-        m_generators_ext[ext].emplace_back(std::move(gen));
-    }
+ private:
+  ScannerManager() = default;
 
-    std::vector<std::shared_ptr<VGMScanner>> scanners() const {
-        std::vector<std::shared_ptr<VGMScanner>> tmp(m_generators.size());
-        std::transform(m_generators.begin(), m_generators.end(), tmp.begin(),
-                       [](auto pair) { return pair.second(); });
-
-        return tmp;
-    }
-
-    std::vector<std::shared_ptr<VGMScanner>> scanners_with_extension(const std::string& ext) const {
-        std::vector<std::shared_ptr<VGMScanner>> tmp;
-        if (auto vec = m_generators_ext.find(ext); vec != m_generators_ext.end()) {
-            tmp.resize(vec->second.size());
-            std::transform(vec->second.begin(), vec->second.end(), tmp.begin(),
-                           [](auto spawner) { return spawner(); });
-        }
-
-        return tmp;
-    }
-
-   private:
-    ScannerManager() = default;
-    ScannerManager(const ScannerManager &) = default;
-    ScannerManager(ScannerManager &&) = default;
-    ~ScannerManager() = default;
-
-    std::unordered_map<std::string, scannerSpawner> m_generators;
-    std::unordered_map<std::string, std::vector<scannerSpawner>> m_generators_ext;
+  std::unordered_map<std::string, scannerSpawner> m_generators;
+  std::unordered_map<std::string, std::vector<scannerSpawner>> m_generators_ext;
 };
 
 namespace vgmtrans::scanners {

--- a/src/main/components/VGMColl.h
+++ b/src/main/components/VGMColl.h
@@ -48,7 +48,7 @@ class VGMColl {
   std::vector<VGMMiscFile *> miscfiles;
 
  protected:
-  void UnpackSampColl(DLSFile &dls, VGMSampColl *sampColl, std::vector<VGMSamp *> &finalSamps);
-  void UnpackSampColl(SynthFile &synthfile, VGMSampColl *sampColl, std::vector<VGMSamp *> &finalSamps);
+  static void UnpackSampColl(DLSFile &dls, const VGMSampColl *sampColl, std::vector<VGMSamp *> &finalSamps);
+  static void UnpackSampColl(SynthFile &synthfile, const VGMSampColl *sampColl, std::vector<VGMSamp *> &finalSamps);
   std::string name;
 };

--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -25,7 +25,7 @@ void VGMFile::AddToUI(VGMItem *parent, void *UI_specific) {
   }
 }
 
-Format *VGMFile::GetFormat() {
+Format *VGMFile::GetFormat() const {
   return Format::GetFormatFromName(format);
 }
 
@@ -48,7 +48,7 @@ void VGMFile::AddCollAssoc(VGMColl *coll) {
 }
 
 void VGMFile::RemoveCollAssoc(VGMColl *coll) {
-  auto iter = find(assocColls.begin(), assocColls.end(), coll);
+  auto iter = std::ranges::find(assocColls, coll);
   if (iter != assocColls.end())
     assocColls.erase(iter);
 }
@@ -59,7 +59,7 @@ RawFile *VGMFile::GetRawFile() const {
   return rawfile;
 }
 
-uint32_t VGMFile::GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) {
+uint32_t VGMFile::GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) const {
   // if unLength != 0, verify that we're within the bounds of the file, and truncate num read
   // bytes to end of file
   if (unLength != 0) {
@@ -76,7 +76,7 @@ uint32_t VGMFile::GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) {
 // VGMHeader
 // *********
 
-VGMHeader::VGMHeader(VGMItem *parItem, uint32_t offset, uint32_t length, const std::string &name)
+VGMHeader::VGMHeader(const VGMItem *parItem, uint32_t offset, uint32_t length, const std::string &name)
     : VGMContainerItem(parItem->vgmfile, offset, length, name) {}
 
 VGMHeader::~VGMHeader() = default;
@@ -98,7 +98,7 @@ void VGMHeader::AddSig(uint32_t offset, uint32_t length, const std::string &name
 // VGMHeaderItem
 // *************
 
-VGMHeaderItem::VGMHeaderItem(VGMHeader *hdr, HdrItemType theType, uint32_t offset, uint32_t length,
+VGMHeaderItem::VGMHeaderItem(const VGMHeader *hdr, HdrItemType theType, uint32_t offset, uint32_t length,
                              const std::string &name)
     : VGMItem(hdr->vgmfile, offset, length, name, CLR_HEADER), type(theType) {}
 

--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -15,16 +15,16 @@ class VGMFile : public VGMContainerItem {
 public:
   VGMFile(std::string format, RawFile *theRawFile, uint32_t offset, uint32_t length = 0,
           std::string theName = "VGM File");
-  virtual ~VGMFile() = default;
+  ~VGMFile() override = default;
 
-  virtual void AddToUI(VGMItem *parent, void *UI_specific);
+  void AddToUI(VGMItem *parent, void *UI_specific) override;
 
   [[nodiscard]] const std::string *GetName() const;
   [[nodiscard]] std::string GetDescription() override;
 
   virtual bool LoadVGMFile() = 0;
   virtual bool Load() = 0;
-  Format *GetFormat();
+  Format *GetFormat() const;
   const std::string &GetFormatName();
 
   virtual uint32_t GetID() { return id; }
@@ -36,7 +36,7 @@ public:
   [[nodiscard]] size_t size() const noexcept { return unLength; }
   [[nodiscard]] std::string name() const noexcept { return m_name; }
 
-  uint32_t GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer);
+  uint32_t GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) const;
 
   inline uint8_t GetByte(uint32_t offset) const { return rawfile->GetByte(offset); }
   inline uint16_t GetShort(uint32_t offset) const { return rawfile->GetShort(offset); }
@@ -45,13 +45,13 @@ public:
   inline uint32_t GetWordBE(uint32_t offset) const { return rawfile->GetWordBE(offset); }
   inline bool IsValidOffset(uint32_t offset) const { return rawfile->IsValidOffset(offset); }
 
-  size_t GetStartOffset() { return dwOffset; }
+  size_t GetStartOffset() const { return dwOffset; }
   /*
    * For whatever reason, you can create null-length VGMItems.
    * The only safe way for now is to
    * assume maximum length
    */
-  size_t GetEndOffset() { return rawfile->size(); }
+  size_t GetEndOffset() const { return rawfile->size(); }
 
   [[nodiscard]] const char *data() const { return rawfile->data() + dwOffset; }
 
@@ -70,11 +70,11 @@ protected:
 
 class VGMHeader : public VGMContainerItem {
 public:
-  VGMHeader(VGMItem *parItem, uint32_t offset = 0, uint32_t length = 0,
+  VGMHeader(const VGMItem *parItem, uint32_t offset = 0, uint32_t length = 0,
             const std::string &name = "Header");
-  virtual ~VGMHeader();
+  ~VGMHeader() override;
 
-  virtual Icon GetIcon() { return ICON_BINARY; };
+  Icon GetIcon() override { return ICON_BINARY; };
 
   void AddPointer(uint32_t offset, uint32_t length, uint32_t destAddress, bool notNull,
                   const std::string &name = "Pointer");
@@ -96,9 +96,9 @@ public:
     HIT_UNKNOWN
   };  // HIT = Header Item Type
 
-  VGMHeaderItem(VGMHeader *hdr, HdrItemType theType, uint32_t offset, uint32_t length,
+  VGMHeaderItem(const VGMHeader *hdr, HdrItemType theType, uint32_t offset, uint32_t length,
                 const std::string &name);
-  virtual Icon GetIcon();
+  Icon GetIcon() override;
 
   HdrItemType type;
 };

--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -4,30 +4,30 @@
 #include "Root.h"
 #include "helper.h"
 
-VGMItem::VGMItem() : color(CLR_UNKNOWN) {
+VGMItem::VGMItem() : vgmfile(nullptr), dwOffset(0), unLength(0), color(CLR_UNKNOWN) {
 }
 
-VGMItem::VGMItem(VGMFile *vgmfile, uint32_t offset, uint32_t length, const std::string name, EventColor color)
-    : vgmfile(vgmfile), name(name), dwOffset(offset), unLength(length), color(color) {
+VGMItem::VGMItem(VGMFile *vgmfile, uint32_t offset, uint32_t length, std::string name, EventColor color)
+    : vgmfile(vgmfile), name(std::move(name)), dwOffset(offset), unLength(length), color(color) {
 }
 
-bool operator>(VGMItem &item1, VGMItem &item2) {
+bool operator>(const VGMItem &item1, const VGMItem &item2) {
   return item1.dwOffset > item2.dwOffset;
 }
 
-bool operator<=(VGMItem &item1, VGMItem &item2) {
+bool operator<=(const VGMItem &item1, const VGMItem &item2) {
   return item1.dwOffset <= item2.dwOffset;
 }
 
-bool operator<(VGMItem &item1, VGMItem &item2) {
+bool operator<(const VGMItem &item1, const VGMItem &item2) {
   return item1.dwOffset < item2.dwOffset;
 }
 
-bool operator>=(VGMItem &item1, VGMItem &item2) {
+bool operator>=(const VGMItem &item1, const VGMItem &item2) {
   return item1.dwOffset >= item2.dwOffset;
 }
 
-RawFile *VGMItem::GetRawFile() {
+RawFile *VGMItem::GetRawFile() const {
   return vgmfile->rawfile;
 }
 
@@ -105,8 +105,7 @@ VGMItem *VGMContainerItem::GetItemFromOffset(uint32_t offset, bool includeContai
   for (const auto *container : containers) {
     for (VGMItem *item : *container) {
       if (item->unLength == 0 || (offset >= item->dwOffset && offset < item->dwOffset + item->unLength)) {
-        VGMItem *foundItem = item->GetItemFromOffset(offset, includeContainer, matchStartOffset);
-        if (foundItem)
+        if (VGMItem *foundItem = item->GetItemFromOffset(offset, includeContainer, matchStartOffset))
           return foundItem;
       }
     }

--- a/src/main/components/VGMMiscFile.h
+++ b/src/main/components/VGMMiscFile.h
@@ -20,5 +20,5 @@ public:
 
   bool LoadVGMFile() override;
   virtual bool LoadMain();
-  virtual bool Load();
+  bool Load() override;
 };

--- a/src/main/components/VGMMultiSectionSeq.cpp
+++ b/src/main/components/VGMMultiSectionSeq.cpp
@@ -9,12 +9,12 @@
 #include "VGMMultiSectionSeq.h"
 #include "helper.h"
 
-VGMMultiSectionSeq::VGMMultiSectionSeq(const std::string &format,
+VGMMultiSectionSeq::VGMMultiSectionSeq(const std::string& format,
                                        RawFile *file,
                                        uint32_t offset,
                                        uint32_t length,
                                        std::string name)
-    : VGMSeq(format, file, offset, length, name),
+    : VGMSeq(format, file, offset, length, std::move(name)),
       dwStartOffset(offset) {
   AddContainer<VGMSeqSection>(aSections);
   RemoveContainer<SeqTrack>(aTracks);

--- a/src/main/components/VGMMultiSectionSeq.h
+++ b/src/main/components/VGMMultiSectionSeq.h
@@ -6,22 +6,22 @@
 class VGMMultiSectionSeq:
     public VGMSeq {
  public:
-  VGMMultiSectionSeq(const std::string &format,
+  VGMMultiSectionSeq(const std::string& format,
                      RawFile *file,
                      uint32_t offset,
                      uint32_t length = 0,
                      std::string name = "VGM Sequence");
-  virtual ~VGMMultiSectionSeq();
+  ~VGMMultiSectionSeq() override;
 
-  virtual void ResetVars();
-  virtual bool LoadMain();
+  void ResetVars() override;
+  bool LoadMain() override;
 
   void AddSection(VGMSeqSection *section);
   bool AddLoopForeverNoItem();
   VGMSeqSection *GetSectionFromOffset(uint32_t offset);
 
  protected:
-  virtual bool LoadTracks(ReadMode readMode, long stopTime = 1000000);
+  bool LoadTracks(ReadMode readMode, long stopTime = 1000000) override;
   virtual bool LoadSection(VGMSeqSection *section, long stopTime = 1000000);
   virtual bool IsOffsetUsed(uint32_t offset);
   virtual bool ReadEvent(long stopTime);
@@ -36,5 +36,5 @@ class VGMMultiSectionSeq:
   int foreverLoops;
 
  private:
-  virtual bool GetTrackPointers(void) { return false; }
+  bool GetTrackPointers() override { return false; }
 };

--- a/src/main/components/VGMSampColl.cpp
+++ b/src/main/components/VGMSampColl.cpp
@@ -17,20 +17,20 @@
 VGMSampColl::VGMSampColl(const std::string &format, RawFile *rawfile, uint32_t offset, uint32_t length,
                          std::string theName)
     : VGMFile(format, rawfile, offset, length, std::move(theName)),
-      parInstrSet(nullptr),
       bLoadOnInstrSetMatch(false),
       bLoaded(false),
-      sampDataOffset(0) {
+      sampDataOffset(0),
+      parInstrSet(nullptr) {
   AddContainer<VGMSamp>(samples);
 }
 
 VGMSampColl::VGMSampColl(const std::string &format, RawFile *rawfile, VGMInstrSet *instrset,
                          uint32_t offset, uint32_t length, std::string theName)
     : VGMFile(format, rawfile, offset, length, std::move(theName)),
-      parInstrSet(instrset),
       bLoadOnInstrSetMatch(false),
       bLoaded(false),
-      sampDataOffset(0) {
+      sampDataOffset(0),
+      parInstrSet(instrset) {
   AddContainer<VGMSamp>(samples);
 }
 
@@ -104,7 +104,7 @@ bool VGMSampColl::GetSampleInfo() {
 VGMSamp *VGMSampColl::AddSamp(uint32_t offset, uint32_t length, uint32_t dataOffset,
                               uint32_t dataLength, uint8_t nChannels, uint16_t bps,
                               uint32_t theRate, std::string name) {
-  VGMSamp *newSamp = new VGMSamp(this, offset, length, dataOffset, dataLength, nChannels, bps, theRate, name);
+  VGMSamp *newSamp = new VGMSamp(this, offset, length, dataOffset, dataLength, nChannels, bps, theRate, std::move(name));
   samples.push_back(newSamp);
   return newSamp;
 }

--- a/src/main/components/VGMSampColl.h
+++ b/src/main/components/VGMSampColl.h
@@ -15,11 +15,11 @@ class VGMSampColl : public VGMFile {
               std::string theName = "VGMSampColl");
   VGMSampColl(const std::string &format, RawFile *rawfile, VGMInstrSet *instrset, uint32_t offset,
                 uint32_t length = 0, std::string theName = "VGMSampColl");
-  virtual ~VGMSampColl(void);
+  ~VGMSampColl() override;
   void UseInstrSet(VGMInstrSet *instrset) { parInstrSet = instrset; }
 
-    bool LoadVGMFile() override;
-  virtual bool Load();
+  bool LoadVGMFile() override;
+  bool Load() override;
   virtual bool GetHeaderInfo();        // retrieve any header data
   virtual bool GetSampleInfo();        // retrieve sample info, including pointers to data, # channels, rate, etc.
 

--- a/src/main/components/VGMTag.cpp
+++ b/src/main/components/VGMTag.cpp
@@ -7,28 +7,28 @@
 #include "VGMTag.h"
 
 VGMTag::VGMTag(std::string _title, std::string _artist, std::string _album)
-    : title(std::move(_title)), album(std::move(_album)), artist(std::move(_artist)) {}
+    : title(std::move(_title)), artist(std::move(_artist)), album(std::move(_album)) {}
 
-bool VGMTag::HasTitle(void) {
+bool VGMTag::HasTitle() const {
   return !title.empty();
 }
 
-bool VGMTag::HasArtist(void) {
+bool VGMTag::HasArtist() const {
   return !album.empty();
 }
 
-bool VGMTag::HasAlbum(void) {
+bool VGMTag::HasAlbum() const {
   return !artist.empty();
 }
 
-bool VGMTag::HasComment(void) {
+bool VGMTag::HasComment() const {
   return !comment.empty();
 }
 
-bool VGMTag::HasTrackNumber(void) {
+bool VGMTag::HasTrackNumber() const {
   return track_number != 0;
 }
 
-bool VGMTag::HasLength(void) {
+bool VGMTag::HasLength() const {
   return length != 0.0;
 }

--- a/src/main/components/VGMTag.h
+++ b/src/main/components/VGMTag.h
@@ -16,12 +16,12 @@ public:
   VGMTag(std::string _title, std::string _artist = "", std::string _album = "");
   ~VGMTag() = default;
 
-  bool HasTitle();
-  bool HasArtist();
-  bool HasAlbum();
-  bool HasComment();
-  bool HasTrackNumber();
-  bool HasLength();
+  bool HasTitle() const;
+  bool HasArtist() const;
+  bool HasAlbum() const;
+  bool HasComment() const;
+  bool HasTrackNumber() const;
+  bool HasLength() const;
 
   std::string title;
   std::string artist;

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -100,8 +100,8 @@ bool VGMInstrSet::LoadInstrs() {
 
 VGMInstr::VGMInstr(VGMInstrSet *instrSet, uint32_t offset, uint32_t length, uint32_t theBank,
                    uint32_t theInstrNum, const std::string &name, float reverb)
-    : VGMContainerItem(instrSet, offset, length, name), parInstrSet(instrSet), bank(theBank),
-      reverb(reverb), instrNum(theInstrNum) {
+    : VGMContainerItem(instrSet, offset, length, std::move(name)), bank(theBank), instrNum(theInstrNum),
+      parInstrSet(instrSet), reverb(reverb) {
   AddContainer<VGMRgn>(aRgns);
 }
 

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -1,8 +1,6 @@
 #pragma once
 #include "common.h"
 #include "VGMFile.h"
-#include "DLSFile.h"
-#include "SF2File.h"
 
 class VGMSampColl;
 class VGMInstr;
@@ -19,20 +17,17 @@ constexpr float defaultReverbPercent = 0.25;
 class VGMInstrSet : public VGMFile {
 public:
   VGMInstrSet(const std::string &format, RawFile *file, uint32_t offset, uint32_t length = 0,
-              std::string name = "VGMInstrSet", VGMSampColl *theSampColl = NULL);
-  virtual ~VGMInstrSet(void);
+              std::string name = "VGMInstrSet", VGMSampColl *theSampColl = nullptr);
+  ~VGMInstrSet() override;
 
   bool LoadVGMFile() override;
-  virtual bool Load();
+  bool Load() override;
   virtual bool GetHeaderInfo();
   virtual bool GetInstrPointers();
   virtual bool LoadInstrs();
 
   VGMInstr *AddInstr(uint32_t offset, uint32_t length, unsigned long bank, unsigned long instrNum,
                      const std::string &instrName = "");
-
-  bool OnSaveAsDLS();
-  bool OnSaveAsSF2();
 
   std::vector<VGMInstr *> aInstrs;
   VGMSampColl *sampColl;
@@ -50,9 +45,9 @@ public:
   VGMInstr(VGMInstrSet *parInstrSet, uint32_t offset, uint32_t length, uint32_t bank,
            uint32_t instrNum, const std::string &name = "Instrument",
            float reverb = defaultReverbPercent);
-  virtual ~VGMInstr(void);
+  ~VGMInstr() override;
 
-  virtual Icon GetIcon() { return ICON_INSTR; };
+  Icon GetIcon() override { return ICON_INSTR; };
 
   inline void SetBank(uint32_t bankNum);
   inline void SetInstrNum(uint32_t theInstrNum);
@@ -65,8 +60,8 @@ public:
 
   uint32_t bank;
   uint32_t instrNum;
+  VGMInstrSet *parInstrSet;
   float reverb;
 
-  VGMInstrSet *parInstrSet;
   std::vector<VGMRgn *> aRgns;
 };

--- a/src/main/components/instr/VGMRgn.cpp
+++ b/src/main/components/instr/VGMRgn.cpp
@@ -17,18 +17,19 @@ VGMRgn::VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length, const std::str
       keyHigh(0x7F),
       velLow(0),
       velHigh(0x7F),
-      sampNum(0),
-      sampOffset(-1),
-      sampCollPtr(NULL),
       unityKey(-1),
       fineTune(0),
-      pan(0.5),
+      sampNum(0),
+      sampOffset(-1),
+      sampCollPtr(nullptr),
       volume(-1),
+      pan(0.5),
       attack_time(0),
       attack_transform(no_transform),
       hold_time(0),
       decay_time(0),
       sustain_level(-1),
+      sustain_time(0),
       release_transform(no_transform),
       release_time(0) {
   AddContainer<VGMRgnItem>(items);
@@ -42,13 +43,13 @@ VGMRgn::VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length, uint8_t theKey
       keyHigh(theKeyHigh),
       velLow(theVelLow),
       velHigh(theVelHigh),
-      sampNum(theSampNum),
-      sampOffset(-1),
-      sampCollPtr(NULL),
       unityKey(-1),
       fineTune(0),
-      pan(0.5),
+      sampNum(theSampNum),
+      sampOffset(-1),
+      sampCollPtr(nullptr),
       volume(-1),
+      pan(0.5),
       attack_time(0),
       attack_transform(no_transform),
       hold_time(0),
@@ -89,7 +90,7 @@ void VGMRgn::SetPan(uint8_t p) {
   else if (pan == 64)
     pan = 0.5;
   else
-    pan = (double) pan / (double) 127;
+    pan = pan / static_cast<double>(127);
 }
 
 void VGMRgn::SetLoopInfo(int theLoopStatus, uint32_t theLoopStart, uint32_t theLoopLength) {
@@ -172,8 +173,8 @@ void VGMRgn::AddSampNum(int sn, uint32_t offset, uint32_t length) {
 // VGMRgnItem
 // **********
 
-VGMRgnItem::VGMRgnItem(VGMRgn *rgn, RgnItemType theType, uint32_t offset, uint32_t length, const std::string &name)
-    : VGMItem(rgn->vgmfile, offset, length, name), type(theType) {
+VGMRgnItem::VGMRgnItem(const VGMRgn *rgn, RgnItemType theType, uint32_t offset, uint32_t length, std::string name)
+    : VGMItem(rgn->vgmfile, offset, length, std::move(name)), type(theType) {
 }
 
 VGMItem::Icon VGMRgnItem::GetIcon() {

--- a/src/main/components/instr/VGMRgn.h
+++ b/src/main/components/instr/VGMRgn.h
@@ -11,13 +11,12 @@ class VGMSampColl;
 // VGMRgn
 // ******
 
-class VGMRgn:
-    public VGMContainerItem {
+class VGMRgn : public VGMContainerItem {
  public:
   VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length = 0, const std::string &name = "Region");
   VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length, uint8_t keyLow, uint8_t keyHigh, uint8_t velLow,
          uint8_t velHigh, int sampNum, const std::string &name = "Region");
-  ~VGMRgn(void);
+  ~VGMRgn() override;
 
   virtual bool LoadRgn() { return true; }
 
@@ -98,8 +97,7 @@ class VGMRgn:
 // **********
 
 
-class VGMRgnItem:
-    public VGMItem {
+class VGMRgnItem : public VGMItem {
  public:
   enum RgnItemType {
     RIT_GENERIC,
@@ -115,8 +113,8 @@ class VGMRgnItem:
     RIT_SAMPNUM
   };        //HIT = Header Item Type
 
-  VGMRgnItem(VGMRgn *rgn, RgnItemType theType, uint32_t offset, uint32_t length, const std::string &name);
-  virtual Icon GetIcon();
+  VGMRgnItem(const VGMRgn *rgn, RgnItemType theType, uint32_t offset, uint32_t length, std::string name);
+  Icon GetIcon() override;
 
  public:
   RgnItemType type;

--- a/src/main/components/instr/VGMSamp.cpp
+++ b/src/main/components/instr/VGMSamp.cpp
@@ -16,8 +16,8 @@
 
 VGMSamp::VGMSamp(VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t dataOffset,
                  uint32_t dataLen, uint8_t nChannels, uint16_t theBPS, uint32_t theRate,
-                 std::string theName)
-    : VGMItem(sampColl->vgmfile, offset, length, theName), dataOff(dataOffset), dataLength(dataLen),
+                 std::string name)
+    : VGMItem(sampColl->vgmfile, offset, length, std::move(name)), dataOff(dataOffset), dataLength(dataLen),
       bps(theBPS), rate(theRate), channels(nChannels), parSampColl(sampColl) {
 }
 
@@ -54,7 +54,7 @@ bool VGMSamp::SaveAsWav(const std::string &filepath) {
   if (this->ulUncompressedSize)
     bufSize = this->ulUncompressedSize;
   else
-    bufSize = (uint32_t)ceil((double)dataLength * GetCompressionRatio());
+    bufSize = static_cast<uint32_t>(ceil(dataLength * GetCompressionRatio()));
 
   std::vector<uint8_t> uncompSampBuf(bufSize);
   ConvertToStdWave(uncompSampBuf.data());
@@ -97,11 +97,11 @@ bool VGMSamp::SaveAsWav(const std::string &filepath) {
 
     uint32_t loopStart =
         (loop.loopStartMeasure == LM_BYTES)
-            ? (uint32_t)((loop.loopStart * compressionRatio) / origFormatBytesPerSamp)
+            ? static_cast<uint32_t>((loop.loopStart * compressionRatio) / origFormatBytesPerSamp)
             : loop.loopStart;
     uint32_t loopLenInSamp =
         (loop.loopLengthMeasure == LM_BYTES)
-            ? (uint32_t)((loopLength * compressionRatio) / origFormatBytesPerSamp)
+            ? static_cast<uint32_t>((loopLength * compressionRatio) / origFormatBytesPerSamp)
             : loopLength;
     uint32_t loopEnd = loopStart + loopLenInSamp;
 
@@ -124,5 +124,5 @@ bool VGMSamp::SaveAsWav(const std::string &filepath) {
     PushTypeOnVect<uint32_t>(waveBuf, 0);                  // playcount
   }
 
-  return pRoot->UI_WriteBufferToFile(filepath, &waveBuf[0], (uint32_t)waveBuf.size());
+  return pRoot->UI_WriteBufferToFile(filepath, &waveBuf[0], waveBuf.size());
 }

--- a/src/main/components/instr/VGMSamp.h
+++ b/src/main/components/instr/VGMSamp.h
@@ -17,9 +17,9 @@ public:
   VGMSamp(VGMSampColl *sampColl, uint32_t offset = 0, uint32_t length = 0, uint32_t dataOffset = 0,
           uint32_t dataLength = 0, uint8_t channels = 1, uint16_t bps = 16, uint32_t rate = 0,
           std::string name = "Sample");
-  virtual ~VGMSamp() = default;
+  ~VGMSamp() override = default;
 
-  virtual Icon GetIcon() { return ICON_SAMP; };
+  Icon GetIcon() override { return ICON_SAMP; };
 
   virtual double GetCompressionRatio();  // ratio of space conserved.  should generally be > 1
   // used to calculate both uncompressed sample size and loopOff after conversion
@@ -31,10 +31,10 @@ public:
   inline void SetNumChannels(uint8_t nChannels) { channels = nChannels; }
   inline void SetDataOffset(uint32_t theDataOff) { dataOff = theDataOff; }
   inline void SetDataLength(uint32_t theDataLength) { dataLength = theDataLength; }
-  inline int GetLoopStatus() { return loop.loopStatus; }
+  inline int GetLoopStatus() const { return loop.loopStatus; }
   inline void SetLoopStatus(int loopStat) { loop.loopStatus = loopStat; }
   inline void SetLoopOffset(uint32_t loopStart) { loop.loopStart = loopStart; }
-  inline int GetLoopLength() { return loop.loopLength; }
+  inline int GetLoopLength() const { return loop.loopLength; }
   inline void SetLoopLength(uint32_t theLoopLength) { loop.loopLength = theLoopLength; }
   inline void SetLoopStartMeasure(LoopMeasure measure) { loop.loopStartMeasure = measure; }
   inline void SetLoopLengthMeasure(LoopMeasure measure) { loop.loopLengthMeasure = measure; }
@@ -55,7 +55,7 @@ public:
   Loop loop;
 
   /* FIXME: these placeholders value are not so clean... */
-  uint8_t unityKey = -1;
+  int8_t unityKey = -1;
   short fineTune = 0;
   double volume = -1;  // as percent of full volume.  This will be converted to attenuation for SynthFile
 

--- a/src/main/components/seq/SeqEvent.cpp
+++ b/src/main/components/seq/SeqEvent.cpp
@@ -17,8 +17,8 @@ SeqEvent::SeqEvent(SeqTrack *pTrack,
                    EventColor color,
                    Icon icon,
                    const std::string &desc)
-    : VGMItem((VGMFile *) pTrack->parentSeq, offset, length, name, color), desc(desc), icon(icon), parentTrack(pTrack) {
-}
+    : VGMItem(pTrack->parentSeq, offset, length, name, color), channel(0),
+      parentTrack(pTrack), icon(icon), desc(desc) {}
 
 // ***************
 // DurNoteSeqEvent

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -50,7 +50,7 @@ class SeqEvent:
                     EventColor color = CLR_UNKNOWN,
                     Icon icon = ICON_BINARY,
                     const std::string &desc = "");
-  virtual ~SeqEvent() = default;
+  ~SeqEvent() override = default;
   std::string GetDescription() override {
     return desc;
   }

--- a/src/main/components/seq/SeqSlider.cpp
+++ b/src/main/components/seq/SeqSlider.cpp
@@ -29,8 +29,8 @@ TNumber SeqSlider<TNumber>::get(uint32_t time) const {
 
   // linear interpolation
   uint32_t step = time - this->time;
-  double alpha = (double) step / this->duration;
-  return (TNumber) (initialValue * (1.0 - alpha) + targetValue * alpha);
+  double alpha = static_cast<double>(step) / this->duration;
+  return static_cast<TNumber>(initialValue * (1.0 - alpha) + targetValue * alpha);
 }
 
 template<typename TNumber>

--- a/src/main/components/seq/SeqSlider.h
+++ b/src/main/components/seq/SeqSlider.h
@@ -14,14 +14,14 @@ template<typename TNumber>
 class SeqSlider: public ISeqSlider {
  public:
   SeqSlider(SeqTrack *track, uint32_t time, uint32_t duration, TNumber initialValue, TNumber targetValue);
-  virtual ~SeqSlider();
+  ~SeqSlider() override;
 
   virtual TNumber get(uint32_t time) const;
-  virtual void write(uint32_t time) const;
+  void write(uint32_t time) const override;
   virtual void writeMessage(TNumber value) const = 0;
   virtual bool changesAt(uint32_t time) const;
-  virtual bool isStarted(uint32_t time) const;
-  virtual bool isActive(uint32_t time) const;
+  bool isStarted(uint32_t time) const override;
+  bool isActive(uint32_t time) const override;
 
  public:
   SeqTrack *track;
@@ -34,23 +34,23 @@ class SeqSlider: public ISeqSlider {
 class VolSlider: public SeqSlider<uint8_t> {
  public:
   VolSlider(SeqTrack *track, uint32_t time, uint32_t duration, uint8_t initialValue, uint8_t targetValue);
-  virtual void writeMessage(uint8_t value) const;
+  void writeMessage(uint8_t value) const override;
 };
 
 class MasterVolSlider: public SeqSlider<uint8_t> {
  public:
   MasterVolSlider(SeqTrack *track, uint32_t time, uint32_t duration, uint8_t initialValue, uint8_t targetValue);
-  virtual void writeMessage(uint8_t value) const;
+  void writeMessage(uint8_t value) const override;
 };
 
 class ExpressionSlider: public SeqSlider<uint8_t> {
  public:
   ExpressionSlider(SeqTrack *track, uint32_t time, uint32_t duration, uint8_t initialValue, uint8_t targetValue);
-  virtual void writeMessage(uint8_t value) const;
+  void writeMessage(uint8_t value) const override;
 };
 
 class PanSlider: public SeqSlider<uint8_t> {
  public:
   PanSlider(SeqTrack *track, uint32_t time, uint32_t duration, uint8_t initialValue, uint8_t targetValue);
-  virtual void writeMessage(uint8_t value) const;
+  void writeMessage(uint8_t value) const override;
 };

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -21,25 +21,25 @@ enum ReadMode : uint8_t;
 class SeqTrack : public VGMContainerItem {
  public:
   SeqTrack(VGMSeq *parentSeqFile, uint32_t offset = 0, uint32_t length = 0, std::string name = "Track");
-  virtual ~SeqTrack(void);
+  ~SeqTrack() override;
   virtual void ResetVars();
   void ResetVisitedAddresses();
 
-  virtual Icon GetIcon() { return ICON_TRACK; };
+  Icon GetIcon() override { return ICON_TRACK; };
 
   virtual bool LoadTrackInit(int trackNum, MidiTrack *preparedMidiTrack);
   virtual void LoadTrackMainLoop(uint32_t stopOffset, int32_t stopTime);
   virtual void SetChannelAndGroupFromTrkNum(int theTrackNum);
   virtual void AddInitialMidiEvents(int trackNum);
-  virtual bool ReadEvent(void);
+  virtual bool ReadEvent();
   virtual void OnTickBegin() { };
   virtual void OnTickEnd() { };
 
-  uint32_t GetTime(void);
-  void SetTime(uint32_t NewDelta);
+  uint32_t GetTime() const;
+  void SetTime(uint32_t NewDelta) const;
   void AddTime(uint32_t AddDelta);
 
-  uint32_t ReadVarLen(uint32_t &offset);
+  uint32_t ReadVarLen(uint32_t &offset) const;
 
  public:
   virtual bool IsOffsetUsed(uint32_t offset);
@@ -52,7 +52,7 @@ class SeqTrack : public VGMContainerItem {
  protected:
   virtual void OnEvent(uint32_t offset, uint32_t length);
   virtual void AddEvent(SeqEvent *pSeqEvent);
-  void AddControllerSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t &prevVal, uint8_t targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t));
+  void AddControllerSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t &prevVal, uint8_t targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t)) const;
  public:
   void AddGenericEvent(uint32_t offset, uint32_t length, const std::string &sEventName, const std::string &sEventDesc, EventColor color, Icon icon = ICON_BINARY);
   void AddSetOctave(uint32_t offset, uint32_t length, uint8_t newOctave, const std::string &sEventName = "Set Octave");
@@ -73,7 +73,7 @@ class SeqTrack : public VGMContainerItem {
   void AddPercNoteOff(uint32_t offset, uint32_t length, int8_t key, const std::string &sEventName = "Percussion Note Off");
   void AddPercNoteOffNoItem(int8_t key);
   void InsertNoteOff(uint32_t offset, uint32_t length, int8_t key, uint32_t absTime, const std::string &sEventName = "Note Off");
-  void InsertNoteOffNoItem(int8_t key, uint32_t absTime);
+  void InsertNoteOffNoItem(int8_t key, uint32_t absTime) const;
 
   void AddNoteByDur(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, const std::string &sEventName = "Note with Duration");
   void AddNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur);
@@ -83,10 +83,10 @@ class SeqTrack : public VGMContainerItem {
   void AddPercNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur);
   void InsertNoteByDur(uint32_t offset, uint32_t length, int8_t key, int8_t vel, uint32_t dur, uint32_t absTime, const std::string &sEventName = "Note On With Duration");
 
-  void MakePrevDurNoteEnd();
-  void MakePrevDurNoteEnd(uint32_t absTime);
-  void LimitPrevDurNoteEnd();
-  void LimitPrevDurNoteEnd(uint32_t absTime);
+  void MakePrevDurNoteEnd() const;
+  void MakePrevDurNoteEnd(uint32_t absTime) const;
+  void LimitPrevDurNoteEnd() const;
+  void LimitPrevDurNoteEnd(uint32_t absTime) const;
   void AddVol(uint32_t offset, uint32_t length, uint8_t vol, const std::string &sEventName = "Volume");
   void AddVolNoItem(uint8_t vol);
   void AddVolSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targVol, const std::string &sEventName = "Volume Slide");
@@ -105,15 +105,15 @@ class SeqTrack : public VGMContainerItem {
   void InsertPan(uint32_t offset, uint32_t length, uint8_t pan, uint32_t absTime, const std::string &sEventName = "Pan");
   void AddReverb(uint32_t offset, uint32_t length, uint8_t reverb, const std::string &sEventName = "Reverb");
   void AddReverbNoItem(uint8_t reverb);
-  void AddMonoNoItem();
+  void AddMonoNoItem() const;
   void InsertReverb(uint32_t offset, uint32_t length, uint8_t reverb, uint32_t absTime, const std::string &sEventName = "Reverb");
   void AddPitchBend(uint32_t offset, uint32_t length, int16_t bend, const std::string &sEventName = "Pitch Bend");
   void AddPitchBendRange(uint32_t offset, uint32_t length, uint8_t semitones, uint8_t cents = 0, const std::string &sEventName = "Pitch Bend Range");
-  void AddPitchBendRangeNoItem(uint8_t range, uint8_t cents = 0);
+  void AddPitchBendRangeNoItem(uint8_t range, uint8_t cents = 0) const;
   void AddFineTuning(uint32_t offset, uint32_t length, double cents, const std::string &sEventName = "Fine Tuning");
-  void AddFineTuningNoItem(double cents);
+  void AddFineTuningNoItem(double cents) const;
   void AddModulationDepthRange(uint32_t offset, uint32_t length, double semitones, const std::string &sEventName = "Modulation Depth Range");
-  void AddModulationDepthRangeNoItem(double semitones);
+  void AddModulationDepthRangeNoItem(double semitones) const;
   void AddTranspose(uint32_t offset, uint32_t length, int8_t transpose, const std::string &sEventName = "Transpose");
   void AddPitchBendMidiFormat(uint32_t offset, uint32_t length, uint8_t lo, uint8_t hi, const std::string &sEventName = "Pitch Bend");
   void AddModulation(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName = "Modulation Depth");
@@ -124,38 +124,38 @@ class SeqTrack : public VGMContainerItem {
   void AddSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName = "Sustain");
   void InsertSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, uint32_t absTime, const std::string &sEventName = "Sustain");
   void AddPortamento(uint32_t offset, uint32_t length, bool bOn, const std::string &sEventName = "Portamento");
-  void AddPortamentoNoItem(bool bOn);
+  void AddPortamentoNoItem(bool bOn) const;
   void InsertPortamento(uint32_t offset, uint32_t length, bool bOn, uint32_t absTime, const std::string &sEventName = "Portamento");
-  void InsertPortamentoNoItem(bool bOn, uint32_t absTime);
+  void InsertPortamentoNoItem(bool bOn, uint32_t absTime) const;
   void AddPortamentoTime(uint32_t offset, uint32_t length, uint8_t time, const std::string &sEventName = "Portamento Time");
-  void AddPortamentoTimeNoItem(uint8_t time);
+  void AddPortamentoTimeNoItem(uint8_t time) const;
   void InsertPortamentoTime(uint32_t offset, uint32_t length, uint8_t time, uint32_t absTime, const std::string &sEventName = "Portamento Time");
-  void InsertPortamentoTimeNoItem(uint8_t time, uint32_t absTime);
+  void InsertPortamentoTimeNoItem(uint8_t time, uint32_t absTime) const;
   void AddPortamentoTime14Bit(uint32_t offset, uint32_t length, uint16_t time, const std::string &sEventName = "Portamento Time");
-  void AddPortamentoTime14BitNoItem(uint16_t time);
-  void AddPortamentoControlNoItem(uint8_t key);
+  void AddPortamentoTime14BitNoItem(uint16_t time) const;
+  void AddPortamentoControlNoItem(uint8_t key) const;
   void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, const std::string &sEventName = "Program Change");
   void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, uint8_t chan, const std::string &sEventName = "Program Change");
   void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, bool requireBank, const std::string &sEventName = "Program Change");
   void AddProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, bool requireBank, uint8_t chan, const std::string &sEventName = "Program Change");
-  void AddProgramChangeNoItem(uint32_t progNum, bool requireBank);
-  void AddBankSelectNoItem(uint8_t bank);
+  void AddProgramChangeNoItem(uint32_t progNum, bool requireBank) const;
+  void AddBankSelectNoItem(uint8_t bank) const;
   void AddTempo(uint32_t offset, uint32_t length, uint32_t microsPerQuarter, const std::string &sEventName = "Tempo");
-  void AddTempoNoItem(uint32_t microsPerQuarter);
+  void AddTempoNoItem(uint32_t microsPerQuarter) const;
   void AddTempoSlide(uint32_t offset, uint32_t length, uint32_t dur, uint32_t targMicrosPerQuarter, const std::string &sEventName = "Tempo Slide");
   void AddTempoBPM(uint32_t offset, uint32_t length, double bpm, const std::string &sEventName = "Tempo");
-  void AddTempoBPMNoItem(double bpm);
+  void AddTempoBPMNoItem(double bpm) const;
   void AddTempoBPMSlide(uint32_t offset, uint32_t length, uint32_t dur, double targBPM, const std::string &sEventName = "Tempo Slide");
   void AddTimeSig(uint32_t offset, uint32_t length, uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter, const std::string &sEventName = "Time Signature");
-  void AddTimeSigNoItem(uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter);
+  void AddTimeSigNoItem(uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter) const;
   void InsertTimeSig(uint32_t offset, uint32_t length, uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter, uint32_t absTime, const std::string &sEventName = "Time Signature");
-  bool AddEndOfTrack(uint32_t offset, uint32_t length, const std::string &sEventName = "Track End");
-  bool AddEndOfTrackNoItem();
+  void AddEndOfTrack(uint32_t offset, uint32_t length, const std::string &sEventName = "Track End");
+  void AddEndOfTrackNoItem();
 
   void AddGlobalTranspose(uint32_t offset, uint32_t length, int8_t semitones, const std::string &sEventName = "Global Transpose");
   void AddMarker(uint32_t offset, uint32_t length, const std::string &markername, uint8_t databyte1, uint8_t databyte2, const std::string &sEventName, int8_t priority = 0, EventColor color = CLR_MISC);
-  void AddMarkerNoItem(const std::string &markername, uint8_t databyte1, uint8_t databyte2, int8_t priority);
-  void InsertMarkerNoItem(uint32_t absTime, const std::string &markername, uint8_t databyte1, uint8_t databyte2, int8_t priority);
+  void AddMarkerNoItem(const std::string &markername, uint8_t databyte1, uint8_t databyte2, int8_t priority) const;
+  void InsertMarkerNoItem(uint32_t absTime, const std::string &markername, uint8_t databyte1, uint8_t databyte2, int8_t priority) const;
 
   bool AddLoopForever(uint32_t offset, uint32_t length, const std::string &sEventName = "Loop Forever");
 

--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -29,9 +29,9 @@ class VGMSeq : public VGMFile {
  public:
   VGMSeq(const std::string &format, RawFile *file, uint32_t offset, uint32_t length = 0,
          std::string name = "VGM Sequence");
-  virtual ~VGMSeq(void);
+  ~VGMSeq() override;
 
-  virtual Icon GetIcon() { return ICON_SEQ; }
+  Icon GetIcon() override { return ICON_SEQ; }
 
   bool LoadVGMFile() override;
   bool Load() override;              // Function to load all the information about the sequence
@@ -42,7 +42,7 @@ class VGMSeq : public VGMFile {
   virtual MidiFile *ConvertToMidi();
   virtual MidiTrack *GetFirstMidiTrack();
   void SetPPQN(uint16_t ppqn);
-  uint16_t GetPPQN();
+  uint16_t GetPPQN() const;
   // void SetTimeSignature(uint8_t numer, denom);
   void AddInstrumentRef(uint32_t progNum);
 
@@ -70,9 +70,9 @@ class VGMSeq : public VGMFile {
     initialPitchBendRangeSemiTones = semitones;
     initialPitchBendRangeCents = cents;
   }
-  void AlwaysWriteInitialTempo(double tempoBPM) {
+  void AlwaysWriteInitialTempo(double beatsPerMin) {
     bAlwaysWriteInitialTempo = true;
-    initialTempoBPM = tempoBPM;
+    initialTempoBPM = beatsPerMin;
   }
 
   void AlwaysWriteInitialMonoMode() {
@@ -91,9 +91,9 @@ class VGMSeq : public VGMFile {
   virtual bool PostLoad();
 
  public:
+  MidiFile *midi;
   uint32_t nNumTracks;
   ReadMode readMode;
-  MidiFile *midi;
   double tempoBPM;
   uint16_t ppqn;
   long time;                // absolute current time (ticks)

--- a/src/main/components/seq/VGMSeqNoTrks.cpp
+++ b/src/main/components/seq/VGMSeqNoTrks.cpp
@@ -6,9 +6,9 @@
 
 #include "VGMSeqNoTrks.h"
 
-VGMSeqNoTrks::VGMSeqNoTrks(const std::string &format, RawFile *file, uint32_t offset, std::string name)
+VGMSeqNoTrks::VGMSeqNoTrks(const std::string &format, RawFile *file, uint32_t offset, const std::string& name)
     : VGMSeq(format, file, offset, 0, name), SeqTrack(this) {
-  ResetVars();
+  VGMSeqNoTrks::ResetVars();
   VGMSeq::AddContainer<SeqEvent>(aEvents);
 }
 
@@ -71,7 +71,7 @@ bool VGMSeqNoTrks::LoadEvents(long stopTime) {
   bInLoop = false;
   curOffset = eventsOffset();  // start at beginning of track
   while (curOffset < rawfile->size()) {
-    if (GetTime() >= (unsigned)stopTime) {
+    if (GetTime() >= static_cast<u_long>(stopTime)) {
       break;
     }
 
@@ -86,27 +86,26 @@ MidiFile *VGMSeqNoTrks::ConvertToMidi() {
   this->SeqTrack::readMode = this->VGMSeq::readMode = READMODE_FIND_DELTA_LENGTH;
 
   if (!LoadEvents())
-    return NULL;
+    return nullptr;
   if (!PostLoad())
-    return NULL;
+    return nullptr;
 
-  long stopTime = -1;
-  stopTime = deltaLength;
+  long stopTime = deltaLength;
 
   MidiFile *newmidi = new MidiFile(this);
   this->midi = newmidi;
   this->SeqTrack::readMode = this->VGMSeq::readMode = READMODE_CONVERT_TO_MIDI;
   if (!LoadEvents(stopTime)) {
     delete midi;
-    this->midi = NULL;
-    return NULL;
+    this->midi = nullptr;
+    return nullptr;
   }
   if (!PostLoad()) {
     delete midi;
-    this->midi = NULL;
-    return NULL;
+    this->midi = nullptr;
+    return nullptr;
   }
-  this->midi = NULL;
+  this->midi = nullptr;
   return newmidi;
 }
 

--- a/src/main/components/seq/VGMSeqNoTrks.h
+++ b/src/main/components/seq/VGMSeqNoTrks.h
@@ -6,28 +6,27 @@
 #pragma once
 #include "VGMSeq.h"
 #include "SeqTrack.h"
+#include "SeqEvent.h"
 
 class VGMSeqNoTrks : public VGMSeq, public SeqTrack {
 public:
   VGMSeqNoTrks(const std::string &format, RawFile *file, uint32_t offset,
-               std::string name = "VGM Sequence");
+               const std::string& name = "VGM Sequence");
 
 public:
-  virtual ~VGMSeqNoTrks(void);
+  ~VGMSeqNoTrks(void) override;
 
-  virtual void ResetVars();
+  void ResetVars() override;
 
-  inline uint32_t GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) {
-    return VGMSeq::GetBytes(nIndex, nCount, pBuffer);
-  }
-  inline uint8_t GetByte(uint32_t offset) { return VGMSeq::GetByte(offset); }
-  inline uint16_t GetShort(uint32_t offset) { return VGMSeq::GetShort(offset); }
-  inline uint32_t GetWord(uint32_t offset) { return VGMSeq::GetWord(offset); }
-  inline uint16_t GetShortBE(uint32_t offset) { return VGMSeq::GetShortBE(offset); }
-  inline uint32_t GetWordBE(uint32_t offset) { return VGMSeq::GetWordBE(offset); }
-  inline uint32_t &offset(void) { return VGMSeq::dwOffset; }
-  inline uint32_t &length(void) { return VGMSeq::unLength; }
-  inline std::string &name(void) { return VGMSeq::m_name; }
+  using VGMSeq::GetBytes;
+  using VGMSeq::GetByte;
+  using VGMSeq::GetShort;
+  using VGMSeq::GetWord;
+  using VGMSeq::GetShortBE;
+  using VGMSeq::GetWordBE;
+  inline uint32_t &offset() { return VGMSeq::dwOffset; }
+  inline uint32_t &length() { return VGMSeq::unLength; }
+  inline std::string &name() { return VGMSeq::m_name; }
 
   inline uint32_t &eventsOffset() { return dwEventsOffset; }
 
@@ -44,10 +43,10 @@ public:
   void SetCurTrack(uint32_t trackNum);
   void TryExpandMidiTracks(uint32_t numTracks);
 
-  virtual bool LoadMain();  // Function to load all the information about the sequence
+  bool LoadMain() override;  // Function to load all the information about the sequence
   virtual bool LoadEvents(long stopTime = 1000000);
-  virtual MidiFile *ConvertToMidi();
-  virtual MidiTrack *GetFirstMidiTrack();
+  MidiFile *ConvertToMidi() override;
+  MidiTrack *GetFirstMidiTrack() override;
 
   uint32_t dwEventsOffset;
 

--- a/src/main/components/seq/VGMSeqSection.cpp
+++ b/src/main/components/seq/VGMSeqSection.cpp
@@ -3,7 +3,8 @@
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
  */
-#include "common.h"
+#include <ranges>
+
 #include "helper.h"
 #include "VGMMultiSectionSeq.h"
 #include "SeqEvent.h"
@@ -11,14 +12,14 @@
 VGMSeqSection::VGMSeqSection(VGMMultiSectionSeq *parentFile,
                              uint32_t theOffset,
                              uint32_t theLength,
-                             const std::string theName,
+                             const std::string& name,
                              EventColor color)
-    : VGMContainerItem(parentFile, theOffset, theLength, theName, color),
+    : VGMContainerItem(parentFile, theOffset, theLength, name, color),
       parentSeq(parentFile) {
   AddContainer<SeqTrack>(aTracks);
 }
 
-VGMSeqSection::~VGMSeqSection(void) {
+VGMSeqSection::~VGMSeqSection() {
   DeleteVect<SeqTrack>(aTracks);
 }
 
@@ -41,7 +42,7 @@ bool VGMSeqSection::GetTrackPointers() {
 bool VGMSeqSection::PostLoad() {
   if (parentSeq->readMode == READMODE_ADD_TO_UI) {
     for (uint32_t i = 0; i < aTracks.size(); i++) {
-      std::sort(aTracks[i]->aEvents.begin(), aTracks[i]->aEvents.end(), ItemPtrOffsetCmp());
+      std::ranges::sort(aTracks[i]->aEvents, ItemPtrOffsetCmp());
     }
   }
 

--- a/src/main/components/seq/VGMSeqSection.h
+++ b/src/main/components/seq/VGMSeqSection.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include "common.h"
 #include "VGMItem.h"
-#include "VGMFile.h"
-#include "VGMMultiSectionSeq.h"
 #include "SeqTrack.h"
 
 class VGMMultiSectionSeq;
@@ -14,9 +11,9 @@ class VGMSeqSection
   VGMSeqSection(VGMMultiSectionSeq *parentFile,
                 uint32_t theOffset,
                 uint32_t theLength = 0,
-                const std::string theName = "Section",
+                const std::string& name = "Section",
                 EventColor color = CLR_HEADER);
-  virtual ~VGMSeqSection(void);
+  ~VGMSeqSection() override;
 
   virtual bool Load();
   virtual bool GetTrackPointers();

--- a/src/main/conversion/RiffFile.cpp
+++ b/src/main/conversion/RiffFile.cpp
@@ -15,9 +15,9 @@ void Chunk::SetData(const void *src, uint32_t datasize) {
 
   // set the size and copy from the data source
   datasize = GetPaddedSize(size);
-  if (data != NULL) {
+  if (data != nullptr) {
     delete[] data;
-    data = NULL;
+    data = nullptr;
   }
   data = new uint8_t[datasize];
   memcpy(data, src, size);
@@ -32,7 +32,7 @@ void Chunk::SetData(const void *src, uint32_t datasize) {
 void Chunk::Write(uint8_t *buffer) {
   uint32_t padsize = GetPaddedSize(size) - size;
   memcpy(buffer, id, 4);
-  *(uint32_t *) (buffer + 4) = size + padsize; // Microsoft says the chunkSize doesn't contain padding size, but many software cannot handle the alignment.
+  *reinterpret_cast<uint32_t*>(buffer + 4) = size + padsize; // Microsoft says the chunkSize doesn't contain padding size, but many software cannot handle the alignment.
   memcpy(buffer + 8, data, GetPaddedSize(size));
 }
 
@@ -43,7 +43,7 @@ Chunk *ListTypeChunk::AddChildChunk(Chunk *ck) {
 
 uint32_t ListTypeChunk::GetSize() {
   uint32_t size = 12;        //id + size + "LIST"
-  for (auto iter = this->childChunks.begin(); iter != childChunks.end(); iter++)
+  for (auto iter = this->childChunks.begin(); iter != childChunks.end(); ++iter)
     size += (*iter)->GetSize();
   return GetPaddedSize(size);
 }
@@ -53,14 +53,14 @@ void ListTypeChunk::Write(uint8_t *buffer) {
   memcpy(buffer + 8, this->type, 4);
 
   uint32_t bufOffset = 12;
-  for (auto iter = this->childChunks.begin(); iter != childChunks.end(); iter++) {
+  for (auto iter = this->childChunks.begin(); iter != childChunks.end(); ++iter) {
     (*iter)->Write(buffer + bufOffset);
     bufOffset += (*iter)->GetSize();
   }
 
   uint32_t size = bufOffset;
   uint32_t padsize = GetPaddedSize(size) - size;
-  *(uint32_t *) (buffer + 4) = size + padsize - 8; // Microsoft says the chunkSize doesn't contain padding size, but many software cannot handle the alignment.
+  *reinterpret_cast<uint32_t*>(buffer + 4) = size + padsize - 8; // Microsoft says the chunkSize doesn't contain padding size, but many software cannot handle the alignment.
 
   // Add pad byte
   if (padsize != 0) {
@@ -68,7 +68,7 @@ void ListTypeChunk::Write(uint8_t *buffer) {
   }
 }
 
-RiffFile::RiffFile(std::string file_name, std::string form)
+RiffFile::RiffFile(const std::string& file_name, const std::string& form)
     : RIFFChunk(form),
       name(file_name) {
 }

--- a/src/main/conversion/RiffFile.h
+++ b/src/main/conversion/RiffFile.h
@@ -15,16 +15,15 @@ class Chunk {
   uint8_t *data;        //  The actual data not including a possible pad byte to word align
 
  public:
-  Chunk(std::string theId)
-      : data(NULL),
-        size(0) {
+  Chunk(const std::string& theId)
+      : size(0), data(nullptr) {
     assert(theId.length() == 4);
     memcpy(id, theId.c_str(), 4);
   }
   virtual ~Chunk() {
-    if (data != NULL) {
+    if (data != nullptr) {
       delete[] data;
-      data = NULL;
+      data = nullptr;
     }
   }
   void SetData(const void *src, uint32_t datasize);
@@ -48,18 +47,18 @@ class ListTypeChunk: public Chunk {
   std::list<Chunk *> childChunks;
 
  public:
-  ListTypeChunk(std::string theId, std::string theType)
+  ListTypeChunk(const std::string& theId, const std::string& theType)
       : Chunk(theId) {
     assert(theType.length() == 4);
     memcpy(type, theType.c_str(), 4);
   }
-  virtual ~ListTypeChunk() {
+  ~ListTypeChunk() override {
     DeleteList(childChunks);
   }
 
   Chunk *AddChildChunk(Chunk *ck);
-  virtual uint32_t GetSize();    //  Returns the size of the chunk in bytes, including any pad byte.
-  virtual void Write(uint8_t *buffer);
+  uint32_t GetSize() override;    //  Returns the size of the chunk in bytes, including any pad byte.
+  void Write(uint8_t *buffer) override;
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -67,7 +66,7 @@ class ListTypeChunk: public Chunk {
 ////////////////////////////////////////////////////////////////////////////
 class RIFFChunk: public ListTypeChunk {
  public:
-  RIFFChunk(std::string form) : ListTypeChunk("RIFF", form) { }
+  RIFFChunk(const std::string& form) : ListTypeChunk("RIFF", form) { }
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -75,16 +74,16 @@ class RIFFChunk: public ListTypeChunk {
 ////////////////////////////////////////////////////////////////////////////
 class LISTChunk: public ListTypeChunk {
  public:
-  LISTChunk(std::string type) : ListTypeChunk("LIST", type) { }
+  LISTChunk(const std::string& type) : ListTypeChunk("LIST", type) { }
 };
 
 
 ////////////////////////////////////////////////////////////////////////////
-// RiffFile		- 
+// RiffFile		-
 ////////////////////////////////////////////////////////////////////////////
 class RiffFile: public RIFFChunk {
  public:
-  RiffFile(std::string file_name, std::string form);
+  RiffFile(const std::string& file_name, const std::string& form);
 
   static void WriteLIST(std::vector<uint8_t> &buf, uint32_t listName, uint32_t listSize) {
     PushTypeOnVectBE<uint32_t>(buf, 0x4C495354);    //write "LIST"
@@ -94,9 +93,9 @@ class RiffFile: public RIFFChunk {
 
   //Adds a null byte and ensures 16 bit alignment of a text string
   static void AlignName(std::string &name) {
-    name += (char) 0x00;
-    if (name.size() % 2)                        //if the size of the name string is odd
-      name += (char) 0x00;                      //add another null byte
+    name += '\x00';
+    if (name.size() % 2)  //if the size of the name string is odd
+      name += '\x00';     //add another null byte
   }
 
 

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -86,7 +86,7 @@ SF2File::SF2File(SynthFile *synthfile)
     SynthInstr *instr = synthfile->vInstrs[i];
 
     sfPresetHeader presetHdr{};
-    memcpy(presetHdr.achPresetName, instr->name.c_str(), std::min(instr->name.length(), 20ul));
+    memcpy(presetHdr.achPresetName, instr->name.c_str(), std::min(instr->name.length(), static_cast<size_t>(20)));
     presetHdr.wPreset = static_cast<uint16_t>(instr->ulInstrument);
 
     // Despite being a 16-bit value, SF2 only supports banks up to 127. Since
@@ -188,7 +188,7 @@ SF2File::SF2File(SynthFile *synthfile)
     SynthInstr *instr = synthfile->vInstrs[i];
 
     sfInst inst{};
-    memcpy(inst.achInstName, instr->name.c_str(), std::min(instr->name.length(),20ul));
+    memcpy(inst.achInstName, instr->name.c_str(), std::min(instr->name.length(), static_cast<size_t>(20)));
     inst.wInstBagNdx = rgnCounter;
     rgnCounter += instr->vRgns.size();
 
@@ -376,7 +376,7 @@ SF2File::SF2File(SynthFile *synthfile)
     SynthWave *wave = synthfile->vWaves[i];
 
     sfSample samp{};
-    memcpy(samp.achSampleName, wave->name.c_str(), std::min(wave->name.length(), 20ul));
+    memcpy(samp.achSampleName, wave->name.c_str(), std::min(wave->name.length(), static_cast<size_t>(20)));
     samp.dwStart = sampOffset;
     samp.dwEnd = samp.dwStart + (wave->dataSize / sizeof(uint16_t));
     sampOffset = samp.dwEnd + 46;        // plus the 46 padding samples required by sf2 spec

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -11,12 +11,10 @@
 #include "ScaleConversion.h"
 #include "Root.h"
 
-using namespace std;
-
-SF2InfoListChunk::SF2InfoListChunk(string name)
+SF2InfoListChunk::SF2InfoListChunk(const std::string& name)
     : LISTChunk("INFO") {
   // Create a date string
-  time_t current_time = time(NULL);
+  time_t current_time = time(nullptr);
   char *c_time_string = ctime(&current_time);
 
   // Add the child info chunks
@@ -28,8 +26,8 @@ SF2InfoListChunk::SF2InfoListChunk(string name)
   AddChildChunk(ifilCk);
   AddChildChunk(new SF2StringChunk("isng", "EMU8000"));
   AddChildChunk(new SF2StringChunk("INAM", name));
-  AddChildChunk(new SF2StringChunk("ICRD", string(c_time_string)));
-  AddChildChunk(new SF2StringChunk("ISFT", string("VGMTrans " + string(VGMTRANS_VERSION))));
+  AddChildChunk(new SF2StringChunk("ICRD", std::string(c_time_string)));
+  AddChildChunk(new SF2StringChunk("ISFT", std::string("VGMTrans " + std::string(VGMTRANS_VERSION))));
 }
 
 
@@ -81,21 +79,20 @@ SF2File::SF2File(SynthFile *synthfile)
   //***********
   Chunk *phdrCk = new Chunk("phdr");
   size_t numInstrs = synthfile->vInstrs.size();
-  phdrCk->size = (uint32_t) ((numInstrs + 1) * sizeof(sfPresetHeader));
+  phdrCk->size = static_cast<uint32_t>((numInstrs + 1) * sizeof(sfPresetHeader));
   phdrCk->data = new uint8_t[phdrCk->size];
 
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
 
-    sfPresetHeader presetHdr;
-    memset(&presetHdr, 0, sizeof(sfPresetHeader));
-    memcpy(presetHdr.achPresetName, instr->name.c_str(), min((unsigned long) instr->name.length(), (unsigned long) 20));
-    presetHdr.wPreset = (uint16_t) instr->ulInstrument;
+    sfPresetHeader presetHdr{};
+    memcpy(presetHdr.achPresetName, instr->name.c_str(), std::min(instr->name.length(), 20ul));
+    presetHdr.wPreset = static_cast<uint16_t>(instr->ulInstrument);
 
     // Despite being a 16-bit value, SF2 only supports banks up to 127. Since
     // it's pretty common to have either MSB or LSB be 0, we'll use whatever
     // one is not zero, with preference for MSB.
-    uint16_t bank16 = (uint16_t)instr->ulBank;
+    uint16_t bank16 = static_cast<uint16_t>(instr->ulBank);
 
     if ((bank16 & 0xFF00) == 0) {
       presetHdr.wBank = bank16 & 0x7F;
@@ -103,7 +100,7 @@ SF2File::SF2File(SynthFile *synthfile)
     else {
       presetHdr.wBank = (bank16 >> 8) & 0x7F;
     }
-    presetHdr.wPresetBagNdx = (uint16_t) i;
+    presetHdr.wPresetBagNdx = static_cast<uint16_t>(i);
     presetHdr.dwLibrary = 0;
     presetHdr.dwGenre = 0;
     presetHdr.dwMorphology = 0;
@@ -111,9 +108,8 @@ SF2File::SF2File(SynthFile *synthfile)
     memcpy(phdrCk->data + (i * sizeof(sfPresetHeader)), &presetHdr, sizeof(sfPresetHeader));
   }
   //  add terminal sfPresetBag
-  sfPresetHeader presetHdr;
-  memset(&presetHdr, 0, sizeof(sfPresetHeader));
-  presetHdr.wPresetBagNdx = (uint16_t) numInstrs;
+  sfPresetHeader presetHdr{};
+  presetHdr.wPresetBagNdx = static_cast<uint16_t>(numInstrs);
   memcpy(phdrCk->data + (numInstrs * sizeof(sfPresetHeader)), &presetHdr, sizeof(sfPresetHeader));
   pdtaCk->AddChildChunk(phdrCk);
 
@@ -121,23 +117,19 @@ SF2File::SF2File(SynthFile *synthfile)
   // pbag chunk
   //***********
   Chunk *pbagCk = new Chunk("pbag");
-  const size_t ITEMS_IN_PGEN = 2;
-  pbagCk->size = (uint32_t) ((numInstrs + 1) * sizeof(sfPresetBag));
+  constexpr size_t ITEMS_IN_PGEN = 2;
+  pbagCk->size = static_cast<uint32_t>((numInstrs + 1) * sizeof(sfPresetBag));
   pbagCk->data = new uint8_t[pbagCk->size];
   for (size_t i = 0; i < numInstrs; i++) {
-    SynthInstr *instr = synthfile->vInstrs[i];
-
-    sfPresetBag presetBag;
-    memset(&presetBag, 0, sizeof(sfPresetBag));
-    presetBag.wGenNdx = (uint16_t) (i * ITEMS_IN_PGEN);
+    sfPresetBag presetBag{};
+    presetBag.wGenNdx = static_cast<uint16_t>(i * ITEMS_IN_PGEN);
     presetBag.wModNdx = 0;
 
     memcpy(pbagCk->data + (i * sizeof(sfPresetBag)), &presetBag, sizeof(sfPresetBag));
   }
   //  add terminal sfPresetBag
-  sfPresetBag presetBag;
-  memset(&presetBag, 0, sizeof(sfPresetBag));
-  presetBag.wGenNdx = (uint16_t) (numInstrs * ITEMS_IN_PGEN);
+  sfPresetBag presetBag{};
+  presetBag.wGenNdx = static_cast<uint16_t>(numInstrs * ITEMS_IN_PGEN);
   memcpy(pbagCk->data + (numInstrs * sizeof(sfPresetBag)), &presetBag, sizeof(sfPresetBag));
   pdtaCk->AddChildChunk(pbagCk);
 
@@ -146,8 +138,7 @@ SF2File::SF2File(SynthFile *synthfile)
   //***********
   Chunk *pmodCk = new Chunk("pmod");
   //  create the terminal field
-  sfModList modList;
-  memset(&modList, 0, sizeof(sfModList));
+  sfModList modList{};
   pmodCk->SetData(&modList, sizeof(sfModList));
   //modList.sfModSrcOper = cc1_Mod;
   //modList.sfModDestOper = startAddrsOffset;
@@ -161,14 +152,13 @@ SF2File::SF2File(SynthFile *synthfile)
   //***********
   Chunk *pgenCk = new Chunk("pgen");
   //pgenCk->size = (synthfile->vInstrs.size()+1) * sizeof(sfGenList);
-  pgenCk->size = (uint32_t) ((synthfile->vInstrs.size() * sizeof(sfGenList) * ITEMS_IN_PGEN) + sizeof(sfGenList));
+  pgenCk->size = static_cast<uint32_t>((synthfile->vInstrs.size() * sizeof(sfGenList) * ITEMS_IN_PGEN) + sizeof(sfGenList));
   pgenCk->data = new uint8_t[pgenCk->size];
   uint32_t dataPtr = 0;
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
 
-    sfGenList genList;
-    memset(&genList, 0, sizeof(sfGenList));
+    sfGenList genList{};
 
     // reverbEffectsSend - Value is in 0.1% units, so multiply by 1000. Ex: 250 == 25%.
     genList.sfGenOper = reverbEffectsSend;
@@ -177,13 +167,12 @@ SF2File::SF2File(SynthFile *synthfile)
     dataPtr += sizeof(sfGenList);
 
     genList.sfGenOper = instrument;
-    genList.genAmount.wAmount = (uint16_t) i;
+    genList.genAmount.wAmount = static_cast<uint16_t>(i);
     memcpy(pgenCk->data + dataPtr, &genList, sizeof(sfGenList));
     dataPtr += sizeof(sfGenList);
   }
   //  add terminal sfGenList
-  sfGenList genList;
-  memset(&genList, 0, sizeof(sfGenList));
+  sfGenList genList{};
   memcpy(pgenCk->data + dataPtr, &genList, sizeof(sfGenList));
 
   pdtaCk->AddChildChunk(pgenCk);
@@ -192,24 +181,22 @@ SF2File::SF2File(SynthFile *synthfile)
   // inst chunk
   //***********
   Chunk *instCk = new Chunk("inst");
-  instCk->size = (uint32_t) ((synthfile->vInstrs.size() + 1) * sizeof(sfInst));
+  instCk->size = static_cast<uint32_t>((synthfile->vInstrs.size() + 1) * sizeof(sfInst));
   instCk->data = new uint8_t[instCk->size];
-  size_t rgnCounter = 0;
+  uint16_t rgnCounter = 0;
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
 
-    sfInst inst;
-    memset(&inst, 0, sizeof(sfInst));
-    memcpy(inst.achInstName, instr->name.c_str(), min((unsigned long) instr->name.length(), (unsigned long) 20));
-    inst.wInstBagNdx = (uint16_t) rgnCounter;
+    sfInst inst{};
+    memcpy(inst.achInstName, instr->name.c_str(), std::min(instr->name.length(),20ul));
+    inst.wInstBagNdx = rgnCounter;
     rgnCounter += instr->vRgns.size();
 
     memcpy(instCk->data + (i * sizeof(sfInst)), &inst, sizeof(sfInst));
   }
   //  add terminal sfInst
-  sfInst inst;
-  memset(&inst, 0, sizeof(sfInst));
-  inst.wInstBagNdx = (uint16_t) rgnCounter;
+  sfInst inst{};
+  inst.wInstBagNdx = rgnCounter;
   memcpy(instCk->data + (numInstrs * sizeof(sfInst)), &inst, sizeof(sfInst));
   pdtaCk->AddChildChunk(instCk);
 
@@ -218,11 +205,11 @@ SF2File::SF2File(SynthFile *synthfile)
   //***********
   Chunk *ibagCk = new Chunk("ibag");
 
-  size_t numRgns = 0;
+  uint32_t numTotalRgns = 0;
   for (size_t i = 0; i < numInstrs; i++)
-    numRgns += synthfile->vInstrs[i]->vRgns.size();
+    numTotalRgns += synthfile->vInstrs[i]->vRgns.size();
 
-  ibagCk->size = (uint32_t) ((numRgns + 1) * sizeof(sfInstBag));
+  ibagCk->size = (numTotalRgns + 1) * sizeof(sfInstBag);
   ibagCk->data = new uint8_t[ibagCk->size];
 
   rgnCounter = 0;
@@ -232,9 +219,7 @@ SF2File::SF2File(SynthFile *synthfile)
 
     size_t numRgns = instr->vRgns.size();
     for (size_t j = 0; j < numRgns; j++) {
-      SynthRgn *rgn = instr->vRgns[j];
-      sfInstBag instBag;
-      memset(&instBag, 0, sizeof(sfInstBag));
+      sfInstBag instBag{};
       instBag.wInstGenNdx = instGenCounter;
       instGenCounter += 12;
       instBag.wInstModNdx = 0;
@@ -243,8 +228,7 @@ SF2File::SF2File(SynthFile *synthfile)
     }
   }
   //  add terminal sfInstBag
-  sfInstBag instBag;
-  memset(&instBag, 0, sizeof(sfInstBag));
+  sfInstBag instBag{};
   instBag.wInstGenNdx = instGenCounter;
   instBag.wInstModNdx = 0;
   memcpy(ibagCk->data + (rgnCounter * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
@@ -263,7 +247,7 @@ SF2File::SF2File(SynthFile *synthfile)
   // igen chunk
   //***********
   Chunk *igenCk = new Chunk("igen");
-  igenCk->size = (uint32_t) ((numRgns * sizeof(sfInstGenList) * 12) + sizeof(sfInstGenList));
+  igenCk->size = (numTotalRgns * sizeof(sfInstGenList) * 12) + sizeof(sfInstGenList);
   igenCk->data = new uint8_t[igenCk->size];
   dataPtr = 0;
   for (size_t i = 0; i < numInstrs; i++) {
@@ -276,8 +260,8 @@ SF2File::SF2File(SynthFile *synthfile)
       sfInstGenList instGenList;
       // Key range - (if exists) this must be the first chunk
       instGenList.sfGenOper = keyRange;
-      instGenList.genAmount.ranges.byLo = (uint8_t) rgn->usKeyLow;
-      instGenList.genAmount.ranges.byHi = (uint8_t) rgn->usKeyHigh;
+      instGenList.genAmount.ranges.byLo = static_cast<uint8_t>(rgn->usKeyLow);
+      instGenList.genAmount.ranges.byHi = static_cast<uint8_t>(rgn->usKeyHigh);
       memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
@@ -285,21 +269,21 @@ SF2File::SF2File(SynthFile *synthfile)
       {
         // Velocity range (if exists) this must be the next chunk
         instGenList.sfGenOper = velRange;
-        instGenList.genAmount.ranges.byLo = (uint8_t) rgn->usVelLow;
-        instGenList.genAmount.ranges.byHi = (uint8_t) rgn->usVelHigh;
+        instGenList.genAmount.ranges.byLo = static_cast<uint8_t>(rgn->usVelLow);
+        instGenList.genAmount.ranges.byHi = static_cast<uint8_t>(rgn->usVelHigh);
         memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
         dataPtr += sizeof(sfInstGenList);
       }
 
       // initialAttenuation
       instGenList.sfGenOper = initialAttenuation;
-      instGenList.genAmount.shAmount = (int16_t) (rgn->sampinfo->attenuation * 10);
+      instGenList.genAmount.shAmount = static_cast<int16_t>(rgn->sampinfo->attenuation * 10);
       memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // pan
       instGenList.sfGenOper = pan;
-      instGenList.genAmount.shAmount = (int16_t) ConvertPercentPanTo10thPercentUnits(rgn->art->pan);
+      instGenList.genAmount.shAmount = static_cast<int16_t>(ConvertPercentPanTo10thPercentUnits(rgn->art->pan));
       memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
@@ -340,7 +324,7 @@ SF2File::SF2File(SynthFile *synthfile)
       instGenList.sfGenOper = sustainVolEnv;
       if (rgn->art->sustain_lev > 100.0)
         rgn->art->sustain_lev = 100.0;
-      instGenList.genAmount.shAmount = (int16_t) (rgn->art->sustain_lev * 10);
+      instGenList.genAmount.shAmount = static_cast<int16_t>(rgn->art->sustain_lev * 10);
       memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
@@ -359,7 +343,7 @@ SF2File::SF2File(SynthFile *synthfile)
 
       // sampleID - this is the terminal chunk
       instGenList.sfGenOper = sampleID;
-      instGenList.genAmount.wAmount = (uint16_t) (rgn->tableIndex);
+      instGenList.genAmount.wAmount = static_cast<uint16_t>(rgn->tableIndex);
       memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
@@ -372,8 +356,7 @@ SF2File::SF2File(SynthFile *synthfile)
     }
   }
   //  add terminal sfInstBag
-  sfInstGenList instGenList;
-  memset(&instGenList, 0, sizeof(sfInstGenList));
+  sfInstGenList instGenList{};
   memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
   //memset(ibagCk->data + (numRgns*sizeof(sfInstBag)), 0, sizeof(sfInstBag));
   //igenCk->SetData(&genList, sizeof(sfGenList));
@@ -385,38 +368,37 @@ SF2File::SF2File(SynthFile *synthfile)
   Chunk *shdrCk = new Chunk("shdr");
 
   size_t numSamps = synthfile->vWaves.size();
-  shdrCk->size = (uint32_t) ((numSamps + 1) * sizeof(sfSample));
+  shdrCk->size = static_cast<uint32_t>((numSamps + 1) * sizeof(sfSample));
   shdrCk->data = new uint8_t[shdrCk->size];
 
   uint32_t sampOffset = 0;
   for (size_t i = 0; i < numSamps; i++) {
     SynthWave *wave = synthfile->vWaves[i];
 
-    sfSample samp;
-    memset(&samp, 0, sizeof(sfSample));
-    memcpy(samp.achSampleName, wave->name.c_str(), min((unsigned long) wave->name.length(), (unsigned long) 20));
+    sfSample samp{};
+    memcpy(samp.achSampleName, wave->name.c_str(), std::min(wave->name.length(), 20ul));
     samp.dwStart = sampOffset;
     samp.dwEnd = samp.dwStart + (wave->dataSize / sizeof(uint16_t));
     sampOffset = samp.dwEnd + 46;        // plus the 46 padding samples required by sf2 spec
 
     // Search through all regions for an associated sampInfo structure with this sample
-    SynthSampInfo *sampInfo = NULL;
+    SynthSampInfo *sampInfo = nullptr;
     for (size_t j = 0; j < numInstrs; j++) {
       SynthInstr *instr = synthfile->vInstrs[j];
 
       size_t numRgns = instr->vRgns.size();
       for (size_t k = 0; k < numRgns; k++) {
         SynthRgn *rgn = instr->vRgns[k];
-        if (rgn->tableIndex == i && rgn->sampinfo != NULL) {
+        if (rgn->tableIndex == i && rgn->sampinfo != nullptr) {
           sampInfo = rgn->sampinfo;
           break;
         }
       }
-      if (sampInfo != NULL)
+      if (sampInfo != nullptr)
         break;
     }
     //  If we didn't find a rgn association, then it should be in the SynthWave structure.
-    if (sampInfo == NULL)
+    if (sampInfo == nullptr)
       sampInfo = wave->sampinfo;
     assert (sampInfo != NULL);
 
@@ -426,8 +408,8 @@ SF2File::SF2File(SynthFile *synthfile)
     samp.dwStartloop = samp.dwStart + sampInfo->ulLoopStart;
     samp.dwEndloop = samp.dwStartloop + sampInfo->ulLoopLength;
     samp.dwSampleRate = wave->dwSamplesPerSec;
-    samp.byOriginalKey = (uint8_t) (sampInfo->usUnityNote) - (sampInfo->sFineTune / 100);
-    samp.chCorrection = (char) (sampInfo->sFineTune % 100);
+    samp.byOriginalKey = static_cast<uint8_t>(sampInfo->usUnityNote) - (sampInfo->sFineTune / 100);
+    samp.chCorrection = static_cast<char>(sampInfo->sFineTune % 100);
     samp.wSampleLink = 0;
     samp.sfSampleType = monoSample;
 

--- a/src/main/conversion/SF2File.h
+++ b/src/main/conversion/SF2File.h
@@ -253,38 +253,31 @@ struct sfSample {
 
 #pragma pack(pop)   /* restore original alignment from stack */
 
-
 class SF2StringChunk: public Chunk {
  public:
-  SF2StringChunk(std::string ckSig, std::string info)
+  SF2StringChunk(const std::string& ckSig, const std::string& info)
       : Chunk(ckSig) {
-    SetData(info.c_str(), (uint32_t) info.length());
+    SetData(info.c_str(), static_cast<u32>(info.length()));
   }
 };
 
 class SF2InfoListChunk: public LISTChunk {
  public:
-  SF2InfoListChunk(std::string name);
+  SF2InfoListChunk(const std::string& name);
 };
-
 
 class SF2sdtaChunk: public LISTChunk {
  public:
   SF2sdtaChunk();
 };
 
-
-inline void WriteLIST(std::vector<uint8_t> &buf, std::string listName, uint32_t listSize);
-inline void AlignName(std::string &name);
-
 class SynthFile;
 
 class SF2File: public RiffFile {
  public:
   SF2File(SynthFile *synthfile);
-  ~SF2File() = default;
+  ~SF2File() override = default;
 
   std::vector<uint8_t> SaveToMem();
   bool SaveSF2File(const std::string &filepath);
-
 };

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -20,16 +20,14 @@ typedef enum {
 
 class SynthFile {
  public:
-  SynthFile(const std::string synth_name = "Instrument Set");
+  SynthFile(std::string synth_name = "Instrument Set");
   ~SynthFile();
 
   SynthInstr *AddInstr(uint32_t bank, uint32_t instrNum, float reverb);
   SynthInstr *AddInstr(uint32_t bank, uint32_t instrNum, std::string Name, float reverb);
-  void DeleteInstr(uint32_t bank, uint32_t instrNum);
   SynthWave *AddWave(uint16_t formatTag, uint16_t channels, int samplesPerSec, int aveBytesPerSec,
                      uint16_t blockAlign, uint16_t bitsPerSample, uint32_t waveDataSize, uint8_t *waveData,
                      std::string name = "Unnamed Wave");
-  void SetName(std::string synth_name);
 
   //int WriteDLSToBuffer(std::vector<uint8_t> &buf);
   //bool SaveDLSFile(const wchar_t* filepath);
@@ -42,36 +40,35 @@ class SynthFile {
 
 class SynthInstr {
  public:
-  SynthInstr(void);
   SynthInstr(uint32_t bank, uint32_t instrument, float reverb);
   SynthInstr(uint32_t bank, uint32_t instrument, std::string instrName, float reverb);
-  SynthInstr(uint32_t bank, uint32_t instrument, std::string instrName, std::vector<SynthRgn *> listRgns, float reverb);
-  ~SynthInstr(void);
+  SynthInstr(uint32_t bank, uint32_t instrument, std::string instrName,
+             const std::vector<SynthRgn *>& listRgns, float reverb);
+  ~SynthInstr();
 
-  void AddRgnList(std::vector<SynthRgn> &RgnList);
-  SynthRgn *AddRgn(void);
-  SynthRgn *AddRgn(SynthRgn rgn);
+  SynthRgn *AddRgn();
+  SynthRgn *AddRgn(const SynthRgn& rgn);
 
  public:
   uint32_t ulBank;
   uint32_t ulInstrument;
+  std::string name;
   float reverb;
 
   std::vector<SynthRgn *> vRgns;
-  std::string name;
 };
 
 class SynthRgn {
  public:
-  SynthRgn(void) : sampinfo(NULL), art(NULL) { }
+  SynthRgn() : sampinfo(nullptr), art(nullptr) { }
   SynthRgn(uint16_t keyLow, uint16_t keyHigh, uint16_t velLow, uint16_t velHigh)
-      : usKeyLow(keyLow), usKeyHigh(keyHigh), usVelLow(velLow), usVelHigh(velHigh), sampinfo(NULL), art(NULL) { }
+      : usKeyLow(keyLow), usKeyHigh(keyHigh), usVelLow(velLow), usVelHigh(velHigh), sampinfo(nullptr), art(nullptr) { }
   SynthRgn(uint16_t keyLow, uint16_t keyHigh, uint16_t velLow, uint16_t velHigh, SynthArt &art);
-  ~SynthRgn(void);
+  ~SynthRgn();
 
-  SynthArt *AddArt(void);
+  SynthArt *AddArt();
   SynthArt *AddArt(std::vector<SynthConnectionBlock *> connBlocks);
-  SynthSampInfo *AddSampInfo(void);
+  SynthSampInfo *AddSampInfo();
   SynthSampInfo *AddSampInfo(SynthSampInfo wsmp);
   void SetRanges(uint16_t keyLow = 0, uint16_t keyHigh = 0x7F, uint16_t velLow = 0, uint16_t velHigh = 0x7F);
   void SetWaveLinkInfo(uint16_t options, uint16_t phaseGroup, uint32_t theChannel, uint32_t theTableIndex);
@@ -150,14 +147,15 @@ class SynthSampInfo {
 class SynthWave {
  public:
   SynthWave()
-      : sampinfo(NULL),
-        data(NULL),
+      : sampinfo(nullptr),
+        data(nullptr),
         name("Untitled Wave") {
     RiffFile::AlignName(name);
   }
   SynthWave(uint16_t formatTag, uint16_t channels, int samplesPerSec, int aveBytesPerSec, uint16_t blockAlign,
             uint16_t bitsPerSample, uint32_t waveDataSize, uint8_t *waveData, std::string waveName = "Untitled Wave")
-      : wFormatTag(formatTag),
+      : sampinfo(nullptr),
+        wFormatTag(formatTag),
         wChannels(channels),
         dwSamplesPerSec(samplesPerSec),
         dwAveBytesPerSec(aveBytesPerSec),
@@ -165,8 +163,7 @@ class SynthWave {
         wBitsPerSample(bitsPerSample),
         dataSize(waveDataSize),
         data(waveData),
-        sampinfo(NULL),
-        name(waveName) {
+        name(std::move(waveName)) {
     RiffFile::AlignName(name);
   }
   ~SynthWave(void);

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.h
@@ -99,9 +99,9 @@ class AkaoSnesSeq
               std::string newName = "Square AKAO SNES Seq");
   virtual ~AkaoSnesSeq(void);
 
-  virtual bool GetHeaderInfo(void);
-  virtual bool GetTrackPointers(void);
-  virtual void ResetVars(void);
+  virtual bool GetHeaderInfo();
+  virtual bool GetTrackPointers();
+  virtual void ResetVars();
 
   double GetTempoInBPM(uint8_t tempo);
 

--- a/src/main/formats/CPS/CPS2Instr.h
+++ b/src/main/formats/CPS/CPS2Instr.h
@@ -90,13 +90,12 @@ struct qs_samp_info {
   uint32_t end_addr;
   uint8_t unity_key;
 
-  qs_samp_info() {
-  }
+  qs_samp_info() = default;
 
   qs_samp_info(qs_samp_info_cps2* cps2) {
     this->start_addr = (cps2->bank << 16) | swap_bytes16(cps2->start_addr);
     this->loop_offset = (cps2->bank << 16) | swap_bytes16(cps2->loop_offset);
-    this->end_addr = swap_bytes16(cps2->end_addr) + (cps2->end_addr == 0) ? (cps2->bank + 1) << 16 : 0;
+    this->end_addr = (swap_bytes16(cps2->end_addr) + (cps2->end_addr == 0)) ? (cps2->bank + 1) << 16 : 0;
     this->unity_key = cps2->unity_key;
   }
 

--- a/src/main/formats/CapcomSnes/CapcomSnesScanner.h
+++ b/src/main/formats/CapcomSnes/CapcomSnesScanner.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Scanner.h"
 #include "BytePattern.h"
+#include "ExtensionDiscriminator.h"
 
 enum CapcomSnesVersion: uint8_t; // see CapcomSnesFormat.h
 

--- a/src/main/formats/ItikitiSnes/ItikitiSnesScanner.h
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesScanner.h
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+#include "common.h"
 #include "Scanner.h"
 
 class ItikitiSnesScanner: public VGMScanner {

--- a/src/main/formats/KonamiGX/KonamiGXScanner.cpp
+++ b/src/main/formats/KonamiGX/KonamiGXScanner.cpp
@@ -17,7 +17,6 @@ void KonamiGXScanner::Scan(RawFile *file, void *info) {
     return;
 
   LoadSeqTable(seqRomGroupEntry->file, seq_table_offset);
-  return;
 }
 
 

--- a/src/main/formats/KonamiGX/KonamiGXScanner.h
+++ b/src/main/formats/KonamiGX/KonamiGXScanner.h
@@ -4,6 +4,7 @@
  * refer to the included LICENSE.txt file
  */
 #pragma once
+#include "common.h"
 #include "Scanner.h"
 
 class KonamiGXScanner:

--- a/src/main/formats/NDS/NDSInstrSet.h
+++ b/src/main/formats/NDS/NDSInstrSet.h
@@ -5,11 +5,9 @@
  */
 
 #pragma once
-#include "RawFile.h"
 #include "VGMInstrSet.h"
 #include "VGMSampColl.h"
 #include "VGMSamp.h"
-#include "VGMColl.h"
 #include "NDSFormat.h"
 
 class NDSInstr;
@@ -22,7 +20,7 @@ class NDSInstrSet : public VGMInstrSet {
 public:
   NDSInstrSet(RawFile *file, uint32_t offset, uint32_t length, VGMSampColl *psg_samples,
               std::string name = "NDS Instrument Bank");
-  virtual bool GetInstrPointers();
+  bool GetInstrPointers() override;
 
   std::vector<VGMSampColl *> sampCollWAList;
 
@@ -40,11 +38,11 @@ public:
   NDSInstr(NDSInstrSet *instrSet, uint32_t offset, uint32_t length, uint32_t bank,
            uint32_t instrNum, uint8_t instrType);
 
-  virtual bool LoadInstr();
+  bool LoadInstr() override;
 
-  void GetSampCollPtr(VGMRgn *rgn, int waNum);
-  void GetArticData(VGMRgn *rgn, uint32_t offset);
-  uint16_t GetFallingRate(uint8_t DecayTime);
+  void GetSampCollPtr(VGMRgn *rgn, int waNum) const;
+  void GetArticData(VGMRgn *rgn, uint32_t offset) const;
+  uint16_t GetFallingRate(uint8_t DecayTime) const;
 
 private:
   uint8_t instrType;
@@ -70,7 +68,7 @@ static const unsigned AdpcmTable[89] = {
     0x1BDC, 0x1EA5, 0x21B6, 0x2515, 0x28CA, 0x2CDF, 0x315B, 0x364B, 0x3BB9, 0x41B2, 0x4844, 0x4F7E,
     0x5771, 0x602F, 0x69CE, 0x7462, 0x7FFF};
 
-static const int IMA_IndexTable[9] = {-1, -1, -1, -1, 2, 4, 6, 8};
+static constexpr int IMA_IndexTable[9] = {-1, -1, -1, -1, 2, 4, 6, 8};
 
 class NDSWaveArch : public VGMSampColl {
 public:
@@ -101,9 +99,9 @@ public:
           uint32_t dataLength = 0, uint8_t channels = 1, uint16_t bps = 16, uint32_t rate = 0,
           uint8_t waveType = 0, std::string name = "Sample");
 
-  virtual double GetCompressionRatio();  // ratio of space conserved.  should generally be > 1
+  double GetCompressionRatio() override;  // ratio of space conserved.  should generally be > 1
   // used to calculate both uncompressed sample size and loopOff after conversion
-  virtual void ConvertToStdWave(uint8_t *buf);
+  void ConvertToStdWave(uint8_t *buf) override;
 
   void ConvertImaAdpcm(uint8_t *buf);
 

--- a/src/main/formats/NinSnes/NinSnesScanner.cpp
+++ b/src/main/formats/NinSnes/NinSnesScanner.cpp
@@ -1428,6 +1428,9 @@ void NinSnesScanner::SearchForNinSnesFromARAM(RawFile *file) {
     case NINSNES_QUINTET_TS:
       quintetAddrBGMInstrLookup = file->GetShort(ofsInstrVCmd + 18);
       break;
+
+    default:
+      break;
   }
 
   // GUESS SONG COUNT

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
@@ -351,7 +351,8 @@ bool TamSoftPS1Track::ReadEvent(void) {
 
       case 0xFF:
         // I'm quite not sure, but it looks like an end event
-        bContinue = AddEndOfTrack(beginOffset, curOffset - beginOffset);
+        AddEndOfTrack(beginOffset, curOffset - beginOffset);
+        bContinue = false;
         break;
 
       default: {

--- a/src/main/io/RawFile.cpp
+++ b/src/main/io/RawFile.cpp
@@ -77,7 +77,7 @@ VirtFile::VirtFile(const RawFile &file, size_t offset, size_t limit)
 }
 
 VirtFile::VirtFile(const uint8_t *data, uint32_t fileSize, std::string name,
-                   std::string parent_fullpath, const VGMTag tag)
+                   std::string parent_fullpath, const VGMTag& tag)
     : m_name(std::move(name)), m_lpath(std::move(parent_fullpath)) {
     std::copy(data, data + fileSize, std::back_inserter(m_data));
 }

--- a/src/main/io/RawFile.h
+++ b/src/main/io/RawFile.h
@@ -121,7 +121,7 @@ class RawFile {
 class DiskFile final : public RawFile {
    public:
     DiskFile(const std::string &path);
-    ~DiskFile() = default;
+    ~DiskFile() override = default;
 
     [[nodiscard]] std::string name() const override { return m_path.filename().string(); };
     [[nodiscard]] std::string path() const override { return m_path.string(); };
@@ -154,8 +154,8 @@ class VirtFile final : public RawFile {
     VirtFile(const RawFile &, size_t offset = 0);
     VirtFile(const RawFile &, size_t offset, size_t limit);
     VirtFile(const uint8_t *data, uint32_t size, std::string name, std::string parent_fullpath = "",
-             VGMTag tag = VGMTag());
-    ~VirtFile() = default;
+             const VGMTag& tag = VGMTag());
+    ~VirtFile() override = default;
 
     [[nodiscard]] std::string name() const override { return m_name; };
     [[nodiscard]] std::string path() const override { return m_lpath.string(); };

--- a/src/ui/cli/CLIVGMRoot.h
+++ b/src/ui/cli/CLIVGMRoot.h
@@ -51,7 +51,7 @@ public:
   std::string UI_GetSaveFilePath(const std::string& suggestedFilename,
                                  const std::string& extension = "") override;
 
-  virtual std::string UI_GetSaveDirPath(const std::string& suggestedDir = "");
+  std::string UI_GetSaveDirPath(const std::string& suggestedDir = "") override;
 
   std::set<fs::path> inputFiles = {};
   fs::path outputDir = fs::path(".");

--- a/src/ui/qt/MenuBar.cpp
+++ b/src/ui/qt/MenuBar.cpp
@@ -44,7 +44,7 @@ void MenuBar::appendOptionsMenu(const QList<QDockWidget *> &dockWidgets) {
   act->setCheckable(true);
   bs_grp->addAction(act);
 
-  connect(bs_grp, &QActionGroup::triggered, [](QAction *bs_style) {
+  connect(bs_grp, &QActionGroup::triggered, [](const QAction *bs_style) {
     if (auto text = bs_style->text(); text == "GS (Default)") {
       ConversionOptions::the().SetBankSelectStyle(BankSelectStyle::GS);
     } else if (text == "MMA") {

--- a/src/ui/qt/QtVGMRoot.cpp
+++ b/src/ui/qt/QtVGMRoot.cpp
@@ -6,17 +6,16 @@
 
 #include <QApplication>
 #include <QFileDialog>
-#include <QString>
 #include "QtVGMRoot.h"
 #include "VGMFileTreeView.h"
 #include "UIHelpers.h"
 
 QtVGMRoot qtVGMRoot;
 
-const std::string QtVGMRoot::UI_GetResourceDirPath() {
+std::string QtVGMRoot::UI_GetResourceDirPath() {
 #if defined(Q_OS_WIN)
   return (QApplication::applicationDirPath() + "/").toStdString();
-#elif defined(Q_OS_OSX)
+#elif defined(Q_OS_MACOS)
   return (QApplication::applicationDirPath() + "/../Resources/").toStdString();
 #elif defined(Q_OS_LINUX)
   return (QApplication::applicationDirPath() + "/").toStdString();

--- a/src/ui/qt/QtVGMRoot.h
+++ b/src/ui/qt/QtVGMRoot.h
@@ -15,10 +15,10 @@ class QtVGMRoot final : public QObject, public VGMRoot {
 public:
   ~QtVGMRoot() override = default;
 
-  const std::string UI_GetResourceDirPath() override;
+  std::string UI_GetResourceDirPath() override;
   void UI_SetRootPtr(VGMRoot** theRoot) override;
   void UI_AddRawFile(RawFile* newFile) override;
-  void UI_CloseRawFile(RawFile* targFile);
+  void UI_CloseRawFile(RawFile* targFile) override;
 
   void UI_OnBeginLoadRawFile() override;
   void UI_OnEndLoadRawFile() override;

--- a/src/ui/qt/services/MenuManager.cpp
+++ b/src/ui/qt/services/MenuManager.cpp
@@ -43,7 +43,7 @@ template<typename T, typename Base>
 void MenuManager::RegisterCommands(const std::vector<std::shared_ptr<Command>>& commands) {
   commandsForType[typeid(T)] = commands;
 
-  if constexpr (std::is_convertible<T*, Base*>::value) {
+  if constexpr (std::is_convertible_v<T*, Base*>) {
     auto checkFunc = [](void* base) -> bool { return dynamic_cast<T*>(static_cast<Base*>(base)) != nullptr; };
     auto typeErasedCheckFunc = static_cast<CheckFunc<void>>(checkFunc);
     commandsForCheckedType[typeid(Base)].emplace_back(typeErasedCheckFunc, commands);

--- a/src/ui/qt/workarea/RawFileListView.h
+++ b/src/ui/qt/workarea/RawFileListView.h
@@ -34,8 +34,8 @@ public:
 
 private:
   void onVGMFileSelected(VGMFile* vgmfile, QWidget* caller);
-  void focusInEvent(QFocusEvent *event);
-  void currentChanged(const QModelIndex &current, const QModelIndex &previous);
+  void focusInEvent(QFocusEvent *event) override;
+  void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
   void keyPressEvent(QKeyEvent *input) override;
   void rawFilesMenu(const QPoint &pos);
   void deleteRawFiles();

--- a/src/ui/qt/workarea/VGMCollView.cpp
+++ b/src/ui/qt/workarea/VGMCollView.cpp
@@ -7,7 +7,6 @@
 #include "VGMCollView.h"
 
 #include <QVBoxLayout>
-#include <QLabel>
 #include <QListView>
 #include <QLineEdit>
 #include <QPushButton>
@@ -56,7 +55,7 @@ QVariant VGMCollViewModel::data(const QModelIndex &index, int role) const {
 
 void VGMCollViewModel::handleNewCollSelected(QModelIndex modelIndex) {
   if (!modelIndex.isValid() || qtVGMRoot.vVGMColl.empty() ||
-      modelIndex.row() >= qtVGMRoot.vVGMColl.size()) {
+      static_cast<size_t>(modelIndex.row()) >= qtVGMRoot.vVGMColl.size()) {
     m_coll = nullptr;
   } else {
     m_coll = qtVGMRoot.vVGMColl[modelIndex.row()];
@@ -171,7 +170,7 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
 
   QObject::connect(collListSelModel, &QItemSelectionModel::currentChanged, [=](QModelIndex index) {
     if (!index.isValid() || qtVGMRoot.vVGMColl.empty() ||
-        index.row() >= qtVGMRoot.vVGMColl.size()) {
+        static_cast<size_t>(index.row()) >= qtVGMRoot.vVGMColl.size()) {
       commit_rename->setEnabled(false);
       m_collection_title->setReadOnly(true);
       m_collection_title->setText("No collection selected");

--- a/src/ui/qt/workarea/VGMCollView.h
+++ b/src/ui/qt/workarea/VGMCollView.h
@@ -22,7 +22,7 @@ public:
   VGMCollViewModel(QItemSelectionModel *collListSelModel, QObject *parent = 0);
 
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-  QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+  QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
   [[nodiscard]] VGMFile *fileFromIndex(QModelIndex index) const;
   [[nodiscard]] QModelIndex indexFromFile(VGMFile* file) const;


### PR DESCRIPTION
I'm going down the list of code files roughly alphabetically, addressing as many compiler warnings as I can. This does not include clang-tidy warnings. I am trying to leave the logic as-is to avoid potentially breaking changes, though there are a couple or so places where I had to change logic.

## Motivation and Context
Clean up the the code and make it easier to read compiler logs.