### PR TITLE
Rename VGMItem / VGMFile fields

### DIFF
--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -151,7 +151,7 @@ void VGMRoot::RemoveVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
   auto targFile = variantToVGMFile(file);
   // First we should call the format's onClose handler in case it needs to use
   // the RawFile before we close it (FilenameMatcher, for ex)
-  if (Format *fmt = targFile->GetFormat()) {
+  if (Format *fmt = targFile->format()) {
     fmt->OnCloseFile(file);
   }
 

--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -141,7 +141,7 @@ bool VGMRoot::CloseRawFile(RawFile *targFile) {
 void VGMRoot::AddVGMFile(
   std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file) {
   m_vgmfiles.push_back(file);
-  L_INFO("Loaded {} successfully.", *variantToVGMFile(file)->GetName());
+  L_INFO("Loaded {} successfully.", variantToVGMFile(file)->name());
   UI_AddVGMFile(file);
 }
 

--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -169,7 +169,7 @@ void VGMRoot::RemoveVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
   }
 
   if (bRemoveEmptyRawFile) {
-    const auto rawFile = targFile->GetRawFile();
+    const auto rawFile = targFile->rawFile();
     rawFile->RemoveContainedVGMFile(file);
     if (rawFile->containedVGMFiles().empty()) {
       CloseRawFile(rawFile);

--- a/src/main/components/Matcher.cpp
+++ b/src/main/components/Matcher.cpp
@@ -92,7 +92,7 @@ void FilegroupMatcher::MakeCollection(VGMInstrSet *instrset, VGMSampColl *sampco
   if (seqs.size() >= 1) {
     for(VGMSeq *seq : seqs) {
       VGMColl *coll = fmt->NewCollection();
-      coll->SetName(seq->GetName());
+      coll->SetName(seq->name());
       coll->UseSeq(seq);
       coll->AddInstrSet(instrset);
       coll->AddSampColl(sampcoll);
@@ -103,7 +103,7 @@ void FilegroupMatcher::MakeCollection(VGMInstrSet *instrset, VGMSampColl *sampco
   }
   else {
     VGMColl *coll = fmt->NewCollection();
-    coll->SetName(instrset->GetName());
+    coll->SetName(instrset->name());
     coll->UseSeq(nullptr);
     coll->AddInstrSet(instrset);
     coll->AddSampColl(sampcoll);
@@ -145,7 +145,7 @@ bool FilegroupMatcher::MakeCollectionsForFile(VGMFile* /*file*/) {
     // into the same VGMCollection
     for(VGMSeq *seq : seqs) {
       VGMColl *coll = fmt->NewCollection();
-      coll->SetName(seq->GetName());
+      coll->SetName(seq->name());
       coll->UseSeq(seq);
       for (VGMInstrSet* instrset : instrsets) {
         for (VGMSampColl* sampcoll : sampcolls) {

--- a/src/main/components/Matcher.h
+++ b/src/main/components/Matcher.h
@@ -74,7 +74,7 @@ class SimpleMatcher : public Matcher {
           VGMColl *coll = fmt->NewCollection();
           if (!coll)
             return false;
-          coll->SetName(seq->GetName());
+          coll->SetName(seq->name());
           coll->UseSeq(seq);
           coll->AddInstrSet(matchingInstrSet);
           coll->AddSampColl(matchingSampColl);
@@ -87,7 +87,7 @@ class SimpleMatcher : public Matcher {
         VGMColl *coll = fmt->NewCollection();
         if (!coll)
           return false;
-        coll->SetName(seq->GetName());
+        coll->SetName(seq->name());
         coll->UseSeq(seq);
         coll->AddInstrSet(matchingInstrSet);
         if (!coll->Load()) {
@@ -138,7 +138,7 @@ class SimpleMatcher : public Matcher {
           VGMColl *coll = fmt->NewCollection();
           if (!coll)
             return false;
-          coll->SetName(matchingSeq->GetName());
+          coll->SetName(matchingSeq->name());
           coll->UseSeq(matchingSeq);
           coll->AddInstrSet(instrset);
           coll->AddSampColl(matchingSampColl);
@@ -148,7 +148,7 @@ class SimpleMatcher : public Matcher {
         VGMColl *coll = fmt->NewCollection();
         if (!coll)
           return false;
-        coll->SetName(matchingSeq->GetName());
+        coll->SetName(matchingSeq->name());
         coll->UseSeq(matchingSeq);
         coll->AddInstrSet(instrset);
         if (!coll->Load()) {
@@ -198,7 +198,7 @@ class SimpleMatcher : public Matcher {
           VGMColl *coll = fmt->NewCollection();
           if (!coll)
             return false;
-          coll->SetName(matchingSeq->GetName());
+          coll->SetName(matchingSeq->name());
           coll->UseSeq(matchingSeq);
           coll->AddInstrSet(matchingInstrSet);
           coll->AddSampColl(sampcoll);

--- a/src/main/components/Matcher.h
+++ b/src/main/components/Matcher.h
@@ -296,7 +296,7 @@ class FilenameMatcher : public SimpleMatcher<std::string> {
       : SimpleMatcher(format, bRequiresSampColl) {}
 
   bool GetSeqId(VGMSeq *seq, std::string &id) override {
-    RawFile *rawfile = seq->GetRawFile();
+    RawFile *rawfile = seq->rawFile();
     id = rawfile->GetParRawFileFullPath();
     if (id.empty()) {
       id = rawfile->path();
@@ -306,7 +306,7 @@ class FilenameMatcher : public SimpleMatcher<std::string> {
   }
 
   bool GetInstrSetId(VGMInstrSet *instrset, std::string &id) override {
-    RawFile *rawfile = instrset->GetRawFile();
+    RawFile *rawfile = instrset->rawFile();
     id = rawfile->GetParRawFileFullPath();
     if (id.empty()) {
       id = rawfile->path();
@@ -316,7 +316,7 @@ class FilenameMatcher : public SimpleMatcher<std::string> {
   }
 
   bool GetSampCollId(VGMSampColl *sampcoll, std::string &id) override {
-    RawFile *rawfile = sampcoll->GetRawFile();
+    RawFile *rawfile = sampcoll->rawFile();
     id = rawfile->GetParRawFileFullPath();
     if (id.empty()) {
         id = rawfile->path();

--- a/src/main/components/VGMColl.cpp
+++ b/src/main/components/VGMColl.cpp
@@ -41,8 +41,8 @@ const std::string &VGMColl::GetName() const {
     return name;
 }
 
-void VGMColl::SetName(const std::string *newName) {
-  name = *newName;
+void VGMColl::SetName(const std::string& newName) {
+  name = newName;
 }
 
 VGMSeq *VGMColl::GetSeq() const {

--- a/src/main/components/VGMColl.cpp
+++ b/src/main/components/VGMColl.cpp
@@ -228,8 +228,8 @@ bool VGMColl::MainDLSCreation(DLSFile &dls) {
         VGMSampColl *sampColl = rgn->sampCollPtr;
         if (!sampColl) {
           // If rgn is of an InstrSet with an embedded SampColl, use that SampColl.
-          if (static_cast<VGMInstrSet*>(rgn->vgmfile)->sampColl)
-            sampColl = static_cast<VGMInstrSet*>(rgn->vgmfile)->sampColl;
+          if (static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl)
+            sampColl = static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl;
 
             // If that does not exist, assume the first SampColl
           else
@@ -430,8 +430,8 @@ SynthFile *VGMColl::CreateSynthFile() {
         VGMSampColl *sampColl = rgn->sampCollPtr;
         if (!sampColl) {
           // If rgn is of an InstrSet with an embedded SampColl, use that SampColl.
-          if (static_cast<VGMInstrSet*>(rgn->vgmfile)->sampColl)
-            sampColl = static_cast<VGMInstrSet*>(rgn->vgmfile)->sampColl;
+          if (static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl)
+            sampColl = static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl;
 
             // If that does not exist, assume the first SampColl
           else

--- a/src/main/components/VGMColl.cpp
+++ b/src/main/components/VGMColl.cpp
@@ -102,7 +102,7 @@ void VGMColl::UnpackSampColl(DLSFile &dls, const VGMSampColl *sampColl, std::vec
 
     uint16_t blockAlign = samp->bps / 8 * samp->channels;
     dls.AddWave(1, samp->channels, samp->rate, samp->rate * blockAlign, blockAlign,
-                samp->bps, bufSize, uncompSampBuf, samp->name);
+                samp->bps, bufSize, uncompSampBuf, samp->name());
     finalSamps.push_back(samp);
   }
 }
@@ -125,12 +125,12 @@ void VGMColl::UnpackSampColl(SynthFile &synthfile, const VGMSampColl *sampColl, 
 
     uint16_t blockAlign = samp->bps / 8 * samp->channels;
     SynthWave *wave = synthfile.AddWave(1, samp->channels, samp->rate, samp->rate * blockAlign, blockAlign,
-                                        samp->bps, bufSize, uncompSampBuf, samp->name);
+                                        samp->bps, bufSize, uncompSampBuf, samp->name());
     finalSamps.push_back(samp);
 
     // If we don't have any loop information, then don't create a sampInfo structure for the Wave
     if (samp->loop.loopStatus == -1) {
-      L_ERROR("No loop information for {} - some parameters might be incorrect", samp->name);
+      L_ERROR("No loop information for {} - some parameters might be incorrect", samp->name());
       return;
     }
 
@@ -202,7 +202,7 @@ bool VGMColl::MainDLSCreation(DLSFile &dls) {
     for (size_t i = 0; i < nInstrs; i++) {
       VGMInstr *vgminstr = set->aInstrs[i];
       size_t nRgns = vgminstr->aRgns.size();
-      std::string name = vgminstr->name;
+      std::string name = vgminstr->name();
       auto bank_no = vgminstr->bank;
       /*
       * The ulBank field follows this structure:

--- a/src/main/components/VGMColl.h
+++ b/src/main/components/VGMColl.h
@@ -24,8 +24,8 @@ class VGMColl {
   virtual ~VGMColl() = default;
 
   void RemoveFileAssocs();
-  [[nodiscard]] const std::string &GetName() const;
-  void SetName(const std::string *newName);
+  [[nodiscard]] const std::string& GetName() const;
+  void SetName(const std::string& newName);
   [[nodiscard]] VGMSeq *GetSeq() const;
   void UseSeq(VGMSeq *theSeq);
   void AddInstrSet(VGMInstrSet *theInstrSet);

--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -9,12 +9,11 @@
 #include "Format.h"
 
 VGMFile::VGMFile(std::string fmt, RawFile *theRawFile, uint32_t offset,
-                 uint32_t length, std::string theName)
-    : VGMContainerItem(this, offset, length),
+                 uint32_t length, std::string name)
+    : VGMContainerItem(this, offset, length, std::move(name)),
       m_rawfile(theRawFile),
       m_format(std::move(fmt)),
-      id(-1),
-      m_name(std::move(theName)) {}
+      id(-1) {}
 
 // Only difference between this AddToUI and VGMItemContainer's version is that we do not add
 // this as an item because we do not want the VGMFile to be itself an item in the Item View

--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -12,7 +12,7 @@ VGMFile::VGMFile(std::string fmt, RawFile *theRawFile, uint32_t offset,
                  uint32_t length, std::string theName)
     : VGMContainerItem(this, offset, length),
       rawfile(theRawFile),
-      format(std::move(fmt)),
+      m_format(std::move(fmt)),
       id(-1),
       m_name(std::move(theName)) {}
 
@@ -25,17 +25,17 @@ void VGMFile::AddToUI(VGMItem* /*parent*/, void* UI_specific) {
   }
 }
 
-Format *VGMFile::GetFormat() const {
-  return Format::GetFormatFromName(format);
+Format *VGMFile::format() const {
+  return Format::GetFormatFromName(m_format);
 }
 
-const std::string& VGMFile::GetFormatName() {
-  return format;
+const std::string& VGMFile::formatName() {
+  return m_format;
 }
 
-std::string VGMFile::GetDescription() {
+std::string VGMFile::description() {
   auto filename = this->rawfile->name();
-  auto formatName = this->GetFormat()->GetName();
+  auto formatName = this->format()->GetName();
   return "Format: " + formatName + "     Source File: \"" + filename + "\"";
 }
 

--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -28,7 +28,7 @@ Format *VGMFile::format() const {
   return Format::GetFormatFromName(m_format);
 }
 
-const std::string& VGMFile::formatName() {
+std::string VGMFile::formatName() {
   return m_format;
 }
 

--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -11,7 +11,7 @@
 VGMFile::VGMFile(std::string fmt, RawFile *theRawFile, uint32_t offset,
                  uint32_t length, std::string theName)
     : VGMContainerItem(this, offset, length),
-      rawfile(theRawFile),
+      m_rawfile(theRawFile),
       m_format(std::move(fmt)),
       id(-1),
       m_name(std::move(theName)) {}
@@ -34,7 +34,7 @@ const std::string& VGMFile::formatName() {
 }
 
 std::string VGMFile::description() {
-  auto filename = this->rawfile->name();
+  auto filename = this->m_rawfile->name();
   auto formatName = this->format()->GetName();
   return "Format: " + formatName + "     Source File: \"" + filename + "\"";
 }
@@ -50,9 +50,9 @@ void VGMFile::RemoveCollAssoc(VGMColl *coll) {
 }
 
 // These functions are common to all VGMItems, but no reason to refer to vgmfile
-// or call GetRawFile() if the item itself is a VGMFile
-RawFile *VGMFile::GetRawFile() const {
-  return rawfile;
+// or call rawFile() if the item itself is a VGMFile
+RawFile *VGMFile::rawFile() const {
+  return m_rawfile;
 }
 
 uint32_t VGMFile::GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) const {
@@ -65,7 +65,7 @@ uint32_t VGMFile::GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) cons
       nCount = endOff - nIndex;
   }
 
-  return rawfile->GetBytes(nIndex, nCount, pBuffer);
+  return m_rawfile->GetBytes(nIndex, nCount, pBuffer);
 }
 
 // *********

--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -72,7 +72,7 @@ uint32_t VGMFile::GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) cons
 // *********
 
 VGMHeader::VGMHeader(const VGMItem *parItem, uint32_t offset, uint32_t length, const std::string &name)
-    : VGMContainerItem(parItem->vgmfile, offset, length, name) {}
+    : VGMContainerItem(parItem->vgmFile(), offset, length, name) {}
 
 VGMHeader::~VGMHeader() = default;
 
@@ -95,7 +95,7 @@ void VGMHeader::AddSig(uint32_t offset, uint32_t length, const std::string &name
 
 VGMHeaderItem::VGMHeaderItem(const VGMHeader *hdr, HdrItemType theType, uint32_t offset, uint32_t length,
                              const std::string &name)
-    : VGMItem(hdr->vgmfile, offset, length, name, CLR_HEADER), type(theType) {}
+    : VGMItem(hdr->vgmFile(), offset, length, name, CLR_HEADER), type(theType) {}
 
 VGMItem::Icon VGMHeaderItem::GetIcon() {
   switch (type) {

--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -33,10 +33,6 @@ const std::string& VGMFile::GetFormatName() {
   return format;
 }
 
-const std::string* VGMFile::GetName() const {
-  return &m_name;
-}
-
 std::string VGMFile::GetDescription() {
   auto filename = this->rawfile->name();
   auto formatName = this->GetFormat()->GetName();

--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -19,12 +19,12 @@ public:
 
   void AddToUI(VGMItem *parent, void *UI_specific) override;
 
-  [[nodiscard]] std::string GetDescription() override;
+  [[nodiscard]] std::string description() override;
 
   virtual bool LoadVGMFile() = 0;
   virtual bool Load() = 0;
-  Format *GetFormat() const;
-  const std::string &GetFormatName();
+  Format* format() const;
+  const std::string& formatName();
 
   virtual uint32_t GetID() { return id; }
 
@@ -54,11 +54,11 @@ public:
 
   [[nodiscard]] const char *data() const { return rawfile->data() + dwOffset; }
 
-  RawFile *rawfile;
-  std::vector<VGMColl *> assocColls;
+  RawFile* rawfile;
+  std::vector<VGMColl*> assocColls;
 
 protected:
-  std::string format;
+  std::string m_format;
   uint32_t id;
   std::string m_name;
 };

--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -26,23 +26,24 @@ public:
   Format* format() const;
   const std::string& formatName();
 
-  virtual uint32_t GetID() { return id; }
+  virtual uint32_t GetID() const { return id; }
+  void setId(uint32_t newId) { id = newId; }
 
   void AddCollAssoc(VGMColl *coll);
   void RemoveCollAssoc(VGMColl *coll);
-  [[nodiscard]] RawFile *GetRawFile() const;
+  [[nodiscard]] RawFile *rawFile() const;
 
   [[nodiscard]] size_t size() const noexcept { return unLength; }
   [[nodiscard]] std::string name() const noexcept { return m_name; }
 
   uint32_t GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) const;
 
-  inline uint8_t GetByte(uint32_t offset) const { return rawfile->GetByte(offset); }
-  inline uint16_t GetShort(uint32_t offset) const { return rawfile->GetShort(offset); }
-  inline uint32_t GetWord(uint32_t offset) const { return rawfile->GetWord(offset); }
-  inline uint16_t GetShortBE(uint32_t offset) const { return rawfile->GetShortBE(offset); }
-  inline uint32_t GetWordBE(uint32_t offset) const { return rawfile->GetWordBE(offset); }
-  inline bool IsValidOffset(uint32_t offset) const { return rawfile->IsValidOffset(offset); }
+  inline uint8_t GetByte(uint32_t offset) const { return m_rawfile->GetByte(offset); }
+  inline uint16_t GetShort(uint32_t offset) const { return m_rawfile->GetShort(offset); }
+  inline uint32_t GetWord(uint32_t offset) const { return m_rawfile->GetWord(offset); }
+  inline uint16_t GetShortBE(uint32_t offset) const { return m_rawfile->GetShortBE(offset); }
+  inline uint32_t GetWordBE(uint32_t offset) const { return m_rawfile->GetWordBE(offset); }
+  inline bool IsValidOffset(uint32_t offset) const { return m_rawfile->IsValidOffset(offset); }
 
   uint32_t GetStartOffset() const { return dwOffset; }
   /*
@@ -50,14 +51,14 @@ public:
    * The only safe way for now is to
    * assume maximum length
    */
-  uint32_t GetEndOffset() const { return static_cast<uint32_t>(rawfile->size()); }
+  uint32_t GetEndOffset() const { return static_cast<uint32_t>(m_rawfile->size()); }
 
-  [[nodiscard]] const char *data() const { return rawfile->data() + dwOffset; }
+  [[nodiscard]] const char *data() const { return m_rawfile->data() + dwOffset; }
 
-  RawFile* rawfile;
   std::vector<VGMColl*> assocColls;
 
-protected:
+private:
+  RawFile* m_rawfile;
   std::string m_format;
   uint32_t id;
   std::string m_name;

--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -24,7 +24,7 @@ public:
   virtual bool LoadVGMFile() = 0;
   virtual bool Load() = 0;
   Format* format() const;
-  const std::string& formatName();
+  [[nodiscard]] std::string formatName();
 
   virtual uint32_t GetID() const { return id; }
   void setId(uint32_t newId) { id = newId; }

--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -19,7 +19,6 @@ public:
 
   void AddToUI(VGMItem *parent, void *UI_specific) override;
 
-  [[nodiscard]] const std::string *GetName() const;
   [[nodiscard]] std::string GetDescription() override;
 
   virtual bool LoadVGMFile() = 0;

--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -14,7 +14,7 @@ class Format;
 class VGMFile : public VGMContainerItem {
 public:
   VGMFile(std::string format, RawFile *theRawFile, uint32_t offset, uint32_t length = 0,
-          std::string theName = "VGM File");
+          std::string name = "VGM File");
   ~VGMFile() override = default;
 
   void AddToUI(VGMItem *parent, void *UI_specific) override;
@@ -34,7 +34,6 @@ public:
   [[nodiscard]] RawFile *rawFile() const;
 
   [[nodiscard]] size_t size() const noexcept { return unLength; }
-  [[nodiscard]] std::string name() const noexcept { return m_name; }
 
   uint32_t GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) const;
 
@@ -61,7 +60,6 @@ private:
   RawFile* m_rawfile;
   std::string m_format;
   uint32_t id;
-  std::string m_name;
 };
 
 // *********

--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -27,8 +27,8 @@ bool operator>=(const VGMItem &item1, const VGMItem &item2) {
   return item1.dwOffset >= item2.dwOffset;
 }
 
-RawFile *VGMItem::GetRawFile() const {
-  return vgmfile->rawfile;
+RawFile *VGMItem::rawFile() const {
+  return vgmfile->rawFile();
 }
 
 bool VGMItem::IsItemAtOffset(uint32_t offset, bool includeContainer, bool matchStartOffset) {

--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -4,11 +4,11 @@
 #include "Root.h"
 #include "helper.h"
 
-VGMItem::VGMItem() : vgmfile(nullptr), dwOffset(0), unLength(0), color(CLR_UNKNOWN) {
+VGMItem::VGMItem() : m_vgmfile(nullptr), dwOffset(0), unLength(0), color(CLR_UNKNOWN) {
 }
 
 VGMItem::VGMItem(VGMFile *vgmfile, uint32_t offset, uint32_t length, std::string name, EventColor color)
-    : vgmfile(vgmfile), m_name(std::move(name)), dwOffset(offset), unLength(length), color(color) {
+    : m_vgmfile(vgmfile), m_name(std::move(name)), dwOffset(offset), unLength(length), color(color) {
 }
 
 bool operator>(const VGMItem &item1, const VGMItem &item2) {
@@ -28,7 +28,7 @@ bool operator>=(const VGMItem &item1, const VGMItem &item2) {
 }
 
 RawFile *VGMItem::rawFile() const {
-  return vgmfile->rawFile();
+  return m_vgmfile->rawFile();
 }
 
 bool VGMItem::IsItemAtOffset(uint32_t offset, bool includeContainer, bool matchStartOffset) {
@@ -48,33 +48,33 @@ void VGMItem::AddToUI(VGMItem *parent, void *UI_specific) {
 }
 
 uint32_t VGMItem::GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) const {
-  return vgmfile->GetBytes(nIndex, nCount, pBuffer);
+  return m_vgmfile->GetBytes(nIndex, nCount, pBuffer);
 }
 
 uint8_t VGMItem::GetByte(uint32_t offset) const {
-  return vgmfile->GetByte(offset);
+  return m_vgmfile->GetByte(offset);
 }
 
 uint16_t VGMItem::GetShort(uint32_t offset) const {
-  return vgmfile->GetShort(offset);
+  return m_vgmfile->GetShort(offset);
 }
 
 uint32_t VGMItem::GetWord(uint32_t offset) const {
-  return vgmfile->GetWord(offset);
+  return m_vgmfile->GetWord(offset);
 }
 
 // GetShort Big Endian
 uint16_t VGMItem::GetShortBE(uint32_t offset) const {
-  return vgmfile->GetShortBE(offset);
+  return m_vgmfile->GetShortBE(offset);
 }
 
 // GetWord Big Endian
 uint32_t VGMItem::GetWordBE(uint32_t offset) const {
-  return vgmfile->GetWordBE(offset);
+  return m_vgmfile->GetWordBE(offset);
 }
 
 bool VGMItem::IsValidOffset(uint32_t offset) const {
-  return vgmfile->IsValidOffset(offset);
+  return m_vgmfile->IsValidOffset(offset);
 }
 
 //  ****************
@@ -175,9 +175,9 @@ void VGMContainerItem::AddItem(VGMItem *item) {
 }
 
 void VGMContainerItem::AddSimpleItem(uint32_t offset, uint32_t length, const std::string &name) {
-  localitems.push_back(new VGMItem(this->vgmfile, offset, length, name, CLR_HEADER));
+  localitems.push_back(new VGMItem(vgmFile(), offset, length, name, CLR_HEADER));
 }
 
 void VGMContainerItem::AddUnknownItem(uint32_t offset, uint32_t length) {
-  localitems.push_back(new VGMItem(this->vgmfile, offset, length, "Unknown"));
+  localitems.push_back(new VGMItem(vgmFile(), offset, length, "Unknown"));
 }

--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -8,7 +8,7 @@ VGMItem::VGMItem() : vgmfile(nullptr), dwOffset(0), unLength(0), color(CLR_UNKNO
 }
 
 VGMItem::VGMItem(VGMFile *vgmfile, uint32_t offset, uint32_t length, std::string name, EventColor color)
-    : vgmfile(vgmfile), name(std::move(name)), dwOffset(offset), unLength(length), color(color) {
+    : vgmfile(vgmfile), m_name(std::move(name)), dwOffset(offset), unLength(length), color(color) {
 }
 
 bool operator>(const VGMItem &item1, const VGMItem &item2) {
@@ -44,7 +44,7 @@ VGMItem *VGMItem::GetItemFromOffset(uint32_t offset, [[maybe_unused]] bool inclu
 }
 
 void VGMItem::AddToUI(VGMItem *parent, void *UI_specific) {
-  pRoot->UI_AddItem(this, parent, name, UI_specific);
+  pRoot->UI_AddItem(this, parent, name(), UI_specific);
 }
 
 uint32_t VGMItem::GetBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) const {

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -83,7 +83,9 @@ public:
   friend bool operator<(VGMItem &item1, VGMItem &item2);
   friend bool operator>=(VGMItem &item1, VGMItem &item2);
 
-  RawFile *GetRawFile() const;
+  void setName(const std::string& newName) { name = newName; }
+
+  RawFile *rawFile() const;
 
   virtual bool IsItemAtOffset(uint32_t offset, bool includeContainer = true, bool matchStartOffset = false);
   virtual VGMItem *GetItemFromOffset(uint32_t offset, bool includeContainer = true, bool matchStartOffset = false);

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -83,7 +83,8 @@ public:
   friend bool operator<(VGMItem &item1, VGMItem &item2);
   friend bool operator>=(VGMItem &item1, VGMItem &item2);
 
-  void setName(const std::string& newName) { name = newName; }
+  [[nodiscard]] std::string name() const noexcept { return m_name; }
+  void setName(const std::string& newName) { m_name = newName; }
 
   RawFile *rawFile() const;
 
@@ -109,10 +110,12 @@ protected:
 
 public:
   VGMFile *vgmfile;
-  std::string name;
   uint32_t dwOffset;  // offset in the pDoc data buffer
   uint32_t unLength;  // num of bytes the event engulfs
   EventColor color;
+
+private:
+  std::string m_name;
 };
 
 //  ****************

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -86,7 +86,8 @@ public:
   [[nodiscard]] std::string name() const noexcept { return m_name; }
   void setName(const std::string& newName) { m_name = newName; }
 
-  RawFile *rawFile() const;
+  [[nodiscard]] VGMFile* vgmFile() const { return m_vgmfile; }
+  [[nodiscard]] RawFile* rawFile() const;
 
   virtual bool IsItemAtOffset(uint32_t offset, bool includeContainer = true, bool matchStartOffset = false);
   virtual VGMItem *GetItemFromOffset(uint32_t offset, bool includeContainer = true, bool matchStartOffset = false);
@@ -109,12 +110,12 @@ protected:
   bool IsValidOffset(uint32_t offset) const;
 
 public:
-  VGMFile *vgmfile;
   uint32_t dwOffset;  // offset in the pDoc data buffer
   uint32_t unLength;  // num of bytes the event engulfs
   EventColor color;
 
 private:
+  VGMFile *m_vgmfile;
   std::string m_name;
 };
 

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -90,7 +90,7 @@ public:
   virtual uint32_t GuessLength() { return unLength; };
   virtual void SetGuessedLength(){};
   virtual std::vector<const char* > *GetMenuItemNames() { return nullptr; }
-  virtual std::string GetDescription() { return ""; }
+  virtual std::string description() { return ""; }
   [[nodiscard]] virtual ItemType GetType() const { return ITEMTYPE_UNDEFINED; }
   virtual Icon GetIcon() { return ICON_BINARY; }
   virtual void AddToUI(VGMItem *parent, void *UI_specific);

--- a/src/main/components/VGMMiscFile.cpp
+++ b/src/main/components/VGMMiscFile.cpp
@@ -27,7 +27,7 @@ bool VGMMiscFile::LoadVGMFile() {
     return false;
   }
 
-  if (auto fmt = GetFormat(); fmt) {
+  if (auto fmt = format(); fmt) {
     fmt->OnNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
   }
 

--- a/src/main/components/VGMMiscFile.cpp
+++ b/src/main/components/VGMMiscFile.cpp
@@ -42,7 +42,7 @@ bool VGMMiscFile::Load() {
     return false;
   }
 
-  rawfile->AddContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(this));
+  rawFile()->AddContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(this));
   pRoot->AddVGMFile(this);
   return true;
 }

--- a/src/main/components/VGMMultiSectionSeq.cpp
+++ b/src/main/components/VGMMultiSectionSeq.cpp
@@ -57,7 +57,7 @@ bool VGMMultiSectionSeq::LoadTracks(ReadMode readMode, uint32_t stopTime) {
   ResetVars();
 
   // load all tracks
-  uint32_t stopOffset = vgmfile->GetEndOffset();
+  uint32_t stopOffset = vgmFile()->GetEndOffset();
   while (curOffset < stopOffset && time < stopTime) {
     if (!ReadEvent(stopTime)) {
       break;

--- a/src/main/components/VGMSampColl.cpp
+++ b/src/main/components/VGMSampColl.cpp
@@ -44,7 +44,7 @@ bool VGMSampColl::LoadVGMFile() {
     return false;
   }
 
-  if (auto fmt = GetFormat(); fmt) {
+  if (auto fmt = format(); fmt) {
     fmt->OnNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
   }
 

--- a/src/main/components/VGMSampColl.cpp
+++ b/src/main/components/VGMSampColl.cpp
@@ -85,7 +85,7 @@ bool VGMSampColl::Load() {
   }
 
   if (!parInstrSet) {
-    rawfile->AddContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(this));
+    rawFile()->AddContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(this));
     pRoot->AddVGMFile(this);
   }
 

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -71,7 +71,7 @@ bool VGMInstrSet::Load() {
     }
   }
 
-  rawfile->AddContainedVGMFile(
+  rawFile()->AddContainedVGMFile(
       std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(this));
   pRoot->AddVGMFile(this);
   return true;

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -43,7 +43,7 @@ bool VGMInstrSet::LoadVGMFile() {
     return false;
   }
 
-  if (auto fmt = GetFormat(); fmt) {
+  if (auto fmt = format(); fmt) {
     fmt->OnNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
   }
 

--- a/src/main/components/instr/VGMRgn.cpp
+++ b/src/main/components/instr/VGMRgn.cpp
@@ -174,7 +174,7 @@ void VGMRgn::AddSampNum(int sn, uint32_t offset, uint32_t length) {
 // **********
 
 VGMRgnItem::VGMRgnItem(const VGMRgn *rgn, RgnItemType theType, uint32_t offset, uint32_t length, std::string name)
-    : VGMItem(rgn->vgmfile, offset, length, std::move(name)), type(theType) {
+    : VGMItem(rgn->vgmFile(), offset, length, std::move(name)), type(theType) {
 }
 
 VGMItem::Icon VGMRgnItem::GetIcon() {

--- a/src/main/components/instr/VGMSamp.cpp
+++ b/src/main/components/instr/VGMSamp.cpp
@@ -43,7 +43,7 @@ void VGMSamp::ConvertToStdWave(uint8_t *buf) {
 }
 
 bool VGMSamp::OnSaveAsWav() {
-  std::string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name), "wav");
+  std::string filepath = pRoot->UI_GetSaveFilePath(ConvertToSafeFileName(name()), "wav");
   if (filepath.empty())
     return SaveAsWav(filepath);
   return false;

--- a/src/main/components/instr/VGMSamp.cpp
+++ b/src/main/components/instr/VGMSamp.cpp
@@ -17,7 +17,7 @@
 VGMSamp::VGMSamp(VGMSampColl *sampColl, uint32_t offset, uint32_t length, uint32_t dataOffset,
                  uint32_t dataLen, uint8_t nChannels, uint16_t bps, uint32_t rate,
                  std::string name)
-    : VGMItem(sampColl->vgmfile, offset, length, std::move(name)), dataOff(dataOffset), dataLength(dataLen),
+    : VGMItem(sampColl->vgmFile(), offset, length, std::move(name)), dataOff(dataOffset), dataLength(dataLen),
       bps(bps), rate(rate), channels(nChannels), parSampColl(sampColl) {
 }
 

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -51,7 +51,7 @@ class SeqEvent:
                     Icon icon = ICON_BINARY,
                     const std::string &desc = "");
   ~SeqEvent() override = default;
-  std::string GetDescription() override {
+  std::string description() override {
     return desc;
   }
   [[nodiscard]] ItemType GetType() const override { return ITEMTYPE_SEQEVENT; }
@@ -83,7 +83,7 @@ class DurNoteSeqEvent:
   EventType GetEventType() override { return EVENTTYPE_DURNOTE; }
   Icon GetIcon() override { return ICON_NOTE; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - abs key: {} ({}), velocity: {}, duration: {}", name,
       static_cast<int>(absKey), MidiEvent::GetNoteName(absKey), static_cast<int>(vel), dur);
   };
@@ -109,7 +109,7 @@ class NoteOnSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_NOTEON; }
   Icon GetIcon() override { return ICON_NOTE; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - abs key: {} ({}), velocity: {}", name,
       static_cast<int>(absKey), MidiEvent::GetNoteName(absKey), static_cast<int>(vel));
   };
@@ -131,7 +131,7 @@ class NoteOffSeqEvent:
   EventType GetEventType() override { return EVENTTYPE_NOTEOFF; }
   Icon GetIcon() override { return ICON_NOTE; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - abs key: {} ({})", name, static_cast<int>(absKey),
       MidiEvent::GetNoteName(absKey));
   };
@@ -151,7 +151,7 @@ class RestSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_REST; }
   Icon GetIcon() override { return ICON_REST; }
 
-  std::string GetDescription() override { return fmt::format("{} - duration: {}", name, dur); };
+  std::string description() override { return fmt::format("{} - duration: {}", name, dur); };
 
  public:
   uint32_t dur;
@@ -166,7 +166,7 @@ class SetOctaveSeqEvent : public SeqEvent {
   SetOctaveSeqEvent(SeqTrack *pTrack, uint8_t octave, uint32_t offset = 0, uint32_t length = 0,
                     const std::string &name = "");
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - octave: {}", name, static_cast<int>(octave));
   };
 
@@ -183,7 +183,7 @@ class VolSeqEvent : public SeqEvent {
               const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_VOLUME; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - volume: {:d}", name, vol);
   };
 
@@ -200,7 +200,7 @@ public:
                       const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_VOLUME; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - volume: {:d}", name, m_volume);
   };
 
@@ -217,7 +217,7 @@ class VolSlideSeqEvent : public SeqEvent {
                    uint32_t length = 0, const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_VOLUMESLIDE; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - target volume: {}, duration: {}", name,
       static_cast<int>(targVol), dur);
   };
@@ -235,7 +235,7 @@ class MastVolSeqEvent : public SeqEvent {
     MastVolSeqEvent(SeqTrack *pTrack, uint8_t volume, uint32_t offset = 0, uint32_t length = 0,
                     const std::string &name = "");
 
-    std::string GetDescription() override {
+    std::string description() override {
         return fmt::format("{} - master volume: {}", name, static_cast<int>(vol));
     };
 
@@ -251,7 +251,7 @@ class MastVolSlideSeqEvent : public SeqEvent {
     MastVolSlideSeqEvent(SeqTrack *pTrack, uint8_t targetVolume, uint32_t duration,
                          uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
 
-    std::string GetDescription() override {
+    std::string description() override {
         return fmt::format("{} - target volume: {}, duration: {}", name,
           static_cast<int>(targVol), dur);
     };
@@ -270,7 +270,7 @@ class ExpressionSeqEvent : public SeqEvent {
                      const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_EXPRESSION; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - expression: {}", name, static_cast<int>(level));
   };
 
@@ -288,7 +288,7 @@ class ExpressionSlideSeqEvent : public SeqEvent {
                             uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_EXPRESSIONSLIDE; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - target expression: {}, duration: {}", name,
       static_cast<int>(targExpr), dur);
   };
@@ -307,7 +307,7 @@ class PanSeqEvent : public SeqEvent {
               const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_PAN; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - pan: {}", name, static_cast<int>(pan));
   };
 
@@ -324,7 +324,7 @@ class PanSlideSeqEvent : public SeqEvent {
   PanSlideSeqEvent(SeqTrack *pTrack, uint8_t targetPan, uint32_t duration, uint32_t offset = 0,
                    uint32_t length = 0, const std::string &name = "");
 
-  std::string GetDescription() override {
+  std::string description() override {
       return fmt::format("{} - target pan: {}, duration: {}", name,
         static_cast<int>(targPan), dur);
   };
@@ -344,7 +344,7 @@ class ReverbSeqEvent : public SeqEvent {
                  const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_REVERB; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - reverb: {}", name, static_cast<int>(reverb));
   };
 
@@ -361,7 +361,7 @@ class PitchBendSeqEvent : public SeqEvent {
                     uint32_t length = 0, const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_PITCHBEND; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - pitch bend: {}", name, static_cast<int>(pitchbend));
   };
 
@@ -378,7 +378,7 @@ class PitchBendRangeSeqEvent : public SeqEvent {
                          uint32_t length = 0, const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_PITCHBENDRANGE; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - pitch bend range: {} semitones {} cents ", name,
       static_cast<int>(semitones), static_cast<int>(cents));
   };
@@ -396,7 +396,7 @@ class FineTuningSeqEvent : public SeqEvent {
   FineTuningSeqEvent(SeqTrack *pTrack, double cents, uint32_t offset = 0, uint32_t length = 0,
                      const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_PITCHBENDRANGE; }
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - fine tuning: {}", name, cents);
   };
 
@@ -412,7 +412,7 @@ class ModulationDepthRangeSeqEvent : public SeqEvent {
   ModulationDepthRangeSeqEvent(SeqTrack *pTrack, double semitones, uint32_t offset = 0,
                                uint32_t length = 0, const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_PITCHBENDRANGE; }
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - modulation depth range: {} cents", name, semitones * 100.0);
   };
 
@@ -429,7 +429,7 @@ class TransposeSeqEvent : public SeqEvent {
                     const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_TRANSPOSE; }
 
-  std::string GetDescription() override {
+  std::string description() override {
       return fmt::format("{} - transpose: {}", name, transpose);
   };
 
@@ -446,7 +446,7 @@ class ModulationSeqEvent : public SeqEvent {
                      const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_MODULATION; }
 
-  std::string GetDescription() override {
+  std::string description() override {
       return fmt::format("{} - depth: {}", name, static_cast<int>(depth));
   };
 
@@ -463,7 +463,7 @@ class BreathSeqEvent : public SeqEvent {
                  const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_BREATH; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - breath: {}", name, static_cast<int>(depth));
   };
 
@@ -480,7 +480,7 @@ class SustainSeqEvent : public SeqEvent {
                   const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_SUSTAIN; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - sustain pedal: {}", name, static_cast<int>(depth));
   };
 
@@ -497,7 +497,7 @@ class PortamentoSeqEvent : public SeqEvent {
                      const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_PORTAMENTO; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - portamento: {}", name, bOn ? "on" : "off");
   };
 
@@ -515,7 +515,7 @@ class PortamentoTimeSeqEvent : public SeqEvent {
                          const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_PORTAMENTOTIME; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - portamento time: {}", name, static_cast<int>(time));
   };
 
@@ -533,7 +533,7 @@ class ProgChangeSeqEvent : public SeqEvent {
                      uint32_t length = 0, const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_PROGCHANGE; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - program number: {}", name, progNum);
   };
 
@@ -552,7 +552,7 @@ class TempoSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_TEMPO; }
   Icon GetIcon() override { return ICON_TEMPO; }
 
-  std::string GetDescription() override { return fmt::format("{} - bpm: {}", name, bpm); };
+  std::string description() override { return fmt::format("{} - bpm: {}", name, bpm); };
 
  public:
   double bpm;
@@ -568,7 +568,7 @@ class TempoSlideSeqEvent : public SeqEvent {
                      uint32_t length = 0, const std::string &name = "");
   Icon GetIcon() override { return ICON_TEMPO; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - target bpm: {}, duration: {}", name, targbpm, dur);
   };
 
@@ -588,7 +588,7 @@ class TimeSigSeqEvent : public SeqEvent {
                 const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_TIMESIG; }
 
-  std::string GetDescription() override {
+  std::string description() override {
     return fmt::format("{} - time signature: {}/{}, ticks per quarter: {}", name,
       static_cast<int>(numer), static_cast<int>(denom), static_cast<int>(ticksPerQuarter));
   };

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -84,7 +84,7 @@ class DurNoteSeqEvent:
   Icon GetIcon() override { return ICON_NOTE; }
 
   std::string description() override {
-    return fmt::format("{} - abs key: {} ({}), velocity: {}, duration: {}", name,
+    return fmt::format("{} - abs key: {} ({}), velocity: {}, duration: {}", name(),
       static_cast<int>(absKey), MidiEvent::GetNoteName(absKey), static_cast<int>(vel), dur);
   };
 
@@ -110,7 +110,7 @@ class NoteOnSeqEvent : public SeqEvent {
   Icon GetIcon() override { return ICON_NOTE; }
 
   std::string description() override {
-    return fmt::format("{} - abs key: {} ({}), velocity: {}", name,
+    return fmt::format("{} - abs key: {} ({}), velocity: {}", name(),
       static_cast<int>(absKey), MidiEvent::GetNoteName(absKey), static_cast<int>(vel));
   };
 
@@ -132,7 +132,7 @@ class NoteOffSeqEvent:
   Icon GetIcon() override { return ICON_NOTE; }
 
   std::string description() override {
-    return fmt::format("{} - abs key: {} ({})", name, static_cast<int>(absKey),
+    return fmt::format("{} - abs key: {} ({})", name(), static_cast<int>(absKey),
       MidiEvent::GetNoteName(absKey));
   };
 
@@ -151,7 +151,7 @@ class RestSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_REST; }
   Icon GetIcon() override { return ICON_REST; }
 
-  std::string description() override { return fmt::format("{} - duration: {}", name, dur); };
+  std::string description() override { return fmt::format("{} - duration: {}", name(), dur); };
 
  public:
   uint32_t dur;
@@ -167,7 +167,7 @@ class SetOctaveSeqEvent : public SeqEvent {
                     const std::string &name = "");
 
   std::string description() override {
-    return fmt::format("{} - octave: {}", name, static_cast<int>(octave));
+    return fmt::format("{} - octave: {}", name(), static_cast<int>(octave));
   };
 
   uint8_t octave;
@@ -184,7 +184,7 @@ class VolSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_VOLUME; }
 
   std::string description() override {
-    return fmt::format("{} - volume: {:d}", name, vol);
+    return fmt::format("{} - volume: {:d}", name(), vol);
   };
 
   uint8_t vol;
@@ -201,7 +201,7 @@ public:
   EventType GetEventType() override { return EVENTTYPE_VOLUME; }
 
   std::string description() override {
-    return fmt::format("{} - volume: {:d}", name, m_volume);
+    return fmt::format("{} - volume: {:d}", name(), m_volume);
   };
 
   uint16_t m_volume;
@@ -218,7 +218,7 @@ class VolSlideSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_VOLUMESLIDE; }
 
   std::string description() override {
-    return fmt::format("{} - target volume: {}, duration: {}", name,
+    return fmt::format("{} - target volume: {}, duration: {}", name(),
       static_cast<int>(targVol), dur);
   };
 
@@ -236,7 +236,7 @@ class MastVolSeqEvent : public SeqEvent {
                     const std::string &name = "");
 
     std::string description() override {
-        return fmt::format("{} - master volume: {}", name, static_cast<int>(vol));
+        return fmt::format("{} - master volume: {}", name(), static_cast<int>(vol));
     };
 
   uint8_t vol;
@@ -252,7 +252,7 @@ class MastVolSlideSeqEvent : public SeqEvent {
                          uint32_t offset = 0, uint32_t length = 0, const std::string &name = "");
 
     std::string description() override {
-        return fmt::format("{} - target volume: {}, duration: {}", name,
+        return fmt::format("{} - target volume: {}, duration: {}", name(),
           static_cast<int>(targVol), dur);
     };
 
@@ -271,7 +271,7 @@ class ExpressionSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_EXPRESSION; }
 
   std::string description() override {
-    return fmt::format("{} - expression: {}", name, static_cast<int>(level));
+    return fmt::format("{} - expression: {}", name(), static_cast<int>(level));
   };
 
  public:
@@ -289,7 +289,7 @@ class ExpressionSlideSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_EXPRESSIONSLIDE; }
 
   std::string description() override {
-    return fmt::format("{} - target expression: {}, duration: {}", name,
+    return fmt::format("{} - target expression: {}, duration: {}", name(),
       static_cast<int>(targExpr), dur);
   };
 
@@ -308,7 +308,7 @@ class PanSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_PAN; }
 
   std::string description() override {
-    return fmt::format("{} - pan: {}", name, static_cast<int>(pan));
+    return fmt::format("{} - pan: {}", name(), static_cast<int>(pan));
   };
 
  public:
@@ -325,7 +325,7 @@ class PanSlideSeqEvent : public SeqEvent {
                    uint32_t length = 0, const std::string &name = "");
 
   std::string description() override {
-      return fmt::format("{} - target pan: {}, duration: {}", name,
+      return fmt::format("{} - target pan: {}, duration: {}", name(),
         static_cast<int>(targPan), dur);
   };
 
@@ -345,7 +345,7 @@ class ReverbSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_REVERB; }
 
   std::string description() override {
-    return fmt::format("{} - reverb: {}", name, static_cast<int>(reverb));
+    return fmt::format("{} - reverb: {}", name(), static_cast<int>(reverb));
   };
 
   uint8_t reverb;
@@ -362,7 +362,7 @@ class PitchBendSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_PITCHBEND; }
 
   std::string description() override {
-    return fmt::format("{} - pitch bend: {}", name, static_cast<int>(pitchbend));
+    return fmt::format("{} - pitch bend: {}", name(), static_cast<int>(pitchbend));
   };
 
   short pitchbend;
@@ -379,7 +379,7 @@ class PitchBendRangeSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_PITCHBENDRANGE; }
 
   std::string description() override {
-    return fmt::format("{} - pitch bend range: {} semitones {} cents ", name,
+    return fmt::format("{} - pitch bend range: {} semitones {} cents ", name(),
       static_cast<int>(semitones), static_cast<int>(cents));
   };
 
@@ -397,7 +397,7 @@ class FineTuningSeqEvent : public SeqEvent {
                      const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_PITCHBENDRANGE; }
   std::string description() override {
-    return fmt::format("{} - fine tuning: {}", name, cents);
+    return fmt::format("{} - fine tuning: {}", name(), cents);
   };
 
   double cents;
@@ -413,7 +413,7 @@ class ModulationDepthRangeSeqEvent : public SeqEvent {
                                uint32_t length = 0, const std::string &name = "");
   EventType GetEventType() override { return EVENTTYPE_PITCHBENDRANGE; }
   std::string description() override {
-    return fmt::format("{} - modulation depth range: {} cents", name, semitones * 100.0);
+    return fmt::format("{} - modulation depth range: {} cents", name(), semitones * 100.0);
   };
 
   double semitones;
@@ -430,7 +430,7 @@ class TransposeSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_TRANSPOSE; }
 
   std::string description() override {
-      return fmt::format("{} - transpose: {}", name, transpose);
+      return fmt::format("{} - transpose: {}", name(), transpose);
   };
 
   int transpose;
@@ -447,7 +447,7 @@ class ModulationSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_MODULATION; }
 
   std::string description() override {
-      return fmt::format("{} - depth: {}", name, static_cast<int>(depth));
+      return fmt::format("{} - depth: {}", name(), static_cast<int>(depth));
   };
 
   uint8_t depth;
@@ -464,7 +464,7 @@ class BreathSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_BREATH; }
 
   std::string description() override {
-    return fmt::format("{} - breath: {}", name, static_cast<int>(depth));
+    return fmt::format("{} - breath: {}", name(), static_cast<int>(depth));
   };
 
   uint8_t depth;
@@ -481,7 +481,7 @@ class SustainSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_SUSTAIN; }
 
   std::string description() override {
-    return fmt::format("{} - sustain pedal: {}", name, static_cast<int>(depth));
+    return fmt::format("{} - sustain pedal: {}", name(), static_cast<int>(depth));
   };
 
   uint8_t depth;
@@ -498,7 +498,7 @@ class PortamentoSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_PORTAMENTO; }
 
   std::string description() override {
-    return fmt::format("{} - portamento: {}", name, bOn ? "on" : "off");
+    return fmt::format("{} - portamento: {}", name(), bOn ? "on" : "off");
   };
 
  public:
@@ -516,7 +516,7 @@ class PortamentoTimeSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_PORTAMENTOTIME; }
 
   std::string description() override {
-    return fmt::format("{} - portamento time: {}", name, static_cast<int>(time));
+    return fmt::format("{} - portamento time: {}", name(), static_cast<int>(time));
   };
 
  public:
@@ -534,7 +534,7 @@ class ProgChangeSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_PROGCHANGE; }
 
   std::string description() override {
-    return fmt::format("{} - program number: {}", name, progNum);
+    return fmt::format("{} - program number: {}", name(), progNum);
   };
 
  public:
@@ -552,7 +552,7 @@ class TempoSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_TEMPO; }
   Icon GetIcon() override { return ICON_TEMPO; }
 
-  std::string description() override { return fmt::format("{} - bpm: {}", name, bpm); };
+  std::string description() override { return fmt::format("{} - bpm: {}", name(), bpm); };
 
  public:
   double bpm;
@@ -569,7 +569,7 @@ class TempoSlideSeqEvent : public SeqEvent {
   Icon GetIcon() override { return ICON_TEMPO; }
 
   std::string description() override {
-    return fmt::format("{} - target bpm: {}, duration: {}", name, targbpm, dur);
+    return fmt::format("{} - target bpm: {}, duration: {}", name(), targbpm, dur);
   };
 
  public:
@@ -589,7 +589,7 @@ class TimeSigSeqEvent : public SeqEvent {
   EventType GetEventType() override { return EVENTTYPE_TIMESIG; }
 
   std::string description() override {
-    return fmt::format("{} - time signature: {}/{}, ticks per quarter: {}", name,
+    return fmt::format("{} - time signature: {}/{}, ticks per quarter: {}", name(),
       static_cast<int>(numer), static_cast<int>(denom), static_cast<int>(ticksPerQuarter));
   };
 

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -151,7 +151,7 @@ void SeqTrack::SetChannelAndGroupFromTrkNum(int theTrackNum) {
 
 void SeqTrack::AddInitialMidiEvents(int trackNum) {
   if (trackNum == 0)
-    pMidiTrack->AddSeqName(*parentSeq->GetName());
+    pMidiTrack->AddSeqName(parentSeq->name());
   std::string ssTrackName = fmt::format("Track: 0x{:02X}", dwStartOffset);
   pMidiTrack->AddTrackName(ssTrackName);
 

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -66,7 +66,7 @@ bool VGMSeq::Load() {
   if (!LoadMain())
     return false;
 
-  rawfile->AddContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
+  rawFile()->AddContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
     VGMMiscFile *>>(this));
   pRoot->AddVGMFile(this);
   return true;

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -55,7 +55,7 @@ bool VGMSeq::LoadVGMFile() {
     return false;
   }
 
-  if (auto fmt = GetFormat(); fmt) {
+  if (auto fmt = format(); fmt) {
     fmt->OnNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
   }
 

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -195,7 +195,7 @@ void VGMSeq::LoadTracksMain(uint32_t stopTime) {
       // check time limit
       if (time >= stopTime) {
         if (readMode == READMODE_ADD_TO_UI) {
-          L_WARN("{} - reached tick-by-tick stop time during load.", *GetName());
+          L_WARN("{} - reached tick-by-tick stop time during load.", name());
         }
 
         InactivateAllTracks();

--- a/src/main/components/seq/VGMSeqNoTrks.cpp
+++ b/src/main/components/seq/VGMSeqNoTrks.cpp
@@ -70,7 +70,7 @@ bool VGMSeqNoTrks::LoadEvents(long stopTime) {
 
   bInLoop = false;
   curOffset = eventsOffset();  // start at beginning of track
-  while (curOffset < rawfile->size()) {
+  while (curOffset < rawFile()->size()) {
     if (GetTime() >= static_cast<u_long>(stopTime)) {
       break;
     }

--- a/src/main/components/seq/VGMSeqNoTrks.h
+++ b/src/main/components/seq/VGMSeqNoTrks.h
@@ -26,7 +26,9 @@ public:
   using VGMSeq::GetWordBE;
   inline uint32_t &offset() { return VGMSeq::dwOffset; }
   inline uint32_t &length() { return VGMSeq::unLength; }
-  inline std::string &name() { return VGMSeq::m_name; }
+  inline std::string name() { return VGMSeq::name(); }
+
+  inline RawFile* rawFile() { return rawFile(); }
 
   inline uint32_t &eventsOffset() { return dwEventsOffset; }
 

--- a/src/main/conversion/VGMExport.cpp
+++ b/src/main/conversion/VGMExport.cpp
@@ -45,7 +45,7 @@ bool SaveAsSF2(const VGMInstrSet &set, const std::string &filepath) {
 void SaveAllAsWav(const VGMSampColl &coll, const std::string &save_dir) {
   for (auto &sample : coll.samples) {
     auto path = fmt::format("{}/{} - {}.wav",
-      save_dir, ConvertToSafeFileName(coll.name()), ConvertToSafeFileName(sample->name));
+      save_dir, ConvertToSafeFileName(coll.name()), ConvertToSafeFileName(sample->name()));
     sample->SaveAsWav(path);
   }
 }

--- a/src/main/conversion/VGMExport.cpp
+++ b/src/main/conversion/VGMExport.cpp
@@ -77,6 +77,6 @@ bool SaveAsOriginal(const RawFile& rawfile, const std::string& filepath) {
 }
 
 bool SaveAsOriginal(const VGMFile& file, const std::string& filepath) {
-  return saveDataToFile(file.rawfile->begin() + file.dwOffset, file.unLength, filepath);
+  return saveDataToFile(file.rawFile()->begin() + file.dwOffset, file.unLength, filepath);
 }
 }  // namespace conversion

--- a/src/main/conversion/VGMExport.cpp
+++ b/src/main/conversion/VGMExport.cpp
@@ -45,7 +45,7 @@ bool SaveAsSF2(const VGMInstrSet &set, const std::string &filepath) {
 void SaveAllAsWav(const VGMSampColl &coll, const std::string &save_dir) {
   for (auto &sample : coll.samples) {
     auto path = fmt::format("{}/{} - {}.wav",
-      save_dir, ConvertToSafeFileName(*coll.GetName()), ConvertToSafeFileName(sample->name));
+      save_dir, ConvertToSafeFileName(coll.name()), ConvertToSafeFileName(sample->name));
     sample->SaveAsWav(path);
   }
 }

--- a/src/main/formats/Akao/AkaoInstr.cpp
+++ b/src/main/formats/Akao/AkaoInstr.cpp
@@ -20,7 +20,7 @@ AkaoInstrSet::AkaoInstrSet(RawFile *file,
                            uint32_t theID,
                            std::string name)
     : VGMInstrSet(AkaoFormat::name, file, 0, length, std::move(name)), version_(version) {
-  id = theID;
+  setId(theID);
   instrSetOff = instrOff;
   drumkitOff = dkitOff;
   bMelInstrs = instrSetOff > 0;
@@ -104,7 +104,7 @@ AkaoInstr::AkaoInstr(AkaoInstrSet *instrSet, uint32_t offset, uint32_t length, u
 }
 
 bool AkaoInstr::LoadInstr() {
-  for (int k = 0; dwOffset + k * 8 < GetRawFile()->size(); k++) {
+  for (int k = 0; dwOffset + k * 8 < rawFile()->size(); k++) {
     if (version() < AkaoPs1Version::VERSION_3_0) {
       if (GetByte(dwOffset + k * 8) >= 0x80) {
         AddSimpleItem(dwOffset + k * 8, 8, "Region Terminator");
@@ -343,7 +343,7 @@ bool AkaoSampColl::GetHeaderInfo() {
     hdr->AddSimpleItem(dwOffset + 0x18, 4, "Starting Articulation ID");
     hdr->AddSimpleItem(dwOffset + 0x1C, 4, "Number of Articulations");
 
-    id = GetShort(0x4 + dwOffset);
+    setId(GetShort(0x4 + dwOffset));
     sample_section_size = GetWord(0x14 + dwOffset);
     starting_art_id = GetWord(0x18 + dwOffset);
     nNumArts = GetWord(0x1C + dwOffset);
@@ -395,7 +395,7 @@ bool AkaoSampColl::GetHeaderInfo() {
 bool AkaoSampColl::GetSampleInfo() {
   //Read Articulation Data
   const uint32_t kAkaoArtSize = (version() >= AkaoPs1Version::VERSION_3_1) ? 0x10 : 0x40;
-  if (arts_offset + kAkaoArtSize * nNumArts > rawfile->size())
+  if (arts_offset + kAkaoArtSize * nNumArts > rawFile()->size())
     return false;
 
   for (uint32_t i = 0; i < nNumArts; i++) {
@@ -604,8 +604,8 @@ bool AkaoSampColl::GetSampleInfo() {
 
   // if the official total file size is greater than the file size of the document
   // then shorten the sample section size to the actual end of the document
-  if (sample_section_offset + sample_section_size > rawfile->size())
-    sample_section_size = static_cast<uint32_t>(rawfile->size()) - sample_section_offset;
+  if (sample_section_offset + sample_section_size > rawFile()->size())
+    sample_section_size = static_cast<uint32_t>(rawFile()->size()) - sample_section_offset;
 
   //check the last 10 bytes to make sure they aren't null, if they are, abbreviate things till there is no 0x10 block of null bytes
   if (GetWord(sample_section_offset + sample_section_size - 0x10) == 0) {
@@ -616,8 +616,8 @@ bool AkaoSampColl::GetSampleInfo() {
 
   // if the official total file size is greater than the file size of the document
   // then shorten the sample section size to the actual end of the document
-  if (sample_section_offset + sample_section_size > rawfile->size())
-    sample_section_size = static_cast<uint32_t>(rawfile->size());
+  if (sample_section_offset + sample_section_size > rawFile()->size())
+    sample_section_size = static_cast<uint32_t>(rawFile()->size());
 
   std::set<uint32_t> sample_offsets;
   for (const auto & art : akArts) {
@@ -634,7 +634,7 @@ bool AkaoSampColl::GetSampleInfo() {
       continue;
     }
 
-    const uint32_t length = PSXSamp::GetSampleLength(rawfile, offset, sample_section_offset + sample_section_size, loop);
+    const uint32_t length = PSXSamp::GetSampleLength(rawFile(), offset, sample_section_offset + sample_section_size, loop);
     auto *samp = new PSXSamp(this, offset, length, offset, length, 1, 16, 44100,
       fmt::format("Sample {}", samples.size()));
 

--- a/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
@@ -307,7 +307,7 @@ bool AkaoSnesDrumKitRgn::InitializePercussionRegion(uint8_t percussionIndex,
                                                     uint16_t addrADSRTable,
                                                     uint16_t addrDrumKitTable)
 {
-  name = fmt::format("Drum {}", percussionIndex);
+  setName(fmt::format("Drum {}", percussionIndex));
 
   uint32_t srcnOffset = addrDrumKitTable + percussionIndex * 3;
   uint32_t keyOffset = srcnOffset + 1;

--- a/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
@@ -38,7 +38,7 @@ bool AkaoSnesInstrSet::GetInstrPointers() {
   uint8_t srcn_max = (version == AKAOSNES_V1) ? 0x7f : 0x3f;
   for (uint8_t srcn = 0; srcn <= srcn_max; srcn++) {
     uint32_t addrDIRentry = spcDirAddr + (srcn * 4);
-    if (!SNESSampColl::IsValidSampleDir(rawfile, addrDIRentry, true)) {
+    if (!SNESSampColl::IsValidSampleDir(rawFile(), addrDIRentry, true)) {
       continue;
     }
 
@@ -97,7 +97,7 @@ bool AkaoSnesInstrSet::GetInstrPointers() {
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(AkaoSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(AkaoSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/CPS/CPS2Instr.cpp
+++ b/src/main/formats/CPS/CPS2Instr.cpp
@@ -494,7 +494,7 @@ CPS2SampColl::CPS2SampColl(RawFile *file, CPS2InstrSet *theinstrset,
 
 
 bool CPS2SampColl::GetHeaderInfo() {
-  unLength = static_cast<uint32_t>(this->rawfile->size());
+  unLength = static_cast<uint32_t>(this->rawFile()->size());
   return true;
 }
 

--- a/src/main/formats/CPS/CPS2Instr.cpp
+++ b/src/main/formats/CPS/CPS2Instr.cpp
@@ -237,7 +237,7 @@ bool CPS2InstrSet::GetInstrPointers() {
         uint32_t bankOff = instr_table_ptrs[bank] - 0x6000000;
 
         auto pointersName = fmt::format("Bank {:d} Instrument Pointers", bank);
-        auto instrPointersItem = new VGMContainerItem(this->vgmfile, bankOff, 128*2, pointersName, CLR_HEADER);
+        auto instrPointersItem = new VGMContainerItem(vgmFile(), bankOff, 128*2, pointersName, CLR_HEADER);
 
         // For each bank, iterate over all instr ptrs and create instruments
         for (uint8_t j = 0; j < 128; j++) {

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -45,10 +45,10 @@ bool CapcomSnesInstrSet::GetInstrPointers() {
       continue;
     }
 
-    if (!CapcomSnesInstr::IsValidHeader(this->rawfile, addrInstrHeader, spcDirAddr, false)) {
+    if (!CapcomSnesInstr::IsValidHeader(this->rawFile(), addrInstrHeader, spcDirAddr, false)) {
       break;
     }
-    if (!CapcomSnesInstr::IsValidHeader(this->rawfile, addrInstrHeader, spcDirAddr, true)) {
+    if (!CapcomSnesInstr::IsValidHeader(this->rawFile(), addrInstrHeader, spcDirAddr, true)) {
       continue;
     }
 
@@ -68,7 +68,7 @@ bool CapcomSnesInstrSet::GetInstrPointers() {
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(CapcomSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(CapcomSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/ChunSnes/ChunSnesInstr.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesInstr.cpp
@@ -96,7 +96,7 @@ bool ChunSnesInstrSet::GetInstrPointers() {
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(ChunSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(ChunSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/CompileSnes/CompileSnesInstr.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesInstr.cpp
@@ -35,7 +35,7 @@ bool CompileSnesInstrSet::GetInstrPointers() {
   usedSRCNs.clear();
   for (uint8_t srcn = 0; srcn <= 0x3f; srcn++) {
     uint32_t addrDIRentry = spcDirAddr + (srcn * 4);
-    if (!SNESSampColl::IsValidSampleDir(rawfile, addrDIRentry, true)) {
+    if (!SNESSampColl::IsValidSampleDir(rawFile(), addrDIRentry, true)) {
       continue;
     }
 
@@ -69,7 +69,7 @@ bool CompileSnesInstrSet::GetInstrPointers() {
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(CompileSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(CompileSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/FFT/FFTInstr.cpp
+++ b/src/main/formats/FFT/FFTInstr.cpp
@@ -34,7 +34,7 @@ bool WdsInstrSet::GetHeaderInfo() {
   //"hdr"構造体へそのまま転送
   GetBytes(dwOffset, sizeof(WdsHdr), &hdr);
   unLength = hdr.szHeader1 + hdr.szSampColl;    //header size + samp coll size
-  id = hdr.iBank;                        //Bank number.
+  setId(hdr.iBank);                        //Bank number.
 
   if (hdr.sig == 0x73647764)
     version = VERSION_DWDS;
@@ -42,7 +42,7 @@ bool WdsInstrSet::GetHeaderInfo() {
     version = VERSION_WDS;
 
   //バイナリエディタ表示用
-  m_name = fmt::format("wds {:d}", id);
+  setName(fmt::format("wds {:d}", GetID()));
 
   //ヘッダーobjectの生成
   VGMHeader *wdsHeader = AddHeader(dwOffset, sizeof(WdsHdr));

--- a/src/main/formats/FFT/FFTSeq.cpp
+++ b/src/main/formats/FFT/FFTSeq.cpp
@@ -42,7 +42,7 @@ bool FFTSeq::GetHeaderInfo(void) {
   int titleLength = ptPercussionTbl - ptSongTitle;
   char *songtitle = new char[titleLength];
   GetBytes(dwOffset + ptSongTitle, titleLength, songtitle);
-  m_name = std::string(songtitle, songtitle + titleLength);
+  setName(std::string(songtitle, songtitle + titleLength));
   delete[] songtitle;
 
   VGMHeader *hdr = AddHeader(dwOffset, 0x22);

--- a/src/main/formats/FFT/FFTSeq.h
+++ b/src/main/formats/FFT/FFTSeq.h
@@ -11,7 +11,7 @@ class FFTSeq : public VGMSeq {
 
   bool GetHeaderInfo() override;
   bool GetTrackPointers() override;
-  uint32_t GetID() override { return assocWdsID; }
+  uint32_t GetID() const override { return assocWdsID; }
 
  protected:
   uint16_t seqID;

--- a/src/main/formats/FalcomSnes/FalcomSnesInstr.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesInstr.cpp
@@ -90,7 +90,7 @@ bool FalcomSnesInstrSet::GetInstrPointers() {
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(FalcomSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(FalcomSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/GraphResSnes/GraphResSnesInstr.cpp
+++ b/src/main/formats/GraphResSnes/GraphResSnesInstr.cpp
@@ -35,7 +35,7 @@ bool GraphResSnesInstrSet::GetInstrPointers() {
   uint16_t addrSampEntryMax = 0xffff;
   for (uint8_t srcn = 0; srcn <= 0x7f; srcn++) {
     uint32_t addrDIRentry = spcDirAddr + (srcn * 4);
-    if (!SNESSampColl::IsValidSampleDir(rawfile, addrDIRentry, true)) {
+    if (!SNESSampColl::IsValidSampleDir(rawFile(), addrDIRentry, true)) {
       continue;
     }
 
@@ -73,7 +73,7 @@ bool GraphResSnesInstrSet::GetInstrPointers() {
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(GraphResSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(GraphResSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/HOSA/HOSAInstr.cpp
+++ b/src/main/formats/HOSA/HOSAInstr.cpp
@@ -16,7 +16,7 @@
 //		Constructor
 //--------------------------------------------------------------
 HOSAInstrSet::HOSAInstrSet(RawFile *file, uint32_t offset)
-    : VGMInstrSet(HOSAFormat::name, file, offset, 0, "HOSAWAH ") {
+    : VGMInstrSet(HOSAFormat::name, file, offset, 0, "HOSAWAH") {
 }
 
 //==============================================================
@@ -36,10 +36,7 @@ bool HOSAInstrSet::GetHeaderInfo() {
 
   //"hdr"構造体へそのまま転送
   GetBytes(dwOffset, sizeof(InstrHeader), &instrheader);
-  id = 0;                        //Bank number.
-
-  //バイナリエディタ表示用
-  m_name = "HOSAWAH";
+  setId(0);                        //Bank number.
 
   //ヘッダーobjectの生成
   VGMHeader *wdsHeader = AddHeader(dwOffset, sizeof(InstrHeader));

--- a/src/main/formats/HOSA/HOSAInstr.cpp
+++ b/src/main/formats/HOSA/HOSAInstr.cpp
@@ -90,7 +90,7 @@ HOSAInstr::HOSAInstr(VGMInstrSet *instrSet, uint32_t offset, uint32_t length, ui
 //		Make the Object "WdsRgn" (Attribute table)
 //--------------------------------------------------------------
 bool HOSAInstr::LoadInstr() {
-  if (dwOffset + sizeof(InstrInfo) > vgmfile->GetEndOffset()) {
+  if (dwOffset + sizeof(InstrInfo) > vgmFile()->GetEndOffset()) {
     return false;
   }
 

--- a/src/main/formats/HOSA/HOSAScanner.cpp
+++ b/src/main/formats/HOSA/HOSAScanner.cpp
@@ -48,7 +48,7 @@ void HOSAScanner::Scan(RawFile *file, void *info) {
     return;
   }
 
-  VGMColl *coll = new VGMColl(*seq->GetName());
+  VGMColl *coll = new VGMColl(seq->name());
   coll->UseSeq(seq);
   coll->AddInstrSet(instrset);
   coll->AddSampColl(sampcoll);

--- a/src/main/formats/HOSA/HOSASeq.h
+++ b/src/main/formats/HOSA/HOSASeq.h
@@ -14,7 +14,7 @@ class HOSASeq: public VGMSeq {
 
   bool GetHeaderInfo() override;
   bool GetTrackPointers() override;
-  uint32_t GetID() override { return assocHOSA_ID; }
+  uint32_t GetID() const override { return assocHOSA_ID; }
 
  protected:
   uint16_t seqID;

--- a/src/main/formats/HeartBeatPS1/HeartBeatPS1Seq.cpp
+++ b/src/main/formats/HeartBeatPS1/HeartBeatPS1Seq.cpp
@@ -63,7 +63,7 @@ bool HeartBeatPS1Seq::GetHeaderInfo() {
 
   // check total file size
   uint32_t total_size = HEARTBEATPS1_SND_HEADER_SIZE + total_instr_size + seq_size;
-  if (total_size > 0x200000 || offset() + total_size > rawfile->size()) {
+  if (total_size > 0x200000 || offset() + total_size > rawFile()->size()) {
     return false;
   }
 
@@ -120,7 +120,7 @@ bool HeartBeatPS1Seq::ReadEvent() {
 
   // in this format, end of track (FF 2F 00) comes without delta-time.
   // so handle that crazy sequence the first.
-  if (curOffset + 3 <= rawfile->size()) {
+  if (curOffset + 3 <= rawFile()->size()) {
     if (GetByte(curOffset) == 0xff &&
         GetByte(curOffset + 1) == 0x2f &&
         GetByte(curOffset + 2) == 0x00) {
@@ -131,7 +131,7 @@ bool HeartBeatPS1Seq::ReadEvent() {
   }
 
   uint32_t delta = ReadVarLen(curOffset);
-  if (curOffset >= rawfile->size())
+  if (curOffset >= rawFile()->size())
     return false;
   AddTime(delta);
 
@@ -486,12 +486,12 @@ bool HeartBeatPS1Seq::ReadEvent() {
 
     case 0xF0 : {
       if (status_byte == 0xFF) {
-        if (curOffset + 1 > rawfile->size())
+        if (curOffset + 1 > rawFile()->size())
           return false;
 
         uint8_t metaNum = GetByte(curOffset++);
         uint32_t metaLen = ReadVarLen(curOffset);
-        if (curOffset + metaLen > rawfile->size())
+        if (curOffset + metaLen > rawFile()->size())
           return false;
 
         switch (metaNum) {

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesInstr.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesInstr.cpp
@@ -60,7 +60,7 @@ bool HeartBeatSnesInstrSet::GetInstrPointers() {
       continue;
     }
 
-    if (!SNESSampColl::IsValidSampleDir(rawfile, offDirEnt, true)) {
+    if (!SNESSampColl::IsValidSampleDir(rawFile(), offDirEnt, true)) {
       // safety logic
       unLength = instrNum * 6;
       break;
@@ -82,7 +82,7 @@ bool HeartBeatSnesInstrSet::GetInstrPointers() {
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(HeartBeatSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(HeartBeatSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/HudsonSnes/HudsonSnesInstr.cpp
+++ b/src/main/formats/HudsonSnes/HudsonSnesInstr.cpp
@@ -42,7 +42,7 @@ bool HudsonSnesInstrSet::GetInstrPointers() {
     uint8_t srcn = GetByte(ofsInstrEntry);
 
     uint32_t addrDIRentry = spcDirAddr + (srcn * 4);
-    if (!SNESSampColl::IsValidSampleDir(rawfile, addrDIRentry, true)) {
+    if (!SNESSampColl::IsValidSampleDir(rawFile(), addrDIRentry, true)) {
       continue;
     }
 
@@ -63,7 +63,7 @@ bool HudsonSnesInstrSet::GetInstrPointers() {
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(HudsonSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(HudsonSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/ItikitiSnes/ItikitiSnesInstr.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesInstr.cpp
@@ -43,7 +43,7 @@ bool ItikitiSnesInstrSet::GetInstrPointers() {
   if (aInstrs.empty())
     return false;
 
-  auto sampleColl = std::make_unique<SNESSampColl>(ItikitiSnesFormat::name, this->rawfile, spc_dir_offset(), srcns);
+  auto sampleColl = std::make_unique<SNESSampColl>(ItikitiSnesFormat::name, this->rawFile(), spc_dir_offset(), srcns);
   if (!sampleColl->LoadVGMFile())
     return false;
   (void)sampleColl.release();

--- a/src/main/formats/KonamiGX/KonamiGXSeq.cpp
+++ b/src/main/formats/KonamiGX/KonamiGXSeq.cpp
@@ -9,7 +9,7 @@ using namespace std;
 // ***********
 
 KonamiGXSeq::KonamiGXSeq(RawFile *file, uint32_t offset)
-    : VGMSeq(KonamiGXFormat::name, file, offset) {
+    : VGMSeq(KonamiGXFormat::name, file, offset, 0, "Konami GX Seq") {
   UseReverb();
   AlwaysWriteInitialVol(127);
 }
@@ -20,10 +20,6 @@ KonamiGXSeq::~KonamiGXSeq(void) {
 bool KonamiGXSeq::GetHeaderInfo(void) {
   //nNumTracks = GetByte(dwOffset+8);
   SetPPQN(0x30);
-
-  ostringstream theName;
-  theName << "Konami GX Seq";
-  m_name = theName.str();
   return true;
 }
 

--- a/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
@@ -27,7 +27,7 @@ void KonamiPS1Seq::ResetVars() {
 }
 
 bool KonamiPS1Seq::GetHeaderInfo() {
-  if (!IsKDT1Seq(rawfile, dwOffset)) {
+  if (!IsKDT1Seq(rawFile(), dwOffset)) {
     return false;
   }
 

--- a/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
@@ -118,7 +118,7 @@ bool KonamiPS1Track::ReadEvent() {
   KonamiPS1Seq *parentSeq = (KonamiPS1Seq *)this->parentSeq;
 
   uint32_t beginOffset = curOffset;
-  if (curOffset >= vgmfile->GetEndOffset()) {
+  if (curOffset >= vgmFile()->GetEndOffset()) {
     return false;
   }
 

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -57,7 +57,7 @@ bool KonamiSnesInstrSet::GetInstrPointers() {
       return false;
     }
 
-    if (!KonamiSnesInstr::IsValidHeader(this->rawfile, version, addrInstrHeader, spcDirAddr, false)) {
+    if (!KonamiSnesInstr::IsValidHeader(this->rawFile(), version, addrInstrHeader, spcDirAddr, false)) {
       if (instr < firstBankedInstr) {
         continue;
       }
@@ -65,7 +65,7 @@ bool KonamiSnesInstrSet::GetInstrPointers() {
         break;
       }
     }
-    if (!KonamiSnesInstr::IsValidHeader(this->rawfile, version, addrInstrHeader, spcDirAddr, true)) {
+    if (!KonamiSnesInstr::IsValidHeader(this->rawFile(), version, addrInstrHeader, spcDirAddr, true)) {
       continue;
     }
 
@@ -97,7 +97,7 @@ bool KonamiSnesInstrSet::GetInstrPointers() {
   aInstrs.push_back(newInstr);
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(KonamiSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(KonamiSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -49,9 +49,7 @@ const uint8_t KonamiSnesSeq::PAN_TABLE[] = {
 };
 
 KonamiSnesSeq::KonamiSnesSeq(RawFile *file, KonamiSnesVersion ver, uint32_t seqdataOffset, std::string newName)
-    : VGMSeq(KonamiSnesFormat::name, file, seqdataOffset), version(ver) {
-  m_name = newName;
-
+    : VGMSeq(KonamiSnesFormat::name, file, seqdataOffset, 0, newName), version(ver) {
   bAllowDiscontinuousTrackData = true;
 
   UseReverb();

--- a/src/main/formats/MP2k/MP2kInstrSet.cpp
+++ b/src/main/formats/MP2k/MP2kInstrSet.cpp
@@ -80,7 +80,7 @@ int MP2kInstrSet::MakeOrGetSample(size_t sample_pointer) {
   samp->rate = m_operating_rate;
   samp->volume = 1;
   samp->bps = 8;
-  samp->name = fmt::format("{:#x}", sample_pointer);
+  samp->setName(fmt::format("{:#x}", sample_pointer));
 
   samp->SetLoopStartMeasure(LM_SAMPLES);
   samp->SetLoopLengthMeasure(LM_SAMPLES);
@@ -135,7 +135,7 @@ bool MP2kInstr::LoadInstr() {
     case 0x30:
       [[fallthrough]];
     case 0x38: {
-      name = "Single-region instrument";
+      setName("Single-region instrument");
       unLength = 12;
 
       bool no_resampling = (m_type & 0xFF) == 0x08;
@@ -147,7 +147,7 @@ bool MP2kInstr::LoadInstr() {
       if (sample_pointer == 0) {
         /* Sometimes the instrument table can have weird values */
         L_INFO("Tried to load a sample that pointed to nothing for instr @{:#x}", dwOffset);
-        name += " (invalid)";
+        setName(name() += " (invalid)");
         break;
       }
 
@@ -159,7 +159,7 @@ bool MP2kInstr::LoadInstr() {
         SetADSR(rgn, m_data.w2);
       } else {
         L_WARN("No sample could be loaded for {:#x}", sample_pointer);
-        name += " (sample missing)";
+        setName(name() += " (sample missing)");
       }
 
       break;
@@ -174,7 +174,7 @@ bool MP2kInstr::LoadInstr() {
       [[fallthrough]];
     case 0x0a: {
       static constexpr const char *cycles[] = {"12,5%", "25%", "50%", "75%"};
-      name = fmt::format("PSG square {}", m_data.w1 < 4 ? cycles[m_data.w1] : "???");
+      setName(fmt::format("PSG square {}", m_data.w1 < 4 ? cycles[m_data.w1] : "???"));
       unLength = 12;
       break;
     }
@@ -183,7 +183,7 @@ bool MP2kInstr::LoadInstr() {
     case 0x03:
       [[fallthrough]];
     case 0x0b: {
-      name = "PSG programmable waveform";
+      setName("PSG programmable waveform");
       unLength = 12;
       break;
     }
@@ -192,14 +192,14 @@ bool MP2kInstr::LoadInstr() {
     case 0x04:
       [[fallthrough]];
     case 0x0c: {
-      name = "PSG noise";
+      setName("PSG noise");
       unLength = 12;
       break;
     }
 
     /* Multi-region instrument */
     case 0x40: {
-      name = "Multi-region instrument";
+      setName("Multi-region instrument");
       unLength = 12;
 
       u32 base_pointer = m_data.w1 & 0x3ffffff;
@@ -256,7 +256,7 @@ bool MP2kInstr::LoadInstr() {
 
     /* Full-keyboard instrument */
     case 0x80: {
-      name = "Full-keyboard instrument";
+      setName("Full-keyboard instrument");
       unLength = 12;
 
       u32 base_pointer = m_data.w1 & 0x3ffffff;

--- a/src/main/formats/MP2k/MP2kInstrSet.cpp
+++ b/src/main/formats/MP2k/MP2kInstrSet.cpp
@@ -32,8 +32,8 @@ bool MP2kInstrSet::LoadInstrs() {
 bool MP2kInstrSet::GetInstrPointers() {
   for (int i = 0; i < m_count; i++) {
     size_t cur_ofs = dwOffset + i * 12;
-    MP2kInstrData data{rawfile->get<u32>(cur_ofs), rawfile->get<u32>(cur_ofs + 4),
-                       rawfile->get<u32>(cur_ofs + 8)};
+    MP2kInstrData data{rawFile()->get<u32>(cur_ofs), rawFile()->get<u32>(cur_ofs + 4),
+                       rawFile()->get<u32>(cur_ofs + 8)};
     aInstrs.push_back(new MP2kInstr(this, cur_ofs, 0, 0, i, data));
   }
 
@@ -41,7 +41,7 @@ bool MP2kInstrSet::GetInstrPointers() {
 }
 
 int MP2kInstrSet::MakeOrGetSample(size_t sample_pointer) {
-  if (sample_pointer == 0 || sample_pointer >= GetRawFile()->size()) {
+  if (sample_pointer == 0 || sample_pointer >= rawFile()->size()) {
     L_WARN("Invalid sample pointer {:#x}", sample_pointer);
     return -1;
   }
@@ -51,10 +51,10 @@ int MP2kInstrSet::MakeOrGetSample(size_t sample_pointer) {
   }
 
   /* First 3 bytes are unused */
-  auto loop = GetRawFile()->getBE<u32>(sample_pointer);
-  auto pitch = GetRawFile()->get<u32>(sample_pointer + 4);
-  auto loop_pos = GetRawFile()->get<u32>(sample_pointer + 8);
-  auto len = GetRawFile()->get<u32>(sample_pointer + 12);
+  auto loop = rawFile()->getBE<u32>(sample_pointer);
+  auto pitch = rawFile()->get<u32>(sample_pointer + 4);
+  auto loop_pos = rawFile()->get<u32>(sample_pointer + 8);
+  auto len = rawFile()->get<u32>(sample_pointer + 12);
   /* Filter out samples with invalid lengths */
   if (len < 16 || len > 0x3FFFFF) {
     return -1;
@@ -211,7 +211,7 @@ bool MP2kInstr::LoadInstr() {
       int current_index;
       /* Scan the whole table for changes and keep track of splits */
       for (int key = 0; key < 128; key++) {
-        int index = GetRawFile()->get<u8>(region_table + key);
+        int index = rawFile()->get<u8>(region_table + key);
 
         current_index = index;
         if (prev_index != current_index) {
@@ -228,13 +228,13 @@ bool MP2kInstr::LoadInstr() {
       for (int i = 0; i < index_list.size(); i++) {
         u32 offset = base_pointer + 12 * index_list[i];
 
-        auto type = GetRawFile()->get<u8>(offset);
+        auto type = rawFile()->get<u8>(offset);
         if (type & 0x07) {
           L_WARN("GameBoy instrument in key-split (what game is this?!)");
           continue;
         }
 
-        u32 sample_pointer = GetRawFile()->get<u32>(offset + 4) & 0x3ffffff;
+        u32 sample_pointer = rawFile()->get<u32>(offset + 4) & 0x3ffffff;
         if (sample_pointer == 0) {
           continue;
         }
@@ -245,7 +245,7 @@ bool MP2kInstr::LoadInstr() {
           VGMRgn *rgn = AddRgn(dwOffset, unLength, sample_id, split_list[i], split_list[i + 1] - 1);
 
           // rgn->sampCollPtr = static_cast<MP2kInstrSet *>(parInstrSet)->sampColl;
-          SetADSR(rgn, GetRawFile()->get<u32>(offset + 8));
+          SetADSR(rgn, rawFile()->get<u32>(offset + 8));
         } else {
           continue;
         }
@@ -264,11 +264,11 @@ bool MP2kInstr::LoadInstr() {
       for (int key = 0; key < 128; key++) {
         u32 offset = base_pointer + 12 * key;
 
-        u32 type = GetRawFile()->get<u8>(offset);
-        u32 keynum = GetRawFile()->get<u8>(offset + 1);
-        u32 pan = GetRawFile()->get<u8>(offset + 3);
+        u32 type = rawFile()->get<u8>(offset);
+        u32 keynum = rawFile()->get<u8>(offset + 1);
+        u32 pan = rawFile()->get<u8>(offset + 3);
 
-        u32 sample_pointer = GetRawFile()->get<u32>(offset + 4) & 0x3ffffff;
+        u32 sample_pointer = rawFile()->get<u32>(offset + 4) & 0x3ffffff;
         if (sample_pointer == 0) {
           continue;
         }
@@ -281,13 +281,13 @@ bool MP2kInstr::LoadInstr() {
             // rgn->sampCollPtr = static_cast<MP2kInstrSet *>(parInstrSet)->sampColl;
             rgn->SetPan(pan);
 
-            u32 pitch = GetRawFile()->get<u32>(sample_pointer + 4);
+            u32 pitch = rawFile()->get<u32>(sample_pointer + 4);
             double delta_note = 12.0 * log2(static_cast<MP2kInstrSet *>(parInstrSet)->sampleRate() *
                                             1024.0 / pitch);
             int rootkey = 60 + int(round(delta_note));
 
             rgn->SetUnityKey(rootkey - keynum + key);
-            SetADSR(rgn, GetRawFile()->get<u32>(offset + 8));
+            SetADSR(rgn, rawFile()->get<u32>(offset + 8));
           }
         } else if ((type & 0x0f) == 4 || (type & 0x0f) == 12) {
           /* Make noise sample here... */

--- a/src/main/formats/MP2k/MP2kSeq.cpp
+++ b/src/main/formats/MP2k/MP2kSeq.cpp
@@ -39,7 +39,7 @@ MP2kSeq::MP2kSeq(RawFile *file, uint32_t offset, std::string name)
 }
 
 bool MP2kSeq::GetHeaderInfo() {
-  if (dwOffset + 2 > vgmfile->GetEndOffset()) {
+  if (dwOffset + 2 > vgmFile()->GetEndOffset()) {
     return false;
   }
 
@@ -50,7 +50,7 @@ bool MP2kSeq::GetHeaderInfo() {
   if (nNumTracks == 0 || nNumTracks > 24) {
     return false;
   }
-  if (dwOffset + 8 + nNumTracks * 4 > vgmfile->GetEndOffset()) {
+  if (dwOffset + 8 + nNumTracks * 4 > vgmFile()->GetEndOffset()) {
     return false;
   }
 
@@ -144,7 +144,7 @@ bool MP2kTrack::ReadEvent() {
 
     // Add next end of track event
     if (readMode == READMODE_ADD_TO_UI) {
-      if (dwEndTrackOffset < this->parentSeq->vgmfile->GetEndOffset()) {
+      if (dwEndTrackOffset < this->parentSeq->vgmFile()->GetEndOffset()) {
         uint8_t nextCmdByte = GetByte(dwEndTrackOffset);
         if (nextCmdByte == 0xB1) {
           AddEndOfTrack(dwEndTrackOffset, 1);

--- a/src/main/formats/MoriSnes/MoriSnesInstr.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesInstr.cpp
@@ -123,7 +123,7 @@ bool MoriSnesInstrSet::GetInstrPointers() {
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(MoriSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(MoriSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/NDS/NDSInstrSet.cpp
+++ b/src/main/formats/NDS/NDSInstrSet.cpp
@@ -68,7 +68,7 @@ bool NDSInstr::LoadInstr() {
   // All of the undefined case values below are used for tone or noise channels
   switch (instrType) {
     case 0x01: {
-      name = "Single-Region Instrument";
+      setName("Single-Region Instrument");
       unLength = 10;
 
       VGMRgn *rgn = AddRgn(dwOffset, 10, GetShort(dwOffset));
@@ -82,7 +82,7 @@ bool NDSInstr::LoadInstr() {
       uint8_t dutyCycle = GetByte(dwOffset) & 0x07;
       std::string dutyCycles[8] = {"12.5%", "25%", "37.5%", "50%",
                                     "62.5%", "75%", "87.5%", "0%"};
-      name = "PSG Wave (" + dutyCycles[dutyCycle] + ")";
+      setName("PSG Wave (" + dutyCycles[dutyCycle] + ")");
       unLength = 10;
 
       VGMRgn *rgn = AddRgn(dwOffset, 10, dutyCycle);
@@ -95,7 +95,7 @@ bool NDSInstr::LoadInstr() {
     }
 
     case 0x03: {
-      name = "PSG Noise";
+      setName("PSG Noise");
       unLength = 10;
 
       /* The noise sample is the 8th in our PSG sample collection */
@@ -109,7 +109,7 @@ bool NDSInstr::LoadInstr() {
     }
 
     case 0x10: {
-      name = "Drumset";
+      setName("Drumset");
 
       uint8_t lowKey = GetByte(dwOffset);
       uint8_t highKey = GetByte(dwOffset + 1);
@@ -126,7 +126,7 @@ bool NDSInstr::LoadInstr() {
     }
 
     case 0x11: {
-      name = "Multi-Region Instrument";
+      setName("Multi-Region Instrument");
       uint8_t keyRanges[8];
       uint8_t nRgns = 0;
       for (int i = 0; i < 8; i++) {
@@ -519,7 +519,7 @@ NDSPSGSamp::NDSPSGSamp(VGMSampColl *sampcoll, uint8_t duty_cycle) : VGMSamp(samp
   SetLoopLengthMeasure(LM_SAMPLES);
   ulUncompressedSize = 32768 * bps / 8;
 
-  name = "PSG_duty_" + std::to_string(duty_cycle);
+  setName("PSG_duty_" + std::to_string(duty_cycle));
 }
 
 void NDSPSGSamp::ConvertToStdWave(uint8_t *buf) {

--- a/src/main/formats/NamcoSnes/NamcoSnesInstr.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesInstr.cpp
@@ -41,7 +41,7 @@ bool NamcoSnesInstrSet::GetInstrPointers() {
   usedSRCNs.clear();
   for (uint8_t srcn = 0; srcn < maxSampCount; srcn++) {
     uint32_t addrDIRentry = spcDirAddr + (srcn * 4);
-    if (!SNESSampColl::IsValidSampleDir(rawfile, addrDIRentry, true)) {
+    if (!SNESSampColl::IsValidSampleDir(rawFile(), addrDIRentry, true)) {
       continue;
     }
 
@@ -73,7 +73,7 @@ fmt::format("Instrument {}", srcn));
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(NamcoSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(NamcoSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
+++ b/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
@@ -60,10 +60,10 @@ bool NeverlandSnesSeq::GetHeaderInfo(void) {
   // set name to the sequence
   if (rawName[0] != ('\0')) {
     std::string nameStr = std::string(rawName);
-    m_name = nameStr;
+    setName(nameStr);
   }
   else {
-    m_name = "NeverlandSnesSeq";
+    setName("NeverlandSnesSeq");
   }
 
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -78,10 +78,10 @@ bool NinSnesInstrSet::GetInstrPointers() {
       // example: Yoshi's Island - Bowser (ff ff ff ff)
       continue;
     }
-    if (!NinSnesInstr::IsValidHeader(this->rawfile, version, addrInstrHeader, spcDirAddr, false)) {
+    if (!NinSnesInstr::IsValidHeader(this->rawFile(), version, addrInstrHeader, spcDirAddr, false)) {
       break;
     }
-    if (!NinSnesInstr::IsValidHeader(this->rawfile, version, addrInstrHeader, spcDirAddr, true)) {
+    if (!NinSnesInstr::IsValidHeader(this->rawFile(), version, addrInstrHeader, spcDirAddr, true)) {
       continue;
     }
 
@@ -108,7 +108,7 @@ bool NinSnesInstrSet::GetInstrPointers() {
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(NinSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(NinSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/Org/OrgSeq.cpp
+++ b/src/main/formats/Org/OrgSeq.cpp
@@ -3,7 +3,7 @@
 DECLARE_FORMAT(Org);
 
 OrgSeq::OrgSeq(RawFile *file, uint32_t offset)
-    : VGMSeq(OrgFormat::name, file, offset) {
+    : VGMSeq(OrgFormat::name, file, offset, 0, "Org Seq") {
 }
 
 OrgSeq::~OrgSeq(void) {
@@ -13,7 +13,6 @@ bool OrgSeq::GetHeaderInfo(void) {
   waitTime = GetShort(dwOffset + 6);
   beatsPerMeasure = GetByte(dwOffset + 8);
   SetPPQN(GetByte(dwOffset + 9));
-  m_name = "Org Seq";
 
   uint32_t notesSoFar = 0;        //this must be used to determine the length of the entire seq
 

--- a/src/main/formats/PS1/PS1Seq.cpp
+++ b/src/main/formats/PS1/PS1Seq.cpp
@@ -38,7 +38,7 @@ bool PS1Seq::GetHeaderInfo() {
 
   if (GetByte(offset() + 0xF) == 0 && GetByte(offset() + 0x10) == 0) {
     SetEventsOffset(offset() + 0x0F + 4);
-    PS1Seq *newPS1Seq = new PS1Seq(rawfile, offset() + GetShortBE(offset() + 0x11) + 0x13 - 6);
+    PS1Seq *newPS1Seq = new PS1Seq(rawFile(), offset() + GetShortBE(offset() + 0x11) + 0x13 - 6);
     if (!newPS1Seq->LoadVGMFile()) {
       delete newPS1Seq;
     }
@@ -67,7 +67,7 @@ void PS1Seq::ResetVars() {
 bool PS1Seq::ReadEvent() {
   uint32_t beginOffset = curOffset;
   uint32_t delta = ReadVarLen(curOffset);
-  if (curOffset >= rawfile->size())
+  if (curOffset >= rawFile()->size())
     return false;
   AddTime(delta);
 

--- a/src/main/formats/PS1/Vab.cpp
+++ b/src/main/formats/PS1/Vab.cpp
@@ -6,10 +6,10 @@
 using namespace std;
 
 Vab::Vab(RawFile *file, uint32_t offset)
-    : VGMInstrSet(PS1Format::name, file, offset) {
+    : VGMInstrSet(PS1Format::name, file, offset, 0, "VAB") {
 }
 
-Vab::~Vab(void) {
+Vab::~Vab() {
 }
 
 
@@ -20,8 +20,6 @@ bool Vab::GetHeaderInfo() {
   if (nMaxLength < 0x20) {
     return false;
   }
-
-  m_name = "VAB";
 
   VGMHeader *vabHdr = AddHeader(dwOffset, 0x20, "VAB Header");
   vabHdr->AddSimpleItem(dwOffset + 0x00, 4, "ID");
@@ -143,7 +141,7 @@ bool Vab::GetInstrPointers() {
     // single VAB file?
     if (dwOffset == 0 && vagLocations.size() != 0) {
       // load samples as well
-      PSXSampColl *newSampColl = new PSXSampColl(m_format, this, vagStartOffset, totalVAGSize, vagLocations);
+      PSXSampColl *newSampColl = new PSXSampColl(formatName(), this, vagStartOffset, totalVAGSize, vagLocations);
       if (newSampColl->LoadVGMFile()) {
         pRoot->AddVGMFile(newSampColl);
         //this->sampColl = newSampColl;

--- a/src/main/formats/PS1/Vab.cpp
+++ b/src/main/formats/PS1/Vab.cpp
@@ -143,7 +143,7 @@ bool Vab::GetInstrPointers() {
     // single VAB file?
     if (dwOffset == 0 && vagLocations.size() != 0) {
       // load samples as well
-      PSXSampColl *newSampColl = new PSXSampColl(format, this, vagStartOffset, totalVAGSize, vagLocations);
+      PSXSampColl *newSampColl = new PSXSampColl(m_format, this, vagStartOffset, totalVAGSize, vagLocations);
       if (newSampColl->LoadVGMFile()) {
         pRoot->AddVGMFile(newSampColl);
         //this->sampColl = newSampColl;

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesInstr.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesInstr.cpp
@@ -69,7 +69,7 @@ bool PandoraBoxSnesInstrSet::GetInstrPointers() {
     uint8_t srcn = std::distance(globalInstrTable.begin(), iterInstrItem);
 
     uint32_t addrDIRentry = spcDirAddr + (srcn * 4);
-    if (!SNESSampColl::IsValidSampleDir(rawfile, addrDIRentry, true)) {
+    if (!SNESSampColl::IsValidSampleDir(rawFile(), addrDIRentry, true)) {
       break;
     }
 
@@ -94,7 +94,7 @@ bool PandoraBoxSnesInstrSet::GetInstrPointers() {
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(PandoraBoxSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(PandoraBoxSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/PrismSnes/PrismSnesInstr.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesInstr.cpp
@@ -39,7 +39,7 @@ bool PrismSnesInstrSet::GetInstrPointers() {
     uint8_t srcn = (uint8_t)srcn16;
 
     uint32_t addrDIRentry = spcDirAddr + (srcn * 4);
-    if (!SNESSampColl::IsValidSampleDir(rawfile, addrDIRentry, true)) {
+    if (!SNESSampColl::IsValidSampleDir(rawFile(), addrDIRentry, true)) {
       continue;
     }
 
@@ -85,7 +85,7 @@ bool PrismSnesInstrSet::GetInstrPointers() {
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(PrismSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(PrismSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/RareSnes/RareSnesInstr.cpp
+++ b/src/main/formats/RareSnes/RareSnesInstr.cpp
@@ -53,8 +53,8 @@ void RareSnesInstrSet::Initialize() {
   }
 
   unLength = 0x100;
-  if (dwOffset + unLength > GetRawFile()->size()) {
-    unLength = GetRawFile()->size() - dwOffset;
+  if (dwOffset + unLength > rawFile()->size()) {
+    unLength = rawFile()->size() - dwOffset;
   }
   ScanAvailableInstruments();
 }
@@ -83,7 +83,7 @@ void RareSnesInstrSet::ScanAvailableInstruments() {
       continue;
     }
 
-    if (!SNESSampColl::IsValidSampleDir(rawfile, offDirEnt, true)) {
+    if (!SNESSampColl::IsValidSampleDir(rawFile(), offDirEnt, true)) {
       continue;
     }
 

--- a/src/main/formats/RareSnes/RareSnesSeq.cpp
+++ b/src/main/formats/RareSnes/RareSnesSeq.cpp
@@ -32,9 +32,7 @@ const uint16_t RareSnesSeq::NOTE_PITCH_TABLE[128] = {
 };
 
 RareSnesSeq::RareSnesSeq(RawFile *file, RareSnesVersion ver, uint32_t seqdataOffset, string newName)
-    : VGMSeq(RareSnesFormat::name, file, seqdataOffset), version(ver) {
-  m_name = newName;
-
+    : VGMSeq(RareSnesFormat::name, file, seqdataOffset, 0, newName), version(ver) {
   bLoadTickByTick = true;
   bAllowDiscontinuousTrackData = true;
 

--- a/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
@@ -8,7 +8,7 @@ using namespace std;
 // ***************
 
 SonyPS2InstrSet::SonyPS2InstrSet(RawFile *file, uint32_t offset)
-    : VGMInstrSet(SonyPS2Format::name, file, offset) {
+    : VGMInstrSet(SonyPS2Format::name, file, offset, 0, "Sony PS2 InstrSet") {
 }
 
 SonyPS2InstrSet::~SonyPS2InstrSet(void) {
@@ -16,8 +16,6 @@ SonyPS2InstrSet::~SonyPS2InstrSet(void) {
 
 
 bool SonyPS2InstrSet::GetHeaderInfo() {
-  m_name = "Sony PS2 InstrSet";
-
   // VERSION CHUNK
   uint32_t curOffset = dwOffset;
   GetBytes(curOffset, 16, &versCk);
@@ -392,7 +390,7 @@ bool SonyPS2SampColl::GetSampleInfo() {
     // Get offset, length, and samplerate from VAGInfo Param
     SonyPS2InstrSet::VAGInfoParam &vagInfoParam = vagInfoCk.vagInfoParam[i];
     uint32_t offset = vagInfoParam.vagOffsetAddr;
-    uint32_t length = (i == numVagInfos - 1) ? this->rawfile->size() - offset :
+    uint32_t length = (i == numVagInfos - 1) ? this->rawFile()->size() - offset :
                       vagInfoCk.vagInfoParam[i + 1].vagOffsetAddr - offset;
 
     // We need to perform a hackish check to make sure the last ADPCM block was not

--- a/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
@@ -89,7 +89,7 @@ void SonyPS2Scanner::SearchForSampColl(RawFile *file) {
     }
 
     SonyPS2SampColl *sampColl = new SonyPS2SampColl(file, 0);
-    Format *fmt = sampColl->GetFormat();
+    Format *fmt = sampColl->format();
     if (fmt)
       fmt->OnNewFile(sampColl);
   }

--- a/src/main/formats/SonyPS2/SonyPS2Seq.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Seq.cpp
@@ -66,7 +66,7 @@ bool SonyPS2Seq::ReadEvent(void) {
   else
     deltaTime = ReadVarLen(curOffset);
   AddTime(deltaTime);
-  if (curOffset >= rawfile->size())
+  if (curOffset >= rawFile()->size())
     return false;
 
   bSkipDeltaTime = false;

--- a/src/main/formats/SquarePS2/SquarePS2Seq.cpp
+++ b/src/main/formats/SquarePS2/SquarePS2Seq.cpp
@@ -69,9 +69,9 @@ bool BGMTrack::ReadEvent(void) {
   AddTime(ReadVarLen(curOffset));
 
   // address range check for safety
-  if (!vgmfile->IsValidOffset(curOffset)) {
+  if (!vgmFile()->IsValidOffset(curOffset)) {
     if (readMode== ReadMode::READMODE_ADD_TO_UI) {
-      L_WARN("{}: Address out of range. Conversion aborted.", vgmfile->name());
+      L_WARN("{}: Address out of range. Conversion aborted.", vgmFile()->name());
     }
     return false;
   }

--- a/src/main/formats/SquarePS2/SquarePS2Seq.cpp
+++ b/src/main/formats/SquarePS2/SquarePS2Seq.cpp
@@ -34,7 +34,7 @@ bool BGMSeq::GetHeaderInfo() {
   theName << "BGM " << seqID;
   if (seqID != assocWDID)
     theName << "using WD " << assocWDID;
-  m_name = theName.str();
+  setName(theName.str());
   return true;
 }
 
@@ -42,7 +42,7 @@ bool BGMSeq::GetTrackPointers() {
   uint32_t pos = dwOffset + 0x20;    //start at first track (fixed offset)
   for (unsigned int i = 0; i < nNumTracks; i++) {
     //HACK FOR TRUNCATED BGMS (ex. FFXII 113 Eastersand.psf2)
-    if (pos >= GetRawFile()->size())
+    if (pos >= rawFile()->size())
       return true;
     //END HACK
     uint32_t trackSize = GetWord(pos);        //get the track size (first word before track data)

--- a/src/main/formats/SquarePS2/WD.cpp
+++ b/src/main/formats/SquarePS2/WD.cpp
@@ -55,7 +55,7 @@ bool WDInstrSet::GetHeaderInfo() {
   header->AddSimpleItem(dwOffset + 0x8, 4, "Number of Instruments");
   header->AddSimpleItem(dwOffset + 0xC, 4, "Number of Regions");
 
-  id = GetShort(0x2 + dwOffset);
+  setId(GetShort(0x2 + dwOffset));
   dwSampSectSize = GetWord(0x4 + dwOffset);
   dwNumInstrs = GetWord(0x8 + dwOffset);
   dwTotalRegions = GetWord(0xC + dwOffset);
@@ -63,7 +63,7 @@ bool WDInstrSet::GetHeaderInfo() {
   if (dwSampSectSize < 0x40)  // Some songs in the Bouncer have bizarre values here
     dwSampSectSize = 0;
 
-  m_name = fmt::format("WD {}", id);
+  setName(fmt::format("WD {}", GetID()));
 
   uint32_t sampCollOff = dwOffset + GetWord(dwOffset + 0x20) + (dwTotalRegions * 0x20);
 

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -47,7 +47,7 @@ bool SuzukiSnesInstrSet::GetInstrPointers() {
     }
 
     uint32_t addrDIRentry = spcDirAddr + (srcn * 4);
-    if (!SNESSampColl::IsValidSampleDir(rawfile, addrDIRentry, true)) {
+    if (!SNESSampColl::IsValidSampleDir(rawFile(), addrDIRentry, true)) {
       continue;
     }
 
@@ -91,7 +91,7 @@ bool SuzukiSnesInstrSet::GetInstrPointers() {
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(SuzukiSnesFormat::name, this->rawfile, spcDirAddr, usedSRCNs);
+  SNESSampColl *newSampColl = new SNESSampColl(SuzukiSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->LoadVGMFile()) {
     delete newSampColl;
     return false;

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
@@ -13,12 +13,12 @@ TamSoftPS1InstrSet::~TamSoftPS1InstrSet() {
 }
 
 bool TamSoftPS1InstrSet::GetHeaderInfo() {
-  if (dwOffset + 0x800 > vgmfile->GetEndOffset()) {
+  if (dwOffset + 0x800 > vgmFile()->GetEndOffset()) {
     return false;
   }
 
   uint32_t sampCollSize = GetWord(0x3fc);
-  if (dwOffset + 0x800 + sampCollSize > vgmfile->GetEndOffset()) {
+  if (dwOffset + 0x800 + sampCollSize > vgmFile()->GetEndOffset()) {
     return false;
   }
   unLength = 0x800 + sampCollSize;

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
@@ -33,7 +33,7 @@ bool TamSoftPS1InstrSet::GetInstrPointers() {
     bool vagLoop;
     uint32_t vagOffset = 0x800 + GetWord(dwOffset + 4 * instrNum);
     if (vagOffset < unLength) {
-      SizeOffsetPair vagLocation(vagOffset - 0x800, PSXSamp::GetSampleLength(rawfile, vagOffset, dwOffset + unLength, vagLoop));
+      SizeOffsetPair vagLocation(vagOffset - 0x800, PSXSamp::GetSampleLength(rawFile(), vagOffset, dwOffset + unLength, vagLoop));
       vagLocations.push_back(vagLocation);
 
       TamSoftPS1Instr *newInstr = new TamSoftPS1Instr(this, instrNum,

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
@@ -62,7 +62,7 @@ bool TamSoftPS1Seq::GetHeaderInfo() {
   SetPPQN(SEQ_PPQN);
 
   uint32_t dwSongItemOffset = dwOffset + 4 * song;
-  if (dwSongItemOffset + 4 > vgmfile->GetEndOffset()) {
+  if (dwSongItemOffset + 4 > vgmFile()->GetEndOffset()) {
     return false;
   }
 
@@ -89,7 +89,7 @@ bool TamSoftPS1Seq::GetHeaderInfo() {
 
       // PS2 version?
       ps2 = false;
-      if (dwHeaderOffset + HEADER_SIZE_PS2 <= vgmfile->GetEndOffset()) {
+      if (dwHeaderOffset + HEADER_SIZE_PS2 <= vgmFile()->GetEndOffset()) {
         ps2 = true;
         for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS_PS2; trackIndex++) {
           uint32_t dwTrackHeaderOffset = dwHeaderOffset + 4 * trackIndex;
@@ -112,7 +112,7 @@ bool TamSoftPS1Seq::GetHeaderInfo() {
         maxTracks = MAX_TRACKS_PS1;
       }
 
-      if (dwHeaderOffset + headerSize > vgmfile->GetEndOffset()) {
+      if (dwHeaderOffset + headerSize > vgmFile()->GetEndOffset()) {
         return false;
       }
 
@@ -131,7 +131,7 @@ bool TamSoftPS1Seq::GetHeaderInfo() {
         trackHeader->AddSimpleItem(dwTrackHeaderOffset + 2, 2, "Track Offset");
 
         if (live != 0) {
-          if (dwHeaderOffset + dwRelTrackOffset < vgmfile->GetEndOffset()) {
+          if (dwHeaderOffset + dwRelTrackOffset < vgmFile()->GetEndOffset()) {
             TamSoftPS1Track *track = new TamSoftPS1Track(this, dwHeaderOffset + dwRelTrackOffset);
             aTracks.push_back(track);
           }
@@ -181,7 +181,7 @@ bool TamSoftPS1Track::ReadEvent() {
   TamSoftPS1Seq *parentSeq = (TamSoftPS1Seq *)this->parentSeq;
 
   uint32_t beginOffset = curOffset;
-  if (curOffset >= vgmfile->GetEndOffset()) {
+  if (curOffset >= vgmFile()->GetEndOffset()) {
     FinalizeAllNotes();
     return false;
   }

--- a/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
@@ -131,7 +131,7 @@ bool TriAcePS1Instr::LoadInstr() {
     rgn->AddSimpleItem(rgn->dwOffset + 14, 1, "Pitch Fine Tune");
     const int kTuningOffset = 22; // approx. 21.500638 from pitch table (0x10be vs 0x1000)
     rgn->fineTune = (short)((double)rgninfo->pitchTuneFine / 64.0 * 100) - kTuningOffset;
-    rgn->sampCollPtr = ((VGMInstrSet *) this->vgmfile)->sampColl;
+    rgn->sampCollPtr = ((VGMInstrSet *) this->vgmFile())->sampColl;
     rgn->AddSimpleItem(rgn->dwOffset + 15, 5, "Unknown values");
 
 

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -18,7 +18,7 @@ PSXSampColl::PSXSampColl(const string &format, RawFile *rawfile, uint32_t offset
 }
 
 PSXSampColl::PSXSampColl(const string &format, VGMInstrSet *instrset, uint32_t offset, uint32_t length)
-    : VGMSampColl(format, instrset->rawfile, instrset, offset, length) {
+    : VGMSampColl(format, instrset->rawFile(), instrset, offset, length) {
 }
 
 PSXSampColl::PSXSampColl(const string &format,
@@ -26,7 +26,7 @@ PSXSampColl::PSXSampColl(const string &format,
                          uint32_t offset,
                          uint32_t length,
                          const std::vector<SizeOffsetPair> &vagLocations)
-    : VGMSampColl(format, instrset->rawfile, instrset, offset, length), vagLocations(vagLocations) {
+    : VGMSampColl(format, instrset->rawFile(), instrset, offset, length), vagLocations(vagLocations) {
 }
 
 bool PSXSampColl::GetSampleInfo() {
@@ -322,7 +322,7 @@ void PSXSamp::ConvertToStdWave(uint8_t *buf) {
       }
     }
 
-    GetRawFile()->GetBytes(dwOffset + k + 2, 14, theBlock.brr);
+    rawFile()->GetBytes(dwOffset + k + 2, 14, theBlock.brr);
 
     //each decompressed pcm block is 52 bytes   EDIT: (wait, isn't it 56 bytes? or is it 28?)
     DecompVAGBlk(uncompBuf + ((k * 28) / 16),

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -296,7 +296,7 @@ void PSXSamp::ConvertToStdWave(uint8_t *buf) {
   bool addrOutOfVirtFile = false;
   for (uint32_t k = 0; k < dataLength; k += 0x10)                //for every adpcm chunk
   {
-    if (dwOffset + k + 16 > vgmfile->GetEndOffset()) {
+    if (dwOffset + k + 16 > vgmFile()->GetEndOffset()) {
       L_WARN("\"{}\" unexpected EOF.", name());
       break;
     }

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -297,11 +297,11 @@ void PSXSamp::ConvertToStdWave(uint8_t *buf) {
   for (uint32_t k = 0; k < dataLength; k += 0x10)                //for every adpcm chunk
   {
     if (dwOffset + k + 16 > vgmfile->GetEndOffset()) {
-      L_WARN("\"{}\" unexpected EOF.", name);
+      L_WARN("\"{}\" unexpected EOF.", name());
       break;
     }
     else if (!addrOutOfVirtFile && k + 16 > unLength) {
-      L_WARN("\"{}\" unexpected end of PSXSamp.", name);
+      L_WARN("\"{}\" unexpected end of PSXSamp.", name());
       addrOutOfVirtFile = true;
     }
 

--- a/src/main/formats/common/SNESDSP.cpp
+++ b/src/main/formats/common/SNESDSP.cpp
@@ -438,7 +438,7 @@ void SNESSamp::ConvertToStdWave(uint8_t *buf) {
   for (uint32_t k = 0; k + 9 <= dataLength; k += 9)  //for every adpcm chunk
   {
     if (dwOffset + k + 9 > rawFile()->size()) {
-      L_WARN("Unexpected EOF ({})", (name));
+      L_WARN("Unexpected EOF ({})", (name()));
       break;
     }
 

--- a/src/main/formats/common/SNESDSP.cpp
+++ b/src/main/formats/common/SNESDSP.cpp
@@ -302,7 +302,7 @@ SNESSampColl::SNESSampColl(const std::string &format, RawFile *rawfile, uint32_t
 }
 
 SNESSampColl::SNESSampColl(const std::string &format, VGMInstrSet *instrset, uint32_t offset, uint32_t maxNumSamps) :
-    VGMSampColl(format, instrset->GetRawFile(), instrset, offset, 0),
+    VGMSampColl(format, instrset->rawFile(), instrset, offset, 0),
     spcDirAddr(offset) {
   SetDefaultTargets(maxNumSamps);
 }
@@ -316,7 +316,7 @@ SNESSampColl::SNESSampColl(const std::string &format, RawFile *rawfile, uint32_t
 
 SNESSampColl::SNESSampColl(const std::string &format, VGMInstrSet *instrset, uint32_t offset,
                            const std::vector<uint8_t> &targetSRCNs, std::string name) :
-    VGMSampColl(format, instrset->GetRawFile(), instrset, offset, 0, std::move(name)),
+    VGMSampColl(format, instrset->rawFile(), instrset, offset, 0, std::move(name)),
     spcDirAddr(offset),
     targetSRCNs(targetSRCNs) {
 }
@@ -342,7 +342,7 @@ bool SNESSampColl::GetSampleInfo() {
     uint8_t srcn = (*itr);
 
     uint32_t offDirEnt = spcDirAddr + (srcn * 4);
-    if (!SNESSampColl::IsValidSampleDir(GetRawFile(), offDirEnt, true)) {
+    if (!SNESSampColl::IsValidSampleDir(rawFile(), offDirEnt, true)) {
       continue;
     }
 
@@ -350,7 +350,7 @@ bool SNESSampColl::GetSampleInfo() {
     uint16_t addrSampLoop = GetShort(offDirEnt + 2);
 
     bool loop;
-    uint32_t length = SNESSamp::GetSampleLength(GetRawFile(), addrSampStart, loop);
+    uint32_t length = SNESSamp::GetSampleLength(rawFile(), addrSampStart, loop);
 
         spcDirHeader->AddSimpleItem(offDirEnt, 2, fmt::format("SA: {:#x}", srcn));
         spcDirHeader->AddSimpleItem(offDirEnt + 2, 2, fmt::format("LSA: {:#x}", srcn));
@@ -437,7 +437,7 @@ void SNESSamp::ConvertToStdWave(uint8_t *buf) {
   assert(dataLength % 9 == 0);
   for (uint32_t k = 0; k + 9 <= dataLength; k += 9)  //for every adpcm chunk
   {
-    if (dwOffset + k + 9 > GetRawFile()->size()) {
+    if (dwOffset + k + 9 > rawFile()->size()) {
       L_WARN("Unexpected EOF ({})", (name));
       break;
     }
@@ -447,7 +447,7 @@ void SNESSamp::ConvertToStdWave(uint8_t *buf) {
     theBlock.flag.end = (GetByte(dwOffset + k) & 0x01) != 0;
     theBlock.flag.loop = (GetByte(dwOffset + k) & 0x02) != 0;
 
-    GetRawFile()->GetBytes(dwOffset + k + 1, 8, theBlock.brr);
+    rawFile()->GetBytes(dwOffset + k + 1, 8, theBlock.brr);
     DecompBRRBlk(reinterpret_cast<int16_t*>(&buf[k * 32 / 9]),
                  &theBlock,
                  &prev1,

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -224,7 +224,7 @@ size_t CLIVGMRoot::UpdateCollections(size_t startOffset) {
   auto files = vgmFiles();
   for (int i = startOffset; i < files.size(); ++i) {
     auto targFile = variantToVGMFile(files[i]);
-    Format *fmt = targFile->GetFormat();
+    Format *fmt = targFile->format();
     if (fmt && fmt->matcher) {
       fmt->matcher->MakeCollectionsForFile(targFile);
     }

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -130,7 +130,7 @@ bool CLIVGMRoot::Init() {
           }
           // update collection name to be unique
           string newCollName = collNameIt->first + suffix;
-          vgmColls()[p.first]->SetName(&newCollName);
+          vgmColls()[p.first]->SetName(newCollName);
         }
       }
     }

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -86,7 +86,7 @@ QListWidget *ManualCollectionDialog::makeSequenceList() {
   for (auto seq : seqs) {
     auto seq_item = new QListWidgetItem(widget);
     seq_item->setData(Qt::UserRole, QVariant::fromValue(static_cast<void*>(seq)));
-    widget->setItemWidget(seq_item, new QRadioButton(QString::fromStdString(*seq->GetName())));
+    widget->setItemWidget(seq_item, new QRadioButton(QString::fromStdString(seq->name())));
   }
 
   return widget;
@@ -107,7 +107,7 @@ QListWidget *ManualCollectionDialog::makeInstrumentSetList() {
   for (auto instrSet : instrSets) {
     auto instrset_item = new QListWidgetItem(widget);
     instrset_item->setData(Qt::UserRole, QVariant::fromValue(static_cast<void*>(instrSet)));
-    widget->setItemWidget(instrset_item, new QCheckBox(QString::fromStdString(*instrSet->GetName())));
+    widget->setItemWidget(instrset_item, new QCheckBox(QString::fromStdString(instrSet->name())));
   }
 
   return widget;
@@ -128,7 +128,7 @@ QListWidget *ManualCollectionDialog::makeSampleCollectionList() {
   for (auto sampColl : sampColls) {
     auto sampcoll_item = new QListWidgetItem(widget);
     sampcoll_item->setData(Qt::UserRole, QVariant::fromValue(static_cast<void*>(sampColl)));
-    widget->setItemWidget(sampcoll_item, new QCheckBox(QString::fromStdString(*sampColl->GetName())));
+    widget->setItemWidget(sampcoll_item, new QCheckBox(QString::fromStdString(sampColl->name())));
   }
 
   return widget;

--- a/src/ui/qt/services/MenuManager.h
+++ b/src/ui/qt/services/MenuManager.h
@@ -230,7 +230,7 @@ public:
   struct has_getname : std::false_type {};
 
   template <typename Base>
-  struct has_getname<Base, decltype(std::declval<Base>().GetName(), void())> : std::true_type {};
+  struct has_getname<Base, decltype(std::declval<Base>().name(), void())> : std::true_type {};
 
   /**
  * Create a QMenu populated with actions for the commands common to all of the instances in the provided vector
@@ -275,7 +275,7 @@ public:
               } else {
                 std::string suggestedFileName;
                 if constexpr (has_getname<T>::value) {
-                  suggestedFileName = ConvertToSafeFileName(*(*items)[0]->GetName());
+                  suggestedFileName = ConvertToSafeFileName((*items)[0]->name());
                 }
                 auto fileExtension = get<std::string>(propSpec.defaultValue);
                 auto path = OpenSaveFileDialog(suggestedFileName, fileExtension);

--- a/src/ui/qt/services/NotificationCenter.cpp
+++ b/src/ui/qt/services/NotificationCenter.cpp
@@ -21,7 +21,7 @@ void NotificationCenter::updateStatusForItem(VGMItem* item) {
     return;
   }
 
-  QString name = QString::fromStdString(item->name);
+  QString name = QString::fromStdString(item->name());
   QString description = QString::fromStdString(item->description());
 
   QString formattedName = QString{"<b>%1</b>"}.arg(name);

--- a/src/ui/qt/services/NotificationCenter.cpp
+++ b/src/ui/qt/services/NotificationCenter.cpp
@@ -22,7 +22,7 @@ void NotificationCenter::updateStatusForItem(VGMItem* item) {
   }
 
   QString name = QString::fromStdString(item->name);
-  QString description = QString::fromStdString(item->GetDescription());
+  QString description = QString::fromStdString(item->description());
 
   QString formattedName = QString{"<b>%1</b>"}.arg(name);
   QIcon icon = iconForItemType(item->GetIcon());

--- a/src/ui/qt/services/commands/SaveCommands.h
+++ b/src/ui/qt/services/commands/SaveCommands.h
@@ -127,7 +127,7 @@ public:
       // and the Save() function still expects a file path, so we construct file paths for each file using GetName()
       if (auto specificFile = dynamic_cast<TSavable*>(file)) {
         auto fileExtension = (GetExtension() == "") ? "" : (std::string(".") + GetExtension());
-        fs::path filePath = path / fs::path(*file->GetName() + fileExtension);
+        fs::path filePath = path / fs::path(file->name() + fileExtension);
         Save(filePath.generic_string(), specificFile);
       }
     }

--- a/src/ui/qt/util/Helpers.cpp
+++ b/src/ui/qt/util/Helpers.cpp
@@ -182,7 +182,7 @@ QColor textColorForEventColor(VGMItem::EventColor eventColor) {
 }
 
 QString getFullDescriptionForTooltip(VGMItem* item) {
-  QString name = QString::fromStdString(item->name);
+  QString name = QString::fromStdString(item->name());
   QString description = QString::fromStdString(item->description());
 
   return QString{"<nobr><h3>%1</h3>%2</nobr>"}.arg(name, description);

--- a/src/ui/qt/util/Helpers.cpp
+++ b/src/ui/qt/util/Helpers.cpp
@@ -183,7 +183,7 @@ QColor textColorForEventColor(VGMItem::EventColor eventColor) {
 
 QString getFullDescriptionForTooltip(VGMItem* item) {
   QString name = QString::fromStdString(item->name);
-  QString description = QString::fromStdString(item->GetDescription());
+  QString description = QString::fromStdString(item->description());
 
   return QString{"<nobr><h3>%1</h3>%2</nobr>"}.arg(name, description);
 }

--- a/src/ui/qt/workarea/RawFileListView.cpp
+++ b/src/ui/qt/workarea/RawFileListView.cpp
@@ -194,7 +194,7 @@ void RawFileListView::onVGMFileSelected(const VGMFile* vgmfile, const QWidget* c
     return;
   }
 
-  auto it = std::ranges::find(qtVGMRoot.rawFiles(), vgmfile->rawfile);
+  auto it = std::ranges::find(qtVGMRoot.rawFiles(), vgmfile->rawFile());
   if (it == qtVGMRoot.rawFiles().end())
     return;
   int row = static_cast<int>(std::distance(qtVGMRoot.rawFiles().begin(), it));

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -86,7 +86,7 @@ void VGMCollNameEditor::setModelData(QWidget *editor, QAbstractItemModel *model,
                                      const QModelIndex &index) const {
   auto *line_edit = qobject_cast<QLineEdit *>(editor);
   auto new_name = line_edit->text().toStdString();
-  qtVGMRoot.vgmColls()[index.row()]->SetName(&new_name);
+  qtVGMRoot.vgmColls()[index.row()]->SetName(new_name);
   model->dataChanged(index, index);
 }
 

--- a/src/ui/qt/workarea/VGMCollView.cpp
+++ b/src/ui/qt/workarea/VGMCollView.cpp
@@ -45,7 +45,7 @@ QVariant VGMCollViewModel::data(const QModelIndex &index, int role) const {
   }
 
   if (role == Qt::DisplayRole) {
-    return QString::fromStdString(*file->GetName());
+    return QString::fromStdString(file->name());
   } else if (role == Qt::DecorationRole) {
     return iconForFile(vgmFileToVariant(file));
   }
@@ -192,7 +192,7 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
 
     auto title = m_collection_title->text().toStdString();
     /* This makes a copy, no worries */
-    qtVGMRoot.vgmColls()[model_index.row()]->SetName(&title);
+    qtVGMRoot.vgmColls()[model_index.row()]->SetName(title);
 
     auto coll_list_model = collListSelModel->model();
     coll_list_model->dataChanged(coll_list_model->index(0, 0),

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -39,7 +39,7 @@ QVariant VGMFileListModel::data(const QModelIndex &index, int role) const {
   switch (index.column()) {
     case Property::Name: {
       if (role == Qt::DisplayRole) {
-        return QString::fromStdString(*vgmfile->GetName());
+        return QString::fromStdString(vgmfile->name());
       } else if (role == Qt::DecorationRole) {
         return iconForFile(vgmfilevariant);
       }

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -48,7 +48,7 @@ QVariant VGMFileListModel::data(const QModelIndex &index, int role) const {
 
     case Property::Format: {
       if (role == Qt::DisplayRole) {
-        return QString::fromStdString(vgmfile->GetFormatName());
+        return QString::fromStdString(vgmfile->formatName());
       }
       break;
     }

--- a/src/ui/qt/workarea/VGMFileTreeView.cpp
+++ b/src/ui/qt/workarea/VGMFileTreeView.cpp
@@ -253,7 +253,7 @@ int VGMFileTreeView::getSortedIndex(const QTreeWidgetItem* parent, const VGMTree
 }
 
 void VGMFileTreeView::setItemText(VGMItem* item, VGMTreeItem* treeItem) const {
-  auto name = QString::fromStdString(item->name);
+  auto name = QString::fromStdString(item->name());
   if (showDetails) {
     if (item->description().empty()) {
       treeItem->setText(0, QString{"<b>%1</b><br>Offset: 0x%2 | Length: 0x%3"}

--- a/src/ui/qt/workarea/VGMFileTreeView.cpp
+++ b/src/ui/qt/workarea/VGMFileTreeView.cpp
@@ -255,7 +255,7 @@ int VGMFileTreeView::getSortedIndex(const QTreeWidgetItem* parent, const VGMTree
 void VGMFileTreeView::setItemText(VGMItem* item, VGMTreeItem* treeItem) const {
   auto name = QString::fromStdString(item->name);
   if (showDetails) {
-    if (item->GetDescription().empty()) {
+    if (item->description().empty()) {
       treeItem->setText(0, QString{"<b>%1</b><br>Offset: 0x%2 | Length: 0x%3"}
                                .arg(name,
                                     QString::number(item->dwOffset, 16),
@@ -263,7 +263,7 @@ void VGMFileTreeView::setItemText(VGMItem* item, VGMTreeItem* treeItem) const {
     } else {
       treeItem->setText(0, QString{"<b>%1</b><br>%2<br>Offset: 0x%3 | Length: 0x%4"}
                                .arg(name,
-                                    QString::fromStdString(item->GetDescription()),
+                                    QString::fromStdString(item->description()),
                                     QString::number(item->dwOffset, 16),
                                     QString::number(item->unLength, 16)));
     }
@@ -271,7 +271,7 @@ void VGMFileTreeView::setItemText(VGMItem* item, VGMTreeItem* treeItem) const {
     treeItem->setText(0, name);
   }
   treeItem->setIcon(0, iconForItemType(item->GetIcon()));
-  treeItem->setToolTip(0, QString::fromStdString(item->GetDescription()));
+  treeItem->setToolTip(0, QString::fromStdString(item->description()));
 }
 
 void VGMFileTreeView::onShowDetailsChanged(bool show) {

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -21,7 +21,7 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
     : QMdiSubWindow(), m_vgmfile(vgmfile), m_hexview(new HexView(vgmfile)) {
   m_splitter = new SnappingSplitter(Qt::Horizontal, this);
 
-  setWindowTitle(QString::fromStdString(*m_vgmfile->GetName()));
+  setWindowTitle(QString::fromStdString(m_vgmfile->name()));
   setWindowIcon(iconForFile(vgmFileToVariant(vgmfile)));
   setAttribute(Qt::WA_DeleteOnClose);
 


### PR DESCRIPTION
- remove `VGMFile::name()` and `VGMFile::m_name` - they are redundant with VGMItem's name field
- rename `VGMItem::name` to `m_name`, make it private and add `name()` / `setName()`
- rename `VGMItem::vgmfile` to `m_vgmfile` and add `vgmFile()`
- rename `VGMItem::GetDescription()` to `description()`
- rename `VGMFile::GetFormat()` to `format()`
- rename `VGMFile::GetFormatName()` to `formatName()`
- add `VGMFile::setId()`
- make most VGMFile fields private

Plan is to squash this PR and add it to the .git-blame-ignore-revs list in the next PR.

## Motivation and Context
Code cleanup. Plus, it's necessary for VGMFile / RawFile to use a name() method in order to generalize the SaveAsOriginal menu command so that it can work with both VGMFile and RawFile. (see upcoming PR).

## How Has This Been Tested?
Files seem to be loading correctly and custom VGMFile/VGMItem names are still applied.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
