### PR TITLE
CPS3: use CPS3-specific IRQ rate for timing calculations, fix out-of-bounds sample check

### DIFF
--- a/src/main/components/VGMColl.cpp
+++ b/src/main/components/VGMColl.cpp
@@ -291,15 +291,14 @@ bool VGMColl::MainDLSCreation(DLSFile &dls) {
         //		realSampNum += finalSampColls[k]->samples.size();	//so now we add all previous sample collection samples to the value to get the real (absolute) sampNum
         //}
 
-
-        DLSRgn *newRgn = newInstr->AddRgn();
-        newRgn->SetRanges(rgn->keyLow, rgn->keyHigh, rgn->velLow, rgn->velHigh);
-        newRgn->SetWaveLinkInfo(0, 0, 1, static_cast<uint32_t>(realSampNum));
-
         if (realSampNum >= finalSamps.size()) {
           L_ERROR("Sample {} does not exist", realSampNum);
           realSampNum = finalSamps.size() - 1;
         }
+
+        DLSRgn *newRgn = newInstr->AddRgn();
+        newRgn->SetRanges(rgn->keyLow, rgn->keyHigh, rgn->velLow, rgn->velHigh);
+        newRgn->SetWaveLinkInfo(0, 0, 1, static_cast<uint32_t>(realSampNum));
 
         VGMSamp *samp = finalSamps[realSampNum]; //sampColl->samples[rgn->sampNum];
         DLSWsmp *newWsmp = newRgn->AddWsmp();

--- a/src/main/formats/CPS/CPS2Instr.h
+++ b/src/main/formats/CPS/CPS2Instr.h
@@ -107,15 +107,16 @@ struct qs_samp_info {
   }
 };
 
-// The QSound interrupt clock is set to 250hz in mame.  But the main sound
+// The QSound interrupt clock is set to 250hz in mame, but the main sound
 // code runs only every 4th tick. (see the "and 3" instruction at 0xF9 in sfa2 code)
-#define QSOUND_TICK_FREQ (1/(250/4.0))
+constexpr double CPS2_DRIVER_RATE_HZ = 250 / 4.0;
+// In CPS3, sound driver iterations are triggered by the vblank interrupt (IRQ 12) which runs at 59.6hz
+constexpr double CPS3_DRIVER_RATE_HZ = 59.599491;
 
+// The following tables are used by all versions of sample-based CPS drivers, with the
+// exception of the sustain level table not present in CPS3 (but it's virtually linear).
 
-// the tables below are taken from sfa2
-//  have verified that the exact same values are stored in dinosaurs & cadillacs (early qsound driver)
-
-const uint16_t linear_table[128] = {
+const uint16_t sustain_level_table[128] = {
     0, 0x3FF, 0x5FE, 0x7FF, 0x9FE, 0xBFE, 0xDFD, 0xFFF, 0x11FE, 0x13FE,
     0x15FD, 0x17FE, 0x19FD, 0x1BFD, 0x1DFC, 0x1FFF, 0x21FD, 0x23FE, 0x25FD,
     0x27FE, 0x29FD, 0x2BFD, 0x2DFC, 0x2FFE, 0x31FD, 0x33FD, 0x35FC, 0x37FD,


### PR DESCRIPTION
We were using the CPS2 driver iteration rate for CPS3. This uses the CPS3 rate, which is the vblank irq. I also fixed a bug I recently introduced whereby a check to ensure sample indexes are valid during synth file generation occurred after already setting the possibly bad index on the region.

## How Has This Been Tested?
Nothing appears to have broken in CPS2 and CPS3 playback.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
