### PR TITLE
CPS3: Add track fine-tune event

### DIFF
--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -455,7 +455,7 @@ void MidiTrack::AddCoarseTuning(uint8_t channel, double semitones) {
 void MidiTrack::InsertCoarseTuning(uint8_t channel, double semitones, uint32_t absTime) {
   semitones = std::max(-64.0, std::min(64.0, semitones));
   int16_t midiTuning = std::min(static_cast<int>(lround(128 * semitones)), 8191) + 8192;
-  InsertFineTuning(channel, midiTuning >> 7, midiTuning & 0x7f, absTime);
+  InsertCoarseTuning(channel, midiTuning >> 7, midiTuning & 0x7f, absTime);
 }
 
 void MidiTrack::AddModulationDepthRange(uint8_t channel, uint8_t msb, uint8_t lsb) {

--- a/src/main/formats/CPS/CPSTrackV1.cpp
+++ b/src/main/formats/CPS/CPSTrackV1.cpp
@@ -402,7 +402,6 @@ bool CPSTrackV1::ReadEvent() {
 
       // Loop Always
       case 0x16 : {
-
         uint32_t jump;
         if (static_cast<CPSSeq*>(parentSeq)->fmt_version <= VER_CPS1_425) {
           jump = GetShortBE(curOffset);
@@ -410,12 +409,9 @@ bool CPSTrackV1::ReadEvent() {
         else {
           jump = curOffset + 2 + static_cast<int16_t>(GetShortBE(curOffset));
         }
-
-//        printf("%X LOOP ALWAYS JUMPING TO %X\n", curOffset, jump);
-        bool bResult = AddLoopForever(beginOffset, 3);
+        bool should_continue = AddLoopForever(beginOffset, 3);
         curOffset = jump;
-
-        return bResult;
+        return should_continue;
       }
 
       case 0x17 :

--- a/src/main/formats/CPS/CPSTrackV2.h
+++ b/src/main/formats/CPS/CPSTrackV2.h
@@ -14,7 +14,7 @@ enum CPSv2SeqEventType {
   C4_PROGCHANGE,
   C5_VIBRATO,
   C6_TRACK_MASTER_VOLUME,
-  EVENT_C7,
+  C7_PAN,
   EVENT_C8,
   C9_PORTAMENTO,
   EVENT_CA,
@@ -46,8 +46,8 @@ enum CPSv2SeqEventType {
   EVENT_E4,
   EVENT_E5,
   EVENT_E6,
-  EVENT_E7,
-  EVENT_E8,
+  E7_FINE_TUNE,
+  E8_META_EVENT,
   FF_END = 0XFF,
 };
 

--- a/src/main/formats/CPS/CPSTrackV2.h
+++ b/src/main/formats/CPS/CPSTrackV2.h
@@ -21,7 +21,7 @@ enum CPSv2SeqEventType {
   EVENT_CB,
   EVENT_CC,
   EVENT_CD,
-  EVENT_CE,
+  CE_GOTO,
   EVENT_CF,
   D0_LOOP_1_START,
   D1_LOOP_2_START,


### PR DESCRIPTION
Also add the CPS3 'meta event' event, and fix an incorrect call in MidiTrack::InsertCoarseTuning (method is unused).

UPDATE: I also added proper handling of LoopForever so that tracks don't abruptly cut off before the rest of a sequence.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
