### PR TITLE
Use MenuManager with RawFileListView. Minor reorganization of MenuManager classes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -13,3 +13,6 @@ ed533cd46d853523d184ff1a60f769223ee97845
 
 # Reorganize core files into subdirectories
 57573b44cf5672a78bb6c81f8b5d9bb71808f770
+
+# Rename VGMItem / VGMFile fields
+2805d09d53698dd0e4745db8bb64497294c589d4

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(
   services/Settings.h
   services/NotificationCenter.cpp
   services/NotificationCenter.h
+  services/commands/Command.h
   services/commands/SaveCommands.h
   services/commands/GeneralCommands.h
   util/Colors.h

--- a/src/ui/qt/services/MenuManager.cpp
+++ b/src/ui/qt/services/MenuManager.cpp
@@ -10,29 +10,31 @@
 
 MenuManager::MenuManager() {
   RegisterCommands<VGMSeq, VGMItem>({
-      std::make_shared<CloseVGMFileCommand>(),
-      std::make_shared<CommandSeparator>(),
       std::make_shared<SaveAsMidiCommand>(),
-      std::make_shared<SaveAsOriginalFormatCommand>(),
+      std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
+      std::make_shared<CommandSeparator>(),
+      std::make_shared<CloseVGMFileCommand>(),
   });
   RegisterCommands<VGMInstrSet, VGMItem>({
-      std::make_shared<CloseVGMFileCommand>(),
-      std::make_shared<CommandSeparator>(),
       std::make_shared<SaveAsSF2Command>(),
       std::make_shared<SaveAsDLSCommand>(),
-      std::make_shared<SaveAsOriginalFormatCommand>(),
+      std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
+      std::make_shared<CommandSeparator>(),
+      std::make_shared<CloseVGMFileCommand>(),
   });
   RegisterCommands<VGMSampColl, VGMItem>({
-      std::make_shared<CloseVGMFileCommand>(),
-      std::make_shared<CommandSeparator>(),
       std::make_shared<SaveWavBatchCommand>(),
-      std::make_shared<SaveAsOriginalFormatCommand>(),
-  });
+      std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
+      std::make_shared<CommandSeparator>(),
+      std::make_shared<CloseVGMFileCommand>(),
+});
   RegisterCommands<VGMFile, VGMItem>({
       std::make_shared<CloseVGMFileCommand>(),
       std::make_shared<CommandSeparator>(),
-      std::make_shared<SaveAsOriginalFormatCommand>(),
-  });
+      std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
+      std::make_shared<CommandSeparator>(),
+      std::make_shared<CloseVGMFileCommand>(),
+});
 
   RegisterCommands<RawFile>({
       std::make_shared<CloseVGMFileCommand>(),

--- a/src/ui/qt/services/MenuManager.cpp
+++ b/src/ui/qt/services/MenuManager.cpp
@@ -27,17 +27,19 @@ MenuManager::MenuManager() {
       std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<CloseVGMFileCommand>(),
-});
+  });
   RegisterCommands<VGMFile, VGMItem>({
       std::make_shared<CloseVGMFileCommand>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<CloseVGMFileCommand>(),
-});
+  });
 
   RegisterCommands<RawFile>({
-      std::make_shared<CloseVGMFileCommand>(),
+      std::make_shared<SaveAsOriginalFormatCommand<RawFile>>(),
+      std::make_shared<CommandSeparator>(),
+      std::make_shared<CloseRawFileCommand>(),
   });
 }
 

--- a/src/ui/qt/services/MenuManager.h
+++ b/src/ui/qt/services/MenuManager.h
@@ -8,8 +8,6 @@
 
 #include "services/commands/Command.h"
 #include <filesystem>
-#include <typeindex>
-#include <typeinfo>
 #include <QMenu>
 #include "common.h"
 #include "Root.h"

--- a/src/ui/qt/services/MenuManager.h
+++ b/src/ui/qt/services/MenuManager.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "services/commands/Command.h"
 #include <filesystem>
 #include <typeindex>
 #include <typeinfo>
@@ -17,116 +18,6 @@
 
 namespace fs = std::filesystem;
 
