### PR TITLE
Fix .git-blame-ignore-revs commit hash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -21,4 +21,4 @@ ed533cd46d853523d184ff1a60f769223ee97845
 48b1d0d95a2f97fef62e6fe1d4a4af30dbaee1c5
 
 # Rename the rest of the vgmtranscore methods (hopefully)
-95dbf01ba6c7047b2f8d6e7de5c51284783ccaf2
+6bcd74f826462ed5ea4ff52c28e9f9dad605251c

--- a/bin/mame_roms.xml
+++ b/bin/mame_roms.xml
@@ -619,6 +619,8 @@
         <romgroup type="qsound" load_method="deinterlace_pairs" load_order="reverse">
             <rom>sfiii2n/sfiii2-simm3.0</rom>
             <rom>sfiii2n/sfiii2-simm3.1</rom>
+            <rom>sfiii2n/sfiii2-simm3.2</rom>
+            <rom>sfiii2n/sfiii2-simm3.3</rom>
         </romgroup>
     </game>
     <game name="sfiii2n" format="CPS2" fmt_version="CPS3">


### PR DESCRIPTION
Also, add missing sound roms for sfiii2 in mame_roms.xml.

Looks like rebase and merge changes the commit hashes even if no rebase is necessary.