### PR TITLE
Warning cleanup 2

### DIFF
--- a/src/main/LogManager.h
+++ b/src/main/LogManager.h
@@ -36,13 +36,13 @@ public:
   }
 
   template<typename... Args>
-  void log(spdlog::level::level_enum lvl, const char* file, int line, fmt::format_string<Args...> fmt, Args&&... args) {
+  void log(spdlog::level::level_enum lvl, const char* file, int line, fmt::format_string<Args...> fmt, Args&&... args) const {
     if (lvl != spdlog::level::off) {
       logger_->log(spdlog::source_loc{file, line, ""}, lvl, fmt, std::forward<Args>(args)...);
     }
   }
 
-  void log(spdlog::level::level_enum lvl, const char* file, int line, const std::string& fmt_string) {
+  void log(spdlog::level::level_enum lvl, const char* file, int line, const std::string& fmt_string) const {
     if (lvl != spdlog::level::off) {
       logger_->log(spdlog::source_loc{file, line, ""}, lvl, "{}", fmt_string);
     }

--- a/src/main/Options.h
+++ b/src/main/Options.h
@@ -27,10 +27,10 @@ public:
 
   ~ConversionOptions() = default;
 
-  BankSelectStyle GetBankSelectStyle() { return m_bs_style; }
+  BankSelectStyle GetBankSelectStyle() const { return m_bs_style; }
   void SetBankSelectStyle(BankSelectStyle style) { m_bs_style = style; }
 
-  int GetNumSequenceLoops() { return m_sequence_loops; }
+  int GetNumSequenceLoops() const { return m_sequence_loops; }
   void SetNumSequenceLoops(int numLoops) { m_sequence_loops = numLoops; }
 
 private:

--- a/src/main/components/VGMColl.cpp
+++ b/src/main/components/VGMColl.cpp
@@ -545,6 +545,8 @@ SynthFile *VGMColl::CreateSynthFile() {
         else
           attenuation = 0;
 
+        sampInfo->SetPitchInfo(realUnityKey, realFineTune, attenuation);
+
         double sustainLevAttenDb;
         if (rgn->sustain_level == -1)
           sustainLevAttenDb = 0.0;
@@ -556,8 +558,6 @@ SynthFile *VGMColl::CreateSynthFile() {
         newArt->AddADSR(rgn->attack_time, static_cast<Transform>(rgn->attack_transform),
           rgn->hold_time, rgn->decay_time, sustainLevAttenDb, rgn->sustain_time, rgn->release_time,
           static_cast<Transform>(rgn->release_transform));
-
-        sampInfo->SetPitchInfo(realUnityKey, realFineTune, attenuation);
       }
     }
   }

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -99,10 +99,8 @@ SynthRgn *SynthInstr::AddRgn(const SynthRgn& rgn) {
 //  ********
 
 SynthRgn::~SynthRgn() {
-  if (sampinfo)
-    delete sampinfo;
-  if (art)
-    delete art;
+  delete sampinfo;
+  delete art;
 }
 
 SynthArt *SynthRgn::AddArt() {
@@ -206,7 +204,7 @@ SynthWave::~SynthWave() {
   delete[] data;
 }
 
-SynthSampInfo *SynthWave::AddSampInfo(void) {
+SynthSampInfo *SynthWave::AddSampInfo() {
   sampinfo = new SynthSampInfo();
   return sampinfo;
 }

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -81,11 +81,9 @@ public:
 
 class SynthRgn {
  public:
-  SynthRgn() : usKeyLow(0), usKeyHigh(0x7F), usVelLow(0), usVelHigh(0x7F),
-        fusOptions(0), usPhaseGroup(0), channel(1), tableIndex(0), sampinfo(nullptr), art(nullptr) { }
+  SynthRgn() = default;
   SynthRgn(uint16_t keyLow, uint16_t keyHigh, uint16_t velLow, uint16_t velHigh)
-      : usKeyLow(keyLow), usKeyHigh(keyHigh), usVelLow(velLow), usVelHigh(velHigh),
-        fusOptions(0), usPhaseGroup(0), channel(1), tableIndex(0), sampinfo(nullptr), art(nullptr) { }
+      : usKeyLow(keyLow), usKeyHigh(keyHigh), usVelLow(velLow), usVelHigh(velHigh) {}
   ~SynthRgn();
 
   SynthArt *AddArt();
@@ -93,18 +91,18 @@ class SynthRgn {
   void SetRanges(uint16_t keyLow = 0, uint16_t keyHigh = 0x7F, uint16_t velLow = 0, uint16_t velHigh = 0x7F);
   void SetWaveLinkInfo(uint16_t options, uint16_t phaseGroup, uint32_t theChannel, uint32_t theTableIndex);
 
-  uint16_t usKeyLow;
-  uint16_t usKeyHigh;
-  uint16_t usVelLow;
-  uint16_t usVelHigh;
+  uint16_t usKeyLow {0};
+  uint16_t usKeyHigh {0x7F};
+  uint16_t usVelLow {0};
+  uint16_t usVelHigh {0x7F};
 
-  uint16_t fusOptions;    // would be used for DLS conversion
-  uint16_t usPhaseGroup;  // ''
-  uint32_t channel;       // ''
-  uint32_t tableIndex;
+  uint16_t fusOptions {0};    // would be used for DLS conversion
+  uint16_t usPhaseGroup {0};  // ''
+  uint32_t channel {1};       // ''
+  uint32_t tableIndex {0};
 
-  SynthSampInfo *sampinfo;
-  SynthArt *art;
+  SynthSampInfo *sampinfo {nullptr};
+  SynthArt *art {nullptr};
 };
 
 class SynthArt {

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "common.h"
 #include "RiffFile.h"
 
 struct Loop;
@@ -9,7 +8,6 @@ class VGMSamp;
 class SynthInstr;
 class SynthRgn;
 class SynthArt;
-class SynthConnectionBlock;
 class SynthSampInfo;
 class SynthWave;
 
@@ -29,10 +27,6 @@ class SynthFile {
                      uint16_t blockAlign, uint16_t bitsPerSample, uint32_t waveDataSize, uint8_t *waveData,
                      std::string name = "Unnamed Wave");
 
-  //int WriteDLSToBuffer(std::vector<uint8_t> &buf);
-  //bool SaveDLSFile(const wchar_t* filepath);
-
- public:
   std::vector<SynthInstr *> vInstrs;
   std::vector<SynthWave *> vWaves;
   std::string name;
@@ -49,7 +43,6 @@ class SynthInstr {
   SynthRgn *AddRgn();
   SynthRgn *AddRgn(const SynthRgn& rgn);
 
- public:
   uint32_t ulBank;
   uint32_t ulInstrument;
   std::string name;
@@ -58,30 +51,56 @@ class SynthInstr {
   std::vector<SynthRgn *> vRgns;
 };
 
+class SynthSampInfo {
+public:
+  SynthSampInfo() = default;
+  SynthSampInfo(uint16_t unityNote,
+                int16_t fineTune,
+                double atten,
+                int8_t sampleLoops,
+                uint32_t loopType,
+                uint32_t loopStart,
+                uint32_t loopLength)
+      : usUnityNote(unityNote), sFineTune(fineTune), attenuation(atten), cSampleLoops(sampleLoops),
+        ulLoopType(loopType),
+        ulLoopStart(loopStart), ulLoopLength(loopLength) { }
+  ~SynthSampInfo() = default;
+
+  void SetLoopInfo(Loop &loop, VGMSamp *samp);
+  void SetPitchInfo(uint16_t unityNote, int16_t fineTune, double attenuation);
+
+  uint16_t usUnityNote;
+  int16_t sFineTune;
+  double attenuation;  // in decibels.
+  int8_t cSampleLoops;
+
+  uint32_t ulLoopType;
+  uint32_t ulLoopStart;
+  uint32_t ulLoopLength;
+};
+
 class SynthRgn {
  public:
-  SynthRgn() : sampinfo(nullptr), art(nullptr) { }
+  SynthRgn() : usKeyLow(0), usKeyHigh(0x7F), usVelLow(0), usVelHigh(0x7F),
+        fusOptions(0), usPhaseGroup(0), channel(1), tableIndex(0), sampinfo(nullptr), art(nullptr) { }
   SynthRgn(uint16_t keyLow, uint16_t keyHigh, uint16_t velLow, uint16_t velHigh)
-      : usKeyLow(keyLow), usKeyHigh(keyHigh), usVelLow(velLow), usVelHigh(velHigh), sampinfo(nullptr), art(nullptr) { }
-  SynthRgn(uint16_t keyLow, uint16_t keyHigh, uint16_t velLow, uint16_t velHigh, SynthArt &art);
+      : usKeyLow(keyLow), usKeyHigh(keyHigh), usVelLow(velLow), usVelHigh(velHigh),
+        fusOptions(0), usPhaseGroup(0), channel(1), tableIndex(0), sampinfo(nullptr), art(nullptr) { }
   ~SynthRgn();
 
   SynthArt *AddArt();
-  SynthArt *AddArt(std::vector<SynthConnectionBlock *> connBlocks);
   SynthSampInfo *AddSampInfo();
-  SynthSampInfo *AddSampInfo(SynthSampInfo wsmp);
   void SetRanges(uint16_t keyLow = 0, uint16_t keyHigh = 0x7F, uint16_t velLow = 0, uint16_t velHigh = 0x7F);
   void SetWaveLinkInfo(uint16_t options, uint16_t phaseGroup, uint32_t theChannel, uint32_t theTableIndex);
 
- public:
   uint16_t usKeyLow;
   uint16_t usKeyHigh;
   uint16_t usVelLow;
   uint16_t usVelHigh;
 
-  uint16_t fusOptions;
-  uint16_t usPhaseGroup;
-  uint32_t channel;
+  uint16_t fusOptions;    // would be used for DLS conversion
+  uint16_t usPhaseGroup;  // ''
+  uint32_t channel;       // ''
   uint32_t tableIndex;
 
   SynthSampInfo *sampinfo;
@@ -90,10 +109,8 @@ class SynthRgn {
 
 class SynthArt {
  public:
-  SynthArt(void) { }
-  SynthArt(std::vector<SynthConnectionBlock> &connectionBlocks);
-  //SynthArt(uint16_t source, uint16_t control, uint16_t destination, uint16_t transform);
-  ~SynthArt(void);
+  SynthArt() = default;
+  ~SynthArt();
 
   void AddADSR(double attack, Transform atk_transform, double hold, double decay, double sustain_lev,
                double sustain_time, double release_time, Transform rls_transform);
@@ -109,49 +126,10 @@ class SynthArt {
   double release_time;    // rate expressed as seconds from 100% to 0% level, even though the sustain level may not be 100%
   Transform attack_transform;
   Transform release_transform;
-
- private:
-  //vector<SynthConnectionBlock*> vConnBlocks;
-};
-
-class SynthSampInfo {
- public:
-  SynthSampInfo(void) { }
-  SynthSampInfo(uint16_t unityNote,
-                int16_t fineTune,
-                double atten,
-                int8_t sampleLoops,
-                uint32_t loopType,
-                uint32_t loopStart,
-                uint32_t loopLength)
-      : usUnityNote(unityNote), sFineTune(fineTune), attenuation(atten), cSampleLoops(sampleLoops),
-        ulLoopType(loopType),
-        ulLoopStart(loopStart), ulLoopLength(loopLength) { }
-  ~SynthSampInfo() { }
-
-  void SetLoopInfo(Loop &loop, VGMSamp *samp);
-  //void SetPitchInfo(uint16_t unityNote, int16_t fineTune, double attenuation);
-  void SetPitchInfo(uint16_t unityNote, int16_t fineTune, double attenuation);
-
- public:
-  uint16_t usUnityNote;
-  int16_t sFineTune;
-  double attenuation;  // in decibels.
-  int8_t cSampleLoops;
-
-  uint32_t ulLoopType;
-  uint32_t ulLoopStart;
-  uint32_t ulLoopLength;
 };
 
 class SynthWave {
  public:
-  SynthWave()
-      : sampinfo(nullptr),
-        data(nullptr),
-        name("Untitled Wave") {
-    RiffFile::AlignName(name);
-  }
   SynthWave(uint16_t formatTag, uint16_t channels, int samplesPerSec, int aveBytesPerSec, uint16_t blockAlign,
             uint16_t bitsPerSample, uint32_t waveDataSize, uint8_t *waveData, std::string waveName = "Untitled Wave")
       : sampinfo(nullptr),

--- a/src/main/conversion/VGMExport.cpp
+++ b/src/main/conversion/VGMExport.cpp
@@ -15,15 +15,12 @@ namespace conversion {
 
 bool SaveAsDLS(const VGMInstrSet &set, const std::string &filepath) {
   DLSFile dlsfile;
-  bool dlsCreationSucceeded = false;
 
   if (set.assocColls.empty()) {
     return false;
   }
 
-  dlsCreationSucceeded = set.assocColls.front()->CreateDLSFile(dlsfile);
-
-  if (dlsCreationSucceeded) {
+  if (set.assocColls.front()->CreateDLSFile(dlsfile)) {
     return dlsfile.SaveDLSFile(filepath);
   }
   return false;
@@ -62,7 +59,7 @@ bool saveDataToFile(const char* begin, uint32_t length, const std::string& filep
   }
 
   try {
-    std::copy(begin,begin + length, std::ostreambuf_iterator<char>(out));
+    std::copy_n(begin, length, std::ostreambuf_iterator<char>(out));
   } catch (...) {
     return false;
   }

--- a/src/main/conversion/VGMExport.h
+++ b/src/main/conversion/VGMExport.h
@@ -3,6 +3,7 @@
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
  */
+#pragma once
 
 #include "common.h"
 #include "DLSFile.h"
@@ -52,8 +53,7 @@ void SaveAs(VGMColl &coll, const std::string &dir_path) {
   }
 
   if constexpr ((options & Target::SF2) != 0) {
-    SF2File *sf2file = coll.CreateSF2File();
-    if (sf2file) {
+    if (SF2File *sf2file = coll.CreateSF2File()) {
       sf2file->SaveSF2File(filepath + ".sf2");
     }
   }

--- a/src/main/io/RawFile.cpp
+++ b/src/main/io/RawFile.cpp
@@ -18,8 +18,7 @@ void RawFile::AddContainedVGMFile(std::shared_ptr<std::variant<VGMSeq *, VGMInst
 }
 
 void RawFile::RemoveContainedVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> vgmfile) {
-    auto iter = std::find_if(m_vgmfiles.begin(), m_vgmfiles.end(),
-      [vgmfile](auto file) { return *file == vgmfile; });
+    auto iter = std::ranges::find_if(m_vgmfiles, [vgmfile](auto file) { return *file == vgmfile; });
     if (iter != m_vgmfiles.end())
         m_vgmfiles.erase(iter);
     else {
@@ -73,11 +72,11 @@ VirtFile::VirtFile(const RawFile &file, size_t offset) : m_name(file.name()), m_
 
 VirtFile::VirtFile(const RawFile &file, size_t offset, size_t limit)
     : m_name(file.name()), m_lpath(file.path()) {
-    std::copy(file.data() + offset, file.data() + offset + limit, std::back_inserter(m_data));
+    std::copy_n(file.data() + offset, limit, std::back_inserter(m_data));
 }
 
 VirtFile::VirtFile(const uint8_t *data, uint32_t fileSize, std::string name,
                    std::string parent_fullpath, const VGMTag& tag)
     : m_name(std::move(name)), m_lpath(std::move(parent_fullpath)) {
-    std::copy(data, data + fileSize, std::back_inserter(m_data));
+    std::copy_n(data, fileSize, std::back_inserter(m_data));
 }

--- a/src/main/io/RawFile.h
+++ b/src/main/io/RawFile.h
@@ -9,7 +9,6 @@
 #include <string_view>
 #include <filesystem>
 #include <vector>
-#include <memory>
 #include <climits>
 #include <cassert>
 #include <variant>

--- a/src/main/loaders/CPS3Decrypt.cpp
+++ b/src/main/loaders/CPS3Decrypt.cpp
@@ -11,9 +11,7 @@ uint16_t CPS3Decrypt::rotate_left(uint16_t value, int n)
 
 uint16_t CPS3Decrypt::rotxor(uint16_t val, uint16_t xorval)
 {
-  uint16_t res;
-
-  res = val + rotate_left(val,2);
+  uint16_t res = val + rotate_left(val,2);
   res = rotate_left(res,4) ^ (res & (val ^ xorval));
 
   return res;
@@ -21,11 +19,9 @@ uint16_t CPS3Decrypt::rotxor(uint16_t val, uint16_t xorval)
 
 uint32_t CPS3Decrypt::cps3_mask(uint32_t address, uint32_t key1, uint32_t key2)
 {
-  uint16_t val;
-
   address ^= key1;
 
-  val = (address & 0xffff) ^ 0xffff;
+  uint16_t val = (address & 0xffff) ^ 0xffff;
   val = rotxor(val, key2 & 0xffff);
   val ^= (address >> 16) ^ 0xffff;
   val = rotxor(val, key2 >> 16);
@@ -35,7 +31,7 @@ uint32_t CPS3Decrypt::cps3_mask(uint32_t address, uint32_t key1, uint32_t key2)
 }
 
 
-void CPS3Decrypt::cps3_decode(uint32_t *src, uint32_t *dest, uint32_t key1, uint32_t key2, uint32_t length) {
+void CPS3Decrypt::cps3_decode(const uint32_t *src, uint32_t *dest, uint32_t key1, uint32_t key2, uint32_t length) {
   for (int i = 0; i < length; i += 4) {
     uint32_t data = swap_bytes32(src[i / 4]) ^ cps3_mask(0x6000000 + i, key1, key2);
     dest[i / 4] = swap_bytes32(data);

--- a/src/main/loaders/CPS3Decrypt.h
+++ b/src/main/loaders/CPS3Decrypt.h
@@ -3,7 +3,7 @@
 class CPS3Decrypt {
 
 public:
-  static void cps3_decode(uint32_t *src, uint32_t *dest, uint32_t key, uint32_t key2, uint32_t length);
+  static void cps3_decode(const uint32_t *src, uint32_t *dest, uint32_t key, uint32_t key2, uint32_t length);
 
 private:
   static uint16_t rotate_left(uint16_t value, int n);

--- a/src/main/loaders/KabukiDecrypt.cpp
+++ b/src/main/loaders/KabukiDecrypt.cpp
@@ -136,7 +136,7 @@ int KabukiDecrypter::bytedecode(int src, int swap_key1, int swap_key2, int xor_k
   return src;
 }
 
-void KabukiDecrypter::kabuki_decode(uint8_t *src,
+void KabukiDecrypter::kabuki_decode(const uint8_t *src,
                                     uint8_t *dest_op,
                                     uint8_t *dest_data,
                                     int base_addr,
@@ -145,12 +145,9 @@ void KabukiDecrypter::kabuki_decode(uint8_t *src,
                                     int swap_key2,
                                     int addr_key,
                                     int xor_key) {
-  int A;
-  int select;
-
-  for (A = 0; A < length; A++) {
+  for (int A = 0; A < length; A++) {
     /* decode opcodes */
-    select = (A + base_addr) + addr_key;
+    int select = (A + base_addr) + addr_key;
     dest_op[A] = bytedecode(src[A], swap_key1, swap_key2, xor_key, select);
 
     /* decode data */

--- a/src/main/loaders/KabukiDecrypt.h
+++ b/src/main/loaders/KabukiDecrypt.h
@@ -3,7 +3,7 @@
 
 class KabukiDecrypter {
  public:
-  static void kabuki_decode(uint8_t *src, uint8_t *dest_op, uint8_t *dest_data,
+  static void kabuki_decode(const uint8_t *src, uint8_t *dest_op, uint8_t *dest_data,
                             int base_addr, int length, int swap_key1, int swap_key2, int addr_key, int xor_key);
 
  private:

--- a/src/main/loaders/Loader.cpp
+++ b/src/main/loaders/Loader.cpp
@@ -1,10 +1,10 @@
 
 #include "Loader.h"
 
-VGMLoader::VGMLoader(void) {
+VGMLoader::VGMLoader() {
 }
 
-VGMLoader::~VGMLoader(void) {
+VGMLoader::~VGMLoader() {
 }
 
 PostLoadCommand VGMLoader::Apply(RawFile *theFile) {

--- a/src/main/loaders/Loader.h
+++ b/src/main/loaders/Loader.h
@@ -6,9 +6,8 @@ enum PostLoadCommand { KEEP_IT, DELETE_IT };
 
 class VGMLoader {
  public:
-  VGMLoader(void);
- public:
-  virtual ~VGMLoader(void);
+  VGMLoader();
+  virtual ~VGMLoader();
 
   virtual PostLoadCommand Apply(RawFile *theFile);
 };

--- a/src/main/loaders/LoaderManager.h
+++ b/src/main/loaders/LoaderManager.h
@@ -9,39 +9,41 @@ class FileLoader;
 using loaderSpawner = std::function<std::shared_ptr<FileLoader>()>;
 
 class LoaderManager final {
-   public:
-    static LoaderManager &get() {
-        static LoaderManager instance;
-        return instance;
-    }
+ public:
+  static LoaderManager &get() {
+    static LoaderManager instance;
+    return instance;
+  }
 
-    void add(const char *loader_name, loaderSpawner gen) {
-        m_generators.try_emplace(loader_name, gen);
-    }
+  LoaderManager(const LoaderManager &) = delete;
+  LoaderManager &operator=(const LoaderManager &) = delete;
+  LoaderManager(LoaderManager &&) = delete;
+  LoaderManager &operator=(LoaderManager &&) = delete;
 
-    std::vector<std::shared_ptr<FileLoader>> loaders() const {
-        std::vector<std::shared_ptr<FileLoader>> tmp(m_generators.size());
-        std::transform(m_generators.begin(), m_generators.end(), tmp.begin(),
-                       [](auto pair) { return pair.second(); });
+  void add(const char *loader_name, loaderSpawner gen) {
+    m_generators.try_emplace(loader_name, gen);
+  }
 
-        return tmp;
-    }
+  std::vector<std::shared_ptr<FileLoader>> loaders() const {
+    std::vector<std::shared_ptr<FileLoader>> tmp(m_generators.size());
+    std::transform(m_generators.begin(), m_generators.end(), tmp.begin(),
+                   [](auto pair) { return pair.second(); });
 
-   private:
-    LoaderManager() = default;
-    LoaderManager(const LoaderManager &) = default;
-    LoaderManager(LoaderManager &&) = default;
-    ~LoaderManager() = default;
+    return tmp;
+  }
 
-    std::unordered_map<std::string, loaderSpawner> m_generators;
+ private:
+  LoaderManager() = default;
+
+  std::unordered_map<std::string, loaderSpawner> m_generators;
 };
 
 namespace vgmtrans::loaders {
 template <typename T>
 class LoaderRegistration final {
-   public:
-    explicit LoaderRegistration(const char *id) {
-        LoaderManager::get().add(id, std::make_shared<T>);
-    }
+ public:
+  explicit LoaderRegistration(const char *id) {
+    LoaderManager::get().add(id, std::make_shared<T>);
+  }
 };
 }  // namespace vgmtrans::loaders

--- a/src/main/loaders/MAMELoader.h
+++ b/src/main/loaders/MAMELoader.h
@@ -30,7 +30,7 @@ void FromString(const std::string &temp, T *out) {
 }
 
 struct MAMERomGroup {
-    MAMERomGroup() : file(nullptr) {}
+    MAMERomGroup() : loadmethod(LM_APPEND), file(nullptr) {}
     template <class T>
     bool GetAttribute(const std::string &attrName, T *out) {
         std::string strValue = attributes[attrName];
@@ -64,17 +64,17 @@ typedef std::map<std::string, MAMEGame *> GameMap;
 class MAMELoader : public FileLoader {
    public:
     MAMELoader();
-    ~MAMELoader();
+    ~MAMELoader() override;
     void apply(const RawFile *theFile) override;
 
    private:
-    VirtFile *LoadRomGroup(const MAMERomGroup &romgroup, const std::string &format,
-                           unzFile &cur_file);
-    void DeleteBuffers(std::list<std::pair<uint8_t *, uint32_t>> &buffers);
+    static VirtFile *LoadRomGroup(const MAMERomGroup &romgroup, const std::string &format,
+                                  const unzFile &cur_file);
+    static void DeleteBuffers(const std::list<std::pair<uint8_t *, uint32_t>> &buffers);
 
     int LoadXML();
-    MAMEGame *LoadGameEntry(TiXmlElement *gameElmt);
-    int LoadRomGroupEntry(TiXmlElement *romgroupElmt, MAMEGame *gameentry);
+    static MAMEGame *LoadGameEntry(TiXmlElement *gameElmt);
+    static int LoadRomGroupEntry(TiXmlElement *romgroupElmt, MAMEGame *gameentry);
 
     GameMap gamemap;
     bool bLoadedXml;

--- a/src/main/loaders/PSF2Loader.cpp
+++ b/src/main/loaders/PSF2Loader.cpp
@@ -10,6 +10,10 @@
 #include "LogManager.h"
 #include "components/PSFFile.h"
 
+namespace vgmtrans::loaders {
+LoaderRegistration<PSF2Loader> _psf2("PSF2");
+}
+
 void PSF2Loader::apply(const RawFile *file) {
     /* Don't bother on a file too small */
     if (file->size() < 0x10) {
@@ -23,38 +27,23 @@ void PSF2Loader::apply(const RawFile *file) {
   }
 }
 
-static u32 get32lsb(u8 *src) {
-    return ((((u32)(src[0])) & 0xFF) << 0) | ((((u32)(src[1])) & 0xFF) << 8) |
-           ((((u32)(src[2])) & 0xFF) << 16) | ((((u32)(src[3])) & 0xFF) << 24);
+static u32 get32lsb(const u8 *src) {
+    return (((static_cast<u32>(src[0])) & 0xFF) << 0) | (((static_cast<u32>(src[1])) & 0xFF) << 8) |
+           (((static_cast<u32>(src[2])) & 0xFF) << 16) | (((static_cast<u32>(src[3])) & 0xFF) << 24);
 }
 
 int PSF2Loader::psf2_decompress_block(const RawFile *file, unsigned fileoffset,
                                       unsigned blocknumber, unsigned numblocks,
                                       unsigned char *decompressedblock, unsigned blocksize) {
-  unsigned int i;
   unsigned long destlen;
-  unsigned long current_block;
-    u8 *blocks;
-    u8 *zblock;
-    blocks = new u8[numblocks * 4];
-
-  if (!blocks) {
-    L_ERROR("Out of memory");
-    return -1;
-  }
+  u8 *blocks = new u8[numblocks * 4];
 
   file->GetBytes(fileoffset, numblocks * 4, blocks);
-  current_block = get32lsb(blocks + (blocknumber * 4));
-    zblock = new u8[current_block];
-
-  if (!zblock) {
-    L_ERROR("Out of memory");
-    delete[] blocks;
-    return -1;
-  }
+  unsigned long current_block = get32lsb(blocks + (blocknumber * 4));
+  u8 *zblock = new u8[current_block];
 
   int tempOffset = fileoffset + numblocks * 4;
-  for (i = 0; i < blocknumber; i++)
+  for (u32 i = 0; i < blocknumber; i++)
     tempOffset += get32lsb(blocks + (i * 4));
   file->GetBytes(tempOffset, current_block, zblock);
 
@@ -72,8 +61,6 @@ int PSF2Loader::psf2_decompress_block(const RawFile *file, unsigned fileoffset,
 }
 
 int PSF2Loader::psf2unpack(const RawFile *file, unsigned long fileoffset, unsigned long dircount) {
-  unsigned int i, j, k;
-
   char filename[37];
   unsigned long offset = 0;
   unsigned long filesize = 0;
@@ -81,12 +68,9 @@ int PSF2Loader::psf2unpack(const RawFile *file, unsigned long fileoffset, unsign
 
   int r;
 
-  unsigned int blockcount;
-  u8 *dblock;
+  memset(filename, 0, std::size(filename));
 
-  memset(filename, 0, sizeof(filename) / sizeof(filename[0]));
-
-  for (i = 0; i < dircount; i++) {
+  for (u32 i = 0; i < dircount; i++) {
     file->GetBytes(i * 48 + fileoffset, 36, filename);
     file->GetBytes(i * 48 + fileoffset + 36, 4, &offset);
     file->GetBytes(i * 48 + fileoffset + 36 + 4, 4, &filesize);
@@ -100,19 +84,15 @@ int PSF2Loader::psf2unpack(const RawFile *file, unsigned long fileoffset, unsign
         return -1;
       }
     } else {
-      blockcount = ((filesize + buffersize) - 1) / buffersize;
+      u32 blockcount = ((filesize + buffersize) - 1) / buffersize;
 
       u8 *newdataBuf = new u8[filesize];
       u32 actualFileSize = filesize;
-      k = 0;
+      u32 k = 0;
 
-      dblock = new u8[buffersize];
-      if (!dblock) {
-        L_ERROR("Out of memory");
-        return -1;
-      }
+      u8 *dblock = new u8[buffersize];
 
-      for (j = 0; j < blockcount; j++) {
+      for (u32 j = 0; j < blockcount; j++) {
         r = psf2_decompress_block(file, offset + 0x10, j, blockcount, dblock, buffersize);
 
         if (r) {

--- a/src/main/loaders/PSF2Loader.h
+++ b/src/main/loaders/PSF2Loader.h
@@ -10,16 +10,11 @@
 
 class PSF2Loader final : public FileLoader {
  public:
-    ~PSF2Loader() = default;
+    ~PSF2Loader() override = default;
     void apply(const RawFile *) override;
 
    private:
-    int psf2_decompress_block(const RawFile *file, unsigned fileoffset, unsigned blocknumber,
-                              unsigned numblocks, unsigned char *decompressedblock,
-                            unsigned blocksize);
+    static int psf2_decompress_block(const RawFile *file, unsigned fileoffset, unsigned blocknumber,
+                                     unsigned numblocks, unsigned char *decompressedblock, unsigned blocksize);
     int psf2unpack(const RawFile *file, unsigned long fileoffset, unsigned long dircount);
 };
-
-namespace vgmtrans::loaders {
-LoaderRegistration<PSF2Loader> _psf2("PSF2");
-}

--- a/src/main/loaders/PSFLoader.cpp
+++ b/src/main/loaders/PSFLoader.cpp
@@ -11,6 +11,11 @@
 
 #include "LogManager.h"
 #include "PSFFile.h"
+#include "LoaderManager.h"
+
+namespace vgmtrans::loaders {
+LoaderRegistration<PSFLoader> psf{"PSF"};
+}
 
 constexpr int PSF1_VERSION = 0x1;
 constexpr int GSF_VERSION = 0x22;
@@ -26,7 +31,7 @@ const std::unordered_map<int, size_t> data_offset = {{PSF1_VERSION, 0x800},
 void PSFLoader::apply(const RawFile *file) {
     if (std::equal(file->begin(), file->begin() + 3, "PSF")) {
         uint8_t version = file->get<u8>(3);
-        if (data_offset.find(version) != data_offset.end()) {
+        if (data_offset.contains(version)) {
             psf_read_exe(file, version);
         }
     }

--- a/src/main/loaders/PSFLoader.h
+++ b/src/main/loaders/PSFLoader.h
@@ -5,19 +5,14 @@
  */
 #pragma once
 #include "components/FileLoader.h"
-#include "LoaderManager.h"
 
 class PSFFile;
 
 class PSFLoader : public FileLoader {
    public:
-    ~PSFLoader() = default;
+    ~PSFLoader() override = default;
     void apply(const RawFile *) override;
 
    private:
     void psf_read_exe(const RawFile *file, int version);
 };
-
-namespace vgmtrans::loaders {
-LoaderRegistration<PSFLoader> psf{"PSF"};
-}

--- a/src/main/loaders/RSNLoader.cpp
+++ b/src/main/loaders/RSNLoader.cpp
@@ -23,7 +23,7 @@ void RSNLoader::apply(const RawFile *file) {
   uint8_t rarHeader[FILE_SIGNATURE_SIZE];
   file->GetBytes(0, FILE_SIGNATURE_SIZE, rarHeader);
 
-  if (memcmp(rarHeader, "Rar!\x1A\x07\x00", FILE_SIGNATURE_SIZE) != 0) {
+  if (memcmp(rarHeader, reinterpret_cast<const void *>("Rar!\x1A\x07\x00"), FILE_SIGNATURE_SIZE) != 0) {
     return;
   }
 

--- a/src/main/loaders/SPC2Loader.cpp
+++ b/src/main/loaders/SPC2Loader.cpp
@@ -9,18 +9,16 @@
 #include "Root.h"
 #include "LogManager.h"
 
-using namespace std;
-
 // SPC2 file specs available here: http://blog.kevtris.org/blogfiles/spc2_file_specification_v1.txt
 
 PostLoadCommand SPC2Loader::Apply(RawFile *file) {
   // Constants
-  const size_t HEADER_SIZE = 16;
-  const size_t SPC_DATA_BLOCK_SIZE = 1024;
-  const size_t RAM_BLOCK_SIZE = 256;
-  const size_t SPC_HEADER_SIZE = 256;
-  const size_t SPC_RAM_SIZE = 65536;
-  const size_t SPC_FILE_SIZE = SPC_HEADER_SIZE + SPC_RAM_SIZE + 128; // 256 byte header + 64KB RAM + 128 bytes DSP Registers
+  constexpr size_t HEADER_SIZE = 16;
+  constexpr size_t SPC_DATA_BLOCK_SIZE = 1024;
+  constexpr size_t RAM_BLOCK_SIZE = 256;
+  constexpr size_t SPC_HEADER_SIZE = 256;
+  constexpr size_t SPC_RAM_SIZE = 65536;
+  constexpr size_t SPC_FILE_SIZE = SPC_HEADER_SIZE + SPC_RAM_SIZE + 128; // 256 byte header + 64KB RAM + 128 bytes DSP Registers
 
   const size_t SPC_FILENAME_OFFSET = 992;
   const size_t SPC_FILENAME_SIZE = 28;
@@ -35,7 +33,7 @@ PostLoadCommand SPC2Loader::Apply(RawFile *file) {
   file->GetBytes(0, HEADER_SIZE, header);
 
   // Check for header signature. Support major revision 1.
-  if (memcmp(header, "KSPC\x1A\x01", 6) != 0) {
+  if (memcmp(header, reinterpret_cast<const void*>("KSPC\x1A\x01"), 6) != 0) {
     return KEEP_IT;
   }
 
@@ -76,7 +74,7 @@ PostLoadCommand SPC2Loader::Apply(RawFile *file) {
       uint8_t ramBlock[RAM_BLOCK_SIZE];
       size_t ramBlockOffset = 16 + (numSPCs * SPC_DATA_BLOCK_SIZE) + (blockIndex * RAM_BLOCK_SIZE);
       file->GetBytes(ramBlockOffset, RAM_BLOCK_SIZE, ramBlock);
-      std::copy(ramBlock, ramBlock + RAM_BLOCK_SIZE, spcFile + SPC_HEADER_SIZE + (j * RAM_BLOCK_SIZE));
+      std::copy_n(ramBlock, RAM_BLOCK_SIZE, spcFile + SPC_HEADER_SIZE + (j * RAM_BLOCK_SIZE));
     }
 
     // Add DSP Registers

--- a/src/main/loaders/SPC2Loader.h
+++ b/src/main/loaders/SPC2Loader.h
@@ -13,7 +13,7 @@ class SPC2Loader:
 public:
   SPC2Loader(void) = default;
 public:
-  virtual ~SPC2Loader(void) = default;
-  virtual PostLoadCommand Apply(RawFile *theFile);
+  ~SPC2Loader() override = default;
+  PostLoadCommand Apply(RawFile *theFile) override;
 };
 

--- a/src/main/loaders/SPCLoader.cpp
+++ b/src/main/loaders/SPCLoader.cpp
@@ -5,6 +5,12 @@
  */
 
 #include "SPCLoader.h"
+#include "LogManager.h"
+#include "LoaderManager.h"
+
+namespace vgmtrans::loaders {
+LoaderRegistration<SPCLoader> _spc{"SPC"};
+}
 
 void SPCLoader::apply(const RawFile *file) {
   if (file->size() < 0x10180) {
@@ -47,7 +53,7 @@ void SPCLoader::apply(const RawFile *file) {
       s_str = s;
       spcFile->tag.artist = (s_str);
 
-      spcFile->tag.length = (double)(file->GetWord(0xa9) & 0xffffff);
+      spcFile->tag.length = file->GetWord(0xa9) & 0xffffff;
     } else {
       // text format
       file->GetBytes(0xb1, 32, s);
@@ -115,6 +121,9 @@ void SPCLoader::apply(const RawFile *file) {
                 // Comments
                 spcFile->tag.comment = xid6_string;
                 break;
+
+              default:
+                L_WARN("Unknown id6 tag id: {} in SPC", xid6_id);
             }
             break;
           }

--- a/src/main/loaders/SPCLoader.h
+++ b/src/main/loaders/SPCLoader.h
@@ -6,14 +6,9 @@
 #pragma once
 
 #include "components/FileLoader.h"
-#include "LoaderManager.h"
 
 class SPCLoader : public FileLoader {
  public:
-    ~SPCLoader() = default;
+    ~SPCLoader() override = default;
     void apply(const RawFile *) override;
 };
-
-namespace vgmtrans::loaders {
-LoaderRegistration<SPCLoader> _spc{"SPC"};
-}

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -36,7 +36,6 @@ void CLIVGMRoot::DisplayHelp() {
 
 // creates the output directory if it does not already exist
 bool CLIVGMRoot::MakeOutputDir() {
-  struct stat sb;
   if (!fs::exists(outputDir)) {
     // directory doesn't exist: need to create it
     if (!fs::create_directory(outputDir)) {
@@ -156,7 +155,7 @@ bool CLIVGMRoot::ExportCollection(VGMColl* coll) {
     return SaveMidi(coll) & SaveSF2(coll) & SaveDLS(coll);
 }
 
-bool CLIVGMRoot::SaveMidi(VGMColl* coll) {
+bool CLIVGMRoot::SaveMidi(const VGMColl* coll) {
   if (coll->seq != nullptr) {
     string collName = coll->GetName();
     string filepath = UI_GetSaveFilePath(collName, "mid");

--- a/src/ui/cli/CLIVGMRoot.h
+++ b/src/ui/cli/CLIVGMRoot.h
@@ -32,7 +32,7 @@ public:
 
   bool ExportCollection(VGMColl* coll);
 
-  bool SaveMidi(VGMColl *coll);
+  bool SaveMidi(const VGMColl *coll);
 
   bool SaveSF2(VGMColl *coll);
 

--- a/src/ui/qt/About.cpp
+++ b/src/ui/qt/About.cpp
@@ -8,13 +8,11 @@
 
 #include <QVBoxLayout>
 #include <QLabel>
-#include <QPixmap>
 #include <QPushButton>
 #include <version.h>
 #include <QListWidget>
 #include <QTextEdit>
 #include <QDir>
-#include <QFile>
 
 About::About(QWidget *parent) : QDialog(parent) {
   setWindowTitle("About VGMTrans");
@@ -52,7 +50,7 @@ void About::setupInfoTab(QWidget* tab) {
     )";
 
   QLabel *text_label =
-      new QLabel(QString(text).arg(VGMTRANS_VERSION).arg(VGMTRANS_REVISION).arg(VGMTRANS_BRANCH));
+      new QLabel(QString(text).arg(VGMTRANS_VERSION, VGMTRANS_REVISION, VGMTRANS_BRANCH));
   text_label->setTextInteractionFlags(Qt::TextBrowserInteraction);
   text_label->setOpenExternalLinks(true);
   text_label->setContentsMargins(15, 0, 15, 0);
@@ -95,8 +93,8 @@ void About::setupLicensesTab(QWidget* tab) {
   QMap<QString, QString> licenses;
   loadLicenses(licenses);
 
-  for (const QString &lib : licenses.keys()) {
-    listWidget->addItem(lib);
+  for (auto it = licenses.constBegin(); it != licenses.constEnd(); ++it) {
+    listWidget->addItem(it.key());
   }
 
   connect(listWidget, &QListWidget::currentTextChanged, [textEdit, licenses](const QString &currentText) {

--- a/src/ui/qt/About.h
+++ b/src/ui/qt/About.h
@@ -15,9 +15,9 @@ class About final : public QDialog {
     explicit About(QWidget *parent = nullptr);
 
    private:
-    void setupInfoTab(QWidget* tab);
+    static void setupInfoTab(QWidget* tab);
     void setupLicensesTab(QWidget* tab);
-    void loadLicenses(QMap<QString, QString>& licenses);
+    static void loadLicenses(QMap<QString, QString>& licenses);
 
     QTabWidget* tabs{};
 };

--- a/src/ui/qt/IconBar.cpp
+++ b/src/ui/qt/IconBar.cpp
@@ -6,8 +6,6 @@
 
 #include "IconBar.h"
 
-#include <QToolBar>
-#include <QIcon>
 #include <QSlider>
 #include <QLabel>
 #include <QLayout>
@@ -33,8 +31,7 @@ void IconBar::setupControls() {
   connect(m_create, &QPushButton::pressed, this, &IconBar::createPressed);
   layout()->addWidget(m_create);
 
-  QFrame *line;
-  line = new QFrame(this);
+  QFrame* line = new QFrame(this);
   line->setFrameShape(QFrame::VLine);
   line->setFrameShadow(QFrame::Sunken);
   layout()->addWidget(line);
@@ -84,7 +81,7 @@ void IconBar::showPlayInfo() {
   m_play->clearFocus();
 }
 
-void IconBar::playbackRangeUpdate(int cur, int max) {
+void IconBar::playbackRangeUpdate(int cur, int max) const {
   if (max != m_slider->maximum()) {
     m_slider->setRange(0, max);
   }
@@ -94,7 +91,7 @@ void IconBar::playbackRangeUpdate(int cur, int max) {
   }
 }
 
-void IconBar::playerStatusChanged(bool playing) {
+void IconBar::playerStatusChanged(bool playing) const {
   if (playing) {
     m_slider->setEnabled(true);
     m_play->setIcon(s_pauseicon);

--- a/src/ui/qt/IconBar.h
+++ b/src/ui/qt/IconBar.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <QToolBar>
-#include <QIcon>
 
 class QSlider;
 class QPushButton;
@@ -28,8 +27,8 @@ signals:
   void createPressed();
 
 private slots:
-  void playerStatusChanged(bool playing);
-  void playbackRangeUpdate(int cur, int max);
+  void playerStatusChanged(bool playing) const;
+  void playbackRangeUpdate(int cur, int max) const;
 
 private:
   void setupControls();

--- a/src/ui/qt/Logger.cpp
+++ b/src/ui/qt/Logger.cpp
@@ -78,7 +78,7 @@ void Logger::exportLog() {
   log.commit();
 }
 
-void Logger::push(const LogItem *item) {
+void Logger::push(const LogItem *item) const {
   static constexpr const char *log_colors[]{"red", "orange", "darkgrey", "black"};
 
   if (item->GetLogLevel() > m_level) {

--- a/src/ui/qt/Logger.h
+++ b/src/ui/qt/Logger.h
@@ -18,7 +18,7 @@ class Logger : public QDockWidget {
 public:
   explicit Logger(QWidget *parent = nullptr);
 
-  void push(const LogItem *item);
+  void push(const LogItem *item) const;
 
 signals:
   void closeEvent(QCloseEvent *) override;

--- a/src/ui/qt/MainWindow.cpp
+++ b/src/ui/qt/MainWindow.cpp
@@ -7,13 +7,11 @@
 #include <QDragEnterEvent>
 #include <QMimeData>
 #include <QFileInfo>
-#include <QSplitter>
 #include <QFileDialog>
 #include <QStandardPaths>
 #include <QGridLayout>
 #include <QPushButton>
 #include <QMessageBox>
-#include <QLabel>
 #include <QStatusBar>
 #include <version.h>
 #include "ManualCollectionDialog.h"
@@ -45,11 +43,11 @@ MainWindow::MainWindow() : QMainWindow(nullptr) {
   routeSignals();
 
   auto infostring = QString("Running %1 (%4, %5), BASS %2, Qt %3")
-                        .arg(VGMTRANS_VERSION)
-                        .arg(int(BASS_GetVersion()), 0, 16)
-                        .arg(qVersion())
-                        .arg(VGMTRANS_REVISION)
-                        .arg(VGMTRANS_BRANCH)
+                        .arg(VGMTRANS_VERSION,
+                             QString::number(BASS_GetVersion(), 16),
+                             qVersion(),
+                             VGMTRANS_REVISION,
+                             VGMTRANS_BRANCH)
                         .toStdString();
   L_INFO(infostring);
 }
@@ -184,7 +182,7 @@ void MainWindow::OpenFile() {
   }
 }
 
-void MainWindow::openFileInternal(QString filename) {
+void MainWindow::openFileInternal(const QString& filename) {
   static QString UNSUPPORTED_RAW_IMAGE_WARNING{
       "'%1' is a raw image file. Data is unlikely to be read correctly, do you wish "
       "to continue anyway?"};

--- a/src/ui/qt/MainWindow.h
+++ b/src/ui/qt/MainWindow.h
@@ -36,7 +36,7 @@ private:
   void routeSignals();
 
   void OpenFile();
-  void openFileInternal(QString filename);
+  void openFileInternal(const QString& filename);
 
   QDockWidget *m_rawfile_dock{};
   QDockWidget *m_vgmfile_dock{};

--- a/src/ui/qt/main_ui.cpp
+++ b/src/ui/qt/main_ui.cpp
@@ -4,12 +4,9 @@
  * See the included LICENSE for more information
  */
 
-#include <QtGlobal>
 #include <QApplication>
-#include <QtPlugin>
 #include <QFile>
 #include <QFontDatabase>
-#include <QStyleFactory>
 #include "MainWindow.h"
 #include "QtVGMRoot.h"
 

--- a/src/ui/qt/main_ui.cpp
+++ b/src/ui/qt/main_ui.cpp
@@ -7,6 +7,7 @@
 #include <QApplication>
 #include <QFile>
 #include <QFontDatabase>
+#include <QStyleFactory>
 #include "MainWindow.h"
 #include "QtVGMRoot.h"
 

--- a/src/ui/qt/services/MenuManager.h
+++ b/src/ui/qt/services/MenuManager.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <sys/syslog.h>
 #include <filesystem>
 #include <typeindex>
 #include <typeinfo>
@@ -13,6 +14,7 @@
 #include "common.h"
 #include "Root.h"
 #include "UIHelpers.h"
+#include "LogManager.h"
 
 namespace fs = std::filesystem;
 
@@ -153,7 +155,7 @@ public:
 
   /**
    * Retrieves the list of commands suitable for a given item.
-   * @param item The object instance for which commands are requested.
+   * @param base The object instance for which commands are requested.
    * @return A vector of shared pointers to the commands.
    */
   template<typename Base>
@@ -286,6 +288,9 @@ public:
               break;
             case PropertySpecValueType::ItemList:
               propMap.insert({ propSpec.key, items });
+              break;
+            default:
+              L_ERROR("Unknown PropertySpecValueType value: {}", static_cast<int>(propSpec.valueType));
               break;
           }
         }

--- a/src/ui/qt/services/MenuManager.h
+++ b/src/ui/qt/services/MenuManager.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <sys/syslog.h>
 #include <filesystem>
 #include <typeindex>
 #include <typeinfo>

--- a/src/ui/qt/services/Settings.cpp
+++ b/src/ui/qt/services/Settings.cpp
@@ -15,14 +15,14 @@ Settings::Settings(QObject *parent) :
 {
 }
 
-void Settings::VGMFileTreeViewSettings::setShowDetails(bool showDetails) {
+void Settings::VGMFileTreeViewSettings::setShowDetails(bool showDetails) const {
   settings.beginGroup("VGMFileTreeView");
   settings.setValue("showDetails", showDetails);
   settings.endGroup();
   NotificationCenter::the()->vgmfiletree_setShowDetails(showDetails);
 }
 
-bool Settings::VGMFileTreeViewSettings::showDetails() {
+bool Settings::VGMFileTreeViewSettings::showDetails() const {
   settings.beginGroup("VGMFileTreeView");
   bool showDetails = settings.value("showDetails", false).toBool();
   settings.endGroup();

--- a/src/ui/qt/services/Settings.h
+++ b/src/ui/qt/services/Settings.h
@@ -35,8 +35,8 @@ public:
   struct VGMFileTreeViewSettings : public SettingsGroup {
     VGMFileTreeViewSettings(Settings* parent): SettingsGroup(parent) {}
 
-    bool showDetails();
-    void setShowDetails(bool);
+    bool showDetails() const;
+    void setShowDetails(bool) const;
   };
   VGMFileTreeViewSettings VGMFileTreeView;
 

--- a/src/ui/qt/services/commands/GeneralCommands.h
+++ b/src/ui/qt/services/commands/GeneralCommands.h
@@ -48,7 +48,7 @@ public:
   [[nodiscard]] std::shared_ptr<CommandContext> CreateContext(const PropertyMap& properties) const override {
     auto context = std::make_shared<ItemListCommandContext<T>>();
 
-    if (properties.find("items") == properties.end()) {
+    if (!properties.contains("items")) {
       return nullptr;
     }
 

--- a/src/ui/qt/services/commands/SaveCommands.h
+++ b/src/ui/qt/services/commands/SaveCommands.h
@@ -62,7 +62,7 @@ public:
   [[nodiscard]] std::shared_ptr<CommandContext> CreateContext(const PropertyMap& properties) const override {
     auto context = std::make_shared<SaveCommandContext<TSavable>>();
 
-    if (properties.find("files") == properties.end() || properties.find("filePath") == properties.end()) {
+    if (!properties.contains("files") || !properties.contains("filePath")) {
       return nullptr;
     }
 
@@ -108,8 +108,7 @@ public:
     if (alwaysSaveToDir) {
       // alwaysSaveToDir indicates we were given a directory path and Save() also expects a directory path
       for (auto file : files) {
-        auto specificFile = dynamic_cast<TSavable*>(file);
-        if (specificFile) {
+        if (auto specificFile = dynamic_cast<TSavable*>(file)) {
           Save(path, specificFile);
         }
         return;
@@ -117,8 +116,7 @@ public:
     }
     if (files.size() == 1) {
       // In this case, path is a file path
-      auto file = dynamic_cast<TSavable*>(files[0]);
-      if (file) {
+      if (auto file = dynamic_cast<TSavable*>(files[0])) {
         Save(path, file);
         return;
       }
@@ -127,8 +125,7 @@ public:
     for (auto file : files) {
       // If alwaysSaveToDir is not set and there are multiple files, the path given is to a directory
       // and the Save() function still expects a file path, so we construct file paths for each file using GetName()
-      auto specificFile = dynamic_cast<TSavable*>(file);
-      if (specificFile) {
+      if (auto specificFile = dynamic_cast<TSavable*>(file)) {
         auto fileExtension = (GetExtension() == "") ? "" : (std::string(".") + GetExtension());
         fs::path filePath = path / fs::path(*file->GetName() + fileExtension);
         Save(filePath.generic_string(), specificFile);

--- a/src/ui/qt/util/Colors.h
+++ b/src/ui/qt/util/Colors.h
@@ -9,19 +9,19 @@
 #include <QColor>
 
 namespace EventColors {
-  auto CLR_BG_DARK = QColor(30,31,34,255);
-  auto CLR_LIGHT_BLUE = QColor(42,172,184,255);
-  auto CLR_BLUE = QColor(86,168,245,255);
-  auto CLR_PERIWINKLE = QColor(181,182,227,255);
-  auto CLR_MAGENTA = QColor(199,125,187,255);
-  auto CLR_ORANGE = QColor(207,142,109,255);
-  auto CLR_RED = QColor(247,84,100,255);
-  auto CLR_LIGHT_RED = QColor(250,102,117,255);
-  auto CLR_GRAY = QColor(188,190,196,255);
-  auto CLR_DARK_GRAY = QColor(122,126,133,255);
-  auto CLR_LIGHTER_GREEN = QColor(179,174,96,255);
-  auto CLR_LIGHT_GREEN = QColor(126,196,230,255);
-  auto CLR_GREEN = QColor(106,171,115,255);
-  auto CLR_DARK_GREEN = QColor(95,130,107,255);
-  auto CLR_YELLOW = QColor(241,250,140,255);
+  inline auto CLR_BG_DARK = QColor(30,31,34,255);
+  inline auto CLR_LIGHT_BLUE = QColor(42,172,184,255);
+  inline auto CLR_BLUE = QColor(86,168,245,255);
+  inline auto CLR_PERIWINKLE = QColor(181,182,227,255);
+  inline auto CLR_MAGENTA = QColor(199,125,187,255);
+  inline auto CLR_ORANGE = QColor(207,142,109,255);
+  inline auto CLR_RED = QColor(247,84,100,255);
+  inline auto CLR_LIGHT_RED = QColor(250,102,117,255);
+  inline auto CLR_GRAY = QColor(188,190,196,255);
+  inline auto CLR_DARK_GRAY = QColor(122,126,133,255);
+  inline auto CLR_LIGHTER_GREEN = QColor(179,174,96,255);
+  inline auto CLR_LIGHT_GREEN = QColor(126,196,230,255);
+  inline auto CLR_GREEN = QColor(106,171,115,255);
+  inline auto CLR_DARK_GREEN = QColor(95,130,107,255);
+  inline auto CLR_YELLOW = QColor(241,250,140,255);
 }

--- a/src/ui/qt/util/LambdaEventFilter.h
+++ b/src/ui/qt/util/LambdaEventFilter.h
@@ -12,7 +12,7 @@ class LambdaEventFilter : public QObject {
   using EventFilterFunction = std::function<bool(QObject*, QEvent*)>;
 
 public:
-  LambdaEventFilter(EventFilterFunction fn, QObject *parent = nullptr)
+  LambdaEventFilter(const EventFilterFunction& fn, QObject *parent = nullptr)
       : QObject(parent), m_function(fn) {}
 
   bool eventFilter(QObject *watched, QEvent *event) override {

--- a/src/ui/qt/widgets/MarqueeLabel.cpp
+++ b/src/ui/qt/widgets/MarqueeLabel.cpp
@@ -26,7 +26,7 @@ QString MarqueeLabel::text() const {
   return m_label_text;
 }
 
-void MarqueeLabel::setText(QString text) {
+void MarqueeLabel::setText(const QString& text) {
   m_label_text = text;
   updateText();
   update();
@@ -55,7 +55,7 @@ void MarqueeLabel::showEvent(QShowEvent *) {
   }
 }
 
-void MarqueeLabel::setSeparator(QString separator) {
+void MarqueeLabel::setSeparator(const QString& separator) {
   m_separator = separator;
   updateText();
   update();

--- a/src/ui/qt/widgets/MarqueeLabel.h
+++ b/src/ui/qt/widgets/MarqueeLabel.h
@@ -17,10 +17,10 @@ public:
   explicit MarqueeLabel(QWidget *parent = nullptr);
 
   QString text() const;
-  void setText(QString text);
+  void setText(const QString& text);
 
   QString separator() const;
-  void setSeparator(QString separator);
+  void setSeparator(const QString& separator);
 
   QSize sizeHint() const override;
   void hideEvent(QHideEvent *event) override;

--- a/src/ui/qt/widgets/StatusBarContent.cpp
+++ b/src/ui/qt/widgets/StatusBarContent.cpp
@@ -7,6 +7,7 @@
 
 #include "StatusBarContent.h"
 #include <QHBoxLayout>
+#include <QIcon>
 #include "services/NotificationCenter.h"
 
 class QIcon;

--- a/src/ui/qt/widgets/StatusBarContent.cpp
+++ b/src/ui/qt/widgets/StatusBarContent.cpp
@@ -7,8 +7,9 @@
 
 #include "StatusBarContent.h"
 #include <QHBoxLayout>
-#include <QIcon>
 #include "services/NotificationCenter.h"
+
+class QIcon;
 
 constexpr int maxHeight = 25; // Maximum height of the status bar
 constexpr int iconLabelWidth = 16;
@@ -55,7 +56,7 @@ StatusBarContent::StatusBarContent(QWidget *parent) : QWidget(parent)
   connect(NotificationCenter::the(), &NotificationCenter::statusUpdated, this, &StatusBarContent::setStatus);
 }
 
-void StatusBarContent::setStatus(const QString& name, const QString& description, const QIcon* icon, int offset, int size) {
+void StatusBarContent::setStatus(const QString& name, const QString& description, const QIcon* icon, int offset, int size) const {
   nameLabel->setText(name);
   descriptionLabel->setText(description);
   if (icon)

--- a/src/ui/qt/widgets/StatusBarContent.h
+++ b/src/ui/qt/widgets/StatusBarContent.h
@@ -16,7 +16,7 @@ public:
   explicit StatusBarContent(QWidget *parent = nullptr);
 
 public slots:
-  void setStatus(const QString& name, const QString& description, const QIcon* icon = nullptr, int offset = -1, int size = -1);
+  void setStatus(const QString& name, const QString& description, const QIcon* icon = nullptr, int offset = -1, int size = -1) const;
 
 private:
   QLabel* iconLabel;

--- a/src/ui/qt/widgets/TableView.h
+++ b/src/ui/qt/widgets/TableView.h
@@ -13,7 +13,7 @@ class TableView : public QTableView {
 
 public:
   explicit TableView(QWidget *parent = nullptr);
-  virtual ~TableView() = default;
+  ~TableView() override = default;
 
   void setModel(QAbstractItemModel *model) override;
 

--- a/src/ui/qt/widgets/TitleBar.h
+++ b/src/ui/qt/widgets/TitleBar.h
@@ -14,7 +14,7 @@ class TitleBar : public QWidget {
 
 public:
   explicit TitleBar(const QString& title, QWidget *parent = nullptr);
-  virtual ~TitleBar() = default;
+  ~TitleBar() override = default;
 
   QSize sizeHint() const override {
     return QSize(200, Size::VTab);

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -31,7 +31,7 @@ protected:
   bool event(QEvent *event) override;
   void changeEvent(QEvent *event) override;
   void keyPressEvent(QKeyEvent *event) override;
-  bool handleOverlayPaintEvent(QObject* obj, QEvent* event);
+  bool handleOverlayPaintEvent(QObject* obj, const QEvent* event) const;
   bool handleSelectedItemPaintEvent(QObject* obj, QEvent* event);
   void paintEvent(QPaintEvent *event) override;
   void mousePressEvent(QMouseEvent *event) override;
@@ -40,39 +40,39 @@ protected:
   void mouseDoubleClickEvent(QMouseEvent* event) override;
 
 private:
-  int hexXOffset();
-  int getVirtualHeight();
-  int getTotalLines();
-  int getOffsetFromPoint(QPoint pos);
-  void resizeOverlays(int height);
+  int hexXOffset() const;
+  int getVirtualHeight() const;
+  int getTotalLines() const;
+  int getOffsetFromPoint(QPoint pos) const;
+  void resizeOverlays(int height) const;
   void redrawOverlay();
-  void printLine(QPainter& painter, int line);
-  void printAddress(QPainter& painter, int line);
-  void printData(QPainter& painter, int startAddress, int endAddress);
+  void printLine(QPainter& painter, int line) const;
+  void printAddress(QPainter& painter, int line) const;
+  void printData(QPainter& painter, int startAddress, int endAddress) const;
   void translateAndPrintHex(QPainter& painter,
-                            uint8_t* data,
+                            const uint8_t* data,
                             int offset,
                             int length,
                             QColor bgColor,
-                            QColor textColor);
+                            QColor textColor) const;
   void printHex(QPainter& painter,
-                uint8_t* data,
+                const uint8_t* data,
                 int length,
                 QColor bgColor,
-                QColor textColor);
+                QColor textColor) const;
   void translateAndPrintAscii(QPainter& painter,
-                  uint8_t* data,
+                  const uint8_t* data,
                   int offset,
                   int length,
                   QColor bgColor,
-                  QColor textColor);
+                  QColor textColor) const;
   void printAscii(QPainter& painter,
-                  uint8_t* data,
+                  const uint8_t* data,
                   int length,
                   QColor bgColor,
-                  QColor textColor);
+                  QColor textColor) const;
   void showOverlay(bool show, bool animate);
-  void drawSelectedItem();
+  void drawSelectedItem() const;
 
   VGMFile* vgmfile;
   VGMItem* selectedItem;

--- a/src/ui/qt/workarea/MdiArea.cpp
+++ b/src/ui/qt/workarea/MdiArea.cpp
@@ -21,8 +21,7 @@ MdiArea::MdiArea(QWidget *parent) : QMdiArea(parent) {
   connect(this, &QMdiArea::subWindowActivated, this, &MdiArea::onSubWindowActivated);
   connect(NotificationCenter::the(), &NotificationCenter::vgmFileSelected, this, &MdiArea::onVGMFileSelected);
 
-  auto *tab_bar = findChild<QTabBar *>();
-  if (tab_bar) {
+  if (auto *tab_bar = findChild<QTabBar *>()) {
     tab_bar->setStyleSheet(QString{"QTabBar::tab { height: %1; }"}.arg(Size::VTab));
     tab_bar->setExpanding(false);
     tab_bar->setUsesScrollButtons(true);
@@ -55,7 +54,7 @@ void MdiArea::newView(VGMFile *file) {
   }
 }
 
-void MdiArea::removeView(VGMFile *file) {
+void MdiArea::removeView(const VGMFile *file) {
   // Let's check if we have a VGMFileView to remove
   auto it = fileToWindowMap.find(file);
   if (it != fileToWindowMap.end()) {
@@ -85,7 +84,7 @@ void MdiArea::onSubWindowActivated(QMdiSubWindow *window) {
   }
 }
 
-void MdiArea::onVGMFileSelected(VGMFile *file, QWidget *caller) {
+void MdiArea::onVGMFileSelected(const VGMFile *file, QWidget *caller) {
   if (caller == this || file == nullptr)
     return;
 

--- a/src/ui/qt/workarea/MdiArea.h
+++ b/src/ui/qt/workarea/MdiArea.h
@@ -30,13 +30,13 @@ public:
   MdiArea &operator=(MdiArea &&) = delete;
 
   void newView(VGMFile *file);
-  void removeView(VGMFile *file);
+  void removeView(const VGMFile *file);
 
 private:
   MdiArea(QWidget *parent = nullptr);
   void onSubWindowActivated(QMdiSubWindow *window);
-  void onVGMFileSelected(VGMFile *file, QWidget *caller);
-  void ensureMaximizedSubWindow(QMdiSubWindow *window);
-  std::unordered_map<VGMFile *, QMdiSubWindow *> fileToWindowMap;
+  void onVGMFileSelected(const VGMFile *file, QWidget *caller);
+  static void ensureMaximizedSubWindow(QMdiSubWindow *window);
+  std::unordered_map<const VGMFile *, QMdiSubWindow *> fileToWindowMap;
   std::unordered_map<QMdiSubWindow *, VGMFile *> windowToFileMap;
 };

--- a/src/ui/qt/workarea/RawFileListView.h
+++ b/src/ui/qt/workarea/RawFileListView.h
@@ -33,13 +33,13 @@ public:
   explicit RawFileListView(QWidget *parent = nullptr);
 
 private:
-  void onVGMFileSelected(VGMFile* vgmfile, QWidget* caller);
+  void onVGMFileSelected(const VGMFile* vgmfile, const QWidget* caller);
   void focusInEvent(QFocusEvent *event) override;
   void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
   void keyPressEvent(QKeyEvent *input) override;
-  void rawFilesMenu(const QPoint &pos);
+  void rawFilesMenu(const QPoint &pos) const;
   void deleteRawFiles();
-  void updateStatusBar();
+  void updateStatusBar() const;
 
   RawFileListViewModel *rawFileListViewModel;
   QMenu *rawfile_context_menu;

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -6,10 +6,8 @@
 
 #include "VGMCollListView.h"
 
-#include <QEvent>
 #include <QMenu>
 #include <QLineEdit>
-#include <QObject>
 #include <VGMColl.h>
 #include <VGMExport.h>
 #include "SequencePlayer.h"
@@ -98,7 +96,7 @@ void VGMCollNameEditor::setModelData(QWidget *editor, QAbstractItemModel *model,
 
 VGMCollListView::VGMCollListView(QWidget *parent) : QListView(parent) {
   auto model = new VGMCollListViewModel(this);
-  setModel(model);
+  VGMCollListView::setModel(model);
   setItemDelegate(new VGMCollNameEditor);
 
   setContextMenuPolicy(Qt::CustomContextMenu);
@@ -128,7 +126,7 @@ VGMCollListView::VGMCollListView(QWidget *parent) : QListView(parent) {
   });
 }
 
-void VGMCollListView::collectionMenu(const QPoint &pos) {
+void VGMCollListView::collectionMenu(const QPoint &pos) const {
   if (selectedIndexes().empty()) {
     return;
   }

--- a/src/ui/qt/workarea/VGMCollListView.h
+++ b/src/ui/qt/workarea/VGMCollListView.h
@@ -41,9 +41,9 @@ signals:
 
 public slots:
   void handlePlaybackRequest();
-  void handleStopRequest();
+  static void handleStopRequest();
 
 private:
-  void collectionMenu(const QPoint &pos);
+  void collectionMenu(const QPoint &pos) const;
   void keyPressEvent(QKeyEvent *e) override;
 };

--- a/src/ui/qt/workarea/VGMCollView.h
+++ b/src/ui/qt/workarea/VGMCollView.h
@@ -19,18 +19,18 @@ class QLineEdit;
 class VGMCollViewModel : public QAbstractListModel {
   Q_OBJECT
 public:
-  VGMCollViewModel(QItemSelectionModel *collListSelModel, QObject *parent = 0);
+  VGMCollViewModel(const QItemSelectionModel *collListSelModel, QObject *parent = nullptr);
 
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
-  [[nodiscard]] VGMFile *fileFromIndex(QModelIndex index) const;
-  [[nodiscard]] QModelIndex indexFromFile(VGMFile* file) const;
-  bool containsVGMFile(VGMFile* file);
+  [[nodiscard]] VGMFile *fileFromIndex(const QModelIndex& index) const;
+  [[nodiscard]] QModelIndex indexFromFile(const VGMFile* file) const;
+  bool containsVGMFile(const VGMFile* file) const;
 
 public slots:
-  void handleNewCollSelected(QModelIndex modelIndex);
-  void removeVGMColl(VGMColl* coll);
+  void handleNewCollSelected(const QModelIndex& modelIndex);
+  void removeVGMColl(const VGMColl* coll);
 
 public:
   VGMColl *m_coll;
@@ -39,16 +39,16 @@ public:
 class VGMCollView : public QGroupBox {
   Q_OBJECT
 public:
-  VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent = 0);
+  VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent = nullptr);
 
 private:
   void keyPressEvent(QKeyEvent *e) override;
 
 private slots:
-  void removeVGMColl(VGMColl *coll);
-  void doubleClickedSlot(QModelIndex);
+  void removeVGMColl(const VGMColl *coll) const;
+  void doubleClickedSlot(const QModelIndex&) const;
   void handleSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
-  void onVGMFileSelected(VGMFile *file, QWidget* caller);
+  void onVGMFileSelected(const VGMFile *file, const QWidget* caller) const;
 
 private:
   VGMCollViewModel *vgmCollViewModel;

--- a/src/ui/qt/workarea/VGMFileListView.h
+++ b/src/ui/qt/workarea/VGMFileListView.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <QTableView>
 #include <QAbstractTableModel>
 #include <QKeyEvent>
 #include <QSortFilterProxyModel>
@@ -42,12 +41,12 @@ class VGMFileListView final : public TableView {
     explicit VGMFileListView(QWidget *parent = nullptr);
 
   public slots:
-    void requestVGMFileView(QModelIndex index);
-    void removeVGMFile(VGMFile *file);
-    void onVGMFileSelected(VGMFile *file, QWidget* caller);
+    static void requestVGMFileView(const QModelIndex& index);
+    void removeVGMFile(const VGMFile *file) const;
+    void onVGMFileSelected(VGMFile *file, const QWidget* caller);
 
   private:
-    void updateStatusBar();
+    void updateStatusBar() const;
     void focusInEvent(QFocusEvent *event) override;
     void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
     void keyPressEvent(QKeyEvent *input) override;

--- a/src/ui/qt/workarea/VGMFileTreeView.h
+++ b/src/ui/qt/workarea/VGMFileTreeView.h
@@ -8,7 +8,6 @@
 
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
-#include <QObject>
 #include <QStyledItemDelegate>
 #include <QHeaderView>
 #include <unordered_map>
@@ -30,10 +29,10 @@ public:
 
 private:
   QCheckBox* detailsCheckBox;
-  void resizeEvent(QResizeEvent *event);
-  void showEvent(QShowEvent *event);
-  void onShowDetailsChanged(bool showDetails);
-  void toggleShowDetails();
+  void resizeEvent(QResizeEvent *event) override;
+  void showEvent(QShowEvent *event) override;
+  void onShowDetailsChanged(bool showDetails) const;
+  void toggleShowDetails() const;
 };
 
 // ***********************************
@@ -50,9 +49,9 @@ public:
         m_parent(item_parent){};
   ~VGMTreeItem() override = default;
 
-  [[nodiscard]] inline auto item_parent() noexcept { return m_parent; }
-  [[nodiscard]] inline auto item_offset() noexcept { return m_item->dwOffset; }
-  [[nodiscard]] inline auto item() noexcept { return m_item; }
+  [[nodiscard]] inline auto item_parent() const noexcept { return m_parent; }
+  [[nodiscard]] inline auto item_offset() const noexcept { return m_item->dwOffset; }
+  [[nodiscard]] inline auto item() const noexcept { return m_item; }
 
 private:
   QString m_name;
@@ -83,7 +82,7 @@ public:
   ~VGMFileTreeView() override = default;
 
   void addVGMItem(VGMItem *item, VGMItem *parent, const std::string &name);
-  auto getTreeWidgetItem(VGMItem *vgm_item) { return m_items.at(vgm_item); };
+  auto getTreeWidgetItem(const VGMItem *vgm_item) const { return m_items.at(vgm_item); };
   void updateStatusBar();
 
 protected:
@@ -94,14 +93,14 @@ protected:
   void keyPressEvent(QKeyEvent *event) override;
 
 private:
-  int getSortedIndex(QTreeWidgetItem* parent, VGMTreeItem* item);
-  void setItemText(VGMItem* item, VGMTreeItem* treeItem);
+  static int getSortedIndex(const QTreeWidgetItem* parent, const VGMTreeItem* item);
+  void setItemText(VGMItem* item, VGMTreeItem* treeItem) const;
   void onShowDetailsChanged(bool showDetails);
   void updateItemTextRecursively(QTreeWidgetItem* item);
 
   bool showDetails = false;
   QTreeWidgetItem *parent_item_cached{};
   VGMItem *parent_cached{};
-  std::unordered_map<VGMItem*, QTreeWidgetItem*> m_items{};
+  std::unordered_map<const VGMItem*, QTreeWidgetItem*> m_items{};
   std::unordered_map<QTreeWidgetItem*, VGMItem*> m_treeItemToVGMItem{};
 };

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -46,7 +46,7 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
   connect(m_hexview, &HexView::selectionChanged, this, &VGMFileView::onSelectionChange);
 
   connect(m_treeview, &VGMFileTreeView::currentItemChanged,
-          [&](QTreeWidgetItem *item, QTreeWidgetItem *) {
+          [&](const QTreeWidgetItem *item, QTreeWidgetItem *) {
             if (item == nullptr) {
               // If the VGMFileTreeView deselected, then so should the HexView
               onSelectionChange(nullptr);
@@ -78,25 +78,25 @@ void VGMFileView::focusInEvent(QFocusEvent* event) {
   m_treeview->updateStatusBar();
 }
 
-void VGMFileView::resetSnapRanges() {
+void VGMFileView::resetSnapRanges() const {
   m_splitter->clearSnapRanges();
   m_splitter->addSnapRange(0, hexViewWidthSansAsciiAndAddress(), hexViewWidthSansAscii());
   m_splitter->addSnapRange(0, hexViewWidthSansAscii(), hexViewWidth());
 }
 
-int VGMFileView::hexViewWidth() {
+int VGMFileView::hexViewWidth() const {
   return m_hexview->getViewportWidth();
 }
 
-int VGMFileView::hexViewWidthSansAscii() {
+int VGMFileView::hexViewWidthSansAscii() const {
   return m_hexview->getViewportWidthSansAscii();
 }
 
-int VGMFileView::hexViewWidthSansAsciiAndAddress() {
+int VGMFileView::hexViewWidthSansAsciiAndAddress() const {
   return m_hexview->getViewportWidthSansAsciiAndAddress();
 }
 
-void VGMFileView::updateHexViewFont(qreal sizeIncrement) {
+void VGMFileView::updateHexViewFont(qreal sizeIncrement) const {
   // Increment the font size until it has an actual effect on width
   QFont font = m_hexview->font();
   QFontMetricsF fontMetrics(font);
@@ -132,7 +132,7 @@ void VGMFileView::closeEvent(QCloseEvent *) {
   MdiArea::the()->removeView(m_vgmfile);
 }
 
-void VGMFileView::onSelectionChange(VGMItem *item) {
+void VGMFileView::onSelectionChange(VGMItem *item) const {
   m_hexview->setSelectedItem(item);
   if (item) {
     auto widget_item = m_treeview->getTreeWidgetItem(item);

--- a/src/ui/qt/workarea/VGMFileView.h
+++ b/src/ui/qt/workarea/VGMFileView.h
@@ -23,13 +23,13 @@ public:
 private:
   static constexpr int treeViewMinimumWidth = 220;
 
-  void resetSnapRanges();
+  void resetSnapRanges() const;
   void focusInEvent(QFocusEvent* event) override;
   void closeEvent(QCloseEvent *closeEvent) override;
-  int hexViewWidth();
-  int hexViewWidthSansAscii();
-  int hexViewWidthSansAsciiAndAddress();
-  void updateHexViewFont(qreal sizeIncrement);
+  int hexViewWidth() const;
+  int hexViewWidthSansAscii() const;
+  int hexViewWidthSansAsciiAndAddress() const;
+  void updateHexViewFont(qreal sizeIncrement) const;
 
   VGMFileTreeView* m_treeview{};
   VGMFile* m_vgmfile{};
@@ -38,5 +38,5 @@ private:
   SnappingSplitter* m_splitter;
 
 public slots:
-  void onSelectionChange(VGMItem* item);
+  void onSelectionChange(VGMItem* item) const;
 };


### PR DESCRIPTION
More code cleanup, mostly to get rid of warnings.

Changes in SynthFile.h are actually minor - i moved one of the classes because it is used as a member for classes below it and removed an unused constructor or two Only logical change was adding default initial values for some members in constructors.

A lot of changes address "weak warnings." You'll see I've made a number of methods const or static. Let me know if you think any of this is overkill. 

## How Has This Been Tested?
Basic testing. Files are loading and playing as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
