### PR TITLE
Update .clang-format, update VGMRoot fields

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@ AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: "Yes"
-BasedOnStyle: Google
+BreakBeforeBraces: WebKit
 ColumnLimit:     100
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
@@ -27,6 +27,7 @@ Language:        Cpp
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 PointerAlignment: Left
+ReferenceAlignment: Left
 ReflowComments:  true
 SortIncludes:    false
 SpaceBeforeParens: ControlStatements

--- a/src/main/LogManager.h
+++ b/src/main/LogManager.h
@@ -21,7 +21,7 @@ protected:
   void sink_it_(const spdlog::details::log_msg& msg) override {
     auto level = convertSpdlogLevel(msg.level);
     auto logItem = new LogItem( fmt::to_string(msg.payload), level, msg.source.filename);
-    pRoot->Log(logItem);
+    g_root->Log(logItem);
   }
 
   void flush_() override {}

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -1,5 +1,5 @@
 /*
- * VGMTrans (c) 2002-2019
+ * VGMTrans (c) 2002-2024
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
  */
@@ -34,45 +34,50 @@ public:
   virtual ~VGMRoot() = default;
 
   virtual bool Init();
-  virtual bool OpenRawFile(const std::string &filename);
+  virtual bool OpenRawFile(const std::string& filename);
   bool CreateVirtFile(const uint8_t* databuf, uint32_t fileSize, const std::string& filename,
                       const std::string& parRawFileFullPath = "", const VGMTag& tag = VGMTag());
   bool SetupNewRawFile(RawFile* newRawFile);
-  bool CloseRawFile(RawFile *targFile);
+  bool CloseRawFile(RawFile* targFile);
   void AddVGMFile(VGMFileVariant file);
   void RemoveVGMFile(VGMFileVariant file, bool bRemoveEmptyRawFile = true);
-  void AddVGMColl(VGMColl *theColl);
-  void RemoveVGMColl(VGMColl *theFile);
-  void Log(LogItem *theLog);
+  void AddVGMColl(VGMColl* theColl);
+  void RemoveVGMColl(VGMColl* theFile);
+  void Log(LogItem* theLog);
 
   virtual std::string UI_GetResourceDirPath();
-  virtual void UI_SetRootPtr(VGMRoot **theRoot) = 0;
-  virtual void UI_AddRawFile(RawFile *) {}
-  virtual void UI_CloseRawFile(RawFile *) {}
+  virtual void UI_SetRootPtr(VGMRoot** theRoot) = 0;
+  virtual void UI_AddRawFile(RawFile*) {}
+  virtual void UI_CloseRawFile(RawFile*) {}
 
   virtual void UI_OnBeginLoadRawFile() {}
   virtual void UI_OnEndLoadRawFile() {}
   virtual void UI_AddVGMFile(VGMFileVariant file);
-  virtual void UI_AddVGMSeq(VGMSeq *) {}
-  virtual void UI_AddVGMInstrSet(VGMInstrSet *) {}
-  virtual void UI_AddVGMSampColl(VGMSampColl *) {}
-  virtual void UI_AddVGMMisc(VGMMiscFile *) {}
-  virtual void UI_AddVGMColl(VGMColl *) {}
-  virtual void UI_RemoveVGMFile(VGMFile *) {}
+  virtual void UI_AddVGMSeq(VGMSeq*) {}
+  virtual void UI_AddVGMInstrSet(VGMInstrSet*) {}
+  virtual void UI_AddVGMSampColl(VGMSampColl*) {}
+  virtual void UI_AddVGMMisc(VGMMiscFile*) {}
+  virtual void UI_AddVGMColl(VGMColl*) {}
+  virtual void UI_RemoveVGMFile(VGMFile*) {}
   virtual void UI_BeginRemoveVGMFiles() {}
   virtual void UI_EndRemoveVGMFiles() {}
-  virtual void UI_Log(LogItem *) { }
+  virtual void UI_Log(LogItem*) {}
 
-  virtual void UI_RemoveVGMColl(VGMColl *) {}
-  virtual void UI_AddItem(VGMItem *, VGMItem *, const std::string &, void *) {}
-  virtual std::string UI_GetSaveFilePath(const std::string &suggestedFilename,
-                                         const std::string &extension = "") = 0;
-  virtual std::string UI_GetSaveDirPath(const std::string &suggestedDir = "") = 0;
-  virtual bool UI_WriteBufferToFile(const std::string &filepath, uint8_t *buf, size_t size);
+  virtual void UI_RemoveVGMColl(VGMColl*) {}
+  virtual void UI_AddItem(VGMItem*, VGMItem*, const std::string&, void*) {}
+  virtual std::string UI_GetSaveFilePath(const std::string& suggestedFilename,
+                                         const std::string& extension = "") = 0;
+  virtual std::string UI_GetSaveDirPath(const std::string& suggestedDir = "") = 0;
+  virtual bool UI_WriteBufferToFile(const std::string& filepath, uint8_t* buf, size_t size);
 
