### PR TITLE
Use CMakePresets, misc CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,27 +112,28 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        target: ["x64"]
+        target: ['x64', 'arm64']
     name: Windows, ${{ matrix.target }}
     steps:
        - uses: actions/checkout@v4
          with:
           submodules: recursive
           show-progress: false
-       - uses: ilammy/msvc-dev-cmd@v1
+       - name: Source vcvars for ${{ matrix.target }}
+         uses: ilammy/msvc-dev-cmd@v1
          with:
-            arch: ${{ matrix.target }}
+            arch: ${{ matrix.target != 'x64' && (format('{0}_{1}', 'amd64', matrix.target)) || matrix.target }}
        - name: "Prepare build"
          run: |
           echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          cmake --preset win-x64
+          cmake --preset win-${{ matrix.target }}
        - name: "Build project"
-         run: cmake --build --preset win-x64-release
+         run: cmake --build --preset win-${{ matrix.target }}-release
        - name: "Package artifact"
-         run: 7z a "VGMTrans.zip" -r .\build\win-x64\bin*
+         run: 7z a "VGMTrans.zip" -r .\build\win-${{ matrix.target }}\bin*
        - name: "Upload artifact"
          uses: actions/upload-artifact@v4
          with:
-           name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-x86_64-${{ runner.os }}
+           name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-${{ matrix.target }}-${{ runner.os }}
            path: VGMTrans.zip
        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,12 @@ on:
 jobs:
   macos:
     name: macOS 11.x+
-    runs-on: ${{ (matrix.target == 'x86_64' && 'macos-13') || 'macos-14' }}
+    runs-on: ${{ (matrix.target == 'intel' && 'macos-13') || 'macos-14' }}
     strategy:
       matrix:
-        target: [ "x86_64", "arm64" ]
+        target: [ "intel", "arm64" ]
     env:
-      osx_min_ver: "11.0"
-      HOMEBREW_PREFIX: ${{ (matrix.target == 'x86_64' && '/usr/local') || '/opt/homebrew' }}
+      HOMEBREW_PREFIX: ${{ (matrix.target == 'intel' && '/usr/local') || '/opt/homebrew' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,24 +25,22 @@ jobs:
           echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
           echo "/usr/local/bin" >> $GITHUB_PATH
       - name: "Prepare build"
-        run: |
-          cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ env.osx_min_ver }} \
-                -DCMAKE_OSX_ARCHITECTURES=${{ matrix.target }} \
-                -B build
+        run: cmake --preset "macos-${{ matrix.target }}"
       - name: "Build project"
-        run: cmake --build build --config "Release" --parallel
-      - working-directory: "build"
-        name: "Package DMG (macOS)"
+        # $(sysctl -n hw.logicalcpu) is required to not make XCode spawn infinite threads...
+        run: cmake --build --preset "macos-${{ matrix.target }}-release" --parallel $(sysctl -n hw.logicalcpu)
+      - name: "Package DMG (macOS)"
+        working-directory: "build/macos-${{ matrix.target }}/"
         run: |
           ${{ env.HOMEBREW_PREFIX }}/bin/macdeployqt \
             bin/VGMTrans.app \
             -verbose=3 -dmg -always-overwrite -appstore-compliant
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VGMTrans-${{ github.sha }}-${{ env.GITHUB_REF_NAME }}-${{ matrix.target }}-${{ runner.os }}.dmg
-          path: "build/bin/VGMTrans.dmg"
-  x86_64-pc-linux-gnu:
+          path: "build/macos-${{ matrix.target }}/bin/VGMTrans.dmg"
+  linux:
     runs-on: ubuntu-20.04
     name: Linux, x64
     steps:
@@ -58,11 +55,12 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 17
+          sudo ./llvm.sh 18
           sudo add-apt-repository ppa:okirby/qt6-backports
           sudo apt-get update && sudo apt-get upgrade -y
