### PR TITLE
Clang warnings fixup

### DIFF
--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -154,6 +154,9 @@ void AkaoSnesSeq::LoadEventMap() {
       STATUS_NOTEINDEX_TIE = 12;
       STATUS_NOTEINDEX_REST = 13;
       break;
+
+    default:
+      break;
   }
 
   // duration table

--- a/src/main/formats/CPS/CPS1Scanner.cpp
+++ b/src/main/formats/CPS/CPS1Scanner.cpp
@@ -103,6 +103,9 @@ void CPS1Scanner::LoadCPS1(MAMEGame *gameentry, CPSFormatVer fmt_ver) {
     case VER_CPS1_502:
       seq_table_length = (uint32_t) (programFile->GetShortBE(seq_table_offset) * 2) + ptrsStart;
       break;
+    default:
+      L_ERROR("Unknown version of CPS1 format: {}", static_cast<uint8_t>(fmt_ver));
+      return;
   }
 
   unsigned int k = 0;

--- a/src/main/formats/CPS/CPS2Scanner.cpp
+++ b/src/main/formats/CPS/CPS2Scanner.cpp
@@ -104,6 +104,9 @@ void CPS2Scanner::Scan(RawFile *file, void *info) {
       if (fmt_ver >= VER_130 && !seqRomGroupEntry->GetHexAttribute("artic_table", &artic_table_offset))
         return;
       break;
+    default:
+      L_ERROR("Unknown version of CPS2 format: {}", static_cast<uint8_t>(fmt_ver));
+      return;
   }
 
   CPS2InstrSet *instrset = 0;

--- a/src/main/formats/CPS/CPSSeq.cpp
+++ b/src/main/formats/CPS/CPSSeq.cpp
@@ -202,11 +202,9 @@ bool CPSSeq::PostLoad() {
           TempoEvent *tempoevent = (TempoEvent *) event;
           mpqn = tempoevent->microSecs;
           mpt = mpqn / ppqn;
-        }
-        break;
-        case MIDIEVENT_ENDOFTRACK:
-
           break;
+        }
+
         case MIDIEVENT_MARKER: {
           MarkerEvent *marker = (MarkerEvent *) event;
 
@@ -253,8 +251,11 @@ bool CPSSeq::PostLoad() {
             pitchbendCents = (short) (((int8_t) marker->databyte1 / 128.0) * fmtPitchBendRange);
             track->InsertPitchBend(channel, (short) (((lfoCents + pitchbendCents) / (double) pitchbendRange) * 8192), curTicks);
           }
+          break;
         }
-        break;
+
+        default:
+          break;
       }
       startAbsTicks = curTicks;
     }

--- a/src/main/formats/CPS/CPSTrackV1.cpp
+++ b/src/main/formats/CPS/CPSTrackV1.cpp
@@ -354,9 +354,10 @@ bool CPSTrackV1::ReadEvent(void) {
           }
         }
         else {
-          if ((GetByte(curOffset) & 0x80) == 0)
-            jump = curOffset - GetByte(curOffset++);
-          else {
+          if ((GetByte(curOffset) & 0x80) == 0) {
+            uint8_t jumpByte = GetByte(curOffset++);
+            jump = curOffset - jumpByte;
+          } else {
             jump = curOffset + 2 + (int16_t)GetShortBE(curOffset);
             curOffset += 2;
           }

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -127,6 +127,9 @@ void CapcomSnesSeq::LoadEventMap() {
       EventMap[0x1e] = EVENT_UNKNOWN1;
       EventMap[0x1f] = EVENT_UNKNOWN1;
       break;
+
+    default:
+      break;
   }
 }
 
@@ -500,6 +503,7 @@ bool CapcomSnesTrack::ReadEvent(void) {
 			case EVENT_REPEAT_UNTIL_2: repeatSlot = 1; repeatEventName = "Repeat Until #2"; break;
 			case EVENT_REPEAT_UNTIL_3: repeatSlot = 2; repeatEventName = "Repeat Until #3"; break;
 			case EVENT_REPEAT_UNTIL_4: repeatSlot = 3; repeatEventName = "Repeat Until #4"; break;
+			default: break;
         }
 
         desc << "Times: " << (int) times << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
@@ -553,6 +557,7 @@ bool CapcomSnesTrack::ReadEvent(void) {
 			case EVENT_REPEAT_BREAK_2: repeatSlot = 1; repeatEventName = "Repeat Break #2"; break;
 			case EVENT_REPEAT_BREAK_3: repeatSlot = 2; repeatEventName = "Repeat Break #3"; break;
 			case EVENT_REPEAT_BREAK_4: repeatSlot = 3; repeatEventName = "Repeat Break #4"; break;
+			default: break;
         }
 
         desc << "Note: { " << "Triplet: " << (isNoteTriplet() ? "On" : "Off") << "  " << "Slur: "

--- a/src/main/formats/CompileSnes/CompileSnesSeq.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesSeq.cpp
@@ -172,6 +172,9 @@ void CompileSnesSeq::LoadEventMap() {
       EventMap[0xa5] = EVENT_UNKNOWN1;
       EventMap[0xa6] = EVENT_UNKNOWN1;
       break;
+
+    default:
+      break;
   }
 }
 

