### PR TITLE
CPS3 improve ADSR timing, clean up tempo logic

### DIFF
--- a/src/main/formats/CPS/CPS2Format.h
+++ b/src/main/formats/CPS/CPS2Format.h
@@ -10,6 +10,12 @@ enum CPSSynth {
 };
 
 constexpr int CPS1_OKIMSM6295_SAMPLE_RATE = 7576; // 1Mhz / 132, rounded
+// The QSound interrupt clock is 250hz, but the main sound code runs only every 4th tick.
+// (see the "and 3" instruction at 0xF9 in sfa2 code)
+constexpr double CPS2_DRIVER_RATE_HZ = 250 / 4.0;
+// In CPS3, sound driver iterations are triggered by the vblank interrupt (IRQ 12) which runs at 59.6hz
+constexpr double CPS3_DRIVER_RATE_HZ = 59.599491;
+
 
 BEGIN_FORMAT(CPS1)
   USING_SCANNER(CPS1Scanner)

--- a/src/main/formats/CPS/CPS2Instr.cpp
+++ b/src/main/formats/CPS/CPS2Instr.cpp
@@ -447,7 +447,7 @@ bool CPS2Instr::LoadInstr() {
       ticks = Dr ? (0xFFFF / Dr) : 0;
       rgn->decay_time = (Dr == 0xFFFF) ? 0 : ticks / UPDATE_RATE_IN_HZ;
     }
-    rgn->decay_time = LinAmpDecayTimeToLinDBDecayTime(rgn->decay_time, 0x800);
+    rgn->decay_time = LinAmpDecayTimeToLinDBDecayTime(rgn->decay_time, 0xFFFF / 2);
 
     // Sustain level
     //    if the Decay rate is 0, then the sustain level is effectively max