-  std::vector<RawFile *> vRawFile;
-  std::vector<VGMColl *> vVGMColl;
-  std::vector<VGMFileVariant> vVGMFile;
+  const std::vector<RawFile*>& rawFiles() { return m_rawfiles; }
+  const std::vector<VGMFileVariant>& vgmFiles() { return m_vgmfiles; }
+  const std::vector<VGMColl*>& vgmColls() { return m_vgmcolls; }
+
+private:
+  std::vector<RawFile*> m_rawfiles;
+  std::vector<VGMFileVariant> m_vgmfiles;
+  std::vector<VGMColl*> m_vgmcolls;
 };
 
-extern VGMRoot *pRoot;
+extern VGMRoot* g_root;

--- a/src/main/components/VGMColl.cpp
+++ b/src/main/components/VGMColl.cpp
@@ -81,7 +81,7 @@ void VGMColl::AddMiscFile(VGMMiscFile *theMiscFile) {
 bool VGMColl::Load() {
   if (!LoadMain())
     return false;
-  pRoot->AddVGMColl(this);
+  g_root->AddVGMColl(this);
   return true;
 }
 

--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -44,7 +44,7 @@ VGMItem *VGMItem::GetItemFromOffset(uint32_t offset, [[maybe_unused]] bool inclu
 }
 
 void VGMItem::AddToUI(VGMItem *parent, void *UI_specific) {
-  pRoot->UI_AddItem(this, parent, name, UI_specific);
+  g_root->UI_AddItem(this, parent, name, UI_specific);
 }
 
 uint32_t VGMItem::GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) const {

--- a/src/main/components/VGMMiscFile.cpp
+++ b/src/main/components/VGMMiscFile.cpp
@@ -43,6 +43,6 @@ bool VGMMiscFile::Load() {
   }
 
   rawfile->AddContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(this));
-  pRoot->AddVGMFile(this);
+  g_root->AddVGMFile(this);
   return true;
 }

--- a/src/main/components/VGMSampColl.cpp
+++ b/src/main/components/VGMSampColl.cpp
@@ -86,7 +86,7 @@ bool VGMSampColl::Load() {
 
   if (!parInstrSet) {
     rawfile->AddContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(this));
-    pRoot->AddVGMFile(this);
+    g_root->AddVGMFile(this);
   }
 
   bLoaded = true;

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -73,7 +73,7 @@ bool VGMInstrSet::Load() {
 
   rawfile->AddContainedVGMFile(
       std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(this));
-  pRoot->AddVGMFile(this);
+  g_root->AddVGMFile(this);
   return true;
 }
 

--- a/src/main/components/instr/VGMSamp.cpp
+++ b/src/main/components/instr/VGMSamp.cpp
@@ -43,7 +43,7 @@ void VGMSamp::ConvertToStdWave(uint8_t *buf) {
 }
 
 bool VGMSamp::OnSaveAsWav() {
-  std::string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), "wav");
+  std::string filepath = g_root->UI_GetSaveFilePath(ConvertToSafeFileName(name), "wav");
   if (filepath.empty())
     return SaveAsWav(filepath);
   return false;
@@ -124,5 +124,5 @@ bool VGMSamp::SaveAsWav(const std::string &filepath) {
     PushTypeOnVect<uint32_t>(waveBuf, 0);                  // playcount
   }
 
-  return pRoot->UI_WriteBufferToFile(filepath, &waveBuf[0], waveBuf.size());
+  return g_root->UI_WriteBufferToFile(filepath, &waveBuf[0], waveBuf.size());
 }

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -68,7 +68,7 @@ bool VGMSeq::Load() {
 
   rawfile->AddContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
     VGMMiscFile *>>(this));
