### PR TITLE
Fix MP2k And SquarePS2 issues

### DIFF
--- a/src/main/formats/CPS/CPSTrackV1.cpp
+++ b/src/main/formats/CPS/CPSTrackV1.cpp
@@ -407,6 +407,12 @@ bool CPSTrackV1::ReadEvent() {
           jump = curOffset + 2 + static_cast<int16_t>(GetShortBE(curOffset));
         }
         bool should_continue = AddLoopForever(beginOffset, 3);
+        if (readMode == READMODE_ADD_TO_UI) {
+          curOffset += 2;
+          if (GetByte(curOffset) == 0x17) {
+            AddEndOfTrack(curOffset, 1);
+          }
+        }
         curOffset = jump;
         return should_continue;
       }

--- a/src/main/formats/CPS/CPSTrackV2.cpp
+++ b/src/main/formats/CPS/CPSTrackV2.cpp
@@ -169,6 +169,11 @@ bool CPSTrackV2::ReadEvent() {
       int16_t relative_offset = static_cast<int16_t>(GetShortBE(curOffset));
       curOffset += 2;
       auto should_continue = AddLoopForever(beginOffset, curOffset - beginOffset);
+      if (readMode == READMODE_ADD_TO_UI) {
+        if (GetByte(curOffset) == 0xFF) {
+          AddEndOfTrack(curOffset, 1);
+        }
+      }
       curOffset += relative_offset;
       return should_continue;;
     }
@@ -205,6 +210,11 @@ bool CPSTrackV2::ReadEvent() {
       uint8_t loopCount = GetByte(curOffset++);
       if (loopCount == 0) {
         auto should_continue = AddLoopForever(beginOffset, curOffset - beginOffset);
+        if (readMode == READMODE_ADD_TO_UI) {
+          if (GetByte(curOffset) == 0xFF) {
+            AddEndOfTrack(curOffset, 1);
+          }
+        }
         curOffset = loopOffset[loopNum];
         return should_continue;
       }

--- a/src/main/formats/MP2k/MP2kInstrSet.cpp
+++ b/src/main/formats/MP2k/MP2kInstrSet.cpp
@@ -23,10 +23,7 @@ MP2kInstrSet::MP2kInstrSet(RawFile *file, int rate, size_t offset, int count,
 }
 
 bool MP2kInstrSet::LoadInstrs() {
-  bool res = VGMInstrSet::LoadInstrs();
-  sampColl = nullptr;
-
-  return res;
+  return VGMInstrSet::LoadInstrs();
 }
 
 bool MP2kInstrSet::GetInstrPointers() {

--- a/src/main/formats/SquarePS2/SquarePS2Seq.h
+++ b/src/main/formats/SquarePS2/SquarePS2Seq.h
@@ -10,7 +10,7 @@ class BGMSeq : public VGMSeq {
 
   bool GetHeaderInfo() override;
   bool GetTrackPointers() override;
-  virtual uint32_t GetID() { return assocWDID; }
+  uint32_t GetID() const override { return assocWDID; }
 
  protected:
   unsigned short seqID;


### PR DESCRIPTION
- Fix MP2k not loading sample collections. `LoadInstrs()` had included the odd instruction `sampColl == nullptr;` which I unthinkingly assumed should be corrected to `sampColl = nullptr;` in one of my cleanup PRs. Nope.
- Fix SquarePS2 matching not working due to the declaration of GetID() having changed to const (`uint32_t GetID() const`) and SquarePS2Seq not updating its method signature (and not using the override keyword, which would have caught this). I've verified this is the only format with the issue.
- Small cleanup of checking for and adding EndTrack events when they occur after forever loops in CPSSeq.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
