### PR TITLE
VGMColl field and method name cleanup

### DIFF
--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -190,7 +190,7 @@ void VGMRoot::RemoveVGMColl(VGMColl *targColl) {
   else
     L_WARN("Requested deletion for VGMColl but it was not found");
 
-  targColl->RemoveFileAssocs();
+  targColl->removeFileAssocs();
   UI_RemoveVGMColl(targColl);
   delete targColl;
 }

--- a/src/main/components/Matcher.cpp
+++ b/src/main/components/Matcher.cpp
@@ -92,22 +92,22 @@ void FilegroupMatcher::MakeCollection(VGMInstrSet *instrset, VGMSampColl *sampco
   if (seqs.size() >= 1) {
     for(VGMSeq *seq : seqs) {
       VGMColl *coll = fmt->NewCollection();
-      coll->SetName(seq->name());
-      coll->UseSeq(seq);
-      coll->AddInstrSet(instrset);
-      coll->AddSampColl(sampcoll);
-      if (!coll->Load()) {
+      coll->setName(seq->name());
+      coll->useSeq(seq);
+      coll->addInstrSet(instrset);
+      coll->addSampColl(sampcoll);
+      if (!coll->load()) {
         delete coll;
       }
     }
   }
   else {
     VGMColl *coll = fmt->NewCollection();
-    coll->SetName(instrset->name());
-    coll->UseSeq(nullptr);
-    coll->AddInstrSet(instrset);
-    coll->AddSampColl(sampcoll);
-    if (!coll->Load()) {
+    coll->setName(instrset->name());
+    coll->useSeq(nullptr);
+    coll->addInstrSet(instrset);
+    coll->addSampColl(sampcoll);
+    if (!coll->load()) {
       delete coll;
     }
   }
@@ -145,15 +145,15 @@ bool FilegroupMatcher::MakeCollectionsForFile(VGMFile* /*file*/) {
     // into the same VGMCollection
     for(VGMSeq *seq : seqs) {
       VGMColl *coll = fmt->NewCollection();
-      coll->SetName(seq->name());
-      coll->UseSeq(seq);
+      coll->setName(seq->name());
+      coll->useSeq(seq);
       for (VGMInstrSet* instrset : instrsets) {
         for (VGMSampColl* sampcoll : sampcolls) {
-          coll->AddInstrSet(instrset);
-          coll->AddSampColl(sampcoll);
+          coll->addInstrSet(instrset);
+          coll->addSampColl(sampcoll);
         }
       }
-      if (!coll->Load()) {
+      if (!coll->load()) {
         delete coll;
       }
     }

--- a/src/main/components/Matcher.h
+++ b/src/main/components/Matcher.h
@@ -74,11 +74,11 @@ class SimpleMatcher : public Matcher {
           VGMColl *coll = fmt->NewCollection();
           if (!coll)
             return false;
-          coll->SetName(seq->name());
-          coll->UseSeq(seq);
-          coll->AddInstrSet(matchingInstrSet);
-          coll->AddSampColl(matchingSampColl);
-          if (!coll->Load()) {
+          coll->setName(seq->name());
+          coll->useSeq(seq);
+          coll->addInstrSet(matchingInstrSet);
+          coll->addSampColl(matchingSampColl);
+          if (!coll->load()) {
             delete coll;
             return false;
           }
@@ -87,10 +87,10 @@ class SimpleMatcher : public Matcher {
         VGMColl *coll = fmt->NewCollection();
         if (!coll)
           return false;
-        coll->SetName(seq->name());
-        coll->UseSeq(seq);
-        coll->AddInstrSet(matchingInstrSet);
-        if (!coll->Load()) {
+        coll->setName(seq->name());
+        coll->useSeq(seq);
+        coll->addInstrSet(matchingInstrSet);
+        if (!coll->load()) {
           delete coll;
           return false;
         }
@@ -138,20 +138,20 @@ class SimpleMatcher : public Matcher {
           VGMColl *coll = fmt->NewCollection();
           if (!coll)
             return false;
-          coll->SetName(matchingSeq->name());
-          coll->UseSeq(matchingSeq);
-          coll->AddInstrSet(instrset);
-          coll->AddSampColl(matchingSampColl);
-          coll->Load();
+          coll->setName(matchingSeq->name());
+          coll->useSeq(matchingSeq);
+          coll->addInstrSet(instrset);
+          coll->addSampColl(matchingSampColl);
+          coll->load();
         }
       } else {
         VGMColl *coll = fmt->NewCollection();
         if (!coll)
           return false;
-        coll->SetName(matchingSeq->name());
-        coll->UseSeq(matchingSeq);
-        coll->AddInstrSet(instrset);
-        if (!coll->Load()) {
+        coll->setName(matchingSeq->name());
+        coll->useSeq(matchingSeq);
+        coll->addInstrSet(instrset);
+        if (!coll->load()) {
           delete coll;
           return false;
         }
@@ -198,11 +198,11 @@ class SimpleMatcher : public Matcher {
           VGMColl *coll = fmt->NewCollection();
           if (!coll)
             return false;
-          coll->SetName(matchingSeq->name());
-          coll->UseSeq(matchingSeq);
-          coll->AddInstrSet(matchingInstrSet);
-          coll->AddSampColl(sampcoll);
-          if (!coll->Load()) {
+          coll->setName(matchingSeq->name());
+          coll->useSeq(matchingSeq);
+          coll->addInstrSet(matchingInstrSet);
+          coll->addSampColl(sampcoll);
+          if (!coll->load()) {
             delete coll;
             return false;
           }

--- a/src/main/components/VGMColl.h
+++ b/src/main/components/VGMColl.h
@@ -23,32 +23,37 @@ class VGMColl {
   explicit VGMColl(std::string name = "Unnamed collection");
   virtual ~VGMColl() = default;
 
-  void RemoveFileAssocs();
-  [[nodiscard]] const std::string& GetName() const;
-  void SetName(const std::string& newName);
-  [[nodiscard]] VGMSeq *GetSeq() const;
-  void UseSeq(VGMSeq *theSeq);
-  void AddInstrSet(VGMInstrSet *theInstrSet);
-  void AddSampColl(VGMSampColl *theSampColl);
-  void AddMiscFile(VGMMiscFile *theMiscFile);
-  bool Load();
-  virtual bool LoadMain() { return true; }
-  virtual bool CreateDLSFile(DLSFile &dls);
-  virtual SF2File *CreateSF2File();
-  virtual void PreSynthFileCreation() {}
-  virtual SynthFile *CreateSynthFile();
-  virtual bool MainDLSCreation(DLSFile &dls);
-  virtual void PostSynthFileCreation() {}
+  void removeFileAssocs();
+  [[nodiscard]] const std::string& name() const;
+  void setName(const std::string& newName);
+  [[nodiscard]] VGMSeq* seq() const;
+  void useSeq(VGMSeq* theSeq);
+  void addInstrSet(VGMInstrSet* theInstrSet);
+  void addSampColl(VGMSampColl* theSampColl);
+  void addMiscFile(VGMMiscFile* theMiscFile);
+  bool load();
+  virtual bool loadMain() { return true; }
+  virtual bool createDLSFile(DLSFile& dls);
+  virtual SF2File* createSF2File();
+  virtual void preSynthFileCreation() {}
+  virtual SynthFile* createSynthFile();
+  virtual bool mainDLSCreation(DLSFile& dls);
+  virtual void postSynthFileCreation() {}
 
   bool containsVGMFile(const VGMFile*) const;
 
-  VGMSeq *seq{};
-  std::vector<VGMInstrSet *> instrsets;
-  std::vector<VGMSampColl *> sampcolls;
-  std::vector<VGMMiscFile *> miscfiles;
+  const std::vector<VGMInstrSet*>& instrSets() { return m_instrsets; }
+  const std::vector<VGMSampColl*>& sampColls() { return m_sampcolls; }
+  const std::vector<VGMMiscFile*>& miscFiles() { return m_miscfiles; }
 
- protected:
-  static void UnpackSampColl(DLSFile &dls, const VGMSampColl *sampColl, std::vector<VGMSamp *> &finalSamps);
-  static void UnpackSampColl(SynthFile &synthfile, const VGMSampColl *sampColl, std::vector<VGMSamp *> &finalSamps);
-  std::string name;
+ private:
+  static void unpackSampColl(DLSFile& dls, const VGMSampColl* sampColl, std::vector<VGMSamp*>& finalSamps);
+  static void unpackSampColl(SynthFile& synthfile, const VGMSampColl* sampColl, std::vector<VGMSamp*>& finalSamps);
+
+  std::vector<VGMInstrSet*> m_instrsets;
+  std::vector<VGMSampColl*> m_sampcolls;
+  std::vector<VGMMiscFile*> m_miscfiles;
+
+  VGMSeq* m_seq{};
+  std::string m_name;
 };

--- a/src/main/conversion/VGMExport.cpp
+++ b/src/main/conversion/VGMExport.cpp
@@ -20,7 +20,7 @@ bool SaveAsDLS(const VGMInstrSet &set, const std::string &filepath) {
     return false;
   }
 
-  if (set.assocColls.front()->CreateDLSFile(dlsfile)) {
+  if (set.assocColls.front()->createDLSFile(dlsfile)) {
     return dlsfile.SaveDLSFile(filepath);
   }
   return false;
@@ -31,7 +31,7 @@ bool SaveAsSF2(const VGMInstrSet &set, const std::string &filepath) {
     return false;
   }
 
-  if (auto sf2file = set.assocColls.front()->CreateSF2File(); sf2file) {
+  if (auto sf2file = set.assocColls.front()->createSF2File(); sf2file) {
     bool bResult = sf2file->SaveSF2File(filepath);
     delete sf2file;
     return bResult;

--- a/src/main/conversion/VGMExport.h
+++ b/src/main/conversion/VGMExport.h
@@ -38,22 +38,22 @@ bool SaveAsOriginal(const RawFile& rawfile, const std::string& filepath);
 
 template <Target options>
 void SaveAs(VGMColl &coll, const std::string &dir_path) {
-  auto filename = ConvertToSafeFileName(coll.GetName());
+  auto filename = ConvertToSafeFileName(coll.name());
   auto filepath = dir_path + "/" + filename;
 
   if constexpr ((options & Target::MIDI) != 0) {
-    coll.seq->SaveAsMidi(filepath + ".mid");
+    coll.seq()->SaveAsMidi(filepath + ".mid");
   }
 
   if constexpr ((options & Target::DLS) != 0) {
     DLSFile dlsfile;
-    if (coll.CreateDLSFile(dlsfile)) {
+    if (coll.createDLSFile(dlsfile)) {
       dlsfile.SaveDLSFile(filepath + ".dls");
     }
   }
 
   if constexpr ((options & Target::SF2) != 0) {
-    if (SF2File *sf2file = coll.CreateSF2File()) {
+    if (SF2File *sf2file = coll.createSF2File()) {
       sf2file->SaveSF2File(filepath + ".sf2");
     }
   }

--- a/src/main/formats/Akao/AkaoFormat.cpp
+++ b/src/main/formats/Akao/AkaoFormat.cpp
@@ -10,9 +10,9 @@
 #include "AkaoInstr.h"
 #include "PSXSPU.h"
 
-bool AkaoColl::LoadMain() {
-  AkaoInstrSet *instrset = reinterpret_cast<AkaoInstrSet *>(instrsets[0]);
-  AkaoSampColl *sampcoll = reinterpret_cast<AkaoSampColl *>(sampcolls[0]);
+bool AkaoColl::loadMain() {
+  AkaoInstrSet *instrset = reinterpret_cast<AkaoInstrSet *>(instrSets()[0]);
+  AkaoSampColl *sampcoll = reinterpret_cast<AkaoSampColl *>(sampColls()[0]);
 
   //Set the sample numbers of each region using the articulation data references of each region
   for (uint32_t i = 0; i < instrset->aInstrs.size(); i++) {
@@ -55,13 +55,13 @@ bool AkaoColl::LoadMain() {
   return true;
 }
 
-void AkaoColl::PreSynthFileCreation() {
-  if (!static_cast<AkaoSeq*>(seq)->bUsesIndividualArts)    //only do this if the 0xA1 event is actually used
+void AkaoColl::preSynthFileCreation() {
+  if (!static_cast<AkaoSeq*>(seq())->bUsesIndividualArts)    //only do this if the 0xA1 event is actually used
     return;
 
-  AkaoInstrSet *instrSet = reinterpret_cast<AkaoInstrSet *>(instrsets[0]);
+  AkaoInstrSet *instrSet = reinterpret_cast<AkaoInstrSet *>(instrSets()[0]);
 
-  AkaoSampColl *sampcoll = reinterpret_cast<AkaoSampColl *>(sampcolls[0]);
+  AkaoSampColl *sampcoll = reinterpret_cast<AkaoSampColl *>(sampColls()[0]);
   const uint32_t numArts = static_cast<uint32_t>(sampcoll->akArts.size());
   numAddedInstrs = numArts;
 
@@ -86,13 +86,13 @@ void AkaoColl::PreSynthFileCreation() {
   }
 }
 
-void AkaoColl::PostSynthFileCreation() {
+void AkaoColl::postSynthFileCreation() {
   //if the 0xA1 event isn't used in the sequence, then we didn't modify the instrset
   //so skip this
-  if (!static_cast<AkaoSeq*>(seq)->bUsesIndividualArts)
+  if (!static_cast<AkaoSeq*>(seq())->bUsesIndividualArts)
     return;
 
-  AkaoInstrSet *instrSet = reinterpret_cast<AkaoInstrSet *>(instrsets[0]);
+  AkaoInstrSet *instrSet = reinterpret_cast<AkaoInstrSet *>(instrSets()[0]);
   for (size_t i = 0; i < numAddedInstrs; i++) {
     delete instrSet->aInstrs.back();
     instrSet->aInstrs.pop_back();

--- a/src/main/formats/Akao/AkaoFormat.h
+++ b/src/main/formats/Akao/AkaoFormat.h
@@ -15,9 +15,9 @@ class AkaoColl final :
  public:
   explicit AkaoColl(std::string name = "Unnamed Collection") : VGMColl(std::move(name)), origInstrSet(nullptr), numAddedInstrs(0) {}
 
-  bool LoadMain() override;
-  void PreSynthFileCreation() override;
-  void PostSynthFileCreation() override;
+  bool loadMain() override;
+  void preSynthFileCreation() override;
+  void postSynthFileCreation() override;
 
   AkaoInstrSet *origInstrSet;
   uint32_t numAddedInstrs;

--- a/src/main/formats/CPS/CPS1Scanner.cpp
+++ b/src/main/formats/CPS/CPS1Scanner.cpp
@@ -136,10 +136,10 @@ void CPS1Scanner::LoadCPS1(MAMEGame *gameentry, CPSFormatVer fmt_ver) {
     auto collName = fmt::format("{} song {}", gameentry->name, seqNum++);
     VGMColl* coll = new VGMColl(collName);
 
-    coll->UseSeq(newSeq);
-    coll->AddInstrSet(instrset);
-    coll->AddSampColl(sampcoll);
-    if (!coll->Load()) {
+    coll->useSeq(newSeq);
+    coll->addInstrSet(instrset);
+    coll->addSampColl(sampcoll);
+    if (!coll->load()) {
       delete coll;
     }
   }

--- a/src/main/formats/CPS/CPS2Scanner.cpp
+++ b/src/main/formats/CPS/CPS2Scanner.cpp
@@ -212,13 +212,13 @@ void CPS2Scanner::Scan(RawFile* /*file*/, void* info) {
     std::string seqName = fmt::format("{} seq {}", gameentry->name, k / 4);
     CPSSeq *newSeq = new CPSSeq(programFile, seqPointer, fmt_ver, seqName);
     if (newSeq->LoadVGMFile()) {
-      coll->UseSeq(newSeq);
-      coll->AddInstrSet(instrset);
-      coll->AddSampColl(sampcoll);
-      coll->AddMiscFile(sampInfoTable);
+      coll->useSeq(newSeq);
+      coll->addInstrSet(instrset);
+      coll->addSampColl(sampcoll);
+      coll->addMiscFile(sampInfoTable);
       if (articTable)
-        coll->AddMiscFile(articTable);
-      if (!coll->Load()) {
+        coll->addMiscFile(articTable);
+      if (!coll->load()) {
         delete coll;
       }
     } else {

--- a/src/main/formats/HOSA/HOSAScanner.cpp
+++ b/src/main/formats/HOSA/HOSAScanner.cpp
@@ -49,10 +49,10 @@ void HOSAScanner::Scan(RawFile *file, void *info) {
   }
 
   VGMColl *coll = new VGMColl(seq->name());
-  coll->UseSeq(seq);
-  coll->AddInstrSet(instrset);
-  coll->AddSampColl(sampcoll);
-  if (!coll->Load()) {
+  coll->useSeq(seq);
+  coll->addInstrSet(instrset);
+  coll->addSampColl(sampcoll);
+  if (!coll->load()) {
     delete coll;
   }
 

--- a/src/main/formats/MP2k/MP2kScanner.cpp
+++ b/src/main/formats/MP2k/MP2kScanner.cpp
@@ -134,11 +134,11 @@ void MP2kScanner::Scan(RawFile *file, void *info) {
       if (seq != seqs.end()) {
         for (auto seqval : seq->second) {
           auto coll = new VGMColl("MP2k Collection");
-          coll->UseSeq(seqval);
-          coll->AddInstrSet(iset);
-          coll->AddSampColl(iset->sampColl);
+          coll->useSeq(seqval);
+          coll->addInstrSet(iset);
+          coll->addSampColl(iset->sampColl);
 
-          if (!coll->Load()) {
+          if (!coll->load()) {
             delete coll;
           }
         }

--- a/src/main/formats/NDS/NDSScanner.cpp
+++ b/src/main/formats/NDS/NDSScanner.cpp
@@ -246,7 +246,7 @@ uint32_t NDSScanner::LoadFromSDAT(RawFile *file, uint32_t baseOff) {
       }
 
       VGMColl *coll = new VGMColl(seqNames[i]);
-      coll->UseSeq(NewNDSSeq);
+      coll->useSeq(NewNDSSeq);
       uint32_t bnkIndex = 0;
       for (uint32_t j = 0; j < BNKs.size(); j++) {
         if (seqFileBnks[i] == BNKs[j].first) {
@@ -256,14 +256,14 @@ uint32_t NDSScanner::LoadFromSDAT(RawFile *file, uint32_t baseOff) {
       }
       
       NDSInstrSet *instrset = BNKs[bnkIndex].second;
-      coll->AddSampColl(psg_sampcoll);
-      coll->AddInstrSet(BNKs[bnkIndex].second);
+      coll->addSampColl(psg_sampcoll);
+      coll->addInstrSet(BNKs[bnkIndex].second);
       for (int j = 0; j < 4; j++) {
         short WAnum = bnkWAs[seqFileBnks[i]][j];
         if (WAnum != -1)
-          coll->AddSampColl(WAs[WAnum]);
+          coll->addSampColl(WAs[WAnum]);
       }
-      if (!coll->Load()) {
+      if (!coll->load()) {
         delete coll;
       }
     }

--- a/src/main/formats/TriAcePS1/TriAcePS1Scanner.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1Scanner.cpp
@@ -77,10 +77,10 @@ void TriAcePS1Scanner::SearchForSLZSeq(RawFile *file) {
 
     std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
     VGMColl *coll = new VGMColl(name);
-    coll->UseSeq(seq);
+    coll->useSeq(seq);
     for (uint32_t i = 0; i < instrsets.size(); i++)
-      coll->AddInstrSet(instrsets[i]);
-    if (!coll->Load()) {
+      coll->addInstrSet(instrsets[i]);
+    if (!coll->load()) {
       delete coll;
     }
   }

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -157,10 +157,10 @@ bool CLIVGMRoot::ExportCollection(VGMColl* coll) {
 }
 
 bool CLIVGMRoot::SaveMidi(const VGMColl* coll) {
-  if (coll->m_seq != nullptr) {
+  if (coll->seq() != nullptr) {
     string collName = coll->name();
     string filepath = UI_GetSaveFilePath(collName, "mid");
-    if (!coll->m_seq->SaveAsMidi(filepath)) {
+    if (!coll->seq()->SaveAsMidi(filepath)) {
       L_ERROR("Failed to save MIDI file");
       return false;
     }

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -80,7 +80,7 @@ bool CLIVGMRoot::Init() {
     else {
       for(size_t i = numColls; i < GetNumCollections(); ++i) {
         VGMColl* coll = vgmColls()[i];
-        string collName = coll->GetName();
+        string collName = coll->name();
         auto it = collNameMap.find(collName);
         pair<size_t, fs::path> p = make_pair(i, infile);
         if (it == collNameMap.end()) {
@@ -130,7 +130,7 @@ bool CLIVGMRoot::Init() {
           }
           // update collection name to be unique
           string newCollName = collNameIt->first + suffix;
-          vgmColls()[p.first]->SetName(newCollName);
+          vgmColls()[p.first]->setName(newCollName);
         }
       }
     }
@@ -144,23 +144,23 @@ bool CLIVGMRoot::Init() {
 bool CLIVGMRoot::ExportAllCollections() {
   bool success = true;
   for (VGMColl* coll : vgmColls()) {
-    string collName = coll->GetName();
+    string collName = coll->name();
     success &= ExportCollection(coll);
   }
   return success;
 }
 
 bool CLIVGMRoot::ExportCollection(VGMColl* coll) {
-    string collName = coll->GetName();
+    string collName = coll->name();
     cout << "Exporting: " << collName << endl;
     return SaveMidi(coll) & SaveSF2(coll) & SaveDLS(coll);
 }
 
 bool CLIVGMRoot::SaveMidi(const VGMColl* coll) {
-  if (coll->seq != nullptr) {
-    string collName = coll->GetName();
+  if (coll->m_seq != nullptr) {
+    string collName = coll->name();
     string filepath = UI_GetSaveFilePath(collName, "mid");
-    if (!coll->seq->SaveAsMidi(filepath)) {
+    if (!coll->m_seq->SaveAsMidi(filepath)) {
       L_ERROR("Failed to save MIDI file");
       return false;
     }
@@ -170,9 +170,9 @@ bool CLIVGMRoot::SaveMidi(const VGMColl* coll) {
 }
 
 bool CLIVGMRoot::SaveSF2(VGMColl* coll) {
-  string collName = coll->GetName();
+  string collName = coll->name();
   string filepath = UI_GetSaveFilePath(collName, "sf2");
-  SF2File *sf2file = coll->CreateSF2File();
+  SF2File *sf2file = coll->createSF2File();
   bool success = false;
   if (sf2file != nullptr) {
     if (sf2file->SaveSF2File(filepath)) {
@@ -190,11 +190,11 @@ bool CLIVGMRoot::SaveSF2(VGMColl* coll) {
 }
 
 bool CLIVGMRoot::SaveDLS(VGMColl* coll) {
-  string collName = coll->GetName();
+  string collName = coll->name();
   string filepath = UI_GetSaveFilePath(collName, "dls");
   DLSFile dlsfile;
   bool success = false;
-  if (coll->CreateDLSFile(dlsfile)) {
+  if (coll->createDLSFile(dlsfile)) {
     if (dlsfile.SaveDLSFile(filepath)) {
       success = true;
     }

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -151,17 +151,17 @@ void ManualCollectionDialog::createCollection() {
     QMessageBox::critical(this, "Error creating collection", "A music sequence must be selected");
     return;
   }
-  coll->UseSeq(chosen_seq);
+  coll->useSeq(chosen_seq);
 
   for (int i = 0; i < m_instr_list->count(); i++) {
     auto item = m_instr_list->item(i);
     auto radio = qobject_cast<QCheckBox *>(m_instr_list->itemWidget(item));
     if (radio->checkState() == (Qt::Checked)) {
       auto chosen_set = static_cast<VGMInstrSet *>(item->data(Qt::UserRole).value<void *>());
-      coll->AddInstrSet(chosen_set);
+      coll->addInstrSet(chosen_set);
     }
   }
-  if (coll->instrsets.empty()) {
+  if (coll->instrSets().empty()) {
     QMessageBox::critical(this, "Error creating collection",
                           "At least an instrument set must be selected");
     return;
@@ -172,10 +172,10 @@ void ManualCollectionDialog::createCollection() {
     auto radio = qobject_cast<QCheckBox *>(m_samp_list->itemWidget(item));
     if (radio->checkState() == (Qt::Checked)) {
       auto sampcoll = static_cast<VGMSampColl *>(item->data(Qt::UserRole).value<void *>());
-      coll->AddSampColl(sampcoll);
+      coll->addSampColl(sampcoll);
     }
   }
-  if (coll->sampcolls.empty()) {
+  if (coll->sampColls().empty()) {
     QMessageBox::warning(this, windowTitle(),
                           "No sample collections were selected\nThe instrument bank will be silent...");
   }

--- a/src/ui/qt/SequencePlayer.cpp
+++ b/src/ui/qt/SequencePlayer.cpp
@@ -158,13 +158,13 @@ bool SequencePlayer::playCollection(VGMColl *coll) {
     return false;
   }
 
-  VGMSeq *seq = coll->GetSeq();
+  VGMSeq *seq = coll->seq();
   if (!seq) {
     L_ERROR("Failed to play collection as it lacks sequence data.");
     return false;
   }
 
-  SF2File *sf2 = coll->CreateSF2File();
+  SF2File *sf2 = coll->createSF2File();
   if (!sf2) {
     L_ERROR("Failed to play collection as a soundfont file could not be produced.");
     return false;
@@ -228,7 +228,7 @@ bool SequencePlayer::playCollection(VGMColl *coll) {
   m_active_vgmcoll = coll;
   m_active_stream = midi_stream;
   m_loaded_sf = sf2_handle;
-  m_song_title = QString::fromStdString(m_active_vgmcoll->GetName());
+  m_song_title = QString::fromStdString(m_active_vgmcoll->name());
   toggle();
 
   return true;

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -56,7 +56,7 @@ int VGMCollListViewModel::rowCount(const QModelIndex &) const {
 
 QVariant VGMCollListViewModel::data(const QModelIndex &index, int role) const {
   if (role == Qt::DisplayRole || role == Qt::EditRole) {
-    return QString::fromStdString(qtVGMRoot.vgmColls()[index.row()]->GetName());
+    return QString::fromStdString(qtVGMRoot.vgmColls()[index.row()]->name());
   } else if (role == Qt::DecorationRole) {
     return VGMCollIcon();
   }
@@ -86,7 +86,7 @@ void VGMCollNameEditor::setModelData(QWidget *editor, QAbstractItemModel *model,
                                      const QModelIndex &index) const {
   auto *line_edit = qobject_cast<QLineEdit *>(editor);
   auto new_name = line_edit->text().toStdString();
-  qtVGMRoot.vgmColls()[index.row()]->SetName(new_name);
+  qtVGMRoot.vgmColls()[index.row()]->setName(new_name);
   model->dataChanged(index, index);
 }
 

--- a/src/ui/qt/workarea/VGMCollView.cpp
+++ b/src/ui/qt/workarea/VGMCollView.cpp
@@ -34,8 +34,8 @@ int VGMCollViewModel::rowCount(const QModelIndex &parent) const {
     return 0;
   }
   // plus one because of the VGMColl sequence
-  return static_cast<int>(m_coll->instrsets.size() + m_coll->sampcolls.size() +
-                          m_coll->miscfiles.size() + 1);
+  return static_cast<int>(m_coll->instrSets().size() + m_coll->sampColls().size() +
+                          m_coll->miscFiles().size() + 1);
 }
 
 QVariant VGMCollViewModel::data(const QModelIndex &index, int role) const {
@@ -66,24 +66,24 @@ void VGMCollViewModel::handleNewCollSelected(const QModelIndex& modelIndex) {
 
 VGMFile *VGMCollViewModel::fileFromIndex(const QModelIndex& index) const {
   size_t row = index.row();
-  auto num_instrsets = m_coll->instrsets.size();
-  auto num_sampcolls = m_coll->sampcolls.size();
-  auto num_miscfiles = m_coll->miscfiles.size();
+  auto num_instrsets = m_coll->instrSets().size();
+  auto num_sampcolls = m_coll->sampColls().size();
+  auto num_miscfiles = m_coll->miscFiles().size();
 
   if (row < num_miscfiles) {
-    return m_coll->miscfiles[row];
+    return m_coll->miscFiles()[row];
   }
 
   row -= num_miscfiles;
   if (row < num_instrsets) {
-    return m_coll->instrsets[row];
+    return m_coll->instrSets()[row];
   }
 
   row -= num_instrsets;
   if (row < num_sampcolls) {
-    return m_coll->sampcolls[row];
+    return m_coll->sampColls()[row];
   } else {
-    return m_coll->seq;
+    return m_coll->seq();
   }
 }
 
@@ -91,28 +91,28 @@ QModelIndex VGMCollViewModel::indexFromFile(const VGMFile* file) const {
   int row = 0;
 
   // Check in miscfiles
-  auto miscIt = std::ranges::find(m_coll->miscfiles, file);
-  if (miscIt != m_coll->miscfiles.end()) {
-    return createIndex(static_cast<int>(std::distance(m_coll->miscfiles.begin(), miscIt)), 0);
+  auto miscIt = std::ranges::find(m_coll->miscFiles(), file);
+  if (miscIt != m_coll->miscFiles().end()) {
+    return createIndex(static_cast<int>(std::distance(m_coll->miscFiles().begin(), miscIt)), 0);
   }
-  row += m_coll->miscfiles.size();
+  row += m_coll->miscFiles().size();
 
   // Check in instrsets
-  auto instrIt = std::ranges::find(m_coll->instrsets, file);
-  if (instrIt != m_coll->instrsets.end()) {
-    return createIndex(row + static_cast<int>(std::distance(m_coll->instrsets.begin(), instrIt)), 0);
+  auto instrIt = std::ranges::find(m_coll->instrSets(), file);
+  if (instrIt != m_coll->instrSets().end()) {
+    return createIndex(row + static_cast<int>(std::distance(m_coll->instrSets().begin(), instrIt)), 0);
   }
-  row += m_coll->instrsets.size();
+  row += m_coll->instrSets().size();
 
   // Check in sampcolls
-  auto sampIt = std::ranges::find(m_coll->sampcolls, file);
-  if (sampIt != m_coll->sampcolls.end()) {
-    return createIndex(row + static_cast<int>(std::distance(m_coll->sampcolls.begin(), sampIt)), 0);
+  auto sampIt = std::ranges::find(m_coll->sampColls(), file);
+  if (sampIt != m_coll->sampColls().end()) {
+    return createIndex(row + static_cast<int>(std::distance(m_coll->sampColls().begin(), sampIt)), 0);
   }
-  row += m_coll->sampcolls.size();
+  row += m_coll->sampColls().size();
 
   // Check if it's seq
-  if (m_coll->seq == file) {
+  if (m_coll->seq() == file) {
     return createIndex(row, 0);
   }
 
@@ -177,7 +177,7 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
       m_collection_title->setText("No collection selected");
     } else {
       m_collection_title->setText(
-          QString::fromStdString(qtVGMRoot.vgmColls()[index.row()]->GetName()));
+          QString::fromStdString(qtVGMRoot.vgmColls()[index.row()]->name()));
       m_collection_title->setReadOnly(false);
       commit_rename->setEnabled(true);
     }
@@ -192,7 +192,7 @@ VGMCollView::VGMCollView(QItemSelectionModel *collListSelModel, QWidget *parent)
 
     auto title = m_collection_title->text().toStdString();
     /* This makes a copy, no worries */
-    qtVGMRoot.vgmColls()[model_index.row()]->SetName(title);
+    qtVGMRoot.vgmColls()[model_index.row()]->setName(title);
 
     auto coll_list_model = collListSelModel->model();
     coll_list_model->dataChanged(coll_list_model->index(0, 0),


### PR DESCRIPTION
This makes every VGMColl member private, adds getters for the vector collections (instrSets(), sampColls(), miscFiles()), and renames all methods and fields to comport with our new style.

Like RawFile, it's necessary to rename GetName() -> name() to for VGMColl to work with the MenuManager SaveCommand class.

As before, I will add this commit to the .git-blame-ignore-revs file in the next PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
