### PR TITLE
Root field getters

### DIFF
--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -105,7 +105,7 @@ bool VGMRoot::SetupNewRawFile(RawFile *newRawFile) {
   }
 
   if (!newRawFile->containedVGMFiles().empty()) {
-    vRawFile.emplace_back(newRawFile);
+    m_rawfiles.emplace_back(newRawFile);
     UI_AddRawFile(newRawFile);
   }
 
@@ -118,8 +118,8 @@ bool VGMRoot::CloseRawFile(RawFile *targFile) {
     return false;
   }
 
-  auto file = std::ranges::find(vRawFile, targFile);
-  if (file != vRawFile.end()) {
+  auto file = std::ranges::find(m_rawfiles, targFile);
+  if (file != m_rawfiles.end()) {
     auto &vgmfiles = (*file)->containedVGMFiles();
     UI_BeginRemoveVGMFiles();
     for (const auto & vgmfile : vgmfiles) {
@@ -127,7 +127,7 @@ bool VGMRoot::CloseRawFile(RawFile *targFile) {
     }
     UI_EndRemoveVGMFiles();
 
-    vRawFile.erase(file);
+    m_rawfiles.erase(file);
 
     UI_CloseRawFile(targFile);
   } else {
@@ -140,7 +140,7 @@ bool VGMRoot::CloseRawFile(RawFile *targFile) {
 
 void VGMRoot::AddVGMFile(
   std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file) {
-  vVGMFile.push_back(file);
+  m_vgmfiles.push_back(file);
   L_INFO("Loaded {} successfully.", *variantToVGMFile(file)->GetName());
   UI_AddVGMFile(file);
 }
@@ -155,11 +155,11 @@ void VGMRoot::RemoveVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
     fmt->OnCloseFile(file);
   }
 
-  auto iter = std::ranges::find(vVGMFile, file);
+  auto iter = std::ranges::find(m_vgmfiles, file);
 
-  if (iter != vVGMFile.end()) {
+  if (iter != m_vgmfiles.end()) {
     UI_RemoveVGMFile(targFile);
-    vVGMFile.erase(iter);
+    m_vgmfiles.erase(iter);
   } else {
     L_WARN("Requested deletion for VGMFile but it was not found");
   }
@@ -179,14 +179,14 @@ void VGMRoot::RemoveVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
 }
 
 void VGMRoot::AddVGMColl(VGMColl *theColl) {
-    vVGMColl.push_back(theColl);
+    m_vgmcolls.push_back(theColl);
     UI_AddVGMColl(theColl);
 }
 
 void VGMRoot::RemoveVGMColl(VGMColl *targColl) {
-  auto iter = std::ranges::find(vVGMColl, targColl);
-  if (iter != vVGMColl.end())
-    vVGMColl.erase(iter);
+  auto iter = std::ranges::find(m_vgmcolls, targColl);
+  if (iter != m_vgmcolls.end())
+    m_vgmcolls.erase(iter);
   else
     L_WARN("Requested deletion for VGMColl but it was not found");
 

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -70,9 +70,14 @@ public:
   virtual std::string UI_GetSaveDirPath(const std::string &suggestedDir = "") = 0;
   virtual bool UI_WriteBufferToFile(const std::string &filepath, uint8_t *buf, size_t size);
 
-  std::vector<RawFile *> vRawFile;
-  std::vector<VGMColl *> vVGMColl;
-  std::vector<VGMFileVariant> vVGMFile;
+  const std::vector<RawFile*>& rawFiles() { return m_rawfiles; }
+  const std::vector<VGMFileVariant>& vgmFiles() { return m_vgmfiles; }
+  const std::vector<VGMColl*>& vgmColls() { return m_vgmcolls; }
+
+private:
+  std::vector<RawFile *> m_rawfiles;
+  std::vector<VGMFileVariant> m_vgmfiles;
+  std::vector<VGMColl *> m_vgmcolls;
 };
 
 extern VGMRoot *pRoot;

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -65,13 +65,14 @@ bool CLIVGMRoot::Init() {
   // get collection for each input file
   size_t inputFileCtr = 0;
   size_t numColls = 0;
+  size_t numVGMFiles = 0;
   // map for deconflicting identical collection names using input filenames
   map<string, vector<pair<size_t, fs::path>>> collNameMap {};
   for (fs::path infile : inputFiles) {
     if (!OpenRawFile(infile.string())) {  // file not found
       return false;
     }
-    UpdateCollections();
+    numVGMFiles = UpdateCollections(numVGMFiles);
     size_t numCollsAdded = GetNumCollections() - numColls;
     if (numCollsAdded == 0) {
       cout << "File " << infile.string() << " is not a recognized music file" << endl;
@@ -219,14 +220,16 @@ void CLIVGMRoot::UI_Log(LogItem* theLog) {
   }
 }
 
-void CLIVGMRoot::UpdateCollections() {
-  for (VGMFileVariant targVariant : vgmFiles()) {
-    auto targFile = variantToVGMFile(targVariant);
+size_t CLIVGMRoot::UpdateCollections(size_t startOffset) {
+  auto files = vgmFiles();
+  for (int i = startOffset; i < files.size(); ++i) {
+    auto targFile = variantToVGMFile(files[i]);
     Format *fmt = targFile->GetFormat();
-    if (fmt->matcher) {
+    if (fmt && fmt->matcher) {
       fmt->matcher->MakeCollectionsForFile(targFile);
     }
   }
+  return vgmFiles().size();
 }
 
 string CLIVGMRoot::UI_GetSaveFilePath(const string& suggestedFilename, const string& extension) {

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -78,7 +78,7 @@ bool CLIVGMRoot::Init() {
     }
     else {
       for(size_t i = numColls; i < GetNumCollections(); ++i) {
-        VGMColl* coll = vVGMColl[i];
+        VGMColl* coll = vgmColls()[i];
         string collName = coll->GetName();
         auto it = collNameMap.find(collName);
         pair<size_t, fs::path> p = make_pair(i, infile);
@@ -129,7 +129,7 @@ bool CLIVGMRoot::Init() {
           }
           // update collection name to be unique
           string newCollName = collNameIt->first + suffix;
-          vVGMColl[p.first]->SetName(&newCollName);
+          vgmColls()[p.first]->SetName(&newCollName);
         }
       }
     }
@@ -142,7 +142,7 @@ bool CLIVGMRoot::Init() {
 
 bool CLIVGMRoot::ExportAllCollections() {
   bool success = true;
-  for (VGMColl* coll : vVGMColl) {
+  for (VGMColl* coll : vgmColls()) {
     string collName = coll->GetName();
     success &= ExportCollection(coll);
   }
@@ -220,14 +220,13 @@ void CLIVGMRoot::UI_Log(LogItem* theLog) {
 }
 
 void CLIVGMRoot::UpdateCollections() {
-  for (VGMFileVariant targVariant : vVGMFile) {
+  for (VGMFileVariant targVariant : vgmFiles()) {
     auto targFile = variantToVGMFile(targVariant);
     Format *fmt = targFile->GetFormat();
     if (fmt->matcher) {
       fmt->matcher->MakeCollectionsForFile(targFile);
     }
   }
-  vVGMFile.clear();
 }
 
 string CLIVGMRoot::UI_GetSaveFilePath(const string& suggestedFilename, const string& extension) {

--- a/src/ui/cli/CLIVGMRoot.h
+++ b/src/ui/cli/CLIVGMRoot.h
@@ -19,7 +19,7 @@ class CLIVGMRoot : public VGMRoot {
 public:
 
   size_t GetNumCollections() {
-    return vVGMColl.size();
+    return vgmColls().size();
   }
 
   void DisplayUsage();
@@ -46,7 +46,7 @@ public:
 
   void UI_Log(LogItem* theLog) override;
 
-  virtual void UpdateCollections();
+  size_t UpdateCollections(size_t startOffset);
 
   std::string UI_GetSaveFilePath(const std::string& suggestedFilename,
                                  const std::string& extension = "") override;

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -73,7 +73,8 @@ ManualCollectionDialog::ManualCollectionDialog(QWidget *parent) : QDialog(parent
 
 QListWidget *ManualCollectionDialog::makeSequenceList() {
   std::vector<VGMFile *> seqs;
-  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
+  const auto& files = qtVGMRoot.vgmFiles();
+  for (const auto& fileVariant : files) {
     if (std::holds_alternative<VGMSeq*>(fileVariant)) {
       if (VGMSeq* seq = std::get<VGMSeq*>(fileVariant)) {
         seqs.push_back(seq);
@@ -93,7 +94,8 @@ QListWidget *ManualCollectionDialog::makeSequenceList() {
 
 QListWidget *ManualCollectionDialog::makeInstrumentSetList() {
   std::vector<VGMFile *> instrSets;
-  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
+  const auto& files = qtVGMRoot.vgmFiles();
+  for (const auto& fileVariant : files) {
     if (std::holds_alternative<VGMInstrSet*>(fileVariant)) {
       if (VGMInstrSet* instrSet = std::get<VGMInstrSet*>(fileVariant)) {
         instrSets.push_back(instrSet);
@@ -113,7 +115,8 @@ QListWidget *ManualCollectionDialog::makeInstrumentSetList() {
 
 QListWidget *ManualCollectionDialog::makeSampleCollectionList() {
   std::vector<VGMFile *> sampColls;
-  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
+  const auto& files = qtVGMRoot.vgmFiles();
+  for (const auto& fileVariant : files) {
     if (std::holds_alternative<VGMSampColl*>(fileVariant)) {
       if (VGMSampColl* sampColl = std::get<VGMSampColl*>(fileVariant)) {
         sampColls.push_back(sampColl);

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -73,7 +73,7 @@ ManualCollectionDialog::ManualCollectionDialog(QWidget *parent) : QDialog(parent
 
 QListWidget *ManualCollectionDialog::makeSequenceList() {
   std::vector<VGMFile *> seqs;
-  for (const auto& fileVariant : qtVGMRoot.vVGMFile) {
+  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
     if (std::holds_alternative<VGMSeq*>(fileVariant)) {
       if (VGMSeq* seq = std::get<VGMSeq*>(fileVariant)) {
         seqs.push_back(seq);
@@ -93,7 +93,7 @@ QListWidget *ManualCollectionDialog::makeSequenceList() {
 
 QListWidget *ManualCollectionDialog::makeInstrumentSetList() {
   std::vector<VGMFile *> instrSets;
-  for (const auto& fileVariant : qtVGMRoot.vVGMFile) {
+  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
     if (std::holds_alternative<VGMInstrSet*>(fileVariant)) {
       if (VGMInstrSet* instrSet = std::get<VGMInstrSet*>(fileVariant)) {
         instrSets.push_back(instrSet);
@@ -113,7 +113,7 @@ QListWidget *ManualCollectionDialog::makeInstrumentSetList() {
 
 QListWidget *ManualCollectionDialog::makeSampleCollectionList() {
   std::vector<VGMFile *> sampColls;
-  for (const auto& fileVariant : qtVGMRoot.vVGMFile) {
+  for (const auto& fileVariant : qtVGMRoot.vgmFiles()) {
     if (std::holds_alternative<VGMSampColl*>(fileVariant)) {
       if (VGMSampColl* sampColl = std::get<VGMSampColl*>(fileVariant)) {
         sampColls.push_back(sampColl);

--- a/src/ui/qt/workarea/RawFileListView.cpp
+++ b/src/ui/qt/workarea/RawFileListView.cpp
@@ -34,7 +34,7 @@ int RawFileListViewModel::rowCount(const QModelIndex &parent) const {
   if (parent.isValid())
     return 0;
 
-  return static_cast<int>(qtVGMRoot.vRawFile.size());
+  return static_cast<int>(qtVGMRoot.rawFiles().size());
 }
 
 int RawFileListViewModel::columnCount(const QModelIndex &parent) const {
@@ -45,7 +45,7 @@ int RawFileListViewModel::columnCount(const QModelIndex &parent) const {
 }
 
 void RawFileListViewModel::AddRawFile() {
-  int position = static_cast<int>(qtVGMRoot.vRawFile.size()) - 1;
+  int position = static_cast<int>(qtVGMRoot.rawFiles().size()) - 1;
   if (position >= 0) {
     beginInsertRows(QModelIndex(), position, position);
     endInsertRows();
@@ -53,7 +53,7 @@ void RawFileListViewModel::AddRawFile() {
 }
 
 void RawFileListViewModel::RemoveRawFile() {
-  int position = static_cast<int>(qtVGMRoot.vRawFile.size()) - 1;
+  int position = static_cast<int>(qtVGMRoot.rawFiles().size()) - 1;
   if (position >= 0) {
     beginRemoveRows(QModelIndex(), position, position);
     endRemoveRows();
@@ -90,7 +90,7 @@ QVariant RawFileListViewModel::data(const QModelIndex &index, int role) const {
   switch (index.column()) {
     case Property::Name: {
       if (role == Qt::DisplayRole) {
-        return QString::fromStdString(qtVGMRoot.vRawFile[index.row()]->name());
+        return QString::fromStdString(qtVGMRoot.rawFiles()[index.row()]->name());
       } else if (role == Qt::DecorationRole) {
         return fileIcon();
       }
@@ -99,7 +99,7 @@ QVariant RawFileListViewModel::data(const QModelIndex &index, int role) const {
 
     case Property::ContainedFiles: {
       if (role == Qt::DisplayRole) {
-        return QString::number(qtVGMRoot.vRawFile[index.row()]->containedVGMFiles().size());
+        return QString::number(qtVGMRoot.rawFiles()[index.row()]->containedVGMFiles().size());
       }
       break;
     }
@@ -133,7 +133,7 @@ RawFileListView::RawFileListView(QWidget *parent) : TableView(parent) {
 
     QModelIndexList list = sm->selectedRows();
     for (auto &index : list) {
-      auto rawfile = qtVGMRoot.vRawFile[index.row()];
+      auto rawfile = qtVGMRoot.rawFiles()[index.row()];
       std::string filepath = pRoot->UI_GetSaveFilePath("");
       if (!filepath.empty()) {
         /* todo: free function in VGMExport */
@@ -179,7 +179,7 @@ void RawFileListView::deleteRawFiles() {
 
   QModelIndexList list = selectionModel()->selectedRows();
   for (auto & idx : std::ranges::reverse_view(list)) {
-    const auto rawfile = qtVGMRoot.vRawFile[idx.row()];
+    const auto rawfile = qtVGMRoot.rawFiles()[idx.row()];
     qtVGMRoot.CloseRawFile(rawfile);
   }
   clearSelection();
@@ -194,10 +194,10 @@ void RawFileListView::onVGMFileSelected(const VGMFile* vgmfile, const QWidget* c
     return;
   }
 
-  auto it = std::ranges::find(qtVGMRoot.vRawFile, vgmfile->rawfile);
-  if (it == qtVGMRoot.vRawFile.end())
+  auto it = std::ranges::find(qtVGMRoot.rawFiles(), vgmfile->rawfile);
+  if (it == qtVGMRoot.rawFiles().end())
     return;
-  int row = static_cast<int>(std::distance(qtVGMRoot.vRawFile.begin(), it));
+  int row = static_cast<int>(std::distance(qtVGMRoot.rawFiles().begin(), it));
 
   // Select the row corresponding to the file
   QModelIndex firstIndex = model()->index(row, 0); // First column of the row
@@ -228,7 +228,7 @@ void RawFileListView::updateStatusBar() const {
     NotificationCenter::the()->updateStatusForItem(nullptr);
     return;
   }
-  RawFile* file = qtVGMRoot.vRawFile[currentIndex().row()];
+  RawFile* file = qtVGMRoot.rawFiles()[currentIndex().row()];
   QString name = QString::fromStdString(file->name());
   NotificationCenter::the()->updateStatus(name, "", &fileIcon(), -1, static_cast<uint32_t>(file->size()));
 }

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -51,12 +51,12 @@ VGMCollListViewModel::VGMCollListViewModel(QObject *parent) : QAbstractListModel
 }
 
 int VGMCollListViewModel::rowCount(const QModelIndex &) const {
-  return static_cast<int>(qtVGMRoot.vVGMColl.size());
+  return static_cast<int>(qtVGMRoot.vgmColls().size());
 }
 
 QVariant VGMCollListViewModel::data(const QModelIndex &index, int role) const {
   if (role == Qt::DisplayRole || role == Qt::EditRole) {
-    return QString::fromStdString(qtVGMRoot.vVGMColl[index.row()]->GetName());
+    return QString::fromStdString(qtVGMRoot.vgmColls()[index.row()]->GetName());
   } else if (role == Qt::DecorationRole) {
     return VGMCollIcon();
   }
@@ -86,7 +86,7 @@ void VGMCollNameEditor::setModelData(QWidget *editor, QAbstractItemModel *model,
                                      const QModelIndex &index) const {
   auto *line_edit = qobject_cast<QLineEdit *>(editor);
   auto new_name = line_edit->text().toStdString();
-  qtVGMRoot.vVGMColl[index.row()]->SetName(&new_name);
+  qtVGMRoot.vgmColls()[index.row()]->SetName(&new_name);
   model->dataChanged(index, index);
 }
 
@@ -139,7 +139,7 @@ void VGMCollListView::collectionMenu(const QPoint &pos) const {
     }
 
     for (auto &index : selectedIndexes()) {
-      if (auto coll = qtVGMRoot.vVGMColl[index.row()]; coll) {
+      if (auto coll = qtVGMRoot.vgmColls()[index.row()]; coll) {
         conversion::SaveAs<conversion::Target::MIDI | conversion::Target::DLS>(*coll, save_path);
       }
     }
@@ -152,7 +152,7 @@ void VGMCollListView::collectionMenu(const QPoint &pos) const {
     }
 
     for (auto &index : selectedIndexes()) {
-      if (auto coll = qtVGMRoot.vVGMColl[index.row()]; coll) {
+      if (auto coll = qtVGMRoot.vgmColls()[index.row()]; coll) {
         conversion::SaveAs<conversion::Target::MIDI | conversion::Target::SF2>(*coll, save_path);
       }
     }
@@ -165,7 +165,7 @@ void VGMCollListView::collectionMenu(const QPoint &pos) const {
     }
 
     for (auto &index : selectedIndexes()) {
-      if (auto coll = qtVGMRoot.vVGMColl[index.row()]; coll) {
+      if (auto coll = qtVGMRoot.vgmColls()[index.row()]; coll) {
         conversion::SaveAs<conversion::Target::MIDI | conversion::Target::DLS |
           conversion::Target::SF2>(*coll, save_path);
       }
@@ -198,7 +198,7 @@ void VGMCollListView::handlePlaybackRequest() {
     return;
   }
 
-  VGMColl *coll = qtVGMRoot.vVGMColl[list[0].row()];
+  VGMColl *coll = qtVGMRoot.vgmColls()[list[0].row()];
   SequencePlayer::the().playCollection(coll);
 }
 

--- a/src/ui/qt/workarea/VGMCollView.cpp
+++ b/src/ui/qt/workarea/VGMCollView.cpp
@@ -54,11 +54,11 @@ QVariant VGMCollViewModel::data(const QModelIndex &index, int role) const {
 }
 
 void VGMCollViewModel::handleNewCollSelected(const QModelIndex& modelIndex) {
-  if (!modelIndex.isValid() || qtVGMRoot.vVGMColl.empty() ||
-      static_cast<size_t>(modelIndex.row()) >= qtVGMRoot.vVGMColl.size()) {
+  if (!modelIndex.isValid() || qtVGMRoot.vgmColls().empty() ||
+      static_cast<size_t>(modelIndex.row()) >= qtVGMRoot.vgmColls().size()) {
     m_coll = nullptr;
   } else {
-    m_coll = qtVGMRoot.vVGMColl[modelIndex.row()];
+    m_coll = qtVGMRoot.vgmColls()[modelIndex.row()];
   }
 
   dataChanged(index(0, 0), modelIndex);
@@ -170,14 +170,14 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
 
   QObject::connect(collListSelModel, &QItemSelectionModel::currentChanged,
     [this, commit_rename](const QModelIndex& index) {
-    if (!index.isValid() || qtVGMRoot.vVGMColl.empty() ||
-        static_cast<size_t>(index.row()) >= qtVGMRoot.vVGMColl.size()) {
+    if (!index.isValid() || qtVGMRoot.vgmColls().empty() ||
+        static_cast<size_t>(index.row()) >= qtVGMRoot.vgmColls().size()) {
       commit_rename->setEnabled(false);
       m_collection_title->setReadOnly(true);
       m_collection_title->setText("No collection selected");
     } else {
       m_collection_title->setText(
-          QString::fromStdString(qtVGMRoot.vVGMColl[index.row()]->GetName()));
+          QString::fromStdString(qtVGMRoot.vgmColls()[index.row()]->GetName()));
       m_collection_title->setReadOnly(false);
       commit_rename->setEnabled(true);
     }
@@ -185,14 +185,14 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
 
   QObject::connect(commit_rename, &QPushButton::pressed, [this, collListSelModel]() {
     auto model_index = collListSelModel->currentIndex();
-    if (!model_index.isValid() || qtVGMRoot.vVGMColl.empty() ||
-        model_index.row() >= qtVGMRoot.vVGMColl.size()) {
+    if (!model_index.isValid() || qtVGMRoot.vgmColls().empty() ||
+        model_index.row() >= qtVGMRoot.vgmColls().size()) {
       return;
     }
 
     auto title = m_collection_title->text().toStdString();
     /* This makes a copy, no worries */
-    qtVGMRoot.vVGMColl[model_index.row()]->SetName(&title);
+    qtVGMRoot.vgmColls()[model_index.row()]->SetName(&title);
 
     auto coll_list_model = collListSelModel->model();
     coll_list_model->dataChanged(coll_list_model->index(0, 0),

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -33,7 +33,7 @@ QVariant VGMFileListModel::data(const QModelIndex &index, int role) const {
     return QVariant();
   }
 
-  VGMFileVariant vgmfilevariant = qtVGMRoot.vVGMFile.at(index.row());
+  VGMFileVariant vgmfilevariant = qtVGMRoot.vgmFiles().at(index.row());
   VGMFile* vgmfile = variantToVGMFile(vgmfilevariant);
 
   switch (index.column()) {
@@ -85,7 +85,7 @@ int VGMFileListModel::rowCount(const QModelIndex &parent) const {
     return 0;
   }
 
-  return static_cast<int>(qtVGMRoot.vVGMFile.size());
+  return static_cast<int>(qtVGMRoot.vgmFiles().size());
 }
 
 int VGMFileListModel::columnCount(const QModelIndex &parent) const {
@@ -97,13 +97,13 @@ int VGMFileListModel::columnCount(const QModelIndex &parent) const {
 }
 
 void VGMFileListModel::AddVGMFile() {
-  int position = static_cast<int>(qtVGMRoot.vVGMFile.size()) - 1;
+  int position = static_cast<int>(qtVGMRoot.vgmFiles().size()) - 1;
   beginInsertRows(QModelIndex(), position, position);
   endInsertRows();
 }
 
 void VGMFileListModel::RemoveVGMFile() {
-  int position = static_cast<int>(qtVGMRoot.vVGMFile.size()) - 1;
+  int position = static_cast<int>(qtVGMRoot.vgmFiles().size()) - 1;
   if (position < 0) {
     return;
   }
@@ -142,7 +142,7 @@ void VGMFileListView::itemMenu(const QPoint &pos) {
   selectedFiles->reserve(list.size());
   for (const auto &index : list) {
     if (index.isValid()) {
-      selectedFiles->push_back(variantToVGMFile(qtVGMRoot.vVGMFile[index.row()]));
+      selectedFiles->push_back(variantToVGMFile(qtVGMRoot.vgmFiles()[index.row()]));
     }
   }
   auto menu = menuManager.CreateMenuForItems<VGMItem>(selectedFiles);
@@ -165,7 +165,7 @@ void VGMFileListView::keyPressEvent(QKeyEvent *input) {
       QModelIndexList list = selectionModel()->selectedRows();
       pRoot->UI_BeginRemoveVGMFiles();
       for (auto & idx : std::ranges::reverse_view(list)) {
-        qtVGMRoot.RemoveVGMFile(qtVGMRoot.vVGMFile[idx.row()], true);
+        qtVGMRoot.RemoveVGMFile(qtVGMRoot.vgmFiles()[idx.row()], true);
       }
       pRoot->UI_EndRemoveVGMFiles();
 
@@ -185,7 +185,7 @@ void VGMFileListView::removeVGMFile(const VGMFile *file) const {
 }
 
 void VGMFileListView::requestVGMFileView(const QModelIndex& index) {
-  MdiArea::the()->newView(variantToVGMFile(qtVGMRoot.vVGMFile[index.row()]));
+  MdiArea::the()->newView(variantToVGMFile(qtVGMRoot.vgmFiles()[index.row()]));
 }
 
 // Update the status bar for the current selection
@@ -194,7 +194,7 @@ void VGMFileListView::updateStatusBar() const {
     NotificationCenter::the()->updateStatusForItem(nullptr);
     return;
   }
-  VGMFile* file = variantToVGMFile(qtVGMRoot.vVGMFile[currentIndex().row()]);
+  VGMFile* file = variantToVGMFile(qtVGMRoot.vgmFiles()[currentIndex().row()]);
   NotificationCenter::the()->updateStatusForItem(file);
 }
 
@@ -212,7 +212,7 @@ void VGMFileListView::currentChanged(const QModelIndex &current, const QModelInd
     return;
   }
 
-  VGMFile *file = variantToVGMFile(qtVGMRoot.vVGMFile[current.row()]);
+  VGMFile *file = variantToVGMFile(qtVGMRoot.vgmFiles()[current.row()]);
   NotificationCenter::the()->selectVGMFile(file, this);
 
   if (this->hasFocus())
@@ -228,7 +228,7 @@ void VGMFileListView::onVGMFileSelected(VGMFile* file, const QWidget* caller) {
     return;
   }
 
-  auto it = std::ranges::find_if(qtVGMRoot.vVGMFile, [&](const VGMFileVariant& var) {
+  auto it = std::ranges::find_if(qtVGMRoot.vgmFiles(), [&](const VGMFileVariant& var) {
       // Use std::visit to access the actual object within the variant
       bool matches = false;
 
@@ -238,9 +238,9 @@ void VGMFileListView::onVGMFileSelected(VGMFile* file, const QWidget* caller) {
 
       return matches;
     });
-  if (it == qtVGMRoot.vVGMFile.end())
+  if (it == qtVGMRoot.vgmFiles().end())
     return;
-  int row = static_cast<int>(std::distance(qtVGMRoot.vVGMFile.begin(), it));
+  int row = static_cast<int>(std::distance(qtVGMRoot.vgmFiles().begin(), it));
 
   // Select the row corresponding to the file
   QModelIndex firstIndex = model()->index(row, 0); // First column of the row


### PR DESCRIPTION
This is #487 without the .clang-format changes:

- Renamed VGMRoot's vRawFile, vVGMFile, vVGMColl to m_rawfiles, m_vgmfiles, m_vgmcolls
- Made the above fields private and created getter functions: rawFiles(), vgmFiles(), vgmColls()
- Renamed pRoot to s_root

I'd still like to change up our .clang-format file, especially so that it doesn't keep using right aligned pointers and references (int *myPtr).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
