### PR TITLE
Fix CPS3 LFO events, add CPS3 region volume

### DIFF
--- a/src/main/components/seq/SeqEvent.cpp
+++ b/src/main/components/seq/SeqEvent.cpp
@@ -88,6 +88,13 @@ SetOctaveSeqEvent::SetOctaveSeqEvent(SeqTrack *pTrack,
 VolSeqEvent::VolSeqEvent(SeqTrack *pTrack, uint8_t volume, uint32_t offset, uint32_t length, const std::string &name)
     : SeqEvent(pTrack, offset, length, name, CLR_VOLUME), vol(volume) { }
 
+// ***********
+// Volume14BitSeqEvent
+// ***********
+
+Volume14BitSeqEvent::Volume14BitSeqEvent(SeqTrack *pTrack, uint16_t volume, uint32_t offset, uint32_t length, const std::string &name)
+    : SeqEvent(pTrack, offset, length, name, CLR_VOLUME), m_volume(volume) { }
+
 // ****************
 // VolSlideSeqEvent
 // ****************

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -184,10 +184,27 @@ class VolSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_VOLUME; }
 
   std::string GetDescription() override {
-    return fmt::format("{} - volume: {}", name, static_cast<int>(vol));
+    return fmt::format("{} - volume: {:d}", name, vol);
   };
 
   uint8_t vol;
+};
+
+//  *******************
+//  Volume14BitSeqEvent
+//  *******************
+
+class Volume14BitSeqEvent : public SeqEvent {
+public:
+  Volume14BitSeqEvent(SeqTrack *pTrack, uint16_t volume, uint32_t offset = 0, uint32_t length = 0,
+                      const std::string &name = "");
+  EventType GetEventType() override { return EVENTTYPE_VOLUME; }
+
+  std::string GetDescription() override {
+    return fmt::format("{} - volume: {:d}", name, m_volume);
+  };
+
+  uint16_t m_volume;
 };
 
 //  ****************

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -89,6 +89,8 @@ class SeqTrack : public VGMContainerItem {
   void LimitPrevDurNoteEnd(uint32_t absTime) const;
   void AddVol(uint32_t offset, uint32_t length, uint8_t vol, const std::string &sEventName = "Volume");
   void AddVolNoItem(uint8_t vol);
+  void AddVolume14Bit(uint32_t offset, uint32_t length, uint16_t volume, const std::string &sEventName = "Volume");
+  void AddVolume14BitNoItem(uint16_t volume);
   void AddVolSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targVol, const std::string &sEventName = "Volume Slide");
   void InsertVol(uint32_t offset, uint32_t length, uint8_t vol, uint32_t absTime, const std::string &sEventName = "Volume");
   void AddExpression(uint32_t offset, uint32_t length, uint8_t level, const std::string &sEventName = "Expression");

--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -294,6 +294,10 @@ void MidiTrack::InsertVol(uint8_t channel, uint8_t vol, uint32_t absTime) {
   aEvents.push_back(new VolumeEvent(this, channel, absTime, vol));
 }
 
+void MidiTrack::AddVolumeFine(uint8_t channel, uint8_t volume_lsb) {
+  aEvents.push_back(new VolumeFineEvent(this, channel, GetDelta(), volume_lsb));
+}
+
 //TODO: Master Volume sysex events are meant to be global to device, not per channel.
 // For per channel master volume, we should add a system for normalizing controller vol events.
 void MidiTrack::AddMasterVol(uint8_t channel, uint8_t mastVol) {

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -97,6 +97,7 @@ class MidiTrack {
   //void InsertVolMarker(uint8_t channel, uint8_t vol, uint32_t absTime, int8_t priority = PRIORITY_HIGHER);
   void AddVol(uint8_t channel, uint8_t vol/*, int8_t priority = PRIORITY_MIDDLE*/);
   void InsertVol(uint8_t channel, uint8_t vol, uint32_t absTime/*, int8_t priority = PRIORITY_MIDDLE*/);
+  void AddVolumeFine(uint8_t channel, uint8_t volume_lsb);
   void AddMasterVol(uint8_t channel, uint8_t mastVol/*, int8_t priority = PRIORITY_HIGHER*/);
   void InsertMasterVol(uint8_t channel, uint8_t mastVol, uint32_t absTime/*, int8_t priority = PRIORITY_HIGHER*/);
   void AddPan(uint8_t channel, uint8_t pan);
@@ -327,6 +328,14 @@ class VolumeEvent
  public:
   VolumeEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t volume)
       : ControllerEvent(prntTrk, channel, absoluteTime, 7, volume, PRIORITY_MIDDLE) { }
+  MidiEventType GetEventType() override { return MIDIEVENT_VOLUME; }
+};
+
+class VolumeFineEvent
+    : public ControllerEvent {
+public:
+  VolumeFineEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t volume_lsb)
+      : ControllerEvent(prntTrk, channel, absoluteTime, 39, volume_lsb, PRIORITY_MIDDLE) { }
   MidiEventType GetEventType() override { return MIDIEVENT_VOLUME; }
 };
 