-          sudo apt-get install -y pkg-config \
-            clang-17 lld-17 ninja-build \
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config \
+            clang-18 lld-18 ninja-build \
             qt6-base-dev libqt6svg6-dev libqt6svg6 \
             qt6-tools-dev qt6-tools-dev-tools libgl1-mesa-dev \
             libjack-dev libsndfile1-dev libpulse-dev
@@ -70,32 +68,29 @@ jobs:
       - name: "Prepare build"
         run: |
           export LDFLAGS="-L/usr/local/opt/llvm/lib"
-          export CPPFLAGS="-I/usr/local/opt/llvm/include"
-          cmake \
-            -DCMAKE_C_COMPILER=clang-17 \
-            -DCMAKE_CXX_COMPILER=clang++-17 \
-            -DCMAKE_INSTALL_PREFIX=/usr \
-            -DCMAKE_BUILD_TYPE=Release \
-            -GNinja \
-            -B build
+          export CPPFLAGS="-I/usr/local/opt/llvm/include -fuse-ld=lld"
+          export CC=clang-18
+          export CXX=clang++-18
+          cmake --preset linux-x64 \
+            -G "Ninja Multi-Config" \
+            -DCMAKE_INSTALL_PREFIX=/usr
       - name: "Build project"
+        run: cmake --build --preset linux-x64-release
+      - name: "Run install target"
         run: |
-         cmake \
-          --build build \
-          --config "Release" \
-          --parallel
+          export DESTDIR=appdir
+          cmake --build --preset linux-x64-release --target install
       - name: "Make AppImage"
-        working-directory: "build"
+        working-directory: "build/linux-x64"
         run: |
           echo "Creating AppDir structure for AppImage"
-          DESTDIR=appdir ninja install
           find appdir/
           mkdir -p appdir/usr/share
-          cp ../bin/mame_roms.xml appdir/usr/bin
-          cp ../src/ui/qt/resources/VGMTrans.desktop appdir/usr/share
-          cp ../src/ui/qt/resources/vgmtrans.png appdir/
+          cp ${{ github.workspace }}/bin/mame_roms.xml appdir/usr/bin
+          cp ${{ github.workspace }}/src/ui/qt/resources/VGMTrans.desktop appdir/usr/share
+          cp ${{ github.workspace }}/src/ui/qt/resources/vgmtrans.png appdir/
           mkdir -p appdir/usr/lib
