### PR TITLE
CPS3 / CPS v2 fixes

### DIFF
--- a/bin/mame_roms.xml
+++ b/bin/mame_roms.xml
@@ -640,9 +640,11 @@
             <rom>sfiii3n/sfiii3-simm1.2</rom>
             <rom>sfiii3n/sfiii3-simm1.3</rom>
         </romgroup>
-        <romgroup type="qsound" load_method="deinterlace">
+        <romgroup type="qsound" load_method="deinterlace_pairs">
             <rom>sfiii3n/sfiii3-simm3.0</rom>
             <rom>sfiii3n/sfiii3-simm3.1</rom>
+            <rom>sfiii3n/sfiii3-simm3.2</rom>
+            <rom>sfiii3n/sfiii3-simm3.3</rom>
         </romgroup>
     </game>
     <game name="sfiii3n" format="CPS2" fmt_version="CPS3">

--- a/src/main/formats/CPS/CPS2Instr.h
+++ b/src/main/formats/CPS/CPS2Instr.h
@@ -41,8 +41,8 @@ struct qs_prog_info_ver_cps3 {
   uint8_t unknown1;
   uint8_t unknown2;
   uint8_t unknown3;
-  uint8_t unknown4;
-  uint8_t sample_index;
+  uint8_t sample_index_hi;
+  uint8_t sample_index_lo;
   uint8_t unknown6;
   uint8_t attack_rate;
   uint8_t decay_rate;
@@ -212,7 +212,7 @@ public:
               CPSSampleInfoTable *sampInfoTable,
               CPSArticTable *articTable,
               std::string name);
-  ~CPS2InstrSet() override;
+  ~CPS2InstrSet() override = default;
 
   bool GetHeaderInfo() override;
   bool GetInstrPointers() override;
@@ -237,7 +237,7 @@ public:
            uint32_t theBank,
            uint32_t theInstrNum,
            std::string name);
-  ~CPS2Instr() override;
+  ~CPS2Instr() override = default;
   bool LoadInstr() override;
 protected:
   CPSFormatVer GetFormatVer() const { return (static_cast<CPS2InstrSet*>(parInstrSet))->fmt_version; }

--- a/src/main/formats/CPS/CPSTrackV2.cpp
+++ b/src/main/formats/CPS/CPSTrackV2.cpp
@@ -119,7 +119,7 @@ bool CPSTrackV2::ReadEvent(void) {
 
     case C6_VOLUME: {
       uint8_t vol = GetByte(curOffset++);
-      vol = ConvertPercentAmpToStdMidiVal(vol_table[vol] / static_cast<double>(0x1FFF));
+      vol = ConvertPercentAmpToStdMidiVal(vol / 127.0);
       this->AddVol(beginOffset, curOffset - beginOffset, vol);
       break;
     }

--- a/src/main/loaders/MAMELoader.h
+++ b/src/main/loaders/MAMELoader.h
@@ -14,7 +14,7 @@
 class TiXmlElement;
 class VirtFile;
 
-enum LoadMethod { LM_APPEND, LM_APPEND_SWAP16, LM_DEINTERLACE };
+enum LoadMethod { LM_APPEND, LM_APPEND_SWAP16, LM_DEINTERLACE, LM_DEINTERLACE_PAIRS };
 
 /**
 Converts a std::string to any class with a proper overload of the >> operator


### PR DESCRIPTION
This fixes a number of problems with the CPS3 driver and also fixes a volume/expression miscalculation issue affecting both CPS3 and CPS v2 (mostly ZN-1 / ZN-2 titles).

* for cps3/v2 don't use CPS2 v1 table for volume/expression, instead treat values as linear scale percent for now (we can add a table later)
* fix instrument length determination, don't rely on 0xFFFF separator - fixes incorrect samples
* add high byte for region sample index - fixes incorrect samples
* add a "deinterlace_pairs" load method to MAMELoader which deinterlaces two files at a time from a rom group entry. Needed to load the rest of sfiii3's samples

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
