### PR TITLE
Linux install fix

### DIFF
--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Svg)
 message(STATUS "Using Qt ${Qt6_VERSION}")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(BUNDLE_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VGMTrans.app")
   set(RESOURCE_DIR "${BUNDLE_PATH}/Contents/Resources")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set(RESOURCE_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
@@ -138,8 +139,6 @@ target_sources(vgmtrans PRIVATE ${UI_RESOURCES})
 # Install & package
 # ~~~
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  set(BUNDLE_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VGMTrans.app")
-
   set_target_properties(
     vgmtrans
     PROPERTIES MACOSX_BUNDLE true

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -29,6 +29,18 @@ endif()
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Svg)
 message(STATUS "Using Qt ${Qt6_VERSION}")
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(RESOURCE_DIR "${BUNDLE_PATH}/Contents/Resources")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  set(RESOURCE_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD|OpenBSD|Linux")
+  set(RESOURCE_DIR "${CMAKE_INSTALL_PREFIX}/share/vgmtrans")
+else()
+  set(RESOURCE_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+endif()
+
+add_definitions(-DRESOURCE_DIR="${RESOURCE_DIR}")
+
 # ~~~
 # Build
 # ~~~
@@ -174,7 +186,7 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
     COMMAND
       ${CMAKE_COMMAND} -E copy_if_different
       "${CMAKE_SOURCE_DIR}/bin/mame_roms.xml"
-      "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+      "${RESOURCE_DIR}")
 
   get_target_property(MOC_EXECUTABLE_LOCATION Qt${Qt_VERSION_MAJOR}::moc
                       IMPORTED_LOCATION)
@@ -214,11 +226,18 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
             "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD|OpenBSD|Linux")
   install(TARGETS vgmtrans DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
-  install(
-    FILES resources/vgmtrans.png
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/512x512/apps")
+  install(FILES resources/vgmtrans.png
+          DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/512x512/apps")
   install(FILES resources/VGMTrans.desktop
           DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
+  install(FILES "${CMAKE_SOURCE_DIR}/bin/mame_roms.xml"
+          DESTINATION "${RESOURCE_DIR}")
+
+  set_target_properties(vgmtrans PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  install(FILES
+          "${CMAKE_SOURCE_DIR}/lib/bass/libbass.so"
+          "${CMAKE_SOURCE_DIR}/lib/bass/libbassmidi.so"
+          DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
 set(CPACK_PACKAGE_NAME "vgmtrans")

--- a/src/ui/qt/QtVGMRoot.cpp
+++ b/src/ui/qt/QtVGMRoot.cpp
@@ -4,8 +4,6 @@
  * refer to the included LICENSE.txt file
  */
 
-#include <QApplication>
-#include <QFileDialog>
 #include "QtVGMRoot.h"
 #include "VGMFileTreeView.h"
 #include "UIHelpers.h"

--- a/src/ui/qt/QtVGMRoot.cpp
+++ b/src/ui/qt/QtVGMRoot.cpp
@@ -13,15 +13,7 @@
 QtVGMRoot qtVGMRoot;
 
 std::string QtVGMRoot::UI_GetResourceDirPath() {
-#if defined(Q_OS_WIN)
-  return (QApplication::applicationDirPath() + "/").toStdString();
-#elif defined(Q_OS_MACOS)
-  return (QApplication::applicationDirPath() + "/../Resources/").toStdString();
-#elif defined(Q_OS_LINUX)
-  return (QApplication::applicationDirPath() + "/").toStdString();
-#else
-  return (QApplication::applicationDirPath() + "/").toStdString();
-#endif
+  return std::string(RESOURCE_DIR) + "/";  // Use the macro defined in ui/qt/CMakeLists.txt
 }
 
 void QtVGMRoot::UI_SetRootPtr(VGMRoot** theRoot) {


### PR DESCRIPTION
This is an attempt to improve the Linux installation. Linux convention isn't my forte, so hopefully I didn't mess this up.

The changes:
* install mame_roms.xml into `${CMAKE_INSTALL_PREFIX}/share/vgmtrans` (ie. /usr/local/share/vgmtrans).
* install libbass.so and libbassmidi.so into `${CMAKE_INSTALL_PREFIX}/lib` (ie. /usr/local/lib)
* move responsibility for defining the resource path to the Qt CMake script. It now passes a RESOURCE_DIR string macro into the project and QtVGMRoot::UI_GetResourceDirPath() simply returns it.

## How Has This Been Tested?
Loaded mame_roms.xml successfully on Ubuntu 22.04, Windows 10, and MacOS Sonoma. libbass loaded successfully on Ubuntu.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.