-          cp ../lib/bass/*.so appdir/usr/lib/
+          cp ${{ github.workspace }}/lib/bass/*.so appdir/usr/lib/
           echo "Downloading linuxdeployqt"
           wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
           chmod a+x linuxdeployqt-continuous-x86_64.AppImage
@@ -106,32 +101,37 @@ jobs:
             -qmake=/usr/lib/qt6/bin/qmake6 \
             -verbose=10
           mkdir -p appdir/usr/share/licenses/VGMTrans
-          cp ../LICENSE/LICENSE appdir/usr/share/licenses/VGMTrans/
+          cp ${{ github.workspace }}/LICENSE/LICENSE appdir/usr/share/licenses/VGMTrans/
           mv VGMTrans*.AppImage VGMTrans.AppImage
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-x86_64-${{ runner.os }}.AppImage
-          path: "build/VGMTrans.AppImage"
-  x86_64-pc-windows-msvc:
+          path: "build/linux-x64/VGMTrans.AppImage"
+  windows:
     runs-on: windows-2022
-    name: Windows, x64
+    strategy:
+      matrix:
+        target: ["x64"]
+    name: Windows, ${{ matrix.target }}
     steps:
        - uses: actions/checkout@v4
          with:
           submodules: recursive
           show-progress: false
        - uses: ilammy/msvc-dev-cmd@v1
+         with:
+            arch: ${{ matrix.target }}
        - name: "Prepare build"
          run: |
           echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          cmake -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release -GNinja -B build
+          cmake --preset win-x64
        - name: "Build project"
-         run: cmake --build build --config "Release" --parallel
+         run: cmake --build --preset win-x64-release
        - name: "Package artifact"
-         run: 7z a "VGMTrans.zip" -r .\build\bin*
+         run: 7z a "VGMTrans.zip" -r .\build\win-x64\bin*
        - name: "Upload artifact"
-         uses: actions/upload-artifact@v3
+         uses: actions/upload-artifact@v4
          with:
            name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-x86_64-${{ runner.os }}
            path: VGMTrans.zip

--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,4 @@ cmake-build-*
 
 # Visual Studio Code
 .vscode
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,24 @@
 # Licensed under the zlib license
 # Check the included LICENSE.txt for details
 
-# For object library linking
-cmake_minimum_required(VERSION 3.12)
+# For cmake-presets v3
+cmake_minimum_required(VERSION 3.21)
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 20)
+
+# Use ccache if present on the system
+find_program(CCACHE ccache)
+if(CCACHE)
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE})
+endif()
 
 project(
   VGMTrans
   VERSION 1.1
   LANGUAGES CXX)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 find_package(Git)
 if(GIT_FOUND)
@@ -47,18 +56,6 @@ else()
   set(VCS_BRANCH "unknown")
 endif()
 
-add_library(g_options INTERFACE)
-add_library(g_warnings INTERFACE)
-
-# Default to Release if build type wasn't specified
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE
-      "Release"
-      CACHE STRING "Build type (Release/Debug/RelWithDebInfo/MinSizeRel)" FORCE)
-endif()
-
-message(STATUS "Will build in ${CMAKE_BUILD_TYPE} mode")
-
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 if(APPLE AND EXISTS /usr/local/lib/)
@@ -70,65 +67,8 @@ endif()
 # Options
 #
 
-option(ENABLE_ASAN "Enable address sanitizer" OFF)
 option(ENABLE_UI_QT "Build the UI (Qt)" ON)
 option(ENABLE_CLI "Build the CLI application" ON)
-option(ENABLE_LIBCPP "Build using libc++" OFF)
-
-#
-# Compiler and build settings
-#
-
-# Use ccache if present on the system
-find_program(CCACHE ccache)
-if(CCACHE)
-  set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE})
-endif()
-
-# Defaulting to C++20
-target_compile_features(g_options INTERFACE cxx_std_20)
-
-if(MSVC)
-  target_compile_options(
-    g_options
-    INTERFACE /permissive- /Zc:strictStrings-)
-  target_compile_definitions(
-    g_options
-    INTERFACE NOMINMAX _CRT_SECURE_NO_DEPRECATE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE _USE_MATH_DEFINES)
-  target_compile_options(g_warnings INTERFACE /W3)
-else()
-  if(ENABLE_ASAN)
-    target_compile_options(g_options INTERFACE -fsanitize=address)
-    target_link_libraries(g_options INTERFACE -fsanitize=address)
-  endif()
-
-  if(NOT ${CMAKE_BUILD_TYPE} MATCHES "Release")
-    target_compile_options(
-      g_warnings
-      INTERFACE -Wall
-                # -Werror turn on, someday
-                -Wextra
-                -Wshadow
-                -Wunused
-                -Wold-style-cast
-                -Woverloaded-virtual
-                -Wcast-align
-                -Wnull-dereference)
-  endif()
-
-  # The c++17 filesystem library requires some thinkering with compile flags
-  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    target_link_libraries(g_options INTERFACE stdc++fs)
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    if(ENABLE_LIBCPP)
-      target_compile_options(g_options INTERFACE -stdlib=libc++)
-    else()
-      if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
-        target_link_libraries(g_options INTERFACE stdc++fs)
-      endif()
-    endif()
-  endif()
-endif()
 
 # Include our own until we switch to TinyXML2 (should also be moved to
 # vgmtranscore)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,6 +33,9 @@
             "architecture": {
                 "value": "arm64",
                 "strategy": "external"
+            },
+            "cacheVariables": {
+                "ENABLE_UI_QT": false
             }
         },
         {
@@ -76,7 +79,8 @@
         {
             "name": "linux-x64",
             "binaryDir": "${sourceDir}/build/${presetName}",
-            "displayName": "Build VGMTrans for Linux x64",
+            "displayName": "Linux x64",
+            "description": "Build VGMTrans for Linux x64",
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,152 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "windows-base",
+            "hidden": true,
+            "generator": "Ninja Multi-Config",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            },
+            "environment": {
+                "CXXFLAGS": "/permissive- /Zc:strictStrings- /W3 -DNOMINMAX -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE -D_USE_MATH_DEFINES"
+            }
+        },
+        {
+            "name": "win-x64",
+            "inherits": "windows-base",
+            "displayName": "Windows x64",
+            "description": "Build VGMTrans for Windows x64",
+            "architecture": {
+                "value": "x64",
+                "strategy": "external"
+            }
+        },
+        {
+            "name": "win-arm64",
+            "inherits": "windows-base",
+            "displayName": "Windows ARM64",
+            "description": "Build VGMTrans for Windows ARM64",
+            "architecture": {
+                "value": "arm64",
+                "strategy": "external"
+            }
+        },
+        {
+            "name": "macos-base",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "hidden": true,
+            "environment": {
+                "CXXFLAGS": "-Wall -Wextra -Wshadow -Wunused -Wold-style-cast -Woverloaded-virtual -Wcast-align -Wnull-dereference"
+            }
+        },
+        {
+            "name": "macos-intel",
+            "inherits": "macos-base",
+            "displayName": "VGMTrans (Intel)",
+            "description": "Build VGMTrans for Intel Macs",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            },
+            "cacheVariables": {
+                "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
+                "CMAKE_OSX_ARCHITECTURES": "x86_64h"
+            }
+        },
+        {
+            "name": "macos-arm64",
+            "inherits": "macos-base",
+            "displayName": "VGMTrans (Apple Silicon)",
+            "description": "Build VGMTrans for Apple Silicon Macs",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            },
+            "cacheVariables": {
+                "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
+                "CMAKE_OSX_ARCHITECTURES": "arm64"
+            }
+        },
+        {
+            "name": "linux-x64",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "displayName": "Build VGMTrans for Linux x64",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            },
+            "environment": {
+                "CXXFLAGS": "$penv{CXXFLAGS} -lstdc++fs -Wall -Wextra -Wshadow -Wunused -Wold-style-cast -Woverloaded-virtual -Wcast-align -Wnull-dereference"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "win-x64-debug",
+            "displayName": "Windows x64, Debug",
+            "configurePreset": "win-x64",
+            "configuration": "Debug"
+        },
+        {
+            "name": "win-x64-release",
+            "displayName": "Windows x64, Release",
+            "configurePreset": "win-x64",
+            "configuration": "Release"
+        },
+        {
+            "name": "win-arm64-debug",
+            "displayName": "Windows ARM64, Debug",
+            "configurePreset": "win-arm64",
+            "configuration": "Debug"
+        },
+        {
+            "name": "win-arm64-release",
+            "displayName": "Windows ARM64, Release",
+            "configurePreset": "win-arm64",
+            "configuration": "Release"
+        },
+        {
+            "name": "macos-intel-debug",
+            "displayName": "macOS Intel, Debug",
+            "configurePreset": "macos-intel",
+            "configuration": "Debug"
+        },
+        {
+            "name": "macos-intel-release",
+            "displayName": "macOS Release, Debug",
+            "configurePreset": "macos-intel",
+            "configuration": "Release"
+        },
+        {
+            "name": "macos-arm64-debug",
+            "displayName": "macOS Apple Silicon, Debug",
+            "configurePreset": "macos-arm64",
+            "configuration": "Debug"
+        },
+        {
+            "name": "macos-arm64-release",
+            "displayName": "macOS Apple Silicon, Release",
+            "configurePreset": "macos-arm64",
+            "configuration": "Release"
+        },
+        {
+            "name": "linux-x64-debug",
+            "displayName": "Linux x64, Debug",
+            "configurePreset": "linux-x64",
+            "configuration": "Debug"
+        },
+        {
+            "name": "linux-x64-release",
+            "displayName": "Linux x64, Release",
+            "configurePreset": "linux-x64",
+            "configuration": "Release"
+        }
+    ]
+}

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -68,4 +68,4 @@ target_include_directories(vgmtranscore PUBLIC
 target_link_libraries(
   vgmtranscore
   PUBLIC spdlog::spdlog unarr zlibstatic minizip tinyxml mio
-  PRIVATE g_options g_warnings)
+)

--- a/src/ui/cli/CMakeLists.txt
+++ b/src/ui/cli/CMakeLists.txt
@@ -6,8 +6,4 @@ add_executable(
 
 target_include_directories(vgmtrans-cli PUBLIC "${PROJECT_BINARY_DIR}/src")
 
-target_link_libraries(
-  vgmtrans-cli
-  PRIVATE g_options
-          g_warnings
-          vgmtranscore)
+target_link_libraries(vgmtrans-cli PRIVATE vgmtranscore)

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -104,9 +104,7 @@ target_include_directories(vgmtrans PRIVATE . ./util ./widgets ./workarea)
 
 target_link_libraries(
   vgmtrans
-  PRIVATE g_options
-          g_warnings
-          vgmtranscore
+  PRIVATE vgmtranscore
           Qt::Widgets
           Qt::Svg
           BASS::MIDI)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Switch to using CMakePresets to manage CMake settings instead of baking them inside the root CMakeLists
- Add Windows ARM64 job

## Motivation and Context
### CMake
All CMake projects should be pluggable and should not define properties of the compiler. Flags and other settings are to be put in external setting files (toolchain files) to prevent potential clashes.
`cmake-presets` is a "new" way of managing CMake settings, acting more or less like VS solution configurations.  It was introduced with CMake 3.19 but we require functionality that was added with CMake 3.21.

With this change, CMakeLists is cleaned up and compiling is simpler. For example, on Windows:
```
cmake --preset win-x64
cmake --build --preset win-x64-release
```
will set up & compile for Windows x64 in Release mode.
Many IDEs speak cmake-presets too (VS, vscode, CLion, ...), prompting devs with handy selection menus:
<img width="742" alt="image" src="https://github.com/vgmtrans/vgmtrans/assets/8491400/24bf65ce-4a59-4261-a319-8ae5bdbb8ca9">

All of the flags have been places in the presets file since we don't have that many. Older flags have been dropped since those compilers are too old for c++20 anyway.

Other misc notes:
- ASAN support is to be left for a future PR. However, if needed, users can easily add `-fsanitize=address` to the CXXFLAGS in CMakeCache.txt and recompile.
- The default build directory now specifies the configuration name to make it easier to switch between different trees, e.g. toggling between compiling for Intel or Apple Silicon.
- `ninja` is not meant to be mandatory but **strongly recommended**, especially as of 1.12: build speed is unparalleled. so, pass `-G "Ninja Multi-Config"` at the configure stage
  - Windows has "Ninja Multi-Config" hardcoded until I can do more testing
- Windows ARM64 is CLI-only for now, need to (cross-)compile Qt first (sigh)
- We also have warnings in release-mode. It makes no sense to hide them

### CI
- Don't install recommended packages on Linux, makes CI boot up faster
- Compile with Clang 18 on Linux
- Stop using deprecated Node v16 actions

## How Has This Been Tested?
Tested on macOS with XCode 15 Command Line Tools. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