--- a/src/main/formats/FFT/FFTSeq.cpp
+++ b/src/main/formats/FFT/FFTSeq.cpp
@@ -188,9 +188,11 @@ bool FFTTrack::ReadEvent(void) {
         //Octave Event
 
         //Set octave
-      case 0x94:
-        AddSetOctave(curOffset - 2, 2, GetByte(curOffset++));
+      case 0x94: {
+        uint8_t newOctave = GetByte(curOffset++);
+        AddSetOctave(beginOffset, curOffset - beginOffset, newOctave);
         break;
+      }
 
         //Inc octave
       case 0x95:
@@ -477,9 +479,11 @@ bool FFTTrack::ReadEvent(void) {
         //Volume Event
 
         // Volume
-      case 0xE0:
-        AddVol(curOffset - 2, 2, GetByte(curOffset++));
+      case 0xE0: {
+        uint8_t volByte = GetByte(curOffset++);
+        AddVol(beginOffset, curOffset - beginOffset, volByte);
         break;
+      }
 
         // add volume... add the value to the current vol.
       case 0xE1:
@@ -528,9 +532,11 @@ bool FFTTrack::ReadEvent(void) {
         //Panpot Event
 
         // Panpot
-      case 0xE8:
-        AddPan(curOffset - 2, 2, GetByte(curOffset++));
+      case 0xE8: {
+        uint8_t panpotByte = GetByte(curOffset++);
+        AddPan(beginOffset, curOffset - beginOffset, panpotByte);
         break;
+      }
 
         // unknown
       case 0xE9:

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -234,6 +234,10 @@ void KonamiSnesSeq::LoadEventMap() {
       EventMap[0xfb] = EVENT_ADSR2;
       EventMap[0xfc] = EVENT_PROGCHANGEVOL;
       break;
+
+    default:
+      L_WARN("Unknown version of Konami SNES format");
+      break;
   }
 }
 

--- a/src/main/formats/MP2k/MP2kInstrSet.cpp
+++ b/src/main/formats/MP2k/MP2kInstrSet.cpp
@@ -24,7 +24,7 @@ MP2kInstrSet::MP2kInstrSet(RawFile *file, int rate, size_t offset, int count,
 
 bool MP2kInstrSet::LoadInstrs() {
   bool res = VGMInstrSet::LoadInstrs();
-  sampColl == nullptr;
+  sampColl = nullptr;
 
   return res;
 }

--- a/src/main/formats/MoriSnes/MoriSnesSeq.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesSeq.cpp
@@ -13,8 +13,8 @@ DECLARE_FORMAT(MoriSnes);
 #define MAX_TRACKS  10
 #define SEQ_PPQN    48
 
-MoriSnesSeq::MoriSnesSeq(RawFile *file, MoriSnesVersion ver, uint32_t seqdataOffset, std::string newName)
-    : VGMSeq(MoriSnesFormat::name, file, seqdataOffset, 0, newName),
+MoriSnesSeq::MoriSnesSeq(RawFile *file, MoriSnesVersion ver, uint32_t seqdataOffset, std::string name)
+    : VGMSeq(MoriSnesFormat::name, file, seqdataOffset, 0, std::move(name)),
       version(ver) {
   bLoadTickByTick = true;
   bAllowDiscontinuousTrackData = true;
@@ -26,10 +26,10 @@ MoriSnesSeq::MoriSnesSeq(RawFile *file, MoriSnesVersion ver, uint32_t seqdataOff
   LoadEventMap();
 }
 
-MoriSnesSeq::~MoriSnesSeq(void) {
+MoriSnesSeq::~MoriSnesSeq() {
 }
 
-void MoriSnesSeq::ResetVars(void) {
+void MoriSnesSeq::ResetVars() {
   VGMSeq::ResetVars();
 
   spcTempo = 0x20;
@@ -39,7 +39,7 @@ void MoriSnesSeq::ResetVars(void) {
   InstrumentHints.clear();
 }
 
-bool MoriSnesSeq::GetHeaderInfo(void) {
+bool MoriSnesSeq::GetHeaderInfo() {
   SetPPQN(SEQ_PPQN);
 
   uint32_t curOffset = dwOffset;
@@ -92,7 +92,7 @@ bool MoriSnesSeq::GetHeaderInfo(void) {
   return true;
 }
 
-bool MoriSnesSeq::GetTrackPointers(void) {
+bool MoriSnesSeq::GetTrackPointers() {
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     if (TrackStartAddress[trackIndex] != 0) {
       MoriSnesTrack *track = new MoriSnesTrack(this, TrackStartAddress[trackIndex]);
@@ -173,12 +173,12 @@ double MoriSnesSeq::GetTempoInBPM(uint8_t tempo, bool fastTempo) {
 
 MoriSnesTrack::MoriSnesTrack(MoriSnesSeq *parentFile, long offset, long length)
     : SeqTrack(parentFile, offset, length) {
-  ResetVars();
+  MoriSnesTrack::ResetVars();
   bDetermineTrackLengthEventByEvent = true;
   bWriteGenericEventAsTextEvent = false;
 }
 
-void MoriSnesTrack::ResetVars(void) {
+void MoriSnesTrack::ResetVars() {
   SeqTrack::ResetVars();
 
   tiedNoteKeys.clear();
@@ -193,8 +193,8 @@ void MoriSnesTrack::ResetVars(void) {
 }
 
 
-bool MoriSnesTrack::ReadEvent(void) {
-  MoriSnesSeq *parentSeq = (MoriSnesSeq *) this->parentSeq;
+bool MoriSnesTrack::ReadEvent() {
+  MoriSnesSeq *parentSeq = static_cast<MoriSnesSeq*>(this->parentSeq);
 
   uint32_t beginOffset = curOffset;
   if (curOffset >= 0x10000) {
@@ -722,16 +722,15 @@ void MoriSnesTrack::ParseInstrumentEvents(uint16_t offset, uint8_t instrNum, boo
   }
 
   bool bContinue = true;
-  uint16_t curOffset = offset;
-  uint16_t seqStartAddress = curOffset;
-  uint16_t seqEndAddress = curOffset;
+  uint32_t curOffset = offset;
+  uint32_t seqStartAddress = curOffset;
+  uint32_t seqEndAddress = curOffset;
 
-  uint8_t instrDeltaTime = 0;
+  // uint8_t instrDeltaTime = 0;
   uint8_t instrCallStackPtr = 0;
   uint8_t instrCallStack[MORISNES_CALLSTACK_SIZE];
 
   while (bContinue) {
-    uint16_t beginOffset = curOffset;
     if (curOffset >= 0xffff) {
       break;
     }
@@ -742,12 +741,12 @@ void MoriSnesTrack::ParseInstrumentEvents(uint16_t offset, uint8_t instrNum, boo
 
     uint8_t statusByte = GetByte(curOffset++);
 
-    uint8_t newDelta = instrDeltaTime;
+    // uint8_t newDelta = instrDeltaTime;
     if (statusByte < 0x80) {
-      newDelta = statusByte;
-      if (newDelta != 0) {
-        instrDeltaTime = newDelta;
-      }
+      // newDelta = statusByte;
+      // if (newDelta != 0) {
+        // instrDeltaTime = newDelta;
+      // }
 
       statusByte = GetByte(curOffset);
       if (statusByte < 0x80) {
@@ -761,7 +760,6 @@ void MoriSnesTrack::ParseInstrumentEvents(uint16_t offset, uint8_t instrNum, boo
         }
       }
 
-      beginOffset = curOffset;
       if (curOffset >= 0xffff) {
         break;
       }

--- a/src/main/formats/MoriSnes/MoriSnesSeq.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesSeq.cpp
@@ -732,7 +732,7 @@ void MoriSnesTrack::ParseInstrumentEvents(uint16_t offset, uint8_t instrNum, boo
 
   while (bContinue) {
     uint16_t beginOffset = curOffset;
-    if (curOffset >= 0x10000) {
+    if (curOffset >= 0xffff) {
       break;
     }
 
@@ -762,7 +762,7 @@ void MoriSnesTrack::ParseInstrumentEvents(uint16_t offset, uint8_t instrNum, boo
       }
 
       beginOffset = curOffset;
-      if (curOffset >= 0x10000) {
+      if (curOffset >= 0xffff) {
         break;
       }
 

--- a/src/main/formats/MoriSnes/MoriSnesSeq.h
+++ b/src/main/formats/MoriSnes/MoriSnesSeq.h
@@ -47,15 +47,14 @@ enum MoriSnesSeqEventType {
   EVENT_TIMEBASE,
 };
 
-class MoriSnesSeq
-    : public VGMSeq {
+class MoriSnesSeq : public VGMSeq {
  public:
-  MoriSnesSeq(RawFile *file, MoriSnesVersion ver, uint32_t seqdataOffset, std::string newName = "Mint SNES Seq");
-  virtual ~MoriSnesSeq(void);
+  MoriSnesSeq(RawFile *file, MoriSnesVersion ver, uint32_t seqdataOffset, std::string name = "Mint SNES Seq");
+  virtual ~MoriSnesSeq();
 
-  virtual bool GetHeaderInfo(void);
-  virtual bool GetTrackPointers(void);
-  virtual void ResetVars(void);
+  virtual bool GetHeaderInfo();
+  virtual bool GetTrackPointers();
+  virtual void ResetVars();
 
   double GetTempoInBPM(uint8_t tempo, bool fastTempo);
 
@@ -70,15 +69,15 @@ class MoriSnesSeq
   bool fastTempo;
 
  private:
-  void LoadEventMap(void);
+  void LoadEventMap();
 };
 
 class MoriSnesTrack
     : public SeqTrack {
  public:
   MoriSnesTrack(MoriSnesSeq *parentFile, long offset = 0, long length = 0);
-  virtual void ResetVars(void);
-  virtual bool ReadEvent(void);
+  virtual void ResetVars();
+  virtual bool ReadEvent();
 
   void ParseInstrument(uint16_t instrAddress, uint8_t instrNum);
   void ParseInstrumentEvents(uint16_t offset, uint8_t instrNum, bool percussion = false, uint8_t percNoteKey = 0);

--- a/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
@@ -530,6 +530,9 @@ bool NamcoSnesSeq::ReadEvent(void) {
                 AddPanNoItem(midiPan);
                 break;
               }
+
+              default:
+                break;
             }
           }
         }

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -557,7 +557,10 @@ void NinSnesSeq::LoadEventMap() {
     case NINSNES_QUINTET_TS:
       EventMap[0xf4] = EVENT_QUINTET_TUNING;
       EventMap[0xff] = EVENT_QUINTET_ADSR;
-	  break;
+      break;
+
+    default:
+      break;
   }
 }
 
@@ -1576,6 +1579,9 @@ bool NinSnesTrack::ReadEvent(void) {
 
             break;
           }
+
+          default:
+            break;
         }
       }
 

--- a/src/main/formats/RareSnes/RareSnesSeq.cpp
+++ b/src/main/formats/RareSnes/RareSnesSeq.cpp
@@ -225,6 +225,9 @@ void RareSnesSeq::LoadEventMap() {
       EventMap[0x30] = EVENT_TREMOLOOFF;
       //EventMap[0x31] = EVENT_RESET;
       break;
+    default:
+      L_WARN("Unknown version of Rare SNES format");
+      break;
   }
 }
 


### PR DESCRIPTION
@TheComputerGuy96, and FYI @sykhro 
This pulls in the commits from from #475 but excludes the vendored zlib update and enabling of -Werror. Instead, we will switch to importing zlib-ng as a git submodule in a future PR, at which point we can probably also enable -Werror. Note that I also added a commit that addresses some of the issues in MoriSnesSeq.cpp.

Given that I already reviewed #475, I will leave this up for a couple days for comment and then merge it if there is no objection or discussion.

## Motivation and Context
In order to keep our git history clean, I've moved the #475 commits into a new branch to avoid the unnecessary vendored update to zlib.

## How Has This Been Tested?
Tested that MoriSnes and FFT drivers are still working as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.