@@ -461,11 +461,11 @@ bool CPS2Instr::LoadInstr() {
     // Sustain rate 138D in sfa2
     ticks = Sr ? 0xFFFF / Sr : 0;
     rgn->sustain_time = (Sr == 0xFFFF) ? 0 : ticks / UPDATE_RATE_IN_HZ;
-    rgn->sustain_time = LinAmpDecayTimeToLinDBDecayTime(rgn->sustain_time, 0x800);
+    rgn->sustain_time = LinAmpDecayTimeToLinDBDecayTime(rgn->sustain_time, 0xFFFF / 2);
 
     ticks = Rr ? 0xFFFF / Rr : 0xFFFF;
     rgn->release_time = (Rr == 0xFFFF) ? 0 : ticks / UPDATE_RATE_IN_HZ;
-    rgn->release_time = LinAmpDecayTimeToLinDBDecayTime(rgn->release_time, 0x800);
+    rgn->release_time = LinAmpDecayTimeToLinDBDecayTime(rgn->release_time, 0xFFFF / 2);
 
     if (rgn->sampNum == 0xFFFF || rgn->sampNum >= (dynamic_cast<CPS2InstrSet*>(parInstrSet))->sampInfoTable->numSamples)
       rgn->sampNum = 0;

--- a/src/main/formats/CPS/CPS2Instr.cpp
+++ b/src/main/formats/CPS/CPS2Instr.cpp
@@ -447,7 +447,7 @@ bool CPS2Instr::LoadInstr() {
       ticks = Dr ? (0xFFFF / Dr) : 0;
       rgn->decay_time = (Dr == 0xFFFF) ? 0 : ticks / UPDATE_RATE_IN_HZ;
     }
-    rgn->decay_time = LinAmpDecayTimeToLinDBDecayTime(rgn->decay_time, 0xFFFF / 2);
+    rgn->decay_time = LinAmpDecayTimeToLinDBDecayTime(rgn->decay_time, 0xFFFF / 8);
 
     // Sustain level
     //    if the Decay rate is 0, then the sustain level is effectively max
@@ -461,11 +461,11 @@ bool CPS2Instr::LoadInstr() {
     // Sustain rate 138D in sfa2
     ticks = Sr ? 0xFFFF / Sr : 0;
     rgn->sustain_time = (Sr == 0xFFFF) ? 0 : ticks / UPDATE_RATE_IN_HZ;
-    rgn->sustain_time = LinAmpDecayTimeToLinDBDecayTime(rgn->sustain_time, 0xFFFF / 2);
+    rgn->sustain_time = LinAmpDecayTimeToLinDBDecayTime(rgn->sustain_time, 0xFFFF / 8);
 
     ticks = Rr ? 0xFFFF / Rr : 0xFFFF;
     rgn->release_time = (Rr == 0xFFFF) ? 0 : ticks / UPDATE_RATE_IN_HZ;
-    rgn->release_time = LinAmpDecayTimeToLinDBDecayTime(rgn->release_time, 0xFFFF / 2);
+    rgn->release_time = LinAmpDecayTimeToLinDBDecayTime(rgn->release_time, 0xFFFF / 8);
 
     if (rgn->sampNum == 0xFFFF || rgn->sampNum >= (dynamic_cast<CPS2InstrSet*>(parInstrSet))->sampInfoTable->numSamples)
       rgn->sampNum = 0;

--- a/src/main/formats/CPS/CPS2Instr.h
+++ b/src/main/formats/CPS/CPS2Instr.h
@@ -2,6 +2,7 @@
 #include "VGMInstrSet.h"
 #include "VGMSampColl.h"
 #include "VGMMiscFile.h"
+#include "CPS2Format.h"
 
 class CPS2Instr;
 
@@ -106,12 +107,6 @@ struct qs_samp_info {
     this->unity_key = static_cast<uint8_t>(swap_bytes32(cps3->unity_key));
   }
 };
-
-// The QSound interrupt clock is set to 250hz in mame, but the main sound
-// code runs only every 4th tick. (see the "and 3" instruction at 0xF9 in sfa2 code)
-constexpr double CPS2_DRIVER_RATE_HZ = 250 / 4.0;
-// In CPS3, sound driver iterations are triggered by the vblank interrupt (IRQ 12) which runs at 59.6hz
-constexpr double CPS3_DRIVER_RATE_HZ = 59.599491;
 
 // The following tables are used by all versions of sample-based CPS drivers, with the
 // exception of the sustain level table not present in CPS3 (but it's virtually linear).

--- a/src/main/formats/CPS/CPSTrackV1.cpp
+++ b/src/main/formats/CPS/CPSTrackV1.cpp
@@ -182,12 +182,12 @@ bool CPSTrackV1::ReadEvent() {
           // First we calculate the iterations per beat: (48 << 8) / ticks per iteration
           // Then we calculate the seconds per beat: iterations per beat / DRIVER_RATE_IN_HZ
           // Convert to microseconds and we're good to go.
-          uint16_t ticksPerIteration = GetShortBE(curOffset);
+          uint16_t ticks_per_iteration = GetShortBE(curOffset);
           curOffset += 2;
           auto internal_ppqn = parentSeq->GetPPQN() << 8;
-          auto iterationsPerBeat = static_cast<double>(internal_ppqn) / ticksPerIteration;
-          const uint32_t microsPerBeat = lround((iterationsPerBeat / CPS2_DRIVER_RATE_HZ) * 1000000);
-          AddTempo(beginOffset, curOffset - beginOffset, microsPerBeat);
+          auto iterations_per_beat = static_cast<double>(internal_ppqn) / ticks_per_iteration;
+          const uint32_t micros_per_beat = lround((iterations_per_beat / CPS2_DRIVER_RATE_HZ) * 1000000);
+          AddTempo(beginOffset, curOffset - beginOffset, micros_per_beat);
         }
         break;
       }