-class VGMFile;
-class VGMSeq;
-class VGMInstrSet;
-class VGMSampColl;
-class RawFile;
-class CommandSeparator;
-
-/**
- * Represents the type of value a property holds in a CommandContext's PropertyMap.
- */
-enum class PropertySpecValueType {
-  Path,           ///< Represents a file path or directory path if an ItemList property is present with > 1 items
-  DirPath,        ///< Represents a directory path
-  ItemList,       ///< Represents a list of items, such as selected files in the VGMFileListView
-};
-
-/**
- * A variant type used to store different types of property values in a PropertyMap
- */
-using PropertyValue = std::variant<
-    int,
-    float,
-    std::string,
-    std::shared_ptr<std::vector<VGMFile*>>,
-    std::shared_ptr<std::vector<VGMSeq*>>,
-    std::shared_ptr<std::vector<VGMInstrSet*>>,
-    std::shared_ptr<std::vector<VGMSampColl*>>,
-    std::shared_ptr<std::vector<RawFile*>>
->;
-
-using PropertyMap = std::map<std::string, PropertyValue>;
-
-/**
- * The base class for a command context. The command context provides an interface for commands
- * to receive data. CommandContexts are created indirectly by CommandContextFactories via the CreateContext() method.
- */
-class CommandContext {
-public:
-  virtual ~CommandContext() = default;
-};
-
-/**
- * PropertySpecifications specify the keys and values types required for the PropertyMap that will
- * be passed into a CommandContextFactory's CreateContext() method. A CommandContextFactory will
- * expose these specifications via the GetPropertySpecifications() method
- */
-struct PropertySpecification {
-  std::string key;
-  PropertySpecValueType valueType;
-  std::string description;
-  PropertyValue defaultValue;
-};
-
-using PropertySpecifications = std::vector<PropertySpecification>;
-
-/**
- * The base class of a factory for creating CommandContext objects. Implementations of this class are responsible
- * for creating a CommandContext that will be passed into a Command's Execute() method. It does this via the
- * CreateContext() method, which expects a PropertyMap. The key and value types required to be set in the PropertyMap
- * are given via the GetPropertySpecifications() method.
- */
-class CommandContextFactory {
-public:
-  virtual ~CommandContextFactory() = default;
-
-  /**
-   * Creates a CommandContext object based on the provided properties.
-   * @param properties A map of properties to be used for context creation.
-   * @return A shared pointer to the created CommandContext object.
-   */
-  [[nodiscard]] virtual std::shared_ptr<CommandContext> CreateContext(const PropertyMap& properties) const = 0;
-
-  /**
-   * Retrieves the specifications for the properties required to be set in the PropertyMap passed to CreateContext().
-   * @return A list of property specifications.
-   */
-  [[nodiscard]] virtual PropertySpecifications GetPropertySpecifications() const = 0;
-};
-
-
-/**
- * Base class for all commands. A Command is the same thing as a menu action. The GetContextFactory() method
- * provides a factory that can be used to generate the CommandContext required by the Execute method.
- */
-class Command {
-public:
-  virtual ~Command() = default;
-
-  /**
-   * Executes the command within the given context.
-   * @param context A reference to the CommandContext which will provide the data needed to execute the command.
-   */
-  virtual void Execute(CommandContext& context) = 0;
-
-  /**
-   * Retrieves the name of the command to appear in the UI. Commands must use unique Names, or they will
-   * break the behavior of batch command processing (an example of batch processing is
-   * selecting multiple sequences and executing the "Save to MIDI" command).
-   * @return The name of the command.
-   */
-  [[nodiscard]] virtual std::string Name() const = 0;
-
-  /**
-   * Gets the factory for creating a command context specific to this command.
-   * @return A shared pointer to the CommandContextFactory.
-   */
-  [[nodiscard]] virtual std::shared_ptr<CommandContextFactory> GetContextFactory() const = 0;
-};
-
-
 /**
  * MenuManager is the service responsible for the registration and retrieval of commands.
  */
@@ -137,6 +28,16 @@ public:
   using CommandsList = std::vector<std::shared_ptr<Command>>;
   template<typename T>
   using CheckedTypeEntry = std::pair<CheckFunc<T>, CommandsList>;
+
+  static auto the() {
+    static MenuManager* instance = new MenuManager();
+    return instance;
+  }
+
+  MenuManager(const MenuManager&) = delete;
+  MenuManager&operator=(const MenuManager&) = delete;
+  MenuManager(MenuManager&&) = delete;
+  MenuManager&operator=(MenuManager&&) = delete;
 
 private:
   std::map<std::type_index, std::vector<std::shared_ptr<Command>>> commandsForType;

--- a/src/ui/qt/services/commands/Command.h
+++ b/src/ui/qt/services/commands/Command.h
@@ -3,7 +3,8 @@
 
 #include <filesystem>
 #include <typeindex>
-#include <typeinfo>
+#include <variant>
+#include <vector>
 #include <map>
 
 class VGMFile;

--- a/src/ui/qt/services/commands/Command.h
+++ b/src/ui/qt/services/commands/Command.h
@@ -3,6 +3,7 @@
 
 #include <filesystem>
 #include <typeindex>
+#include <typeinfo>
 #include <map>
 
 class VGMFile;

--- a/src/ui/qt/services/commands/GeneralCommands.h
+++ b/src/ui/qt/services/commands/GeneralCommands.h
@@ -6,18 +6,8 @@
 
 #pragma once
 
-#include "services/MenuManager.h"
+#include "services/commands/Command.h"
 #include "VGMFile.h"