--- a/src/main/formats/CPS/CPS2Instr.cpp
+++ b/src/main/formats/CPS/CPS2Instr.cpp
@@ -359,7 +359,10 @@ bool CPS2Instr::LoadInstr() {
       rgn->AddKeyHigh(progInfo.key_high, off + 0, 1);
       rgn->keyLow = prevKeyHigh + 1;
       prevKeyHigh = progInfo.key_high;
-      rgn->AddSampNum((progInfo.sample_index_hi << 8) + progInfo.sample_index_lo, off+5, 1);
+
+      auto volume_percent = ((64 + progInfo.volume_adjustment) & 0x7F) / 64.0;
+      rgn->AddVolume(volume_percent, off+2, 1);
+      rgn->AddSampNum((progInfo.sample_index_hi << 8) + progInfo.sample_index_lo, off+4, 2);
       rgn->AddSimpleItem(off + 7, 1, "Attack Rate");
       rgn->AddSimpleItem(off + 8, 1, "Decay Rate");
       rgn->AddSimpleItem(off + 9, 1, "Sustain Level");

--- a/src/main/formats/CPS/CPS2Instr.h
+++ b/src/main/formats/CPS/CPS2Instr.h
@@ -39,7 +39,7 @@ struct qs_prog_info_ver_130 {
 struct qs_prog_info_ver_cps3 {
   uint8_t key_high;
   uint8_t unknown1;
-  uint8_t unknown2;
+  int8_t volume_adjustment;  // range of -64 to +63, where -64 is silence and +63 (almost) doubles the volume
   uint8_t unknown3;
   uint8_t sample_index_hi;
   uint8_t sample_index_lo;

--- a/src/main/formats/CPS/CPSTrackV1.cpp
+++ b/src/main/formats/CPS/CPSTrackV1.cpp
@@ -68,12 +68,10 @@ bool CPSTrackV1::ReadEvent() {
     // effectively, use the highest 3 bits of the status byte as index to delta_table.
     // this code starts at 0xBB3 in sfa2
     uint32_t delta = delta_table[curDeltaTable][((status_byte >> 5) & 7) - 1];
-    delta <<= 4;
 
     //if it's not a rest
     if ((status_byte & 0x1F) != 0) {
-      // for 100% accuracy, we'd be shifting by 8, but that seems excessive for MIDI
-      uint32_t absDur = static_cast<uint32_t>((delta / static_cast<double>(256 << 4)) * (noteDuration << 4));
+      uint32_t absDur = static_cast<uint32_t>((delta / 256.0) * noteDuration);
 
       if (channelSynth == CPSSynth::OKIM6295) {
         // OKIM6295 doesn't control pitch, so we'll use middle C for all notes

--- a/src/main/formats/CPS/CPSTrackV2.cpp
+++ b/src/main/formats/CPS/CPSTrackV2.cpp
@@ -30,7 +30,7 @@ uint32_t CPSTrackV2::ReadVarLength() {
   return delta;
 }
 
-bool CPSTrackV2::ReadEvent(void) {
+bool CPSTrackV2::ReadEvent() {
   uint32_t beginOffset = curOffset;
   uint8_t status_byte = GetByte(curOffset++);
 
@@ -86,15 +86,14 @@ bool CPSTrackV2::ReadEvent(void) {
 
     case C3_PITCHBEND: {
       int8_t pitch = GetByte(curOffset++);
-      AddPitchBend(beginOffset, curOffset - beginOffset, pitch * 64);
-//      AddMarker(beginOffset,
-//                curOffset - beginOffset,
-//                string("pitchbend"),
-//                pitchbend,
-//                0,
-//                "Pitch Bend",
-//                PRIORITY_MIDDLE,
-//                CLR_PITCHBEND);
+      AddMarker(beginOffset,
+                curOffset - beginOffset,
+                "pitchbend",
+                pitch,
+                0,
+                "Pitch Bend",
+                PRIORITY_MIDDLE,
+                CLR_PITCHBEND);
       break;
     }
 
@@ -252,44 +251,41 @@ bool CPSTrackV2::ReadEvent(void) {
 
     case E0_RESET_LFO: {
       //TODO: Go back and tweak this logic. It's doing something more.
-      curOffset++;
-//      uint8_t data = GetByte(curOffset++);
-//      AddMarker(beginOffset,
-//                curOffset - beginOffset,
-//                string("resetlfo"),
-//                data,
-//                0,
-//                "LFO Reset",
-//                PRIORITY_MIDDLE,
-//                CLR_LFO);
+      uint8_t data = GetByte(curOffset++);
+      AddMarker(beginOffset,
+                curOffset - beginOffset,
+                "resetlfo",
+                data,
+                0,
+                "LFO Reset",
+                PRIORITY_MIDDLE,
+                CLR_LFO);
       break;
     }
 
     case E1_LFO_RATE: {
-      curOffset++;
-//      uint8_t rate = GetByte(curOffset++);
-//      AddMarker(beginOffset,
-//                curOffset - beginOffset,
-//                string("lfo"),
-//                rate,
-//                0,
-//                "LFO Rate",
-//                PRIORITY_MIDDLE,
-//                CLR_LFO);
+      uint8_t rate = GetByte(curOffset++);
+      AddMarker(beginOffset,
+                curOffset - beginOffset,
+                "lfo",
+                rate,
+                0,
+                "LFO Rate",
+                PRIORITY_MIDDLE,
+                CLR_LFO);
       break;
     }
 
     case E2_TREMELO: {
-      curOffset++;
-//      uint8_t tremeloDepth = GetByte(curOffset++);
-//      AddMarker(beginOffset,
-//                curOffset - beginOffset,
-//                string("tremelo"),
-//                tremeloDepth,
-//                0,
-//                "Tremelo",
-//                PRIORITY_MIDDLE,
-//                CLR_EXPRESSION);
+      uint8_t tremeloDepth = GetByte(curOffset++);
+      AddMarker(beginOffset,
+                curOffset - beginOffset,
+                "tremelo",
+                tremeloDepth,
+                0,
+                "Tremelo",
+                PRIORITY_MIDDLE,
+                CLR_EXPRESSION);
       break;
     }
 

--- a/src/main/formats/CPS/CPSTrackV2.h
+++ b/src/main/formats/CPS/CPSTrackV2.h
@@ -13,7 +13,7 @@ enum CPSv2SeqEventType {
   C3_PITCHBEND,
   C4_PROGCHANGE,
   C5_VIBRATO,
-  C6_VOLUME,
+  C6_TRACK_MASTER_VOLUME,
   EVENT_C7,
   EVENT_C8,
   C9_PORTAMENTO,
@@ -65,6 +65,8 @@ private:
   CPSFormatVer GetVersion() const { return static_cast<CPSSeq*>(this->parentSeq)->fmt_version; }
   uint32_t ReadVarLength();
 
+  uint8_t m_master_volume{0};
+  uint8_t m_secondary_volume{0x40};
   int8_t loopCounter[4];
   uint32_t loopOffset[4];    //used for detecting infinite loops
 };

--- a/src/main/util/ScaleConversion.cpp
+++ b/src/main/util/ScaleConversion.cpp
@@ -117,13 +117,13 @@ uint8_t Convert7bitPercentVolValToStdMidiVal(uint8_t percentVal) {
   return ConvertPercentAmpToStdMidiVal(percentVal / 127.0);
 }
 
-// Takes a percentage amplitude value - that is one using a -20*log10(percent) scale for db attenuation
+// Takes a percentage amplitude value - one using a -20*log10(percent) scale for db attenuation
 // and converts it to a standard midi value that uses -40*log10(x/127) for db attenuation
 uint8_t ConvertPercentAmpToStdMidiVal(double percent) {
   return std::round(127.0 * sqrt(percent));
 }
 
-// Takes a percentage amplitude value - that is one using a -20*log10(percent) scale for db attenuation
+// Takes a percentage amplitude value - one using a -20*log10(percent) scale for db attenuation
 // and converts it to a standard 14 bit midi value that uses -40*log10(x/(127*127)) for db attenuation
 uint16_t ConvertPercentAmpToStd14BitMidiVal(double percent) {
   return std::round((127.0 * 127.0) * sqrt(percent));

--- a/src/main/util/ScaleConversion.cpp
+++ b/src/main/util/ScaleConversion.cpp
@@ -123,6 +123,12 @@ uint8_t ConvertPercentAmpToStdMidiVal(double percent) {
   return std::round(127.0 * sqrt(percent));
 }
 
+// Takes a percentage amplitude value - that is one using a -20*log10(percent) scale for db attenuation
+// and converts it to a standard 14 bit midi value that uses -40*log10(x/(127*127)) for db attenuation
+uint16_t ConvertPercentAmpToStd14BitMidiVal(double percent) {
+  return std::round((127.0 * 127.0) * sqrt(percent));
+}
+
 // db attenuation is expressed as a positive value. So, a reduction of 3.2db is expressed as 3.2, not -3.2.
 uint8_t ConvertDBAttenuationToStdMidiVal(double dbAtten) {
   return std::round(pow(10, -dbAtten / 40.0));

--- a/src/main/util/ScaleConversion.h
+++ b/src/main/util/ScaleConversion.h
@@ -11,6 +11,7 @@ double LinAmpDecayTimeToLinDBDecayTime(double secondsToFullAtten, int linearVolu
 
 uint8_t Convert7bitPercentVolValToStdMidiVal(uint8_t percentVal);
 uint8_t ConvertPercentAmpToStdMidiVal(double percent);
+uint16_t ConvertPercentAmpToStd14BitMidiVal(double percent);
 uint8_t ConvertDBAttenuationToStdMidiVal(double dbAtten);
 double ConvertLogScaleValToAtten(double percent);
 double ConvertPercentAmplitudeToAttenDB(double percent);


### PR DESCRIPTION
- Fix our handling of LFO post-processing for CPS v2 sequences (CPS3, ZN-1/ZN-2, Super Puzzle Fighter).
- Add CPS3 region volume adjustment
- Add 14bit Volume events for MIDI and VGMSeq
- Get rid of CPS1/2 unnecessarily using higher resolution PPQN.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
