### PR TITLE
Update RawFile::path() to return std::filesystem::path, add stem()

### DIFF
--- a/src/main/components/ExtensionDiscriminator.cpp
+++ b/src/main/components/ExtensionDiscriminator.cpp
@@ -19,7 +19,7 @@ int ExtensionDiscriminator::AddExtensionScannerAssoc(const std::string& extensio
 }
 
 std::list<VGMScanner *> *ExtensionDiscriminator::GetScannerList(const std::string& extension) {
-  std::map<std::string, std::list<VGMScanner *> >::iterator iter = mScannerExt.find(StringToLower(extension));
+  std::map<std::string, std::list<VGMScanner *> >::iterator iter = mScannerExt.find(toLower(extension));
   if (iter == mScannerExt.end())
     return NULL;
   else

--- a/src/main/formats/AkaoSnes/AkaoSnesScanner.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesScanner.cpp
@@ -334,7 +334,7 @@ void AkaoSnesScanner::Scan(RawFile* file, void* /*info*/) {
 void AkaoSnesScanner::SearchForAkaoSnesFromARAM(RawFile *file) {
   AkaoSnesVersion version;
   AkaoSnesMinorVersion minorVersion = AKAOSNES_NOMINORVERSION;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   // search for note length table
   uint32_t ofsReadNoteLength;

--- a/src/main/formats/CapcomSnes/CapcomSnesScanner.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesScanner.cpp
@@ -119,7 +119,7 @@ void CapcomSnesScanner::SearchForCapcomSnesFromARAM(RawFile *file) const {
   uint32_t addrBGMHeader{0};
   uint32_t addrInstrTable;
 
-  std::string basefilename = removeExtFromPath(file->name());
+  std::string basefilename = file->stem();
   std::string name = file->tag.HasTitle() ? file->tag.title : basefilename;
 
   // find a song list

--- a/src/main/formats/ChunSnes/ChunSnesScanner.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesScanner.cpp
@@ -406,7 +406,7 @@ void ChunSnesScanner::Scan(RawFile* file, void* /*info*/) {
 void ChunSnesScanner::SearchForChunSnesFromARAM(RawFile *file) {
   ChunSnesVersion version;
   ChunSnesMinorVersion minorVersion;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   // search song list and detect engine version
   uint32_t ofsLoadSeq;

--- a/src/main/formats/CompileSnes/CompileSnesScanner.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesScanner.cpp
@@ -52,7 +52,7 @@ void CompileSnesScanner::Scan(RawFile* file, void* /*info*/) {
 void CompileSnesScanner::SearchForCompileSnesFromARAM(RawFile *file) {
   CompileSnesVersion version;
 
-  std::string basefilename = removeExtFromPath(file->name());
+  std::string basefilename = file->stem();
   std::string name = file->tag.HasTitle() ? file->tag.title : basefilename;
 
   // scan for table pointer initialize code

--- a/src/main/formats/FalcomSnes/FalcomSnesScanner.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesScanner.cpp
@@ -90,7 +90,7 @@ void FalcomSnesScanner::Scan(RawFile *file, void *info) {
 
 void FalcomSnesScanner::SearchForFalcomSnesFromARAM(RawFile *file) {
   FalcomSnesVersion version;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   uint32_t ofsLoadSeq;
   uint16_t addrSeqHeader;

--- a/src/main/formats/GraphResSnes/GraphResSnesScanner.cpp
+++ b/src/main/formats/GraphResSnes/GraphResSnesScanner.cpp
@@ -69,7 +69,7 @@ void GraphResSnesScanner::Scan(RawFile *file, void *info) {
 }
 
 void GraphResSnesScanner::SearchForGraphResSnesFromARAM(RawFile *file) {
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   // search song header
   uint32_t ofsLoadSeq;

--- a/src/main/formats/HOSA/HOSAScanner.cpp
+++ b/src/main/formats/HOSA/HOSAScanner.cpp
@@ -60,7 +60,7 @@ void HOSAScanner::Scan(RawFile *file, void *info) {
 }
 
 HOSASeq *HOSAScanner::SearchForHOSASeq(RawFile *file) {
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   size_t nFileLength = file->size();
   for (uint32_t i = 0; i + 4 < nFileLength; i++) {

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesScanner.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesScanner.cpp
@@ -113,7 +113,7 @@ void HeartBeatSnesScanner::Scan(RawFile *file, void *info) {
 
 void HeartBeatSnesScanner::SearchForHeartBeatSnesFromARAM(RawFile *file) {
   HeartBeatSnesVersion version;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   // search song list
   uint32_t ofsReadSongList;

--- a/src/main/formats/HudsonSnes/HudsonSnesScanner.cpp
+++ b/src/main/formats/HudsonSnes/HudsonSnesScanner.cpp
@@ -122,7 +122,7 @@ void HudsonSnesScanner::Scan(RawFile* file, void* /*info*/) {
 
 void HudsonSnesScanner::SearchForHudsonSnesFromARAM(RawFile *file) {
   HudsonSnesVersion version = HUDSONSNES_NONE;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   // search for note length table
   uint32_t ofsNoteLenTable;

--- a/src/main/formats/ItikitiSnes/ItikitiSnesScanner.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesScanner.cpp
@@ -22,7 +22,7 @@ void ItikitiSnesScanner::Scan(RawFile *file, void *info) {
 
 void ItikitiSnesScanner::ScanFromApuRam(RawFile *file) {
   std::string name =
-      file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+      file->tag.HasTitle() ? file->tag.title : file->stem();
 
   uint32_t song_header_offset{};
   if (!ScanSongHeader(file, song_header_offset))

--- a/src/main/formats/KonamiPS1/KonamiPS1Scanner.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Scanner.cpp
@@ -17,7 +17,7 @@ void KonamiPS1Scanner::Scan(RawFile *file, void *info) {
   int numSeqFiles = 0;
   while (offset < file->size()) {
     if (KonamiPS1Seq::IsKDT1Seq(file, offset)) {
-      std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+      std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
       if (numSeqFiles >= 1) {
         name += fmt::format("({})", numSeqFiles + 1);
       }

--- a/src/main/formats/KonamiSnes/KonamiSnesScanner.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesScanner.cpp
@@ -507,7 +507,7 @@ void KonamiSnesScanner::SearchForKonamiSnesFromARAM(RawFile *file) {
 
   bool hasSongList;
 
-  std::string basefilename = removeExtFromPath(file->name());
+  std::string basefilename = file->stem();
   std::string name = file->tag.HasTitle() ? file->tag.title : basefilename;
 
   // TODO: Unsupported games

--- a/src/main/formats/MoriSnes/MoriSnesScanner.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesScanner.cpp
@@ -55,7 +55,7 @@ void MoriSnesScanner::Scan(RawFile *file, void *info) {
 
 void MoriSnesScanner::SearchForMoriSnesFromARAM(RawFile *file) {
   MoriSnesVersion version = MORISNES_NONE;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   // scan for song list table
   uint32_t ofsLoadSeq;

--- a/src/main/formats/NamcoSnes/NamcoSnesScanner.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesScanner.cpp
@@ -128,7 +128,7 @@ void NamcoSnesScanner::Scan(RawFile *file, void *info) {
 
 void NamcoSnesScanner::SearchForNamcoSnesFromARAM(RawFile *file) {
   NamcoSnesVersion version = NAMCOSNES_NONE;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   // search song list
   uint32_t ofsReadSongList;

--- a/src/main/formats/NeverlandSnes/NeverlandSnesScanner.cpp
+++ b/src/main/formats/NeverlandSnes/NeverlandSnesScanner.cpp
@@ -74,7 +74,7 @@ void NeverlandSnesScanner::Scan(RawFile *file, void *info) {
 void NeverlandSnesScanner::SearchForNeverlandSnesFromARAM(RawFile *file) {
   NeverlandSnesVersion version = NEVERLANDSNES_NONE;
 
-  std::string basefilename = removeExtFromPath(file->name());
+  std::string basefilename = file->stem();
   std::string name = file->tag.HasTitle() ? file->tag.title : basefilename;
 
   uint32_t ofsLoadSong;

--- a/src/main/formats/NinSnes/NinSnesScanner.cpp
+++ b/src/main/formats/NinSnes/NinSnesScanner.cpp
@@ -912,7 +912,7 @@ void NinSnesScanner::Scan(RawFile *file, void *info) {
 void NinSnesScanner::SearchForNinSnesFromARAM(RawFile *file) {
   NinSnesVersion version = NINSNES_NONE;
 
-  std::string basefilename = removeExtFromPath(file->name());
+  std::string basefilename = file->stem();
   std::string name = file->tag.HasTitle() ? file->tag.title : basefilename;
 
   // get section pointer address

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesScanner.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesScanner.cpp
@@ -100,7 +100,7 @@ void PandoraBoxSnesScanner::Scan(RawFile *file, void *info) {
 
 void PandoraBoxSnesScanner::SearchForPandoraBoxSnesFromARAM(RawFile *file) {
   PandoraBoxSnesVersion version = PANDORABOXSNES_NONE;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   uint32_t ofsLoadSeq;
   uint16_t addrSeqHeader;

--- a/src/main/formats/PrismSnes/PrismSnesScanner.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesScanner.cpp
@@ -134,7 +134,7 @@ void PrismSnesScanner::Scan(RawFile *file, void *info) {
 
 void PrismSnesScanner::SearchForPrismSnesFromARAM(RawFile *file) {
   PrismSnesVersion version = PRISMSNES_NONE;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   // search song list
   uint32_t ofsLoadSeq;

--- a/src/main/formats/RareSnes/RareSnesScanner.cpp
+++ b/src/main/formats/RareSnes/RareSnesScanner.cpp
@@ -123,7 +123,7 @@ void RareSnesScanner::SearchForRareSnesFromARAM(RawFile *file) {
   uint32_t ofsVCmdExecASM;
   uint32_t addrSeqHeader;
   uint32_t addrVCmdTable;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   // find a sequence
   if (file->SearchBytePattern(ptnSongLoadDKC2, ofsSongLoadASM)) {

--- a/src/main/formats/SoftCreatSnes/SoftCreatSnesScanner.cpp
+++ b/src/main/formats/SoftCreatSnes/SoftCreatSnesScanner.cpp
@@ -72,7 +72,7 @@ void SoftCreatSnesScanner::Scan(RawFile *file, void *info) {
 
 void SoftCreatSnesScanner::SearchForSoftCreatSnesFromARAM(RawFile *file) {
   SoftCreatSnesVersion version = SOFTCREATSNES_NONE;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   // search song list
   uint32_t ofsLoadSeq;

--- a/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
@@ -73,7 +73,7 @@ void SonyPS2Scanner::SearchForSampColl(RawFile *file) {
     return;
   }
 
-  if (StringToLower(file->extension()) == "bd") {
+  if (file->extension() == "bd") {
     // Hack for incorrectly ripped bd files.  Should ALWAYS start with 16 0x00 bytes (must...
     // suppress... rage) If it doesn't, we'll throw out this file and create a new one with the
     // correct formating

--- a/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
@@ -158,7 +158,7 @@ void SuzukiSnesScanner::Scan(RawFile *file, void *info) {
 
 void SuzukiSnesScanner::SearchForSuzukiSnesFromARAM(RawFile *file) {
   SuzukiSnesVersion version = SUZUKISNES_NONE;
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
 
   // search for note length table
   uint32_t ofsSongLoad;

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Scanner.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Scanner.cpp
@@ -14,8 +14,8 @@ ScannerRegistration<TamSoftPS1Scanner> s_tamsoft_ps1("TAMSOFTPS1", {"tsq", "tvb"
 }
 
 void TamSoftPS1Scanner::Scan(RawFile *file, void *info) {
-  std::string basename(removeExtFromPath(file->name()));
-  std::string extension(StringToLower(file->extension()));
+  std::string basename(file->stem());
+  std::string extension(file->extension());
 
   if (extension == "tsq") {
     uint8_t numSongs = 0;

--- a/src/main/formats/TriAcePS1/TriAcePS1Scanner.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1Scanner.cpp
@@ -75,7 +75,7 @@ void TriAcePS1Scanner::SearchForSLZSeq(RawFile *file) {
     if (!instrsets.size())
       return;
 
-    std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+    std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
     VGMColl *coll = new VGMColl(name);
     coll->useSeq(seq);
     for (uint32_t i = 0; i < instrsets.size(); i++)
@@ -214,7 +214,7 @@ TriAcePS1Seq *TriAcePS1Scanner::TriAceSLZDecompress(RawFile *file, uint32_t cfOf
   // pRoot->UI_WriteBufferToFile("uncomp.raw", uf, ufOff);
 
   // Create the new virtual file, and analyze the sequence
-  std::string name = file->tag.HasTitle() ? file->tag.title : removeExtFromPath(file->name());
+  std::string name = file->tag.HasTitle() ? file->tag.title : file->stem();
   auto newVirtFile = new VirtFile(uf, ufOff, name + std::string(" Sequence"),
     file->GetParRawFileFullPath().c_str());
 

--- a/src/main/loaders/MAMELoader.cpp
+++ b/src/main/loaders/MAMELoader.cpp
@@ -176,11 +176,7 @@ void MAMELoader::apply(const RawFile* file) {
   if (!bLoadedXml || file->extension() != "zip")
     return;
 
-  std::string fullfilename = file->name();
-  size_t endoffilename = fullfilename.rfind('.');
-  if (endoffilename == std::string::npos)
-    return;  // no '.' found in filename, so don't do anything
-  std::string filename = fullfilename.substr(0, endoffilename);
+  std::string filename = file->stem();
 
   /* Look for the game in our databse */
   GameMap::iterator it = gamemap.find(filename);

--- a/src/main/util/common.cpp
+++ b/src/main/util/common.cpp
@@ -2,25 +2,18 @@
 #include <filesystem>
 #include "common.h"
 
-std::string removeExtFromPath(const std::string& s) {
-  std::filesystem::path p(s);
-  return (p.parent_path() / p.stem()).string();
+std::string toUpper(const std::string& input) {
+  std::string output = input;
+  std::transform(output.begin(), output.end(), output.begin(),
+                 [](unsigned char c) { return std::toupper(c); });
+  return output;
 }
 
-std::string StringToUpper(std::string myString) {
-  const size_t length = myString.length();
-  for (size_t i = 0; i != length; ++i) {
-    myString[i] = toupper(myString[i]);
-  }
-  return myString;
-}
-
-std::string StringToLower(std::string myString) {
-  const size_t length = myString.length();
-  for (size_t i = 0; i != length; ++i) {
-    myString[i] = tolower(myString[i]);
-  }
-  return myString;
+std::string toLower(const std::string& input) {
+  std::string output = input;
+  std::transform(output.begin(), output.end(), output.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return output;
 }
 
 std::string ConvertToSafeFileName(const std::string &str) {

--- a/src/main/util/common.h
+++ b/src/main/util/common.h
@@ -50,10 +50,8 @@ class VGMMiscFile;
 
 using VGMFileVariant = std::variant<VGMSeq*, VGMInstrSet*, VGMSampColl*, VGMMiscFile*>;
 
-std::string removeExtFromPath(const std::string& s);
-
-std::string StringToUpper(std::string myString);
-std::string StringToLower(std::string myString);
+std::string toUpper(const std::string& input);
+std::string toLower(const std::string& input);
 
 std::string ConvertToSafeFileName(const std::string &str);
 


### PR DESCRIPTION
Following up on [this discussion](https://github.com/vgmtrans/vgmtrans/pull/488#discussion_r1614486970).

- rawfile: make path() return std::filesystem::path instead of std::string
- rawfile: add stem() virtual method
- rawfile: make extension() returns lowercased string
- common: remove removeExtFromPath(), and update all usage to RawFile::stem()
- common: rename StringToLower() -> toLower(), StringToUpper() -> toUpper(), also rewrite the logic
- MAMELoader: simplify some logic by employing stem()

## How Has This Been Tested?
Tested that VirtFile::stem() is returning the expected output. Tested MAMELoader. Tested some of the Scanners.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