-
-class CommandSeparator : public Command {
-public:
-  CommandSeparator() = default;
-
-  void Execute(CommandContext&) override {}
-
-  [[nodiscard]] std::shared_ptr<CommandContextFactory> GetContextFactory() const override { return nullptr; }
-  [[nodiscard]] std::string Name() const override { return "separator"; }
-};
 
 /**
  * A command context that provides a vector of pointers

--- a/src/ui/qt/services/commands/SaveCommands.h
+++ b/src/ui/qt/services/commands/SaveCommands.h
@@ -142,17 +142,18 @@ public:
   virtual void Save(const std::string& path, TSavable* specificFile) const = 0;
 };
 
-class SaveAsOriginalFormatCommand : public SaveCommand<VGMFile> {
+template<typename TFile>
+class SaveAsOriginalFormatCommand : public SaveCommand<TFile> {
 public:
-  SaveAsOriginalFormatCommand() : SaveCommand<VGMFile>(false) {}
+  SaveAsOriginalFormatCommand() : SaveCommand<TFile>(false) {}
 
-  void Save(const std::string& path, VGMFile* file) const override {
+  void Save(const std::string& path, TFile* file) const override {
+    // SaveHelper(path, file, std::is_same<TFile, VGMFile>());
     conversion::SaveAsOriginal(*file, path);
   }
   [[nodiscard]] std::string Name() const override { return "Save as original format"; }
   [[nodiscard]] std::string GetExtension() const override { return ""; }
 };
-
 
 class SaveAsMidiCommand : public SaveCommand<VGMSeq, VGMFile> {
 public:

--- a/src/ui/qt/services/commands/SaveCommands.h
+++ b/src/ui/qt/services/commands/SaveCommands.h
@@ -148,7 +148,6 @@ public:
   SaveAsOriginalFormatCommand() : SaveCommand<TFile>(false) {}
 
   void Save(const std::string& path, TFile* file) const override {
-    // SaveHelper(path, file, std::is_same<TFile, VGMFile>());
     conversion::SaveAsOriginal(*file, path);
   }
   [[nodiscard]] std::string Name() const override { return "Save as original format"; }

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -12,13 +12,13 @@
 #include "Helpers.h"
 #include "QtVGMRoot.h"
 #include "MdiArea.h"
-#include "services/commands/GeneralCommands.h"
 #include "services/NotificationCenter.h"
 #include "VGMFile.h"
 #include "VGMInstrSet.h"
 #include "VGMSeq.h"
 #include "VGMMiscFile.h"
 #include "VGMSampColl.h"
+#include "services/MenuManager.h"
 
 /*
  *  VGMFileListModel
@@ -123,6 +123,8 @@ VGMFileListView::VGMFileListView(QWidget *parent) : TableView(parent) {
   setSelectionMode(QAbstractItemView::ExtendedSelection);
   setSelectionBehavior(QAbstractItemView::SelectRows);
 
+  setContextMenuPolicy(Qt::CustomContextMenu);
+
   connect(&qtVGMRoot, &QtVGMRoot::UI_RemoveVGMFile, this, &VGMFileListView::removeVGMFile);
   connect(this, &QAbstractItemView::customContextMenuRequested, this, &VGMFileListView::itemMenu);
   connect(this, &QAbstractItemView::doubleClicked, this, &VGMFileListView::requestVGMFileView);
@@ -130,7 +132,6 @@ VGMFileListView::VGMFileListView(QWidget *parent) : TableView(parent) {
 }
 
 void VGMFileListView::itemMenu(const QPoint &pos) {
-
   auto selectedFiles = std::make_shared<std::vector<VGMFile*>>();
 
   if (!selectionModel()->hasSelection()) {
@@ -145,7 +146,7 @@ void VGMFileListView::itemMenu(const QPoint &pos) {
       selectedFiles->push_back(variantToVGMFile(qtVGMRoot.vgmFiles()[index.row()]));
     }
   }
-  auto menu = menuManager.CreateMenuForItems<VGMItem>(selectedFiles);
+  auto menu = MenuManager::the()->CreateMenuForItems<VGMItem>(selectedFiles);
   menu->exec(mapToGlobal(pos));
   menu->deleteLater();
 }

--- a/src/ui/qt/workarea/VGMFileListView.h
+++ b/src/ui/qt/workarea/VGMFileListView.h
@@ -11,8 +11,6 @@
 #include <QSortFilterProxyModel>
 #include "TableView.h"
 
-#include "services/MenuManager.h"
-
 #include "VGMFile.h"
 
 class VGMFileListModel : public QAbstractTableModel {
@@ -51,8 +49,6 @@ class VGMFileListView final : public TableView {
     void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
     void keyPressEvent(QKeyEvent *input) override;
     void itemMenu(const QPoint &pos);
-
-    MenuManager menuManager;
 
     VGMFileListModel *view_model;
 };


### PR DESCRIPTION
This updates the RawFileListView class to use MenuManager. To enable this, I made some small changes to various MenuManager-related classes.

It may look like a lot of changes to the MenuManager, but rest assured, it's mostly moving stuff around. The only logical changes there are to make MenuManager a singleton, make SaveAsOriginalFormatCommand a generic class, and update the RawFile menu registration.

## Description
- generalize SaveAsOriginalFormatCommand so that it will support any class that implements a SaveAsOriginal() method
- reorder the Close command in VGMFile menus
- flesh out the RawFile MenuManager menu and use it in RawFileListView
- make MenuManager a singleton()
- move Command base class and types into its own header file to resolve circular dependency

## Motivation and Context
It would be good to unify context menu code to use the MenuManager service.

## How Has This Been Tested?
The RawFile menu commands are working for both single and multiple selection.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactoring

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