-  pRoot->AddVGMFile(this);
+  g_root->AddVGMFile(this);
   return true;
 }
 

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -133,7 +133,7 @@ int DLSFile::WriteDLSToBuffer(std::vector<uint8_t> &buf) {
 bool DLSFile::SaveDLSFile(const std::string &filepath) {
   std::vector<uint8_t> dlsBuf;
   WriteDLSToBuffer(dlsBuf);
-  return pRoot->UI_WriteBufferToFile(filepath, dlsBuf.data(), static_cast<uint32_t>(dlsBuf.size()));
+  return g_root->UI_WriteBufferToFile(filepath, dlsBuf.data(), static_cast<uint32_t>(dlsBuf.size()));
 }
 
 //  *******

--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -70,7 +70,7 @@ void MidiFile::Sort() {
 bool MidiFile::SaveMidiFile(const std::string &filepath) {
   std::vector<uint8_t> midiBuf;
   WriteMidiToBuffer(midiBuf);
-  return pRoot->UI_WriteBufferToFile(filepath, &midiBuf[0], midiBuf.size());
+  return g_root->UI_WriteBufferToFile(filepath, &midiBuf[0], midiBuf.size());
 }
 
 void MidiFile::WriteMidiToBuffer(std::vector<uint8_t> &buf) {

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -431,6 +431,6 @@ std::vector<uint8_t> SF2File::SaveToMem() {
 
 bool SF2File::SaveSF2File(const std::string &filepath) {
   auto buf = SaveToMem();
-  bool result = pRoot->UI_WriteBufferToFile(filepath, buf.data(), buf.size());
+  bool result = g_root->UI_WriteBufferToFile(filepath, buf.data(), buf.size());
   return result;
 }

--- a/src/main/formats/HOSA/HOSAScanner.cpp
+++ b/src/main/formats/HOSA/HOSAScanner.cpp
@@ -40,7 +40,7 @@ void HOSAScanner::Scan(RawFile *file, void *info) {
 
   for (size_t i = 0; i < sampcolls.size(); i++) {
     if (sampcolls[i] != sampcoll) {
-      pRoot->RemoveVGMFile(sampcolls[i]);
+      g_root->RemoveVGMFile(sampcolls[i]);
     }
   }
 

--- a/src/main/formats/PS1/Vab.cpp
+++ b/src/main/formats/PS1/Vab.cpp
@@ -145,7 +145,7 @@ bool Vab::GetInstrPointers() {
       // load samples as well
       PSXSampColl *newSampColl = new PSXSampColl(format, this, vagStartOffset, totalVAGSize, vagLocations);
       if (newSampColl->LoadVGMFile()) {
-        pRoot->AddVGMFile(newSampColl);
+        g_root->AddVGMFile(newSampColl);
         //this->sampColl = newSampColl;
       }
       else {

--- a/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
@@ -379,7 +379,7 @@ int8_t SonyPS2Instr::ConvertPanVal(uint8_t panVal) {
 SonyPS2SampColl::SonyPS2SampColl(RawFile *rawfile, uint32_t offset, uint32_t length)
     : VGMSampColl(SonyPS2Format::name, rawfile, offset, length) {
   this->LoadOnInstrMatch();
-  pRoot->AddVGMFile(this);
+  g_root->AddVGMFile(this);
 }
 
 bool SonyPS2SampColl::GetSampleInfo() {

--- a/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
@@ -83,7 +83,7 @@ void SonyPS2Scanner::SearchForSampColl(RawFile *file) {
       uint8_t *newdataBuf = new uint8_t[newFileSize];
       file->GetBytes(0, file->size(), newdataBuf + 16);
       memset(newdataBuf, 0, 16);
-      pRoot->CreateVirtFile(newdataBuf, newFileSize, file->name(),
+      g_root->CreateVirtFile(newdataBuf, newFileSize, file->name(),
                             file->GetParRawFileFullPath().c_str());
       return;
     }

--- a/src/main/formats/TriAcePS1/TriAcePS1Scanner.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1Scanner.cpp
@@ -223,7 +223,7 @@ TriAcePS1Seq *TriAcePS1Scanner::TriAceSLZDecompress(RawFile *file, uint32_t cfOf
 
   newVirtFile->setUseLoaders(false);
   newVirtFile->setUseScanners(false);
-  pRoot->SetupNewRawFile(newVirtFile);
+  g_root->SetupNewRawFile(newVirtFile);
 
   if (bLoadSucceed)
     return newSeq;

--- a/src/main/loaders/MAMELoader.cpp
+++ b/src/main/loaders/MAMELoader.cpp
@@ -54,7 +54,7 @@ MAMELoader::~MAMELoader() {
 }
 
 int MAMELoader::LoadXML() {
-    const std::string xmlFilePath = pRoot->UI_GetResourceDirPath() + "mame_roms.xml";
+    const std::string xmlFilePath = g_root->UI_GetResourceDirPath() + "mame_roms.xml";
 
     TiXmlDocument doc(xmlFilePath);
     if (!doc.LoadFile())  // if loading the xml file fails

--- a/src/main/loaders/SPC2Loader.cpp
+++ b/src/main/loaders/SPC2Loader.cpp
@@ -81,7 +81,7 @@ PostLoadCommand SPC2Loader::Apply(RawFile *file) {
     std::copy(spcDataBlock + 512, spcDataBlock + 640, spcFile + SPC_HEADER_SIZE + SPC_RAM_SIZE);
 
     // Save the reconstructed SPC file
-    if (!pRoot->CreateVirtFile(spcFile, SPC_FILE_SIZE, originalSpcFilename, "", file->tag)) {
+    if (!g_root->CreateVirtFile(spcFile, SPC_FILE_SIZE, originalSpcFilename, "", file->tag)) {
       L_ERROR("Failed to save SPC file: {}", originalSpcFilename);
     }
   }

--- a/src/ui/cli/CLIVGMRoot.h
+++ b/src/ui/cli/CLIVGMRoot.h
@@ -19,7 +19,7 @@ class CLIVGMRoot : public VGMRoot {
 public:
 
   size_t GetNumCollections() {
-    return vVGMColl.size();
+    return vgmColls().size();
   }
 
   void DisplayUsage();
@@ -46,7 +46,7 @@ public:
 
   void UI_Log(LogItem* theLog) override;
 
-  virtual void UpdateCollections();
+  size_t UpdateCollections(size_t startOffset);
 
   std::string UI_GetSaveFilePath(const std::string& suggestedFilename,
                                  const std::string& extension = "") override;

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -73,7 +73,8 @@ ManualCollectionDialog::ManualCollectionDialog(QWidget *parent) : QDialog(parent
 
 QListWidget *ManualCollectionDialog::makeSequenceList() {
   std::vector<VGMFile *> seqs;
-  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
+  const auto& files = qtVGMRoot.vgmFiles();
+  for (const auto& fileVariant : files) {
     if (std::holds_alternative<VGMSeq*>(fileVariant)) {
       if (VGMSeq* seq = std::get<VGMSeq*>(fileVariant)) {
         seqs.push_back(seq);
@@ -93,7 +94,8 @@ QListWidget *ManualCollectionDialog::makeSequenceList() {
 
 QListWidget *ManualCollectionDialog::makeInstrumentSetList() {
   std::vector<VGMFile *> instrSets;
-  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
+  const auto& files = qtVGMRoot.vgmFiles();
+  for (const auto& fileVariant : files) {
     if (std::holds_alternative<VGMInstrSet*>(fileVariant)) {
       if (VGMInstrSet* instrSet = std::get<VGMInstrSet*>(fileVariant)) {
         instrSets.push_back(instrSet);
@@ -113,7 +115,8 @@ QListWidget *ManualCollectionDialog::makeInstrumentSetList() {
 
 QListWidget *ManualCollectionDialog::makeSampleCollectionList() {
   std::vector<VGMFile *> sampColls;
-  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
+  const auto& files = qtVGMRoot.vgmFiles();
+  for (const auto& fileVariant : files) {
     if (std::holds_alternative<VGMSampColl*>(fileVariant)) {
       if (VGMSampColl* sampColl = std::get<VGMSampColl*>(fileVariant)) {
         sampColls.push_back(sampColl);

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -73,7 +73,7 @@ ManualCollectionDialog::ManualCollectionDialog(QWidget *parent) : QDialog(parent
 
 QListWidget *ManualCollectionDialog::makeSequenceList() {
   std::vector<VGMFile *> seqs;
-  for (const auto& fileVariant : qtVGMRoot.vVGMFile) {
+  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
     if (std::holds_alternative<VGMSeq*>(fileVariant)) {
       if (VGMSeq* seq = std::get<VGMSeq*>(fileVariant)) {
         seqs.push_back(seq);
@@ -93,7 +93,7 @@ QListWidget *ManualCollectionDialog::makeSequenceList() {
 
 QListWidget *ManualCollectionDialog::makeInstrumentSetList() {
   std::vector<VGMFile *> instrSets;
-  for (const auto& fileVariant : qtVGMRoot.vVGMFile) {
+  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
     if (std::holds_alternative<VGMInstrSet*>(fileVariant)) {
       if (VGMInstrSet* instrSet = std::get<VGMInstrSet*>(fileVariant)) {
         instrSets.push_back(instrSet);
@@ -113,7 +113,7 @@ QListWidget *ManualCollectionDialog::makeInstrumentSetList() {
 
 QListWidget *ManualCollectionDialog::makeSampleCollectionList() {
   std::vector<VGMFile *> sampColls;
-  for (const auto& fileVariant : qtVGMRoot.vVGMFile) {
+  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
     if (std::holds_alternative<VGMSampColl*>(fileVariant)) {
       if (VGMSampColl* sampColl = std::get<VGMSampColl*>(fileVariant)) {
         sampColls.push_back(sampColl);

--- a/src/ui/qt/QtVGMRoot.h
+++ b/src/ui/qt/QtVGMRoot.h
@@ -36,9 +36,9 @@ public:
   void UI_AddItem(VGMItem* item, VGMItem* parent, const std::string& itemName,
                   void* UI_specific) override;
   std::string UI_GetOpenFilePath(const std::string& suggestedFilename = "",
-                                          const std::string& extension = "");
+                                 const std::string& extension = "");
   std::string UI_GetSaveFilePath(const std::string& suggestedFilename,
-                                          const std::string& extension = "") override;
+                                 const std::string& extension = "") override;
   std::string UI_GetSaveDirPath(const std::string& suggestedDir = "") override;
 
 private:

--- a/src/ui/qt/services/commands/GeneralCommands.h
+++ b/src/ui/qt/services/commands/GeneralCommands.h
@@ -103,7 +103,7 @@ public:
   CloseVGMFileCommand() : CloseCommand<VGMFile>() {}
 
   void Close(VGMFile* file) const override {
-    pRoot->RemoveVGMFile(vgmFileToVariant(file));
+    g_root->RemoveVGMFile(vgmFileToVariant(file));
   }
 };
 
@@ -115,6 +115,6 @@ public:
   CloseRawFileCommand() : CloseCommand<RawFile>() {}
 
   void Close(RawFile* file) const override {
-    pRoot->CloseRawFile(file);
+    g_root->CloseRawFile(file);
   }
 };

--- a/src/ui/qt/workarea/RawFileListView.cpp
+++ b/src/ui/qt/workarea/RawFileListView.cpp
@@ -34,7 +34,7 @@ int RawFileListViewModel::rowCount(const QModelIndex &parent) const {
   if (parent.isValid())
     return 0;
 
-  return static_cast<int>(qtVGMRoot.vRawFile.size());
+  return static_cast<int>(qtVGMRoot.rawFiles().size());
 }
 
 int RawFileListViewModel::columnCount(const QModelIndex &parent) const {
@@ -45,7 +45,7 @@ int RawFileListViewModel::columnCount(const QModelIndex &parent) const {
 }
 
 void RawFileListViewModel::AddRawFile() {
-  int position = static_cast<int>(qtVGMRoot.vRawFile.size()) - 1;
+  int position = static_cast<int>(qtVGMRoot.rawFiles().size()) - 1;
   if (position >= 0) {
     beginInsertRows(QModelIndex(), position, position);
     endInsertRows();
@@ -53,7 +53,7 @@ void RawFileListViewModel::AddRawFile() {
 }
 
 void RawFileListViewModel::RemoveRawFile() {
-  int position = static_cast<int>(qtVGMRoot.vRawFile.size()) - 1;
+  int position = static_cast<int>(qtVGMRoot.rawFiles().size()) - 1;
   if (position >= 0) {
     beginRemoveRows(QModelIndex(), position, position);
     endRemoveRows();
@@ -90,7 +90,7 @@ QVariant RawFileListViewModel::data(const QModelIndex &index, int role) const {
   switch (index.column()) {
     case Property::Name: {
       if (role == Qt::DisplayRole) {
-        return QString::fromStdString(qtVGMRoot.vRawFile[index.row()]->name());
+        return QString::fromStdString(qtVGMRoot.rawFiles()[index.row()]->name());
       } else if (role == Qt::DecorationRole) {
         return fileIcon();
       }
@@ -99,7 +99,7 @@ QVariant RawFileListViewModel::data(const QModelIndex &index, int role) const {
 
     case Property::ContainedFiles: {
       if (role == Qt::DisplayRole) {
-        return QString::number(qtVGMRoot.vRawFile[index.row()]->containedVGMFiles().size());
+        return QString::number(qtVGMRoot.rawFiles()[index.row()]->containedVGMFiles().size());
       }
       break;
     }
@@ -133,8 +133,8 @@ RawFileListView::RawFileListView(QWidget *parent) : TableView(parent) {
 
     QModelIndexList list = sm->selectedRows();
     for (auto &index : list) {
-      auto rawfile = qtVGMRoot.vRawFile[index.row()];
-      std::string filepath = pRoot->UI_GetSaveFilePath("");
+      auto rawfile = qtVGMRoot.rawFiles()[index.row()];
+      std::string filepath = g_root->UI_GetSaveFilePath("");
       if (!filepath.empty()) {
         /* todo: free function in VGMExport */
         conversion::SaveAsOriginal(*rawfile, filepath);
@@ -179,7 +179,7 @@ void RawFileListView::deleteRawFiles() {
 
   QModelIndexList list = selectionModel()->selectedRows();
   for (auto & idx : std::ranges::reverse_view(list)) {
-    const auto rawfile = qtVGMRoot.vRawFile[idx.row()];
+    const auto rawfile = qtVGMRoot.rawFiles()[idx.row()];
     qtVGMRoot.CloseRawFile(rawfile);
   }
   clearSelection();
@@ -194,10 +194,10 @@ void RawFileListView::onVGMFileSelected(const VGMFile* vgmfile, const QWidget* c
     return;
   }
 
-  auto it = std::ranges::find(qtVGMRoot.vRawFile, vgmfile->rawfile);
-  if (it == qtVGMRoot.vRawFile.end())
+  auto it = std::ranges::find(qtVGMRoot.rawFiles(), vgmfile->rawfile);
+  if (it == qtVGMRoot.rawFiles().end())
     return;
-  int row = static_cast<int>(std::distance(qtVGMRoot.vRawFile.begin(), it));
+  int row = static_cast<int>(std::distance(qtVGMRoot.rawFiles().begin(), it));
 
   // Select the row corresponding to the file
   QModelIndex firstIndex = model()->index(row, 0); // First column of the row
@@ -228,7 +228,7 @@ void RawFileListView::updateStatusBar() const {
     NotificationCenter::the()->updateStatusForItem(nullptr);
     return;
   }
-  RawFile* file = qtVGMRoot.vRawFile[currentIndex().row()];
+  RawFile* file = qtVGMRoot.rawFiles()[currentIndex().row()];
   QString name = QString::fromStdString(file->name());
   NotificationCenter::the()->updateStatus(name, "", &fileIcon(), -1, static_cast<uint32_t>(file->size()));
 }

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -51,12 +51,12 @@ VGMCollListViewModel::VGMCollListViewModel(QObject *parent) : QAbstractListModel
 }
 
 int VGMCollListViewModel::rowCount(const QModelIndex &) const {
-  return static_cast<int>(qtVGMRoot.vVGMColl.size());
+  return static_cast<int>(qtVGMRoot.vgmColls().size());
 }
 
 QVariant VGMCollListViewModel::data(const QModelIndex &index, int role) const {
   if (role == Qt::DisplayRole || role == Qt::EditRole) {
-    return QString::fromStdString(qtVGMRoot.vVGMColl[index.row()]->GetName());
+    return QString::fromStdString(qtVGMRoot.vgmColls()[index.row()]->GetName());
   } else if (role == Qt::DecorationRole) {
     return VGMCollIcon();
   }
@@ -86,7 +86,7 @@ void VGMCollNameEditor::setModelData(QWidget *editor, QAbstractItemModel *model,
                                      const QModelIndex &index) const {
   auto *line_edit = qobject_cast<QLineEdit *>(editor);
   auto new_name = line_edit->text().toStdString();
-  qtVGMRoot.vVGMColl[index.row()]->SetName(&new_name);
+  qtVGMRoot.vgmColls()[index.row()]->SetName(&new_name);
   model->dataChanged(index, index);
 }
 
@@ -139,7 +139,7 @@ void VGMCollListView::collectionMenu(const QPoint &pos) const {
     }
 
     for (auto &index : selectedIndexes()) {
-      if (auto coll = qtVGMRoot.vVGMColl[index.row()]; coll) {
+      if (auto coll = qtVGMRoot.vgmColls()[index.row()]; coll) {
         conversion::SaveAs<conversion::Target::MIDI | conversion::Target::DLS>(*coll, save_path);
       }
     }
@@ -152,7 +152,7 @@ void VGMCollListView::collectionMenu(const QPoint &pos) const {
     }
 
     for (auto &index : selectedIndexes()) {
-      if (auto coll = qtVGMRoot.vVGMColl[index.row()]; coll) {
+      if (auto coll = qtVGMRoot.vgmColls()[index.row()]; coll) {
         conversion::SaveAs<conversion::Target::MIDI | conversion::Target::SF2>(*coll, save_path);
       }
     }
@@ -165,7 +165,7 @@ void VGMCollListView::collectionMenu(const QPoint &pos) const {
     }
 
     for (auto &index : selectedIndexes()) {
-      if (auto coll = qtVGMRoot.vVGMColl[index.row()]; coll) {
+      if (auto coll = qtVGMRoot.vgmColls()[index.row()]; coll) {
         conversion::SaveAs<conversion::Target::MIDI | conversion::Target::DLS |
           conversion::Target::SF2>(*coll, save_path);
       }
@@ -198,7 +198,7 @@ void VGMCollListView::handlePlaybackRequest() {
     return;
   }
 
-  VGMColl *coll = qtVGMRoot.vVGMColl[list[0].row()];
+  VGMColl *coll = qtVGMRoot.vgmColls()[list[0].row()];
   SequencePlayer::the().playCollection(coll);
 }
 

--- a/src/ui/qt/workarea/VGMCollView.cpp
+++ b/src/ui/qt/workarea/VGMCollView.cpp
@@ -54,11 +54,11 @@ QVariant VGMCollViewModel::data(const QModelIndex &index, int role) const {
 }
 
 void VGMCollViewModel::handleNewCollSelected(const QModelIndex& modelIndex) {
-  if (!modelIndex.isValid() || qtVGMRoot.vVGMColl.empty() ||
-      static_cast<size_t>(modelIndex.row()) >= qtVGMRoot.vVGMColl.size()) {
+  if (!modelIndex.isValid() || qtVGMRoot.vgmColls().empty() ||
+      static_cast<size_t>(modelIndex.row()) >= qtVGMRoot.vgmColls().size()) {
     m_coll = nullptr;
   } else {
-    m_coll = qtVGMRoot.vVGMColl[modelIndex.row()];
+    m_coll = qtVGMRoot.vgmColls()[modelIndex.row()];
   }
 
   dataChanged(index(0, 0), modelIndex);
@@ -170,14 +170,14 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
 
   QObject::connect(collListSelModel, &QItemSelectionModel::currentChanged,
     [this, commit_rename](const QModelIndex& index) {
-    if (!index.isValid() || qtVGMRoot.vVGMColl.empty() ||
-        static_cast<size_t>(index.row()) >= qtVGMRoot.vVGMColl.size()) {
+    if (!index.isValid() || qtVGMRoot.vgmColls().empty() ||
+        static_cast<size_t>(index.row()) >= qtVGMRoot.vgmColls().size()) {
       commit_rename->setEnabled(false);
       m_collection_title->setReadOnly(true);
       m_collection_title->setText("No collection selected");
     } else {
       m_collection_title->setText(
-          QString::fromStdString(qtVGMRoot.vVGMColl[index.row()]->GetName()));
+          QString::fromStdString(qtVGMRoot.vgmColls()[index.row()]->GetName()));
       m_collection_title->setReadOnly(false);
       commit_rename->setEnabled(true);
     }
@@ -185,14 +185,14 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
 
   QObject::connect(commit_rename, &QPushButton::pressed, [this, collListSelModel]() {
     auto model_index = collListSelModel->currentIndex();
-    if (!model_index.isValid() || qtVGMRoot.vVGMColl.empty() ||
-        model_index.row() >= qtVGMRoot.vVGMColl.size()) {
+    if (!model_index.isValid() || qtVGMRoot.vgmColls().empty() ||
+        model_index.row() >= qtVGMRoot.vgmColls().size()) {
       return;
     }
 
     auto title = m_collection_title->text().toStdString();
     /* This makes a copy, no worries */
-    qtVGMRoot.vVGMColl[model_index.row()]->SetName(&title);
+    qtVGMRoot.vgmColls()[model_index.row()]->SetName(&title);
 
     auto coll_list_model = collListSelModel->model();
     coll_list_model->dataChanged(coll_list_model->index(0, 0),

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -33,7 +33,7 @@ QVariant VGMFileListModel::data(const QModelIndex &index, int role) const {
     return QVariant();
   }
 
-  VGMFileVariant vgmfilevariant = qtVGMRoot.vVGMFile.at(index.row());
+  VGMFileVariant vgmfilevariant = qtVGMRoot.vgmFiles().at(index.row());
   VGMFile* vgmfile = variantToVGMFile(vgmfilevariant);
 
   switch (index.column()) {
@@ -85,7 +85,7 @@ int VGMFileListModel::rowCount(const QModelIndex &parent) const {
     return 0;
   }
 
-  return static_cast<int>(qtVGMRoot.vVGMFile.size());
+  return static_cast<int>(qtVGMRoot.vgmFiles().size());
 }
 
 int VGMFileListModel::columnCount(const QModelIndex &parent) const {
@@ -97,13 +97,13 @@ int VGMFileListModel::columnCount(const QModelIndex &parent) const {
 }
 
 void VGMFileListModel::AddVGMFile() {
-  int position = static_cast<int>(qtVGMRoot.vVGMFile.size()) - 1;
+  int position = static_cast<int>(qtVGMRoot.vgmFiles().size()) - 1;
   beginInsertRows(QModelIndex(), position, position);
   endInsertRows();
 }
 
 void VGMFileListModel::RemoveVGMFile() {
-  int position = static_cast<int>(qtVGMRoot.vVGMFile.size()) - 1;
+  int position = static_cast<int>(qtVGMRoot.vgmFiles().size()) - 1;
   if (position < 0) {
     return;
   }
@@ -142,7 +142,7 @@ void VGMFileListView::itemMenu(const QPoint &pos) {
   selectedFiles->reserve(list.size());
   for (const auto &index : list) {
     if (index.isValid()) {
-      selectedFiles->push_back(variantToVGMFile(qtVGMRoot.vVGMFile[index.row()]));
+      selectedFiles->push_back(variantToVGMFile(qtVGMRoot.vgmFiles()[index.row()]));
     }
   }
   auto menu = menuManager.CreateMenuForItems<VGMItem>(selectedFiles);
@@ -163,11 +163,11 @@ void VGMFileListView::keyPressEvent(QKeyEvent *input) {
         return;
 
       QModelIndexList list = selectionModel()->selectedRows();
-      pRoot->UI_BeginRemoveVGMFiles();
+      g_root->UI_BeginRemoveVGMFiles();
       for (auto & idx : std::ranges::reverse_view(list)) {
-        qtVGMRoot.RemoveVGMFile(qtVGMRoot.vVGMFile[idx.row()], true);
+        qtVGMRoot.RemoveVGMFile(qtVGMRoot.vgmFiles()[idx.row()], true);
       }
-      pRoot->UI_EndRemoveVGMFiles();
+      g_root->UI_EndRemoveVGMFiles();
 
       clearSelection();
       return;
@@ -185,7 +185,7 @@ void VGMFileListView::removeVGMFile(const VGMFile *file) const {
 }
 
 void VGMFileListView::requestVGMFileView(const QModelIndex& index) {
-  MdiArea::the()->newView(variantToVGMFile(qtVGMRoot.vVGMFile[index.row()]));
+  MdiArea::the()->newView(variantToVGMFile(qtVGMRoot.vgmFiles()[index.row()]));
 }
 
 // Update the status bar for the current selection
@@ -194,7 +194,7 @@ void VGMFileListView::updateStatusBar() const {
     NotificationCenter::the()->updateStatusForItem(nullptr);
     return;
   }
-  VGMFile* file = variantToVGMFile(qtVGMRoot.vVGMFile[currentIndex().row()]);
+  VGMFile* file = variantToVGMFile(qtVGMRoot.vgmFiles()[currentIndex().row()]);
   NotificationCenter::the()->updateStatusForItem(file);
 }
 
@@ -212,7 +212,7 @@ void VGMFileListView::currentChanged(const QModelIndex &current, const QModelInd
     return;
   }
 
-  VGMFile *file = variantToVGMFile(qtVGMRoot.vVGMFile[current.row()]);
+  VGMFile *file = variantToVGMFile(qtVGMRoot.vgmFiles()[current.row()]);
   NotificationCenter::the()->selectVGMFile(file, this);
 
   if (this->hasFocus())
@@ -228,7 +228,7 @@ void VGMFileListView::onVGMFileSelected(VGMFile* file, const QWidget* caller) {
     return;
   }
 
-  auto it = std::ranges::find_if(qtVGMRoot.vVGMFile, [&](const VGMFileVariant& var) {
+  auto it = std::ranges::find_if(qtVGMRoot.vgmFiles(), [&](const VGMFileVariant& var) {
       // Use std::visit to access the actual object within the variant
       bool matches = false;
 
@@ -238,9 +238,9 @@ void VGMFileListView::onVGMFileSelected(VGMFile* file, const QWidget* caller) {
 
       return matches;
     });
-  if (it == qtVGMRoot.vVGMFile.end())
+  if (it == qtVGMRoot.vgmFiles().end())
     return;
-  int row = static_cast<int>(std::distance(qtVGMRoot.vVGMFile.begin(), it));
+  int row = static_cast<int>(std::distance(qtVGMRoot.vgmFiles().begin(), it));
 
   // Select the row corresponding to the file
   QModelIndex firstIndex = model()->index(row, 0); // First column of the row


### PR DESCRIPTION
Consider this dipping a toe in the water for code reformatting.

There aren't actually that many changes here:

- Updated .clang-format
    - Removed `BasedOnStyle: Google`
    - Added: `BreakBeforeBraces: WebKit` and `ReferenceAlignment: Left`
- Renamed VGMRoot's vRawFile, vVGMFile, vVGMColl to m_rawfiles, m_vgmfiles, m_vgmcolls
- Made the above fields private and created getter functions: rawFiles(), vgmFiles(), vgmColls()
- Renamed pRoot to s_root
- Applied formatting to Root.h and Root.cpp to test the waters.

UPDATE:
I also needed to update CLIVGMRoot slightly. It was clearing the root vgmfile list, which is no longer possible as the getter returns a const and the field itself is private (but also, it was kind of a hack approach in the first place).

## Description

The `BreakBeforeBraces: WebKit` rule just adds a new line before the opening brace of a function, ie:
```
void myFunc()
{
  ...
}
```

instead of:
```
void myFunc() {
  ...
}
```

I went with this since it seems very common, but I don't feel strongly about it. The clang format style option doc is [here](https://clang.llvm.org/docs/ClangFormatStyleOptions.html).

I was tempted to use `BasedOnStyle: WebKit', but it resulted in some minor formatting issues that I didn't know how to override, like empty braces being separated with a space (`{ }` instead of `{}`), and putting the `= 0` of a multiline abstract method declaration on its own line. 🤷‍♂️ I'm concerned that we might lose good baseline rules by not using a BasedOnStyle definition.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