--- a/src/main/formats/CPS/CPSTrackV2.cpp
+++ b/src/main/formats/CPS/CPSTrackV2.cpp
@@ -72,14 +72,14 @@ bool CPSTrackV2::ReadEvent() {
 
     case C1_TEMPO: {
       // Shares same logic as version < 1.40.  See comment on tempo in CPSTrackV1 for explanation.
-      uint16_t ticksPerIteration = GetShortBE(curOffset);
+      uint16_t ticks_per_iteration = GetShortBE(curOffset);
       curOffset += 2;
       auto internal_ppqn = parentSeq->GetPPQN() << 8;
-      auto iterationsPerBeat = static_cast<double>(internal_ppqn) / ticksPerIteration;
+      auto iterations_per_beat = static_cast<double>(internal_ppqn) / ticks_per_iteration;
       auto fmt_version = static_cast<CPSSeq*>(parentSeq)->fmt_version;
       const double ITERATIONS_PER_SEC = fmt_version == VER_CPS3 ? CPS3_DRIVER_RATE_HZ : CPS2_DRIVER_RATE_HZ;
-      const uint32_t microsPerBeat = lround((iterationsPerBeat / ITERATIONS_PER_SEC) * 1000000);
-      AddTempo(beginOffset, curOffset - beginOffset, microsPerBeat);
+      const uint32_t micros_per_beat = lround((iterations_per_beat / ITERATIONS_PER_SEC) * 1000000);
+      AddTempo(beginOffset, curOffset - beginOffset, micros_per_beat);
       break;
     }
 

--- a/src/main/formats/CPS/CPSTrackV2.cpp
+++ b/src/main/formats/CPS/CPSTrackV2.cpp
@@ -58,7 +58,7 @@ bool CPSTrackV2::ReadEvent() {
   if (status_byte < 0xC0) {
     uint8_t velocity = status_byte & 0x3F;
     uint8_t midiVel = ConvertPercentAmpToStdMidiVal(static_cast<double>(velocity) / static_cast<double>(0x3F));
-    uint8_t note = GetByte(curOffset++);
+    uint8_t note = GetByte(curOffset++) & 0x7F;
     uint32_t duration = ReadVarLength();
     AddNoteByDur(beginOffset, curOffset - beginOffset, note, midiVel, duration);
     return true;

--- a/src/main/formats/CPS/CPSTrackV2.cpp
+++ b/src/main/formats/CPS/CPSTrackV2.cpp
@@ -72,12 +72,12 @@ bool CPSTrackV2::ReadEvent() {
 
     case C1_TEMPO: {
       // Shares same logic as version < 1.40.  See comment on tempo in CPSTrackV1 for explanation.
-      uint16_t tempo = GetShortBE(curOffset);
+      uint16_t ticksPerIteration = GetShortBE(curOffset);
       curOffset += 2;
-      const double tempoDiv = static_cast<CPSSeq*>(this->parentSeq)->fmt_version == VER_CPS3 ? 3.4 : 3.2768;
-      double fTempo = tempo / tempoDiv;
-
-      AddTempoBPM(beginOffset, curOffset - beginOffset, fTempo);
+      auto internal_ppqn = parentSeq->GetPPQN() << 8;
+      auto iterationsPerBeat = static_cast<double>(internal_ppqn) / ticksPerIteration;
+      const uint32_t microsPerBeat = lround((iterationsPerBeat / CPS3_DRIVER_RATE_HZ) * 1000000);
+      AddTempo(beginOffset, curOffset - beginOffset, microsPerBeat);
       break;
     }
 

--- a/src/main/formats/CPS/CPSTrackV2.cpp
+++ b/src/main/formats/CPS/CPSTrackV2.cpp
@@ -76,7 +76,9 @@ bool CPSTrackV2::ReadEvent() {
       curOffset += 2;
       auto internal_ppqn = parentSeq->GetPPQN() << 8;
       auto iterationsPerBeat = static_cast<double>(internal_ppqn) / ticksPerIteration;
-      const uint32_t microsPerBeat = lround((iterationsPerBeat / CPS3_DRIVER_RATE_HZ) * 1000000);
+      auto fmt_version = static_cast<CPSSeq*>(parentSeq)->fmt_version;
+      const double ITERATIONS_PER_SEC = fmt_version == VER_CPS3 ? CPS3_DRIVER_RATE_HZ : CPS2_DRIVER_RATE_HZ;
+      const uint32_t microsPerBeat = lround((iterationsPerBeat / ITERATIONS_PER_SEC) * 1000000);
       AddTempo(beginOffset, curOffset - beginOffset, microsPerBeat);
       break;
     }


### PR DESCRIPTION
There's no perfect way to convert % amplitude curves to the decibel (logarithmic) curves of SF2 and DLS, but this shortens the timing and sounds more accurate. I also rewrote non-BPM tempo event logic to employ the IRQ rate constants instead of relying on magic numbers.

## How Has This Been Tested?
Tested affected formats.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
