### PR TITLE
Rename methods in Qt implementation

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -22,3 +22,6 @@ ed533cd46d853523d184ff1a60f769223ee97845
 
 # Rename the rest of the vgmtranscore methods (hopefully)
 6bcd74f826462ed5ea4ff52c28e9f9dad605251c
+
+# Rename the Qt implementation methods
+f21c279c8dbeadda11ee065c0db19473006d8b55

--- a/src/main/components/VGMColl.cpp
+++ b/src/main/components/VGMColl.cpp
@@ -101,7 +101,7 @@ void VGMColl::unpackSampColl(DLSFile &dls, const VGMSampColl *sampColl, std::vec
     samp->convertToStdWave(uncompSampBuf);            // and uncompress into that space
 
     uint16_t blockAlign = samp->bps / 8 * samp->channels;
-    dls.AddWave(1, samp->channels, samp->rate, samp->rate * blockAlign, blockAlign,
+    dls.addWave(1, samp->channels, samp->rate, samp->rate * blockAlign, blockAlign,
                 samp->bps, bufSize, uncompSampBuf, samp->name());
     finalSamps.push_back(samp);
   }
@@ -218,7 +218,7 @@ bool VGMColl::mainDLSCreation(DLSFile &dls) {
         const uint8_t bank_lsb = bank_no & 0x7f;
         bank_no = (bank_msb << 8) | bank_lsb;
       }
-      DLSInstr *newInstr = dls.AddInstr(bank_no, vgminstr->instrNum, name);
+      DLSInstr *newInstr = dls.addInstr(bank_no, vgminstr->instrNum, name);
       for (uint32_t j = 0; j < nRgns; j++) {
         VGMRgn *rgn = vgminstr->regions()[j];
         //				if (rgn->sampNum+1 > sampColl->samples.size())	//does thereferenced sample exist?
@@ -311,10 +311,10 @@ bool VGMColl::mainDLSCreation(DLSFile &dls) {
         if (samp->bPSXLoopInfoPrioritizing) {
           if (samp->loop.loopStatus != -1) {
             if (samp->loop.loopStart != 0 || samp->loop.loopLength != 0)
-              newWsmp->SetLoopInfo(samp->loop, samp);
+              newWsmp->setLoopInfo(samp->loop, samp);
             else {
               rgn->loop.loopStatus = samp->loop.loopStatus;
-              newWsmp->SetLoopInfo(rgn->loop, samp);
+              newWsmp->setLoopInfo(rgn->loop, samp);
             }
           } else
               throw;
@@ -323,11 +323,11 @@ bool VGMColl::mainDLSCreation(DLSFile &dls) {
           // If it doesn't, then use the sample's loop info.
         else if (rgn->loop.loopStatus == -1) {
           if (samp->loop.loopStatus != -1)
-            newWsmp->SetLoopInfo(samp->loop, samp);
+            newWsmp->setLoopInfo(samp->loop, samp);
           else
             throw;
         } else
-          newWsmp->SetLoopInfo(rgn->loop, samp);
+          newWsmp->setLoopInfo(rgn->loop, samp);
 
         int8_t realUnityKey;
         if (rgn->unityKey == -1)
@@ -366,10 +366,10 @@ bool VGMColl::mainDLSCreation(DLSFile &dls) {
         long convRelease = static_cast<long>(std::round(secondsToTimecents(rgn->release_time) * 65536));
 
         DLSArt *newArt = newRgn->addArt();
-        newArt->AddPan(convertPercentPanTo10thPercentUnits(rgn->pan) * 65536);
+        newArt->addPan(convertPercentPanTo10thPercentUnits(rgn->pan) * 65536);
         newArt->addADSR(convAttack, 0, convHold, convDecay, convSustainLev, convRelease, 0);
 
-        newWsmp->SetPitchInfo(realUnityKey, realFineTune, realAttenuation);
+        newWsmp->setPitchInfo(realUnityKey, realFineTune, realAttenuation);
       }
     }
   }

--- a/src/main/components/VGMMultiSectionSeq.cpp
+++ b/src/main/components/VGMMultiSectionSeq.cpp
@@ -74,7 +74,7 @@ bool VGMMultiSectionSeq::postLoad() {
       return false;
     }
   } else if (readMode == READMODE_CONVERT_TO_MIDI) {
-    midi->Sort();
+    midi->sort();
   }
 
   return true;

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -85,7 +85,7 @@ class DurNoteSeqEvent:
 
   std::string description() override {
     return fmt::format("{} - abs key: {} ({}), velocity: {}, duration: {}", name(),
-      static_cast<int>(absKey), MidiEvent::GetNoteName(absKey), static_cast<int>(vel), dur);
+      static_cast<int>(absKey), MidiEvent::getNoteName(absKey), static_cast<int>(vel), dur);
   };
 
  public:
@@ -111,7 +111,7 @@ class NoteOnSeqEvent : public SeqEvent {
 
   std::string description() override {
     return fmt::format("{} - abs key: {} ({}), velocity: {}", name(),
-      static_cast<int>(absKey), MidiEvent::GetNoteName(absKey), static_cast<int>(vel));
+      static_cast<int>(absKey), MidiEvent::getNoteName(absKey), static_cast<int>(vel));
   };
 
  public:
@@ -133,7 +133,7 @@ class NoteOffSeqEvent:
 
   std::string description() override {
     return fmt::format("{} - abs key: {} ({})", name(), static_cast<int>(absKey),
-      MidiEvent::GetNoteName(absKey));
+      MidiEvent::getNoteName(absKey));
   };
 
  public:

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -62,7 +62,7 @@ bool SeqTrack::loadTrackInit(int trackNum, MidiTrack *preparedMidiTrack) {
       pMidiTrack = preparedMidiTrack;
     }
     else {
-      pMidiTrack = parentSeq->midi->AddTrack();
+      pMidiTrack = parentSeq->midi->addTrack();
     }
   }
   setChannelAndGroupFromTrkNum(trackNum);
@@ -140,22 +140,22 @@ void SeqTrack::setChannelAndGroupFromTrkNum(int theTrackNum) {
   channel = theTrackNum % 16;
   channelGroup = theTrackNum / 16;
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->SetChannelGroup(channelGroup);
+    pMidiTrack->setChannelGroup(channelGroup);
 }
 
 void SeqTrack::addInitialMidiEvents(int trackNum) {
   if (trackNum == 0)
-    pMidiTrack->AddSeqName(parentSeq->name());
+    pMidiTrack->addSeqName(parentSeq->name());
   std::string ssTrackName = fmt::format("Track: 0x{:02X}", dwStartOffset);
-  pMidiTrack->AddTrackName(ssTrackName);
+  pMidiTrack->addTrackName(ssTrackName);
 
-  pMidiTrack->AddMidiPort(channelGroup);
+  pMidiTrack->addMidiPort(channelGroup);
 
   if (trackNum == 0) {
-    pMidiTrack->AddGMReset();
-    pMidiTrack->AddGM2Reset();
+    pMidiTrack->addGMReset();
+    pMidiTrack->addGM2Reset();
     if (parentSeq->alwaysWriteInitialTempo())
-      pMidiTrack->AddTempoBPM(parentSeq->initialTempoBPM);
+      pMidiTrack->addTempoBPM(parentSeq->initialTempoBPM);
   }
   if (parentSeq->alwaysWriteInitialVol())
     addVolNoItem(parentSeq->initialVolume());
@@ -176,7 +176,7 @@ uint32_t SeqTrack::getTime() const {
 void SeqTrack::setTime(uint32_t NewDelta) const {
   parentSeq->time = NewDelta;
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->SetDelta(NewDelta);
+    pMidiTrack->setDelta(NewDelta);
 }
 
 void SeqTrack::addTime(uint32_t AddDelta) {
@@ -186,7 +186,7 @@ void SeqTrack::addTime(uint32_t AddDelta) {
   else {
     parentSeq->time += AddDelta;
     if (readMode == READMODE_CONVERT_TO_MIDI)
-      pMidiTrack->AddDelta(AddDelta);
+      pMidiTrack->addDelta(AddDelta);
   }
 }
 
@@ -293,7 +293,7 @@ void SeqTrack::addGenericEvent(uint32_t offset,
         miditext += " - ";
         miditext += sEventDesc;
       }
-      pMidiTrack->AddText(miditext);
+      pMidiTrack->addText(miditext);
     }
   }
 }
@@ -315,7 +315,7 @@ void SeqTrack::addUnknown(uint32_t offset,
         miditext += " - ";
         miditext += sEventDesc;
       }
-      pMidiTrack->AddText(miditext);
+      pMidiTrack->addText(miditext);
     }
   }
 }
@@ -351,7 +351,7 @@ void SeqTrack::addRest(uint32_t offset, uint32_t length, uint32_t restTime, cons
     addEvent(new RestSeqEvent(this, restTime, offset, length, sEventName));
   }
   else if (readMode == READMODE_CONVERT_TO_MIDI) {
-    pMidiTrack->PurgePrevNoteOffs();
+    pMidiTrack->purgePrevNoteOffs();
   }
   addTime(restTime);
 }
@@ -378,7 +378,7 @@ void SeqTrack::addNoteOnNoItem(int8_t key, int8_t velocity) {
       finalVel = convert7bitPercentVolValToStdMidiVal(velocity);
 
     if (cDrumNote == -1) {
-      pMidiTrack->AddNoteOn(channel, key + cKeyCorrection + transpose, finalVel);
+      pMidiTrack->addNoteOn(channel, key + cKeyCorrection + transpose, finalVel);
     }
     else
       addPercNoteOnNoItem(cDrumNote, finalVel);
@@ -430,7 +430,7 @@ void SeqTrack::insertNoteOn(uint32_t offset,
     addEvent(new NoteOnSeqEvent(this, key, vel, offset, length, sEventName));
   }
   else if (readMode == READMODE_CONVERT_TO_MIDI) {
-    pMidiTrack->InsertNoteOn(channel, key + cKeyCorrection + transpose, finalVel, absTime);
+    pMidiTrack->insertNoteOn(channel, key + cKeyCorrection + transpose, finalVel, absTime);
   }
   prevKey = key;
   prevVel = vel;
@@ -449,7 +449,7 @@ void SeqTrack::addNoteOffNoItem(int8_t key) {
     return;
 
   if (cDrumNote == -1) {
-    pMidiTrack->AddNoteOff(channel, key + cKeyCorrection + transpose);
+    pMidiTrack->addNoteOff(channel, key + cKeyCorrection + transpose);
   }
   else {
     addPercNoteOffNoItem(cDrumNote);
@@ -497,7 +497,7 @@ void SeqTrack::insertNoteOff(uint32_t offset,
 
 void SeqTrack::insertNoteOffNoItem(int8_t key, uint32_t absTime) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
-    pMidiTrack->InsertNoteOff(channel, key + cKeyCorrection + transpose, absTime);
+    pMidiTrack->insertNoteOff(channel, key + cKeyCorrection + transpose, absTime);
   }
 }
 
@@ -521,7 +521,7 @@ void SeqTrack::addNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur) {
       finalVel = convert7bitPercentVolValToStdMidiVal(vel);
 
     if (cDrumNote == -1) {
-      pMidiTrack->AddNoteByDur(channel, key + cKeyCorrection + transpose, finalVel, dur);
+      pMidiTrack->addNoteByDur(channel, key + cKeyCorrection + transpose, finalVel, dur);
     }
     else
       addPercNoteByDurNoItem(cDrumNote, vel, dur);
@@ -550,7 +550,7 @@ void SeqTrack::addNoteByDurNoItem_Extend(int8_t key, int8_t vel, uint32_t dur) {
       finalVel = convert7bitPercentVolValToStdMidiVal(vel);
 
     if (cDrumNote == -1) {
-      pMidiTrack->AddNoteByDur_TriAce(channel, key + cKeyCorrection + transpose, finalVel, dur);
+      pMidiTrack->addNoteByDur_TriAce(channel, key + cKeyCorrection + transpose, finalVel, dur);
     }
     else
       addPercNoteByDurNoItem(cDrumNote, vel, dur);
@@ -615,7 +615,7 @@ void SeqTrack::insertNoteByDur(uint32_t offset,
     if (parentSeq->usesLinearAmplitudeScale())
       finalVel = convert7bitPercentVolValToStdMidiVal(vel);
 
-    pMidiTrack->InsertNoteByDur(channel, key + cKeyCorrection + transpose, finalVel, dur, absTime);
+    pMidiTrack->insertNoteByDur(channel, key + cKeyCorrection + transpose, finalVel, dur, absTime);
   }
   prevKey = key;
   prevVel = vel;
@@ -628,7 +628,7 @@ void SeqTrack::makePrevDurNoteEnd() const {
 void SeqTrack::makePrevDurNoteEnd(uint32_t absTime) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     for (auto& prevDurNoteOff : pMidiTrack->prevDurNoteOffs) {
-      prevDurNoteOff->AbsTime = absTime;
+      prevDurNoteOff->absTime = absTime;
     }
   }
 }
@@ -640,8 +640,8 @@ void SeqTrack::limitPrevDurNoteEnd() const {
 void SeqTrack::limitPrevDurNoteEnd(uint32_t absTime) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     for (auto& prevDurNoteOff : pMidiTrack->prevDurNoteOffs) {
-      if (prevDurNoteOff->AbsTime > absTime) {
-        prevDurNoteOff->AbsTime = absTime;
+      if (prevDurNoteOff->absTime > absTime) {
+        prevDurNoteOff->absTime = absTime;
       }
     }
   }
@@ -664,7 +664,7 @@ void SeqTrack::addVolNoItem(uint8_t newVol) {
       newVolPercent = sqrt(newVolPercent);
 
     const uint8_t finalVol = static_cast<uint8_t>(std::min(newVolPercent * 127, 127.0));
-    pMidiTrack->AddVol(channel, finalVol);
+    pMidiTrack->addVol(channel, finalVol);
   }
   vol = newVol;
 }
@@ -690,8 +690,8 @@ void SeqTrack::addVolume14BitNoItem(uint16_t volume) {
     const uint16_t finalVol = static_cast<uint16_t>(std::min(newVolPercent * 16383.0, 16383.0));
     uint8_t volume_hi = static_cast<uint8_t>((finalVol >> 7) & 0x7F);
     uint8_t volume_lo = static_cast<uint8_t>(finalVol & 0x7F);
-    pMidiTrack->AddVolumeFine(channel, volume_lo);
-    pMidiTrack->AddVol(channel, volume_hi);
+    pMidiTrack->addVolumeFine(channel, volume_lo);
+    pMidiTrack->addVol(channel, volume_hi);
   }
   vol = static_cast<uint8_t>((volume >> 7) & 0x7F);
 }
@@ -710,7 +710,7 @@ void SeqTrack::addVolSlide(uint32_t offset,
                        vol,
                        targVol,
                        parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentVolValToStdMidiVal : nullptr,
-                       &MidiTrack::InsertVol);
+                       &MidiTrack::insertVol);
 }
 
 void SeqTrack::insertVol(uint32_t offset,
@@ -730,7 +730,7 @@ void SeqTrack::insertVol(uint32_t offset,
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new VolSeqEvent(this, newVol, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->InsertVol(channel, finalVol, absTime);
+    pMidiTrack->insertVol(channel, finalVol, absTime);
   vol = newVol;
 }
 
@@ -751,7 +751,7 @@ void SeqTrack::addExpressionNoItem(uint8_t level) {
       newVolPercent = sqrt(newVolPercent);
 
     const uint8_t finalExpression = static_cast<uint8_t>(std::min(newVolPercent * 127, 127.0));
-    pMidiTrack->AddExpression(channel, finalExpression);
+    pMidiTrack->addExpression(channel, finalExpression);
   }
   expression = level;
 }
@@ -770,7 +770,7 @@ void SeqTrack::addExpressionSlide(uint32_t offset,
                        expression,
                        targExpr,
                        parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentVolValToStdMidiVal : nullptr,
-                       &MidiTrack::InsertExpression);
+                       &MidiTrack::insertExpression);
 }
 
 void SeqTrack::insertExpression(uint32_t offset,
@@ -790,7 +790,7 @@ void SeqTrack::insertExpression(uint32_t offset,
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new ExpressionSeqEvent(this, level, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->InsertExpression(channel, finalExpression, absTime);
+    pMidiTrack->insertExpression(channel, finalExpression, absTime);
   expression = level;
 }
 
@@ -809,7 +809,7 @@ void SeqTrack::addMasterVolNoItem(uint8_t newVol) {
     if (parentSeq->usesLinearAmplitudeScale())
       finalVol = convert7bitPercentVolValToStdMidiVal(newVol);
 
-    pMidiTrack->AddMasterVol(channel, finalVol);
+    pMidiTrack->addMasterVol(channel, finalVol);
   }
   mastVol = newVol;
 }
@@ -828,7 +828,7 @@ void SeqTrack::addMastVolSlide(uint32_t offset,
                        mastVol,
                        targVol,
                        parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentVolValToStdMidiVal : nullptr,
-                       &MidiTrack::InsertMasterVol);
+                       &MidiTrack::insertMasterVol);
 }
 
 void SeqTrack::addPan(uint32_t offset, uint32_t length, uint8_t pan, const std::string &sEventName) {
@@ -844,7 +844,7 @@ void SeqTrack::addPanNoItem(uint8_t pan) {
     const uint8_t midiPan = parentSeq->usesLinearAmplitudeScale()
       ? convert7bitLinearPercentPanValToStdMidiVal(pan, &panVolumeCorrectionRate)
       : pan;
-    pMidiTrack->AddPan(channel, midiPan);
+    pMidiTrack->addPan(channel, midiPan);
 
     switch (parentSeq->panVolumeCorrectionMode) {
     case PanVolumeCorrectionMode::kAdjustVolumeController:
@@ -872,7 +872,7 @@ void SeqTrack::addPanSlide(uint32_t offset,
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new PanSlideSeqEvent(this, targPan, dur, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    addControllerSlide(dur, prevPan, targPan, nullptr, &MidiTrack::InsertPan);
+    addControllerSlide(dur, prevPan, targPan, nullptr, &MidiTrack::insertPan);
 }
 
 
@@ -889,7 +889,7 @@ void SeqTrack::insertPan(uint32_t offset,
     const uint8_t midiPan = parentSeq->usesLinearAmplitudeScale()
       ? convert7bitLinearPercentPanValToStdMidiVal(pan, &panVolumeCorrectionRate)
       : pan;
-    pMidiTrack->InsertPan(channel, midiPan, absTime);
+    pMidiTrack->insertPan(channel, midiPan, absTime);
 
     // TODO: (bugfix) Pan volume compensation does not work properly when using pan slider and volume slider at the same time
     switch (parentSeq->panVolumeCorrectionMode) {
@@ -917,14 +917,14 @@ void SeqTrack::addReverb(uint32_t offset, uint32_t length, uint8_t reverb, const
 
 void SeqTrack::addReverbNoItem(uint8_t reverb) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
-    pMidiTrack->AddReverb(channel, reverb);
+    pMidiTrack->addReverb(channel, reverb);
   }
   prevReverb = reverb;
 }
 
 void SeqTrack::addMonoNoItem() const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
-    pMidiTrack->AddMono(channel);
+    pMidiTrack->addMono(channel);
   }
 }
 
@@ -938,7 +938,7 @@ void SeqTrack::insertReverb(uint32_t offset,
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new ReverbSeqEvent(this, reverb, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->InsertReverb(channel, reverb, absTime);
+    pMidiTrack->insertReverb(channel, reverb, absTime);
 }
 
 void SeqTrack::addPitchBendMidiFormat(uint32_t offset,
@@ -955,7 +955,7 @@ void SeqTrack::addPitchBend(uint32_t offset, uint32_t length, int16_t bend, cons
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new PitchBendSeqEvent(this, bend, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddPitchBend(channel, bend);
+    pMidiTrack->addPitchBend(channel, bend);
 }
 
 void SeqTrack::addPitchBendRange(uint32_t offset, uint32_t length, uint16_t cents, const std::string &sEventName) {
@@ -964,12 +964,12 @@ void SeqTrack::addPitchBendRange(uint32_t offset, uint32_t length, uint16_t cent
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new PitchBendRangeSeqEvent(this, cents, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddPitchBendRange(channel, cents);
+    pMidiTrack->addPitchBendRange(channel, cents);
 }
 
 void SeqTrack::addPitchBendRangeNoItem(uint16_t cents) const {
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddPitchBendRange(channel, cents);
+    pMidiTrack->addPitchBendRange(channel, cents);
 }
 
 void SeqTrack::addFineTuning(uint32_t offset, uint32_t length, double cents, const std::string &sEventName) {
@@ -978,12 +978,12 @@ void SeqTrack::addFineTuning(uint32_t offset, uint32_t length, double cents, con
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new FineTuningSeqEvent(this, cents, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddFineTuning(channel, cents);
+    pMidiTrack->addFineTuning(channel, cents);
 }
 
 void SeqTrack::addFineTuningNoItem(double cents) const {
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddFineTuning(channel, cents);
+    pMidiTrack->addFineTuning(channel, cents);
 }
 
 void SeqTrack::addModulationDepthRange(uint32_t offset,
@@ -995,12 +995,12 @@ void SeqTrack::addModulationDepthRange(uint32_t offset,
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new ModulationDepthRangeSeqEvent(this, semitones, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddModulationDepthRange(channel, semitones);
+    pMidiTrack->addModulationDepthRange(channel, semitones);
 }
 
 void SeqTrack::addModulationDepthRangeNoItem(double semitones) const {
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddModulationDepthRange(channel, semitones);
+    pMidiTrack->addModulationDepthRange(channel, semitones);
 }
 
 void SeqTrack::addTranspose(uint32_t offset, uint32_t length, int8_t theTranspose, const std::string &sEventName) {
@@ -1018,7 +1018,7 @@ void SeqTrack::addModulation(uint32_t offset, uint32_t length, uint8_t depth, co
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new ModulationSeqEvent(this, depth, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddModulation(channel, depth);
+    pMidiTrack->addModulation(channel, depth);
 }
 
 void SeqTrack::insertModulation(uint32_t offset,
@@ -1031,7 +1031,7 @@ void SeqTrack::insertModulation(uint32_t offset,
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new ModulationSeqEvent(this, depth, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->InsertModulation(channel, depth, absTime);
+    pMidiTrack->insertModulation(channel, depth, absTime);
 }
 
 void SeqTrack::addBreath(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName) {
@@ -1040,7 +1040,7 @@ void SeqTrack::addBreath(uint32_t offset, uint32_t length, uint8_t depth, const 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new BreathSeqEvent(this, depth, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddBreath(channel, depth);
+    pMidiTrack->addBreath(channel, depth);
 }
 
 void SeqTrack::insertBreath(uint32_t offset,
@@ -1053,7 +1053,7 @@ void SeqTrack::insertBreath(uint32_t offset,
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new BreathSeqEvent(this, depth, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->InsertBreath(channel, depth, absTime);
+    pMidiTrack->insertBreath(channel, depth, absTime);
 }
 
 void SeqTrack::addSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName) {
@@ -1062,7 +1062,7 @@ void SeqTrack::addSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new SustainSeqEvent(this, depth, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddSustain(channel, depth);
+    pMidiTrack->addSustain(channel, depth);
 }
 
 void SeqTrack::insertSustainEvent(uint32_t offset,
@@ -1075,7 +1075,7 @@ void SeqTrack::insertSustainEvent(uint32_t offset,
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new SustainSeqEvent(this, depth, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->InsertSustain(channel, depth, absTime);
+    pMidiTrack->insertSustain(channel, depth, absTime);
 }
 
 void SeqTrack::addPortamento(uint32_t offset, uint32_t length, bool bOn, const std::string &sEventName) {
@@ -1088,7 +1088,7 @@ void SeqTrack::addPortamento(uint32_t offset, uint32_t length, bool bOn, const s
 
 void SeqTrack::addPortamentoNoItem(bool bOn) const {
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddPortamento(channel, bOn);
+    pMidiTrack->addPortamento(channel, bOn);
 }
 
 void SeqTrack::insertPortamento(uint32_t offset,
@@ -1101,12 +1101,12 @@ void SeqTrack::insertPortamento(uint32_t offset,
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new PortamentoSeqEvent(this, bOn, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->InsertPortamento(channel, bOn, absTime);
+    pMidiTrack->insertPortamento(channel, bOn, absTime);
 }
 
 void SeqTrack::insertPortamentoNoItem(bool bOn, uint32_t absTime) const {
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->InsertPortamento(channel, bOn, absTime);
+    pMidiTrack->insertPortamento(channel, bOn, absTime);
 }
 
 void SeqTrack::addPortamentoTime(uint32_t offset, uint32_t length, uint8_t time, const std::string &sEventName) {
@@ -1119,7 +1119,7 @@ void SeqTrack::addPortamentoTime(uint32_t offset, uint32_t length, uint8_t time,
 
 void SeqTrack::addPortamentoTimeNoItem(uint8_t time) const {
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddPortamentoTime(channel, time);
+    pMidiTrack->addPortamentoTime(channel, time);
 }
 
 void SeqTrack::addPortamentoTime14Bit(uint32_t offset, uint32_t length, uint16_t time, const std::string &sEventName) {
@@ -1134,8 +1134,8 @@ void SeqTrack::addPortamentoTime14BitNoItem(uint16_t time) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t lsb = time & 127;
     uint8_t msb = (time >> 7) & 127;
-    pMidiTrack->AddPortamentoTimeFine(channel, lsb);
-    pMidiTrack->AddPortamentoTime(channel, msb);
+    pMidiTrack->addPortamentoTimeFine(channel, lsb);
+    pMidiTrack->addPortamentoTime(channel, msb);
   }
 }
 
@@ -1153,12 +1153,12 @@ void SeqTrack::insertPortamentoTime(uint32_t offset,
 
 void SeqTrack::insertPortamentoTimeNoItem(uint8_t time, uint32_t absTime) const {
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->InsertPortamentoTime(channel, time, absTime);
+    pMidiTrack->insertPortamentoTime(channel, time, absTime);
 }
 
 void SeqTrack::addPortamentoControlNoItem(uint8_t key) const {
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddPortamentoControl(channel, key);
+    pMidiTrack->addPortamentoControl(channel, key);
 }
 
 /*void InsertNoteOnEvent(int8_t key, int8_t vel, uint32_t absTime);
@@ -1235,13 +1235,13 @@ void SeqTrack::addProgramChangeNoItem(uint32_t progNum, bool requireBank) const 
     if (requireBank) {
       if (auto style = ConversionOptions::the().bankSelectStyle();
           style == BankSelectStyle::GS) {
-        pMidiTrack->AddBankSelect(channel, (progNum >> 7) & 0x7f);
+        pMidiTrack->addBankSelect(channel, (progNum >> 7) & 0x7f);
       } else if (style == BankSelectStyle::MMA) {
-        pMidiTrack->AddBankSelect(channel, (progNum >> 14) & 0x7f);
-        pMidiTrack->AddBankSelectFine(channel, (progNum >> 7) & 0x7f);
+        pMidiTrack->addBankSelect(channel, (progNum >> 14) & 0x7f);
+        pMidiTrack->addBankSelectFine(channel, (progNum >> 7) & 0x7f);
       }
     }
-    pMidiTrack->AddProgramChange(channel, progNum & 0x7f);
+    pMidiTrack->addProgramChange(channel, progNum & 0x7f);
   }
 }
 
@@ -1249,10 +1249,10 @@ void SeqTrack::addBankSelectNoItem(uint8_t bank) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     if (auto style = ConversionOptions::the().bankSelectStyle();
         style == BankSelectStyle::GS) {
-      pMidiTrack->AddBankSelect(channel, bank & 0x7f);
+      pMidiTrack->addBankSelect(channel, bank & 0x7f);
     } else if (style == BankSelectStyle::MMA) {
-      pMidiTrack->AddBankSelect(channel, bank >> 7);
-      pMidiTrack->AddBankSelectFine(channel, bank & 0x7f);
+      pMidiTrack->addBankSelect(channel, bank >> 7);
+      pMidiTrack->addBankSelectFine(channel, bank & 0x7f);
     }
   }
 }
@@ -1271,7 +1271,7 @@ void SeqTrack::addTempoNoItem(uint32_t microsPerQuarter) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     // Some MIDI tool can recognise tempo event only in the first track.
     MidiTrack *pFirstMidiTrack = parentSeq->firstMidiTrack();
-    pFirstMidiTrack->InsertTempo(microsPerQuarter, pMidiTrack->GetDelta());
+    pFirstMidiTrack->insertTempo(microsPerQuarter, pMidiTrack->getDelta());
   }
 }
 
@@ -1296,7 +1296,7 @@ void SeqTrack::addTempoBPMNoItem(double bpm) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     // Some MIDI tool can recognise tempo event only in the first track.
     MidiTrack *pFirstMidiTrack = parentSeq->firstMidiTrack();
-    pFirstMidiTrack->InsertTempoBPM(bpm, pMidiTrack->GetDelta());
+    pFirstMidiTrack->insertTempoBPM(bpm, pMidiTrack->getDelta());
   }
 }
 
@@ -1315,7 +1315,7 @@ void SeqTrack::addTempoBPMSlide(uint32_t offset,
       // Some MIDI software only recognise tempo events in the first track.
       MidiTrack *pFirstMidiTrack = parentSeq->firstMidiTrack();
       double newTempo = parentSeq->tempoBPM + (tempoInc * (i + 1));
-      pFirstMidiTrack->InsertTempoBPM(newTempo, getTime() + i);
+      pFirstMidiTrack->insertTempoBPM(newTempo, getTime() + i);
     }
   }
   parentSeq->tempoBPM = targBPM;
@@ -1338,7 +1338,7 @@ void SeqTrack::addTimeSig(uint32_t offset,
 void SeqTrack::addTimeSigNoItem(uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     MidiTrack *pFirstMidiTrack = parentSeq->firstMidiTrack();
-    pFirstMidiTrack->AddTimeSig(numer, denom, ticksPerQuarter);
+    pFirstMidiTrack->addTimeSig(numer, denom, ticksPerQuarter);
   }
 }
 
@@ -1356,7 +1356,7 @@ void SeqTrack::insertTimeSig(uint32_t offset,
   }
   else if (readMode == READMODE_CONVERT_TO_MIDI) {
     MidiTrack *pFirstMidiTrack = parentSeq->firstMidiTrack();
-    pFirstMidiTrack->InsertTimeSig(numer, denom, ticksPerQuarter, absTime);
+    pFirstMidiTrack->insertTimeSig(numer, denom, ticksPerQuarter, absTime);
   }
 }
 
@@ -1366,7 +1366,7 @@ void SeqTrack::addEndOfTrack(uint32_t offset, uint32_t length, const std::string
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new TrackEndSeqEvent(this, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddEndOfTrack();
+    pMidiTrack->addEndOfTrack();
   return addEndOfTrackNoItem();
 }
 
@@ -1381,7 +1381,7 @@ void SeqTrack::addGlobalTranspose(uint32_t offset, uint32_t length, int8_t semit
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new TransposeSeqEvent(this, semitones, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI)
-    parentSeq->midi->globalTrack.InsertGlobalTranspose(getTime(), semitones);
+    parentSeq->midi->globalTrack.insertGlobalTranspose(getTime(), semitones);
 }
 
 void SeqTrack::addMarker(uint32_t offset,
@@ -1404,7 +1404,7 @@ void SeqTrack::addMarkerNoItem(const std::string &markername,
                                uint8_t databyte2,
                                int8_t priority) const {
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->AddMarker(channel, markername, databyte1, databyte2, priority);
+    pMidiTrack->addMarker(channel, markername, databyte1, databyte2, priority);
 }
 
 void SeqTrack::insertMarkerNoItem(uint32_t absTime,
@@ -1413,7 +1413,7 @@ void SeqTrack::insertMarkerNoItem(uint32_t absTime,
                                   uint8_t databyte2,
                                   int8_t priority) const {
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->InsertMarker(channel, markername, databyte1, databyte2, priority, absTime);
+    pMidiTrack->insertMarker(channel, markername, databyte1, databyte2, priority, absTime);
 }
 
 // when in FIND_DELTA_LENGTH mode, returns true until we've hit the max number of loops defined in options

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -129,7 +129,7 @@ bool VGMSeq::postLoad() {
       return false;
     }
   } else if (readMode == READMODE_CONVERT_TO_MIDI) {
-    midi->Sort();
+    midi->sort();
   }
 
   return true;
@@ -224,7 +224,7 @@ void VGMSeq::loadTracksMain(uint32_t stopTime) {
       if (readMode == READMODE_CONVERT_TO_MIDI) {
         for (uint32_t trackNum = 0; trackNum < nNumTracks; trackNum++) {
           if (aTracks.at(trackNum)->pMidiTrack != nullptr) {
-            aTracks[trackNum]->pMidiTrack->SetDelta(time);
+            aTracks[trackNum]->pMidiTrack->setDelta(time);
           }
         }
       }
@@ -303,7 +303,7 @@ void VGMSeq::resetVars() {
 void VGMSeq::setPPQN(uint16_t ppqn) {
   this->m_ppqn = ppqn;
   if (readMode == READMODE_CONVERT_TO_MIDI)
-    midi->SetPPQN(ppqn);
+    midi->setPPQN(ppqn);
 }
 
 uint16_t VGMSeq::ppqn() const {
@@ -321,7 +321,7 @@ bool VGMSeq::saveAsMidi(const std::string &filepath) {
   MidiFile *midi = this->convertToMidi();
   if (!midi)
     return false;
-  bool result = midi->SaveMidiFile(filepath);
+  bool result = midi->saveMidiFile(filepath);
   delete midi;
   return result;
 }

--- a/src/main/components/seq/VGMSeqNoTrks.cpp
+++ b/src/main/components/seq/VGMSeqNoTrks.cpp
@@ -131,7 +131,7 @@ void VGMSeqNoTrks::tryExpandMidiTracks(uint32_t numTracks) {
   if (midiTracks.size() < numTracks) {
     size_t initialTrackSize = midiTracks.size();
     for (size_t i = 0; i < numTracks - initialTrackSize; i++)
-      midiTracks.push_back(midi->AddTrack());
+      midiTracks.push_back(midi->addTrack());
   }
 }
 
@@ -147,6 +147,6 @@ void VGMSeqNoTrks::addTime(uint32_t delta) {
   VGMSeq::time += delta;
   if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
     for (uint32_t i = 0; i < midiTracks.size(); i++)
-      midiTracks[i]->AddDelta(delta);
+      midiTracks[i]->addDelta(delta);
   }
 }

--- a/src/main/conversion/DLSFile.h
+++ b/src/main/conversion/DLSFile.h
@@ -93,9 +93,9 @@ class DLSFile : public RiffFile {
 public:
   DLSFile(std::string dls_name = "Instrument Set");
 
-  DLSInstr *AddInstr(unsigned long bank, unsigned long instrNum);
-  DLSInstr *AddInstr(unsigned long bank, unsigned long instrNum, std::string Name);
-  DLSWave *AddWave(uint16_t formatTag, uint16_t channels, int samplesPerSec, int aveBytesPerSec,
+  DLSInstr *addInstr(unsigned long bank, unsigned long instrNum);
+  DLSInstr *addInstr(unsigned long bank, unsigned long instrNum, std::string Name);
+  DLSWave *addWave(uint16_t formatTag, uint16_t channels, int samplesPerSec, int aveBytesPerSec,
                    uint16_t blockAlign, uint16_t bitsPerSample, uint32_t waveDataSize,
                    uint8_t *waveData, std::string name = "Unnamed Wave");
 
@@ -169,7 +169,7 @@ public:
                   int32_t scale)
       : usSource(source), usControl(control), usDestination(destination), usTransform(transform),
         lScale(scale) {}
-  ~ConnectionBlock(void) {}
+  ~ConnectionBlock() {}
 
   static uint32_t size() { return 12; }
   void write(std::vector<uint8_t> &buf) const;
@@ -188,7 +188,7 @@ public:
 
   void addADSR(long attack_time, uint16_t atk_transform, long hold_time, long decay_time,
                long sustain_lev, long release_time, uint16_t rls_transform);
-  void AddPan(long pan);
+  void addPan(long pan);
 
   uint32_t GetSize() const;
   void Write(std::vector<uint8_t> &buf) const;
@@ -201,11 +201,11 @@ class DLSWsmp {
 public:
   DLSWsmp() = default;
 
-  void SetLoopInfo(Loop &loop, VGMSamp *samp);
-  void SetPitchInfo(uint16_t unityNote, int16_t fineTune, int32_t attenuation);
+  void setLoopInfo(Loop &loop, VGMSamp *samp);
+  void setPitchInfo(uint16_t unityNote, int16_t fineTune, int32_t attenuation);
 
-  uint32_t GetSize() const;
-  void Write(std::vector<uint8_t> &buf) const;
+  [[nodiscard]] uint32_t size() const;
+  void write(std::vector<uint8_t> &buf) const;
 
 private:
   uint16_t usUnityNote;
@@ -231,14 +231,14 @@ public:
 
   //	This function will always return an even value, to maintain the alignment
   // necessary for the RIFF format.
-  unsigned long GetSampleSize() const {
+  unsigned long sampleSize() const {
     if (m_wave_data.size() % 2)
       return m_wave_data.size() + 1;
     else
       return m_wave_data.size();
   }
-  uint32_t GetSize() const;
-  void Write(std::vector<uint8_t> &buf);
+  uint32_t size() const;
+  void write(std::vector<uint8_t> &buf);
 
 private:
   uint16_t wFormatTag;

--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -18,19 +18,19 @@ MidiFile::MidiFile(VGMSeq *theAssocSeq)
   this->bMonophonicTracks = assocSeq->usesMonophonicTracks();
   this->globalTrack.bMonophonic = this->bMonophonicTracks;
 
-  this->ppqn = assocSeq->ppqn();
+  this->m_ppqn = assocSeq->ppqn();
 }
 
 MidiFile::~MidiFile() {
   deleteVect<MidiTrack>(aTracks);
 }
 
-MidiTrack *MidiFile::AddTrack() {
+MidiTrack *MidiFile::addTrack() {
   aTracks.push_back(new MidiTrack(this, bMonophonicTracks));
   return aTracks.back();
 }
 
-MidiTrack *MidiFile::InsertTrack(uint32_t trackNum) {
+MidiTrack *MidiFile::insertTrack(uint32_t trackNum) {
   if (trackNum + 1 > aTracks.size())
     aTracks.resize(trackNum + 1, nullptr);
 
@@ -38,7 +38,7 @@ MidiTrack *MidiFile::InsertTrack(uint32_t trackNum) {
   return aTracks[trackNum];
 }
 
-int MidiFile::GetMidiTrackIndex(const MidiTrack *midiTrack) {
+int MidiFile::getMidiTrackIndex(const MidiTrack *midiTrack) {
   auto it = std::ranges::find(aTracks, midiTrack);
   if (it != aTracks.end()) {
     return static_cast<int>(std::distance(aTracks.begin(), it));
@@ -47,33 +47,33 @@ int MidiFile::GetMidiTrackIndex(const MidiTrack *midiTrack) {
   }
 }
 
-void MidiFile::SetPPQN(uint16_t ppqn) {
-  this->ppqn = ppqn;
+void MidiFile::setPPQN(uint16_t ppqn) {
+  this->m_ppqn = ppqn;
 }
 
-uint32_t MidiFile::GetPPQN() const {
-  return ppqn;
+uint32_t MidiFile::ppqn() const {
+  return m_ppqn;
 }
 
-void MidiFile::Sort() {
+void MidiFile::sort() {
   for (uint32_t i = 0; i < aTracks.size(); i++) {
     if (aTracks[i]) {
       if (aTracks[i]->aEvents.empty()) {
         delete aTracks[i];
         aTracks.erase(aTracks.begin() + i--);
       } else
-        aTracks[i]->Sort();
+        aTracks[i]->sort();
     }
   }
 }
 
-bool MidiFile::SaveMidiFile(const std::string &filepath) {
+bool MidiFile::saveMidiFile(const std::string &filepath) {
   std::vector<uint8_t> midiBuf;
-  WriteMidiToBuffer(midiBuf);
+  writeMidiToBuffer(midiBuf);
   return pRoot->UI_writeBufferToFile(filepath, &midiBuf[0], midiBuf.size());
 }
 
-void MidiFile::WriteMidiToBuffer(std::vector<uint8_t> &buf) {
+void MidiFile::writeMidiToBuffer(std::vector<uint8_t> &buf) {
   size_t nNumTracks = aTracks.size();
   buf.push_back('M');
   buf.push_back('T');
@@ -87,16 +87,16 @@ void MidiFile::WriteMidiToBuffer(std::vector<uint8_t> &buf) {
   buf.push_back(1);                //Midi format - type 1
   buf.push_back((nNumTracks & 0xFF00) >> 8);  //num tracks hi
   buf.push_back(nNumTracks & 0x00FF);         //num tracks lo
-  buf.push_back((ppqn & 0xFF00) >> 8);
-  buf.push_back(ppqn & 0xFF);
+  buf.push_back((m_ppqn & 0xFF00) >> 8);
+  buf.push_back(m_ppqn & 0xFF);
 
-  Sort();
+  sort();
 
   for (auto& aTrack : aTracks) {
     if (aTrack) {
       std::vector<uint8_t> trackBuf;
       globalTranspose = 0;
-      aTrack->WriteTrack(trackBuf);
+      aTrack->writeTrack(trackBuf);
       buf.insert(buf.end(), trackBuf.begin(), trackBuf.end());
     }
   }
@@ -121,17 +121,17 @@ MidiTrack::~MidiTrack() {
   deleteVect<MidiEvent>(aEvents);
 }
 
-void MidiTrack::Sort() {
+void MidiTrack::sort() {
   std::ranges::stable_sort(aEvents, PriorityCmp()); // Sort all the events by priority
   std::ranges::stable_sort(aEvents, AbsTimeCmp());  // Sort all the events by absolute time,
                                                              // so that delta times can be recorded correctly
   if (!bHasEndOfTrack && !aEvents.empty()) {
-    aEvents.push_back(new EndOfTrackEvent(this, aEvents.back()->AbsTime));
+    aEvents.push_back(new EndOfTrackEvent(this, aEvents.back()->absTime));
     bHasEndOfTrack = true;
   }
 }
 
-void MidiTrack::WriteTrack(std::vector<uint8_t> &buf) const {
+void MidiTrack::writeTrack(std::vector<uint8_t> &buf) const {
   buf.push_back('M');
   buf.push_back('T');
   buf.push_back('r');
@@ -153,7 +153,7 @@ void MidiTrack::WriteTrack(std::vector<uint8_t> &buf) const {
   size_t numEvents = finalEvents.size();
 
   for (size_t i = 0; i < numEvents; i++)
-    time = finalEvents[i]->WriteEvent(buf, time);  // write all events into the buffer
+    time = finalEvents[i]->writeEvent(buf, time);  // write all events into the buffer
 
   size_t trackSize = buf.size() - 8;  // -8 for MTrk and size that shouldn't be accounted for
   buf[4] = static_cast<uint8_t>((trackSize & 0xFF000000) >> 24);
@@ -162,58 +162,58 @@ void MidiTrack::WriteTrack(std::vector<uint8_t> &buf) const {
   buf[7] = static_cast<uint8_t>(trackSize & 0x000000FF);
 }
 
-void MidiTrack::SetChannelGroup(int theChannelGroup) {
+void MidiTrack::setChannelGroup(int theChannelGroup) {
   channelGroup = theChannelGroup;
 }
 
 // Delta Time Functions
-uint32_t MidiTrack::GetDelta() const {
+uint32_t MidiTrack::getDelta() const {
   return DeltaTime;
 }
 
-void MidiTrack::SetDelta(uint32_t NewDelta) {
+void MidiTrack::setDelta(uint32_t NewDelta) {
   DeltaTime = NewDelta;
 }
 
-void MidiTrack::AddDelta(uint32_t AddDelta) {
+void MidiTrack::addDelta(uint32_t AddDelta) {
   DeltaTime += AddDelta;
 }
 
-void MidiTrack::SubtractDelta(uint32_t SubtractDelta) {
+void MidiTrack::subtractDelta(uint32_t SubtractDelta) {
   DeltaTime -= SubtractDelta;
 }
 
-void MidiTrack::ResetDelta() {
+void MidiTrack::resetDelta() {
   DeltaTime = 0;
 }
 
-void MidiTrack::AddNoteOn(uint8_t channel, int8_t key, int8_t vel) {
-  aEvents.push_back(new NoteEvent(this, channel, GetDelta(), true, key, vel));
+void MidiTrack::addNoteOn(uint8_t channel, int8_t key, int8_t vel) {
+  aEvents.push_back(new NoteEvent(this, channel, getDelta(), true, key, vel));
 }
 
-void MidiTrack::InsertNoteOn(uint8_t channel, int8_t key, int8_t vel, uint32_t absTime) {
+void MidiTrack::insertNoteOn(uint8_t channel, int8_t key, int8_t vel, uint32_t absTime) {
   aEvents.push_back(new NoteEvent(this, channel, absTime, true, key, vel));
 }
 
-void MidiTrack::AddNoteOff(uint8_t channel, int8_t key) {
-  aEvents.push_back(new NoteEvent(this, channel, GetDelta(), false, key));
+void MidiTrack::addNoteOff(uint8_t channel, int8_t key) {
+  aEvents.push_back(new NoteEvent(this, channel, getDelta(), false, key));
 }
 
-void MidiTrack::InsertNoteOff(uint8_t channel, int8_t key, uint32_t absTime) {
+void MidiTrack::insertNoteOff(uint8_t channel, int8_t key, uint32_t absTime) {
   aEvents.push_back(new NoteEvent(this, channel, absTime, false, key));
 }
 
-void MidiTrack::AddNoteByDur(uint8_t channel, int8_t key, int8_t vel, uint32_t duration) {
-  PurgePrevNoteOffs(GetDelta());
-  aEvents.push_back(new NoteEvent(this, channel, GetDelta(), true, key, vel));  // add note on
-  NoteEvent *prevDurNoteOff = new NoteEvent(this, channel, GetDelta() + duration, false, key);
+void MidiTrack::addNoteByDur(uint8_t channel, int8_t key, int8_t vel, uint32_t duration) {
+  purgePrevNoteOffs(getDelta());
+  aEvents.push_back(new NoteEvent(this, channel, getDelta(), true, key, vel));  // add note on
+  NoteEvent *prevDurNoteOff = new NoteEvent(this, channel, getDelta() + duration, false, key);
   prevDurNoteOffs.push_back(prevDurNoteOff);
   aEvents.push_back(prevDurNoteOff);  // add note off at end of dur
 }
 
 //TODO: MOVE! This definitely doesn't belong here.
-void MidiTrack::AddNoteByDur_TriAce(uint8_t channel, int8_t key, int8_t vel, uint32_t duration) {
-  uint32_t CurDelta = GetDelta();
+void MidiTrack::addNoteByDur_TriAce(uint8_t channel, int8_t key, int8_t vel, uint32_t duration) {
+  uint32_t CurDelta = getDelta();
   size_t nNumEvents = aEvents.size();
 
   NoteEvent* ContNote = nullptr;  // Continuted Note
@@ -228,7 +228,7 @@ void MidiTrack::AddNoteByDur_TriAce(uint8_t channel, int8_t key, int8_t vel, uin
     // Note: In previous TriAce drivers (like MegaDrive and SNES versions),
     //       a Note gets extended by a Note On event at the tick where another note expires.
     //       Valkyrie Profile: 225 Fragments of the Heart confirms, that this is NOT the case in the PS1 version.
-    if (aEvents[curEvt]->AbsTime > CurDelta && aEvents[curEvt]->GetEventType() == MIDIEVENT_NOTEON) {
+    if (aEvents[curEvt]->absTime > CurDelta && aEvents[curEvt]->eventType() == MIDIEVENT_NOTEON) {
       NoteEvent *NoteEvt = dynamic_cast<NoteEvent*>(aEvents[curEvt]);
       if (NoteEvt->key == key && !NoteEvt->bNoteDown) {
         ContNote = NoteEvt;
@@ -238,31 +238,31 @@ void MidiTrack::AddNoteByDur_TriAce(uint8_t channel, int8_t key, int8_t vel, uin
   }
 
   if (ContNote == nullptr) {
-    PurgePrevNoteOffs(CurDelta);
+    purgePrevNoteOffs(CurDelta);
     aEvents.push_back(new NoteEvent(this, channel, CurDelta, true, key, vel));  // add note on
     NoteEvent *prevDurNoteOff = new NoteEvent(this, channel, CurDelta + duration, false, key);
     prevDurNoteOffs.push_back(prevDurNoteOff);
     aEvents.push_back(prevDurNoteOff);  // add note off at end of dur
   } else {
-    ContNote->AbsTime = CurDelta + duration;  // fix DeltaTime of the already inserted NoteOff event
+    ContNote->absTime = CurDelta + duration;  // fix DeltaTime of the already inserted NoteOff event
   }
 }
 
-void MidiTrack::InsertNoteByDur(uint8_t channel, int8_t key, int8_t vel, uint32_t duration, uint32_t absTime) {
-  PurgePrevNoteOffs(std::max(GetDelta(), absTime));
+void MidiTrack::insertNoteByDur(uint8_t channel, int8_t key, int8_t vel, uint32_t duration, uint32_t absTime) {
+  purgePrevNoteOffs(std::max(getDelta(), absTime));
   aEvents.push_back(new NoteEvent(this, channel, absTime, true, key, vel));  // add note on
   NoteEvent *prevDurNoteOff = new NoteEvent(this, channel, absTime + duration, false, key);
   prevDurNoteOffs.push_back(prevDurNoteOff);
   aEvents.push_back(prevDurNoteOff);  // add note off at end of dur
 }
 
-void MidiTrack::PurgePrevNoteOffs() {
+void MidiTrack::purgePrevNoteOffs() {
   prevDurNoteOffs.clear();
 }
 
-void MidiTrack::PurgePrevNoteOffs(uint32_t absTime) {
+void MidiTrack::purgePrevNoteOffs(uint32_t absTime) {
   prevDurNoteOffs.erase(std::remove_if(prevDurNoteOffs.begin(), prevDurNoteOffs.end(),
-    [absTime](const NoteEvent *e) { return e && e->AbsTime <= absTime; }),
+    [absTime](const NoteEvent *e) { return e && e->absTime <= absTime; }),
     prevDurNoteOffs.end());
 }
 
@@ -278,135 +278,135 @@ void MidiTrack::InsertVolMarker(uint8_t channel, uint8_t vol, uint32_t absTime, 
 	aEvents.push_back(newEvent);
 }*/
 
-void MidiTrack::AddControllerEvent(uint8_t channel, uint8_t controllerNum, uint8_t theDataByte) {
-  aEvents.push_back(new ControllerEvent(this, channel, GetDelta(), controllerNum, theDataByte));
+void MidiTrack::addControllerEvent(uint8_t channel, uint8_t controllerNum, uint8_t theDataByte) {
+  aEvents.push_back(new ControllerEvent(this, channel, getDelta(), controllerNum, theDataByte));
 }
 
-void MidiTrack::InsertControllerEvent(uint8_t channel, uint8_t controllerNum, uint8_t theDataByte, uint32_t absTime) {
+void MidiTrack::insertControllerEvent(uint8_t channel, uint8_t controllerNum, uint8_t theDataByte, uint32_t absTime) {
   aEvents.push_back(new ControllerEvent(this, channel, absTime, controllerNum, theDataByte));
 }
 
-void MidiTrack::AddVol(uint8_t channel, uint8_t vol) {
-  aEvents.push_back(new VolumeEvent(this, channel, GetDelta(), vol));
+void MidiTrack::addVol(uint8_t channel, uint8_t vol) {
+  aEvents.push_back(new VolumeEvent(this, channel, getDelta(), vol));
 }
 
-void MidiTrack::InsertVol(uint8_t channel, uint8_t vol, uint32_t absTime) {
+void MidiTrack::insertVol(uint8_t channel, uint8_t vol, uint32_t absTime) {
   aEvents.push_back(new VolumeEvent(this, channel, absTime, vol));
 }
 
-void MidiTrack::AddVolumeFine(uint8_t channel, uint8_t volume_lsb) {
-  aEvents.push_back(new VolumeFineEvent(this, channel, GetDelta(), volume_lsb));
+void MidiTrack::addVolumeFine(uint8_t channel, uint8_t volume_lsb) {
+  aEvents.push_back(new VolumeFineEvent(this, channel, getDelta(), volume_lsb));
 }
 
 //TODO: Master Volume sysex events are meant to be global to device, not per channel.
 // For per channel master volume, we should add a system for normalizing controller vol events.
-void MidiTrack::AddMasterVol(uint8_t channel, uint8_t mastVol) {
-  MidiEvent *newEvent = new MasterVolEvent(this, channel, GetDelta(), mastVol);
+void MidiTrack::addMasterVol(uint8_t channel, uint8_t mastVol) {
+  MidiEvent *newEvent = new MasterVolEvent(this, channel, getDelta(), mastVol);
   aEvents.push_back(newEvent);
 }
 
-void MidiTrack::InsertMasterVol(uint8_t channel, uint8_t mastVol, uint32_t absTime) {
+void MidiTrack::insertMasterVol(uint8_t channel, uint8_t mastVol, uint32_t absTime) {
   MidiEvent *newEvent = new MasterVolEvent(this, channel, absTime, mastVol);
   aEvents.push_back(newEvent);
 }
 
-void MidiTrack::AddExpression(uint8_t channel, uint8_t expression) {
-  aEvents.push_back(new ExpressionEvent(this, channel, GetDelta(), expression));
+void MidiTrack::addExpression(uint8_t channel, uint8_t expression) {
+  aEvents.push_back(new ExpressionEvent(this, channel, getDelta(), expression));
 }
 
-void MidiTrack::InsertExpression(uint8_t channel, uint8_t expression, uint32_t absTime) {
+void MidiTrack::insertExpression(uint8_t channel, uint8_t expression, uint32_t absTime) {
   aEvents.push_back(new ExpressionEvent(this, channel, absTime, expression));
 }
 
-void MidiTrack::AddSustain(uint8_t channel, uint8_t depth) {
-  aEvents.push_back(new SustainEvent(this, channel, GetDelta(), depth));
+void MidiTrack::addSustain(uint8_t channel, uint8_t depth) {
+  aEvents.push_back(new SustainEvent(this, channel, getDelta(), depth));
 }
 
-void MidiTrack::InsertSustain(uint8_t channel, uint8_t depth, uint32_t absTime) {
+void MidiTrack::insertSustain(uint8_t channel, uint8_t depth, uint32_t absTime) {
   aEvents.push_back(new SustainEvent(this, channel, absTime, depth));
 }
 
-void MidiTrack::AddPortamento(uint8_t channel, bool bOn) {
-  aEvents.push_back(new PortamentoEvent(this, channel, GetDelta(), bOn));
+void MidiTrack::addPortamento(uint8_t channel, bool bOn) {
+  aEvents.push_back(new PortamentoEvent(this, channel, getDelta(), bOn));
 }
 
-void MidiTrack::InsertPortamento(uint8_t channel, bool bOn, uint32_t absTime) {
+void MidiTrack::insertPortamento(uint8_t channel, bool bOn, uint32_t absTime) {
   aEvents.push_back(new PortamentoEvent(this, channel, absTime, bOn));
 }
 
-void MidiTrack::AddPortamentoTime(uint8_t channel, uint8_t time) {
-  aEvents.push_back(new PortamentoTimeEvent(this, channel, GetDelta(), time));
+void MidiTrack::addPortamentoTime(uint8_t channel, uint8_t time) {
+  aEvents.push_back(new PortamentoTimeEvent(this, channel, getDelta(), time));
 }
 
-void MidiTrack::InsertPortamentoTime(uint8_t channel, uint8_t time, uint32_t absTime) {
+void MidiTrack::insertPortamentoTime(uint8_t channel, uint8_t time, uint32_t absTime) {
   aEvents.push_back(new PortamentoTimeEvent(this, channel, absTime, time));
 }
 
-void MidiTrack::AddPortamentoTimeFine(uint8_t channel, uint8_t time) {
-  aEvents.push_back(new PortamentoTimeFineEvent(this, channel, GetDelta(), time));
+void MidiTrack::addPortamentoTimeFine(uint8_t channel, uint8_t time) {
+  aEvents.push_back(new PortamentoTimeFineEvent(this, channel, getDelta(), time));
 }
 
-void MidiTrack::InsertPortamentoTimeFine(uint8_t channel, uint8_t time, uint32_t absTime) {
+void MidiTrack::insertPortamentoTimeFine(uint8_t channel, uint8_t time, uint32_t absTime) {
   aEvents.push_back(new PortamentoTimeFineEvent(this, channel, absTime, time));
 }
 
-void MidiTrack::AddPortamentoControl(uint8_t channel, uint8_t key) {
-  aEvents.push_back(new PortamentoControlEvent(this, channel, GetDelta(), key));
+void MidiTrack::addPortamentoControl(uint8_t channel, uint8_t key) {
+  aEvents.push_back(new PortamentoControlEvent(this, channel, getDelta(), key));
 }
 
-void MidiTrack::AddMono(uint8_t channel) {
-  aEvents.push_back(new MonoEvent(this, channel, GetDelta()));
+void MidiTrack::addMono(uint8_t channel) {
+  aEvents.push_back(new MonoEvent(this, channel, getDelta()));
 }
 
-void MidiTrack::InsertMono(uint8_t channel, uint32_t absTime) {
+void MidiTrack::insertMono(uint8_t channel, uint32_t absTime) {
   aEvents.push_back(new MonoEvent(this, channel, absTime));
 }
 
-void MidiTrack::AddPan(uint8_t channel, uint8_t pan) {
-  aEvents.push_back(new PanEvent(this, channel, GetDelta(), pan));
+void MidiTrack::addPan(uint8_t channel, uint8_t pan) {
+  aEvents.push_back(new PanEvent(this, channel, getDelta(), pan));
 }
 
-void MidiTrack::InsertPan(uint8_t channel, uint8_t pan, uint32_t absTime) {
+void MidiTrack::insertPan(uint8_t channel, uint8_t pan, uint32_t absTime) {
   aEvents.push_back(new PanEvent(this, channel, absTime, pan));
 }
 
-void MidiTrack::AddReverb(uint8_t channel, uint8_t reverb) {
-  aEvents.push_back(new ControllerEvent(this, channel, GetDelta(), 91, reverb));
+void MidiTrack::addReverb(uint8_t channel, uint8_t reverb) {
+  aEvents.push_back(new ControllerEvent(this, channel, getDelta(), 91, reverb));
 }
 
-void MidiTrack::InsertReverb(uint8_t channel, uint8_t reverb, uint32_t absTime) {
+void MidiTrack::insertReverb(uint8_t channel, uint8_t reverb, uint32_t absTime) {
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 91, reverb));
 }
 
-void MidiTrack::AddModulation(uint8_t channel, uint8_t depth) {
-  aEvents.push_back(new ModulationEvent(this, channel, GetDelta(), depth));
+void MidiTrack::addModulation(uint8_t channel, uint8_t depth) {
+  aEvents.push_back(new ModulationEvent(this, channel, getDelta(), depth));
 }
 
-void MidiTrack::InsertModulation(uint8_t channel, uint8_t depth, uint32_t absTime) {
+void MidiTrack::insertModulation(uint8_t channel, uint8_t depth, uint32_t absTime) {
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 1, depth));
 }
 
-void MidiTrack::AddBreath(uint8_t channel, uint8_t depth) {
-  aEvents.push_back(new BreathEvent(this, channel, GetDelta(), depth));
+void MidiTrack::addBreath(uint8_t channel, uint8_t depth) {
+  aEvents.push_back(new BreathEvent(this, channel, getDelta(), depth));
 }
 
-void MidiTrack::InsertBreath(uint8_t channel, uint8_t depth, uint32_t absTime) {
+void MidiTrack::insertBreath(uint8_t channel, uint8_t depth, uint32_t absTime) {
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 2, depth));
 }
 
-void MidiTrack::AddPitchBend(uint8_t channel, int16_t bend) {
-  aEvents.push_back(new PitchBendEvent(this, channel, GetDelta(), bend));
+void MidiTrack::addPitchBend(uint8_t channel, int16_t bend) {
+  aEvents.push_back(new PitchBendEvent(this, channel, getDelta(), bend));
 }
 
-void MidiTrack::InsertPitchBend(uint8_t channel, int16_t bend, uint32_t absTime) {
+void MidiTrack::insertPitchBend(uint8_t channel, int16_t bend, uint32_t absTime) {
   aEvents.push_back(new PitchBendEvent(this, channel, absTime, bend));
 }
 
-void MidiTrack::AddPitchBendRange(uint8_t channel, uint16_t cents) {
-  InsertPitchBendRange(channel, cents, GetDelta());
+void MidiTrack::addPitchBendRange(uint8_t channel, uint16_t cents) {
+  insertPitchBendRange(channel, cents, getDelta());
 }
 
-void MidiTrack::InsertPitchBendRange(uint8_t channel, uint16_t cents, uint32_t absTime) {
+void MidiTrack::insertPitchBendRange(uint8_t channel, uint16_t cents, uint32_t absTime) {
   uint8_t semitones = cents / 100;
   uint8_t finetune_cents = cents % 100;
   // We push the LSB controller event first as somee virtual instruments only react upon receiving MSB
@@ -416,11 +416,11 @@ void MidiTrack::InsertPitchBendRange(uint8_t channel, uint16_t cents, uint32_t a
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 6, semitones, PRIORITY_HIGHER - 1));
 }
 
-void MidiTrack::AddFineTuning(uint8_t channel, uint8_t msb, uint8_t lsb) {
-  InsertFineTuning(channel, msb, lsb, GetDelta());
+void MidiTrack::addFineTuning(uint8_t channel, uint8_t msb, uint8_t lsb) {
+  insertFineTuning(channel, msb, lsb, getDelta());
 }
 
-void MidiTrack::InsertFineTuning(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime) {
+void MidiTrack::insertFineTuning(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime) {
   // We push the LSB controller event first as somee virtual instruments only react upon receiving MSB
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 101, 0, PRIORITY_HIGHER - 1));
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 100, 1, PRIORITY_HIGHER - 1));
@@ -428,178 +428,178 @@ void MidiTrack::InsertFineTuning(uint8_t channel, uint8_t msb, uint8_t lsb, uint
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 6, msb, PRIORITY_HIGHER - 1));
 }
 
-void MidiTrack::AddFineTuning(uint8_t channel, double cents) {
-  InsertFineTuning(channel, cents, GetDelta());
+void MidiTrack::addFineTuning(uint8_t channel, double cents) {
+  insertFineTuning(channel, cents, getDelta());
 }
 
-void MidiTrack::InsertFineTuning(uint8_t channel, double cents, uint32_t absTime) {
+void MidiTrack::insertFineTuning(uint8_t channel, double cents, uint32_t absTime) {
   double semitones = std::max(-1.0, std::min(1.0, cents / 100.0));
   int16_t midiTuning = std::min(static_cast<int>(lround(8192 * semitones)), 8191) + 8192;
 
-  InsertFineTuning(channel, midiTuning >> 7, midiTuning & 0x7f, absTime);
+  insertFineTuning(channel, midiTuning >> 7, midiTuning & 0x7f, absTime);
 }
 
-void MidiTrack::AddCoarseTuning(uint8_t channel, uint8_t msb, uint8_t lsb) {
-  InsertCoarseTuning(channel, msb, lsb, GetDelta());
+void MidiTrack::addCoarseTuning(uint8_t channel, uint8_t msb, uint8_t lsb) {
+  insertCoarseTuning(channel, msb, lsb, getDelta());
 }
 
-void MidiTrack::InsertCoarseTuning(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime) {
+void MidiTrack::insertCoarseTuning(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime) {
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 101, 0, PRIORITY_HIGHER - 1));
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 100, 2, PRIORITY_HIGHER - 1));
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 38, lsb, PRIORITY_HIGHER - 1));
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 6, msb, PRIORITY_HIGHER - 1));
 }
 
-void MidiTrack::AddCoarseTuning(uint8_t channel, double semitones) {
-  InsertCoarseTuning(channel, semitones, GetDelta());
+void MidiTrack::addCoarseTuning(uint8_t channel, double semitones) {
+  insertCoarseTuning(channel, semitones, getDelta());
 }
 
-void MidiTrack::InsertCoarseTuning(uint8_t channel, double semitones, uint32_t absTime) {
+void MidiTrack::insertCoarseTuning(uint8_t channel, double semitones, uint32_t absTime) {
   semitones = std::max(-64.0, std::min(64.0, semitones));
   int16_t midiTuning = std::min(static_cast<int>(lround(128 * semitones)), 8191) + 8192;
-  InsertCoarseTuning(channel, midiTuning >> 7, midiTuning & 0x7f, absTime);
+  insertCoarseTuning(channel, midiTuning >> 7, midiTuning & 0x7f, absTime);
 }
 
-void MidiTrack::AddModulationDepthRange(uint8_t channel, uint8_t msb, uint8_t lsb) {
-  InsertModulationDepthRange(channel, msb, lsb, GetDelta());
+void MidiTrack::addModulationDepthRange(uint8_t channel, uint8_t msb, uint8_t lsb) {
+  insertModulationDepthRange(channel, msb, lsb, getDelta());
 }
 
-void MidiTrack::InsertModulationDepthRange(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime) {
+void MidiTrack::insertModulationDepthRange(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime) {
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 101, 0, PRIORITY_HIGHER - 1));
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 100, 5, PRIORITY_HIGHER - 1));
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 38, lsb, PRIORITY_HIGHER - 1));
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 6, msb, PRIORITY_HIGHER - 1));
 }
 
-void MidiTrack::AddModulationDepthRange(uint8_t channel, double semitones) {
-  InsertModulationDepthRange(channel, semitones, GetDelta());
+void MidiTrack::addModulationDepthRange(uint8_t channel, double semitones) {
+  insertModulationDepthRange(channel, semitones, getDelta());
 }
 
-void MidiTrack::InsertModulationDepthRange(uint8_t channel, double semitones, uint32_t absTime) {
+void MidiTrack::insertModulationDepthRange(uint8_t channel, double semitones, uint32_t absTime) {
   semitones = std::max(-64.0, std::min(64.0, semitones));
   int16_t midiTuning = std::min(static_cast<int>(lround(128 * semitones)), 8191) + 8192;
-  InsertFineTuning(channel, midiTuning >> 7, midiTuning & 0x7f, absTime);
+  insertFineTuning(channel, midiTuning >> 7, midiTuning & 0x7f, absTime);
 }
 
-void MidiTrack::AddProgramChange(uint8_t channel, uint8_t progNum) {
-  aEvents.push_back(new ProgChangeEvent(this, channel, GetDelta(), progNum));
+void MidiTrack::addProgramChange(uint8_t channel, uint8_t progNum) {
+  aEvents.push_back(new ProgChangeEvent(this, channel, getDelta(), progNum));
 }
 
-void MidiTrack::AddBankSelect(uint8_t channel, uint8_t bank) {
-  aEvents.push_back(new BankSelectEvent(this, channel, GetDelta(), bank));
+void MidiTrack::addBankSelect(uint8_t channel, uint8_t bank) {
+  aEvents.push_back(new BankSelectEvent(this, channel, getDelta(), bank));
 }
 
-void MidiTrack::AddBankSelectFine(uint8_t channel, uint8_t lsb) {
-  aEvents.push_back(new BankSelectFineEvent(this, channel, GetDelta(), lsb));
+void MidiTrack::addBankSelectFine(uint8_t channel, uint8_t lsb) {
+  aEvents.push_back(new BankSelectFineEvent(this, channel, getDelta(), lsb));
 }
 
-void MidiTrack::InsertBankSelect(uint8_t channel, uint8_t bank, uint32_t absTime) {
+void MidiTrack::insertBankSelect(uint8_t channel, uint8_t bank, uint32_t absTime) {
   aEvents.push_back(new ControllerEvent(this, channel, absTime, 0, bank));
 }
 
-void MidiTrack::AddTempo(uint32_t microSeconds) {
-  aEvents.push_back(new TempoEvent(this, GetDelta(), microSeconds));
+void MidiTrack::addTempo(uint32_t microSeconds) {
+  aEvents.push_back(new TempoEvent(this, getDelta(), microSeconds));
   //bAddedTempo = true;
 }
 
-void MidiTrack::AddTempoBPM(double BPM) {
+void MidiTrack::addTempoBPM(double BPM) {
   uint32_t microSecs = static_cast<uint32_t>(std::round(60000000.0 / BPM));
-  aEvents.push_back(new TempoEvent(this, GetDelta(), microSecs));
+  aEvents.push_back(new TempoEvent(this, getDelta(), microSecs));
   //bAddedTempo = true;
 }
 
-void MidiTrack::InsertTempo(uint32_t microSeconds, uint32_t absTime) {
+void MidiTrack::insertTempo(uint32_t microSeconds, uint32_t absTime) {
   aEvents.push_back(new TempoEvent(this, absTime, microSeconds));
   //bAddedTempo = true;
 }
 
-void MidiTrack::InsertTempoBPM(double BPM, uint32_t absTime) {
+void MidiTrack::insertTempoBPM(double BPM, uint32_t absTime) {
   uint32_t microSecs = static_cast<uint32_t>(std::round(60000000.0 / BPM));
   aEvents.push_back(new TempoEvent(this, absTime, microSecs));
   //bAddedTempo = true;
 }
 
-void MidiTrack::AddMidiPort(uint8_t port) {
-  aEvents.push_back(new MidiPortEvent(this, GetDelta(), port));
+void MidiTrack::addMidiPort(uint8_t port) {
+  aEvents.push_back(new MidiPortEvent(this, getDelta(), port));
 }
 
-void MidiTrack::InsertMidiPort(uint8_t port, uint32_t absTime) {
+void MidiTrack::insertMidiPort(uint8_t port, uint32_t absTime) {
   aEvents.push_back(new MidiPortEvent(this, absTime, port));
 }
 
-void MidiTrack::AddTimeSig(uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter) {
-  aEvents.push_back(new TimeSigEvent(this, GetDelta(), numer, denom, ticksPerQuarter));
+void MidiTrack::addTimeSig(uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter) {
+  aEvents.push_back(new TimeSigEvent(this, getDelta(), numer, denom, ticksPerQuarter));
   //bAddedTimeSig = true;
 }
 
-void MidiTrack::InsertTimeSig(uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter, uint32_t absTime) {
+void MidiTrack::insertTimeSig(uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter, uint32_t absTime) {
   aEvents.push_back(new TimeSigEvent(this, absTime, numer, denom, ticksPerQuarter));
   //bAddedTimeSig = true;
 }
 
-void MidiTrack::AddEndOfTrack() {
-  aEvents.push_back(new EndOfTrackEvent(this, GetDelta()));
+void MidiTrack::addEndOfTrack() {
+  aEvents.push_back(new EndOfTrackEvent(this, getDelta()));
   bHasEndOfTrack = true;
 }
 
-void MidiTrack::InsertEndOfTrack(uint32_t absTime) {
+void MidiTrack::insertEndOfTrack(uint32_t absTime) {
   aEvents.push_back(new EndOfTrackEvent(this, absTime));
   bHasEndOfTrack = true;
 }
 
-void MidiTrack::AddText(const std::string &str) {
-  aEvents.push_back(new TextEvent(this, GetDelta(), str));
+void MidiTrack::addText(const std::string &str) {
+  aEvents.push_back(new TextEvent(this, getDelta(), str));
 }
 
-void MidiTrack::InsertText(const std::string &str, uint32_t absTime) {
+void MidiTrack::insertText(const std::string &str, uint32_t absTime) {
   aEvents.push_back(new TextEvent(this, absTime, str));
 }
 
-void MidiTrack::AddSeqName(const std::string &str) {
-  aEvents.push_back(new SeqNameEvent(this, GetDelta(), str));
+void MidiTrack::addSeqName(const std::string &str) {
+  aEvents.push_back(new SeqNameEvent(this, getDelta(), str));
 }
 
-void MidiTrack::InsertSeqName(const std::string &str, uint32_t absTime) {
+void MidiTrack::insertSeqName(const std::string &str, uint32_t absTime) {
   aEvents.push_back(new SeqNameEvent(this, absTime, str));
 }
 
-void MidiTrack::AddTrackName(const std::string &str) {
-  aEvents.push_back(new TrackNameEvent(this, GetDelta(), str));
+void MidiTrack::addTrackName(const std::string &str) {
+  aEvents.push_back(new TrackNameEvent(this, getDelta(), str));
 }
 
-void MidiTrack::InsertTrackName(const std::string &str, uint32_t absTime) {
+void MidiTrack::insertTrackName(const std::string &str, uint32_t absTime) {
   aEvents.push_back(new TrackNameEvent(this, absTime, str));
 }
 
-void MidiTrack::AddGMReset() {
-  aEvents.push_back(new GMResetEvent(this, GetDelta()));
+void MidiTrack::addGMReset() {
+  aEvents.push_back(new GMResetEvent(this, getDelta()));
 }
 
-void MidiTrack::InsertGMReset(uint32_t absTime) {
+void MidiTrack::insertGMReset(uint32_t absTime) {
   aEvents.push_back(new GMResetEvent(this, absTime));
 }
 
-void MidiTrack::AddGM2Reset() {
-  aEvents.push_back(new GM2ResetEvent(this, GetDelta()));
+void MidiTrack::addGM2Reset() {
+  aEvents.push_back(new GM2ResetEvent(this, getDelta()));
 }
 
-void MidiTrack::InsertGM2Reset(uint32_t absTime) {
+void MidiTrack::insertGM2Reset(uint32_t absTime) {
   aEvents.push_back(new GM2ResetEvent(this, absTime));
 }
 
-void MidiTrack::AddGSReset() {
-  aEvents.push_back(new GSResetEvent(this, GetDelta()));
+void MidiTrack::addGSReset() {
+  aEvents.push_back(new GSResetEvent(this, getDelta()));
 }
 
-void MidiTrack::InsertGSReset(uint32_t absTime) {
+void MidiTrack::insertGSReset(uint32_t absTime) {
   aEvents.push_back(new GSResetEvent(this, absTime));
 }
 
-void MidiTrack::AddXGReset() {
-  aEvents.push_back(new XGResetEvent(this, GetDelta()));
+void MidiTrack::addXGReset() {
+  aEvents.push_back(new XGResetEvent(this, getDelta()));
 }
 
-void MidiTrack::InsertXGReset(uint32_t absTime) {
+void MidiTrack::insertXGReset(uint32_t absTime) {
   aEvents.push_back(new XGResetEvent(this, absTime));
 }
 
@@ -613,20 +613,20 @@ void MidiTrack::InsertXGReset(uint32_t absTime) {
 //	aEvents.push_back(new TransposeEvent(this, GetDelta(), semitones));
 //}
 
-void MidiTrack::InsertGlobalTranspose(uint32_t absTime, int8_t semitones) {
+void MidiTrack::insertGlobalTranspose(uint32_t absTime, int8_t semitones) {
   aEvents.push_back(new GlobalTransposeEvent(this, absTime, semitones));
 }
 
 
-void MidiTrack::AddMarker(uint8_t channel,
+void MidiTrack::addMarker(uint8_t channel,
                           const std::string &markername,
                           uint8_t databyte1,
                           uint8_t databyte2,
                           int8_t priority) {
-  aEvents.push_back(new MarkerEvent(this, channel, GetDelta(), markername, databyte1, databyte2, priority));
+  aEvents.push_back(new MarkerEvent(this, channel, getDelta(), markername, databyte1, databyte2, priority));
 }
 
-void MidiTrack::InsertMarker(uint8_t channel,
+void MidiTrack::insertMarker(uint8_t channel,
                   const std::string &markername,
                   uint8_t databyte1,
                   uint8_t databyte2,
@@ -640,11 +640,11 @@ void MidiTrack::InsertMarker(uint8_t channel,
 //  *********
 
 MidiEvent::MidiEvent(MidiTrack *thePrntTrk, uint32_t absoluteTime, uint8_t theChannel, int8_t thePriority)
-    : prntTrk(thePrntTrk), channel(theChannel), AbsTime(absoluteTime), priority(thePriority) {
+    : prntTrk(thePrntTrk), channel(theChannel), absTime(absoluteTime), priority(thePriority) {
 }
 
-bool MidiEvent::IsMetaEvent() {
-  MidiEventType type = GetEventType();
+bool MidiEvent::isMetaEvent() {
+  MidiEventType type = eventType();
   return type == MIDIEVENT_TEMPO ||
          type == MIDIEVENT_TEXT ||
          type == MIDIEVENT_MIDIPORT ||
@@ -652,13 +652,13 @@ bool MidiEvent::IsMetaEvent() {
          type == MIDIEVENT_ENDOFTRACK;
 }
 
-bool MidiEvent::IsSysexEvent() {
-  MidiEventType type = GetEventType();
+bool MidiEvent::isSysexEvent() {
+  MidiEventType type = eventType();
   return type == MIDIEVENT_MASTERVOL ||
          type == MIDIEVENT_RESET;
 }
 
-void MidiEvent::WriteVarLength(std::vector<uint8_t> &buf, uint32_t value) {
+void MidiEvent::writeVarLength(std::vector<uint8_t> &buf, uint32_t value) {
   uint32_t buffer = value & 0x7F;
 
   while ((value >>= 7)) {
@@ -675,26 +675,26 @@ void MidiEvent::WriteVarLength(std::vector<uint8_t> &buf, uint32_t value) {
   }
 }
 
-uint32_t MidiEvent::WriteMetaEvent(std::vector<uint8_t> &buf,
+uint32_t MidiEvent::writeMetaEvent(std::vector<uint8_t> &buf,
                                    uint32_t time,
                                    uint8_t metaType,
                                    const uint8_t* data,
                                    size_t dataSize) const {
-  WriteVarLength(buf, AbsTime - time);
+  writeVarLength(buf, absTime - time);
   buf.push_back(0xFF);
   buf.push_back(metaType);
-  WriteVarLength(buf, static_cast<uint32_t>(dataSize));
+  writeVarLength(buf, static_cast<uint32_t>(dataSize));
   for (size_t dataIndex = 0; dataIndex < dataSize; dataIndex++) {
     buf.push_back(data[dataIndex]);
   }
-  return AbsTime;
+  return absTime;
 }
 
-uint32_t MidiEvent::WriteMetaTextEvent(std::vector<uint8_t> &buf, uint32_t time, uint8_t metaType, const std::string& str) const {
-  return WriteMetaEvent(buf, time, metaType, (uint8_t *)str.c_str(), str.length());
+uint32_t MidiEvent::writeMetaTextEvent(std::vector<uint8_t> &buf, uint32_t time, uint8_t metaType, const std::string& str) const {
+  return writeMetaEvent(buf, time, metaType, (uint8_t *)str.c_str(), str.length());
 }
 
-std::string MidiEvent::GetNoteName(int noteNumber) {
+std::string MidiEvent::getNoteName(int noteNumber) {
   const char* noteNames[12] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
 
   int octave;
@@ -712,11 +712,11 @@ std::string MidiEvent::GetNoteName(int noteNumber) {
 }
 
 bool MidiEvent::operator<(const MidiEvent &theMidiEvent) const {
-  return (AbsTime < theMidiEvent.AbsTime);
+  return (absTime < theMidiEvent.absTime);
 }
 
 bool MidiEvent::operator>(const MidiEvent &theMidiEvent) const {
-  return (AbsTime > theMidiEvent.AbsTime);
+  return (absTime > theMidiEvent.absTime);
 }
 
 //  *********
@@ -736,8 +736,8 @@ NoteEvent::NoteEvent(MidiTrack *prntTrk,
       vel(theVel) {
 }
 
-uint32_t NoteEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
-  WriteVarLength(buf, AbsTime - time);
+uint32_t NoteEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
+  writeVarLength(buf, absTime - time);
   if (bNoteDown)
     buf.push_back(0x90 + channel);
   else
@@ -748,7 +748,7 @@ uint32_t NoteEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
 
   buf.push_back(vel);
 
-  return AbsTime;
+  return absTime;
 }
 
 //  ************
@@ -803,12 +803,12 @@ ControllerEvent::ControllerEvent(MidiTrack *prntTrk,
     : MidiEvent(prntTrk, absoluteTime, channel, thePriority), controlNum(controllerNum), dataByte(theDataByte) {
 }
 
-uint32_t ControllerEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
-  WriteVarLength(buf, AbsTime - time);
+uint32_t ControllerEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
+  writeVarLength(buf, absTime - time);
   buf.push_back(0xB0 + channel);
   buf.push_back(controlNum & 0x7F);
   buf.push_back(dataByte);
-  return AbsTime;
+  return absTime;
 }
 
 //  **********
@@ -822,12 +822,12 @@ SysexEvent::SysexEvent(MidiTrack *prntTrk,
     : MidiEvent(prntTrk, absoluteTime, 0, thePriority), sysexData(sysexData) {
 }
 
-uint32_t SysexEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
-  WriteVarLength(buf, AbsTime - time);
+uint32_t SysexEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
+  writeVarLength(buf, absTime - time);
   buf.push_back(0xF0);
   buf.insert(buf.end(), sysexData.begin(), sysexData.end());
   buf.push_back(0xF7);
-  return AbsTime;
+  return absTime;
 }
 
 //  ***************
@@ -838,11 +838,11 @@ ProgChangeEvent::ProgChangeEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t a
     : MidiEvent(prntTrk, absoluteTime, channel, PRIORITY_HIGH), programNum(progNum) {
 }
 
-uint32_t ProgChangeEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
-  WriteVarLength(buf, AbsTime - time);
+uint32_t ProgChangeEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
+  writeVarLength(buf, absTime - time);
   buf.push_back(0xC0 + channel);
   buf.push_back(programNum & 0x7F);
-  return AbsTime;
+  return absTime;
 }
 
 //  **************
@@ -853,14 +853,14 @@ PitchBendEvent::PitchBendEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t abs
     : MidiEvent(prntTrk, absoluteTime, channel, PRIORITY_MIDDLE), bend(bendAmt) {
 }
 
-uint32_t PitchBendEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
+uint32_t PitchBendEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
   uint8_t loByte = (bend + 0x2000) & 0x7F;
   uint8_t hiByte = ((bend + 0x2000) & 0x3F80) >> 7;
-  WriteVarLength(buf, AbsTime - time);
+  writeVarLength(buf, absTime - time);
   buf.push_back(0xE0 + channel);
   buf.push_back(loByte);
   buf.push_back(hiByte);
-  return AbsTime;
+  return absTime;
 }
 
 //  **********
@@ -871,13 +871,13 @@ TempoEvent::TempoEvent(MidiTrack *prntTrk, uint32_t absoluteTime, uint32_t micro
     : MidiEvent(prntTrk, absoluteTime, 0, PRIORITY_HIGHEST), microSecs(microSeconds) {
 }
 
-uint32_t TempoEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
+uint32_t TempoEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
   uint8_t data[3] = {
       static_cast<uint8_t>((microSecs & 0xFF0000) >> 16),
       static_cast<uint8_t>((microSecs & 0x00FF00) >> 8),
       static_cast<uint8_t>(microSecs & 0x0000FF)
   };
-  return WriteMetaEvent(buf, time, 0x51, data, 3);
+  return writeMetaEvent(buf, time, 0x51, data, 3);
 }
 
 
@@ -889,8 +889,8 @@ MidiPortEvent::MidiPortEvent(MidiTrack *prntTrk, uint32_t absoluteTime, uint8_t 
     : MidiEvent(prntTrk, absoluteTime, 0, PRIORITY_HIGHEST), port(port) {
 }
 
-uint32_t MidiPortEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
-  return WriteMetaEvent(buf, time, 0x21, &port, 1);
+uint32_t MidiPortEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
+  return writeMetaEvent(buf, time, 0x21, &port, 1);
 }
 
 
@@ -907,7 +907,7 @@ TimeSigEvent::TimeSigEvent(MidiTrack *prntTrk,
       ticksPerQuarter(clicksPerQuarter) {
 }
 
-uint32_t TimeSigEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
+uint32_t TimeSigEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
   //denom is expressed in power of 2... so if we have 6/8 time.  it's 6 = 2^x  ==  ln6 / ln2
   uint8_t data[4] = {
       numer,
@@ -915,7 +915,7 @@ uint32_t TimeSigEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
       ticksPerQuarter,
       8
   };
-  return WriteMetaEvent(buf, time, 0x58, data, 4);
+  return writeMetaEvent(buf, time, 0x58, data, 4);
 }
 
 //  ***************
@@ -927,8 +927,8 @@ EndOfTrackEvent::EndOfTrackEvent(MidiTrack *prntTrk, uint32_t absoluteTime)
 }
 
 
-uint32_t EndOfTrackEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
-  return WriteMetaEvent(buf, time, 0x2F, nullptr, 0);
+uint32_t EndOfTrackEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
+  return writeMetaEvent(buf, time, 0x2F, nullptr, 0);
 }
 
 //  *********
@@ -939,8 +939,8 @@ TextEvent::TextEvent(MidiTrack *prntTrk, uint32_t absoluteTime, std::string str)
     : MidiEvent(prntTrk, absoluteTime, 0, PRIORITY_LOWEST), text(std::move(str)) {
 }
 
-uint32_t TextEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
-  return WriteMetaTextEvent(buf, time, 0x01, text);
+uint32_t TextEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
+  return writeMetaTextEvent(buf, time, 0x01, text);
 }
 
 //  ************
@@ -951,8 +951,8 @@ SeqNameEvent::SeqNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, std::strin
     : MidiEvent(prntTrk, absoluteTime, 0, PRIORITY_LOWEST), text(std::move(str)) {
 }
 
-uint32_t SeqNameEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
-  return WriteMetaTextEvent(buf, time, 0x03, text);
+uint32_t SeqNameEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
+  return writeMetaTextEvent(buf, time, 0x03, text);
 }
 
 //  **************
@@ -963,8 +963,8 @@ TrackNameEvent::TrackNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, std::s
     : MidiEvent(prntTrk, absoluteTime, 0, PRIORITY_LOWEST), text(std::move(str)) {
 }
 
-uint32_t TrackNameEvent::WriteEvent(std::vector<uint8_t> &buf, uint32_t time) {
-  return WriteMetaTextEvent(buf, time, 0x03, text);
+uint32_t TrackNameEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
+  return writeMetaTextEvent(buf, time, 0x03, text);
 }
 
 //***************
@@ -981,7 +981,7 @@ GlobalTransposeEvent::GlobalTransposeEvent(MidiTrack *prntTrk, uint32_t absolute
   semitones = theSemitones;
 }
 
-uint32_t GlobalTransposeEvent::WriteEvent(std::vector<uint8_t>& /*buf*/, uint32_t time) {
+uint32_t GlobalTransposeEvent::writeEvent(std::vector<uint8_t>& /*buf*/, uint32_t time) {
   this->prntTrk->parentSeq->globalTranspose = this->semitones;
   return time;
 }

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -63,121 +63,117 @@ typedef enum {
 class MidiTrack {
  public:
   MidiTrack(MidiFile *parentSeq, bool bMonophonic);
-  virtual ~MidiTrack(void);
+  virtual ~MidiTrack();
 
-  void Sort(void);
-  void WriteTrack(std::vector<uint8_t> &buf) const;
+  void sort();
+  void writeTrack(std::vector<uint8_t> &buf) const;
 
-  //void SetChannel(int theChannel);
-  void SetChannelGroup(int theChannelGroup);
+  //void setChannel(int theChannel);
+  void setChannelGroup(int theChannelGroup);
 
-  uint32_t GetDelta() const;
-  void SetDelta(uint32_t NewDelta);
-  void AddDelta(uint32_t AddDelta);
-  void SubtractDelta(uint32_t SubtractDelta);
-  void ResetDelta();
+  uint32_t getDelta() const;
+  void setDelta(uint32_t NewDelta);
+  void addDelta(uint32_t AddDelta);
+  void subtractDelta(uint32_t SubtractDelta);
+  void resetDelta();
 
-  void AddNoteOn(uint8_t channel, int8_t key, int8_t vel);
-  void InsertNoteOn(uint8_t channel, int8_t key, int8_t vel, uint32_t absTime);
-  void AddNoteOff(uint8_t channel, int8_t key);
-  void InsertNoteOff(uint8_t channel, int8_t key, uint32_t absTime);
-  void AddNoteByDur(uint8_t channel, int8_t key, int8_t vel, uint32_t duration);
-  void AddNoteByDur_TriAce(uint8_t channel, int8_t key, int8_t vel, uint32_t duration);
-  void InsertNoteByDur(uint8_t channel, int8_t key, int8_t vel, uint32_t duration, uint32_t absTime);
-  void PurgePrevNoteOffs();
-  void PurgePrevNoteOffs(uint32_t absTime);
-  void AddControllerEvent(uint8_t channel,
+  void addNoteOn(uint8_t channel, int8_t key, int8_t vel);
+  void insertNoteOn(uint8_t channel, int8_t key, int8_t vel, uint32_t absTime);
+  void addNoteOff(uint8_t channel, int8_t key);
+  void insertNoteOff(uint8_t channel, int8_t key, uint32_t absTime);
+  void addNoteByDur(uint8_t channel, int8_t key, int8_t vel, uint32_t duration);
+  void addNoteByDur_TriAce(uint8_t channel, int8_t key, int8_t vel, uint32_t duration);
+  void insertNoteByDur(uint8_t channel, int8_t key, int8_t vel, uint32_t duration, uint32_t absTime);
+  void purgePrevNoteOffs();
+  void purgePrevNoteOffs(uint32_t absTime);
+  void addControllerEvent(uint8_t channel,
                           uint8_t controllerNum,
                           uint8_t theDataByte); // This function should be used for only redirection output of MIDI-like formats
-  void InsertControllerEvent(uint8_t channel,
+  void insertControllerEvent(uint8_t channel,
                              uint8_t controllerNum,
                              uint8_t theDataByte,
                              uint32_t absTime); // This function should be used for only redirection output of MIDI-like formats
-  //void AddVolMarker(uint8_t channel, uint8_t vol, int8_t priority = PRIORITY_HIGHER);
-  //void InsertVolMarker(uint8_t channel, uint8_t vol, uint32_t absTime, int8_t priority = PRIORITY_HIGHER);
-  void AddVol(uint8_t channel, uint8_t vol/*, int8_t priority = PRIORITY_MIDDLE*/);
-  void InsertVol(uint8_t channel, uint8_t vol, uint32_t absTime/*, int8_t priority = PRIORITY_MIDDLE*/);
-  void AddVolumeFine(uint8_t channel, uint8_t volume_lsb);
-  void AddMasterVol(uint8_t channel, uint8_t mastVol/*, int8_t priority = PRIORITY_HIGHER*/);
-  void InsertMasterVol(uint8_t channel, uint8_t mastVol, uint32_t absTime/*, int8_t priority = PRIORITY_HIGHER*/);
-  void AddPan(uint8_t channel, uint8_t pan);
-  void InsertPan(uint8_t channel, uint8_t pan, uint32_t absTime);
-  void AddExpression(uint8_t channel, uint8_t expression);
-  void InsertExpression(uint8_t channel, uint8_t expression, uint32_t absTime);
-  void AddReverb(uint8_t channel, uint8_t reverb);
-  void InsertReverb(uint8_t channel, uint8_t reverb, uint32_t absTime);
-  void AddModulation(uint8_t channel, uint8_t depth);
-  void InsertModulation(uint8_t channel, uint8_t depth, uint32_t absTime);
-  void AddBreath(uint8_t channel, uint8_t depth);
-  void InsertBreath(uint8_t channel, uint8_t depth, uint32_t absTime);
-  void AddSustain(uint8_t channel, uint8_t depth);
-  void InsertSustain(uint8_t channel, uint8_t depth, uint32_t absTime);
-  void AddPortamento(uint8_t channel, bool bOn);
-  void InsertPortamento(uint8_t channel, bool bOn, uint32_t absTime);
-  void AddPortamentoTime(uint8_t channel, uint8_t time);
-  void InsertPortamentoTime(uint8_t channel, uint8_t time, uint32_t absTime);
-  void AddPortamentoTimeFine(uint8_t channel, uint8_t time);
-  void InsertPortamentoTimeFine(uint8_t channel, uint8_t time, uint32_t absTime);
-  void AddPortamentoControl(uint8_t channel, uint8_t key);
-  void AddMono(uint8_t channel);
-  void InsertMono(uint8_t channel, uint32_t absTime);
+  void addVol(uint8_t channel, uint8_t vol/*, int8_t priority = PRIORITY_MIDDLE*/);
+  void insertVol(uint8_t channel, uint8_t vol, uint32_t absTime/*, int8_t priority = PRIORITY_MIDDLE*/);
+  void addVolumeFine(uint8_t channel, uint8_t volume_lsb);
+  void addMasterVol(uint8_t channel, uint8_t mastVol/*, int8_t priority = PRIORITY_HIGHER*/);
+  void insertMasterVol(uint8_t channel, uint8_t mastVol, uint32_t absTime/*, int8_t priority = PRIORITY_HIGHER*/);
+  void addPan(uint8_t channel, uint8_t pan);
+  void insertPan(uint8_t channel, uint8_t pan, uint32_t absTime);
+  void addExpression(uint8_t channel, uint8_t expression);
+  void insertExpression(uint8_t channel, uint8_t expression, uint32_t absTime);
+  void addReverb(uint8_t channel, uint8_t reverb);
+  void insertReverb(uint8_t channel, uint8_t reverb, uint32_t absTime);
+  void addModulation(uint8_t channel, uint8_t depth);
+  void insertModulation(uint8_t channel, uint8_t depth, uint32_t absTime);
+  void addBreath(uint8_t channel, uint8_t depth);
+  void insertBreath(uint8_t channel, uint8_t depth, uint32_t absTime);
+  void addSustain(uint8_t channel, uint8_t depth);
+  void insertSustain(uint8_t channel, uint8_t depth, uint32_t absTime);
+  void addPortamento(uint8_t channel, bool bOn);
+  void insertPortamento(uint8_t channel, bool bOn, uint32_t absTime);
+  void addPortamentoTime(uint8_t channel, uint8_t time);
+  void insertPortamentoTime(uint8_t channel, uint8_t time, uint32_t absTime);
+  void addPortamentoTimeFine(uint8_t channel, uint8_t time);
+  void insertPortamentoTimeFine(uint8_t channel, uint8_t time, uint32_t absTime);
+  void addPortamentoControl(uint8_t channel, uint8_t key);
+  void addMono(uint8_t channel);
+  void insertMono(uint8_t channel, uint32_t absTime);
 
-  void AddPitchBend(uint8_t channel, int16_t bend);
-  void InsertPitchBend(uint8_t channel, short bend, uint32_t absTime);
-  void AddPitchBendRange(uint8_t channel, uint16_t cents);
-  void InsertPitchBendRange(uint8_t channel, uint16_t cents, uint32_t absTime);
-  void AddFineTuning(uint8_t channel, uint8_t msb, uint8_t lsb);
-  void InsertFineTuning(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime);
-  void AddFineTuning(uint8_t channel, double cents);
-  void InsertFineTuning(uint8_t channel, double cents, uint32_t absTime);
-  void AddCoarseTuning(uint8_t channel, uint8_t msb, uint8_t lsb);
-  void InsertCoarseTuning(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime);
-  void AddCoarseTuning(uint8_t channel, double semitones);
-  void InsertCoarseTuning(uint8_t channel, double semitones, uint32_t absTime);
-  void AddModulationDepthRange(uint8_t channel, uint8_t msb, uint8_t lsb);
-  void InsertModulationDepthRange(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime);
-  void AddModulationDepthRange(uint8_t channel, double semitones);
-  void InsertModulationDepthRange(uint8_t channel, double semitones, uint32_t absTime);
-  //void AddTranspose(uint8_t channel, int transpose);
-  void AddProgramChange(uint8_t channel, uint8_t progNum);
-  void AddBankSelect(uint8_t channel, uint8_t bank);
-  void AddBankSelectFine(uint8_t channel, uint8_t lsb);
-  void InsertBankSelect(uint8_t channel, uint8_t bank, uint32_t absTime);
+  void addPitchBend(uint8_t channel, int16_t bend);
+  void insertPitchBend(uint8_t channel, short bend, uint32_t absTime);
+  void addPitchBendRange(uint8_t channel, uint16_t cents);
+  void insertPitchBendRange(uint8_t channel, uint16_t cents, uint32_t absTime);
+  void addFineTuning(uint8_t channel, uint8_t msb, uint8_t lsb);
+  void insertFineTuning(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime);
+  void addFineTuning(uint8_t channel, double cents);
+  void insertFineTuning(uint8_t channel, double cents, uint32_t absTime);
+  void addCoarseTuning(uint8_t channel, uint8_t msb, uint8_t lsb);
+  void insertCoarseTuning(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime);
+  void addCoarseTuning(uint8_t channel, double semitones);
+  void insertCoarseTuning(uint8_t channel, double semitones, uint32_t absTime);
+  void addModulationDepthRange(uint8_t channel, uint8_t msb, uint8_t lsb);
+  void insertModulationDepthRange(uint8_t channel, uint8_t msb, uint8_t lsb, uint32_t absTime);
+  void addModulationDepthRange(uint8_t channel, double semitones);
+  void insertModulationDepthRange(uint8_t channel, double semitones, uint32_t absTime);
+  void addProgramChange(uint8_t channel, uint8_t progNum);
+  void addBankSelect(uint8_t channel, uint8_t bank);
+  void addBankSelectFine(uint8_t channel, uint8_t lsb);
+  void insertBankSelect(uint8_t channel, uint8_t bank, uint32_t absTime);
 
-  void AddTempo(uint32_t microSeconds);
-  void AddTempoBPM(double BPM);
-  void InsertTempo(uint32_t microSeconds, uint32_t absTime);
-  void InsertTempoBPM(double BPM, uint32_t absTime);
-  void AddMidiPort(uint8_t port);
-  void InsertMidiPort(uint8_t port, uint32_t absTime);
-  void AddTimeSig(uint8_t numer, uint8_t denom, uint8_t clicksPerQuarter);
-  void InsertTimeSig(uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter, uint32_t absTime);
-  void AddEndOfTrack(void);
-  void InsertEndOfTrack(uint32_t absTime);
-  void AddText(const std::string &str);
-  void InsertText(const std::string &str, uint32_t absTime);
-  void AddSeqName(const std::string &str);
-  void InsertSeqName(const std::string &str, uint32_t absTime);
-  void AddTrackName(const std::string &str);
-  void InsertTrackName(const std::string &str, uint32_t absTime);
-  void AddGMReset();
-  void InsertGMReset(uint32_t absTime);
-  void AddGM2Reset();
-  void InsertGM2Reset(uint32_t absTime);
-  void AddGSReset();
-  void InsertGSReset(uint32_t absTime);
-  void AddXGReset();
-  void InsertXGReset(uint32_t absTime);
+  void addTempo(uint32_t microSeconds);
+  void addTempoBPM(double BPM);
+  void insertTempo(uint32_t microSeconds, uint32_t absTime);
+  void insertTempoBPM(double BPM, uint32_t absTime);
+  void addMidiPort(uint8_t port);
+  void insertMidiPort(uint8_t port, uint32_t absTime);
+  void addTimeSig(uint8_t numer, uint8_t denom, uint8_t clicksPerQuarter);
+  void insertTimeSig(uint8_t numer, uint8_t denom, uint8_t ticksPerQuarter, uint32_t absTime);
+  void addEndOfTrack();
+  void insertEndOfTrack(uint32_t absTime);
+  void addText(const std::string &str);
+  void insertText(const std::string &str, uint32_t absTime);
+  void addSeqName(const std::string &str);
+  void insertSeqName(const std::string &str, uint32_t absTime);
+  void addTrackName(const std::string &str);
+  void insertTrackName(const std::string &str, uint32_t absTime);
+  void addGMReset();
+  void insertGMReset(uint32_t absTime);
+  void addGM2Reset();
+  void insertGM2Reset(uint32_t absTime);
+  void addGSReset();
+  void insertGSReset(uint32_t absTime);
+  void addXGReset();
+  void insertXGReset(uint32_t absTime);
 
   // SPECIAL EVENTS
-  //void AddTranspose(int8_t semitones);
-  void InsertGlobalTranspose(uint32_t absTime, int8_t semitones);
-  void AddMarker(uint8_t channel,
+  void insertGlobalTranspose(uint32_t absTime, int8_t semitones);
+  void addMarker(uint8_t channel,
                  const std::string &markername,
                  uint8_t databyte1,
                  uint8_t databyte2,
                  int8_t priority = PRIORITY_MIDDLE);
-  void InsertMarker(uint8_t channel,
+  void insertMarker(uint8_t channel,
                     const std::string &markername,
                     uint8_t databyte1,
                     uint8_t databyte2,
@@ -204,14 +200,14 @@ class MidiFile {
  public:
   MidiFile(VGMSeq *assocSeq);
   ~MidiFile();
-  MidiTrack *AddTrack();
-  MidiTrack *InsertTrack(uint32_t trackNum);
-  int GetMidiTrackIndex(const MidiTrack *midiTrack);
-  void SetPPQN(uint16_t ppqn);
-  uint32_t GetPPQN() const;
-  void WriteMidiToBuffer(std::vector<uint8_t> &buf);
-  void Sort(void);
-  bool SaveMidiFile(const std::string &filepath);
+  MidiTrack *addTrack();
+  MidiTrack *insertTrack(uint32_t trackNum);
+  int getMidiTrackIndex(const MidiTrack *midiTrack);
+  void setPPQN(uint16_t ppqn);
+  uint32_t ppqn() const;
+  void writeMidiToBuffer(std::vector<uint8_t> &buf);
+  void sort();
+  bool saveMidiFile(const std::string &filepath);
 
  protected:
   //bool bAddedTempo;
@@ -219,37 +215,38 @@ class MidiFile {
 
  public:
   VGMSeq *assocSeq;
-  uint16_t ppqn;
 
   std::vector<MidiTrack *> aTracks;
   MidiTrack globalTrack;            //events in the globalTrack will be copied into every other track
   int8_t globalTranspose;
   bool bMonophonicTracks;
+
+private:
+  uint16_t m_ppqn;
 };
 
 class MidiEvent {
  public:
   MidiEvent(MidiTrack *thePrntTrk, uint32_t absoluteTime, uint8_t theChannel, int8_t thePriority);
   virtual ~MidiEvent() = default;
-  virtual MidiEventType GetEventType() = 0;
-  bool IsMetaEvent();
-  bool IsSysexEvent();
-  static void WriteVarLength(std::vector<uint8_t> &buf, uint32_t value);
-  //virtual void PrepareWrite(void/*vector<MidiEvent*> & aEvents*/);
-  virtual uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) = 0;
-  uint32_t WriteMetaEvent(std::vector<uint8_t> &buf, uint32_t time, uint8_t metaType,
+  virtual MidiEventType eventType() = 0;
+  bool isMetaEvent();
+  bool isSysexEvent();
+  static void writeVarLength(std::vector<uint8_t> &buf, uint32_t value);
+  virtual uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) = 0;
+  uint32_t writeMetaEvent(std::vector<uint8_t> &buf, uint32_t time, uint8_t metaType,
     const uint8_t* data, size_t dataSize) const;
-  uint32_t WriteMetaTextEvent(std::vector<uint8_t> &buf, uint32_t time, uint8_t metaType,
+  uint32_t writeMetaTextEvent(std::vector<uint8_t> &buf, uint32_t time, uint8_t metaType,
     const std::string& str) const;
 
-  static std::string GetNoteName(int noteNumber);
+  static std::string getNoteName(int noteNumber);
 
   bool operator<(const MidiEvent &) const;
   bool operator>(const MidiEvent &) const;
 
   MidiTrack *prntTrk;
   uint8_t channel;
-  uint32_t AbsTime;            //absolute time... the number of ticks from the very beginning of the sequence at which this event occurs
+  uint32_t absTime;            //absolute time... the number of ticks from the very beginning of the sequence at which this event occurs
   int8_t priority;
 };
 
@@ -263,7 +260,7 @@ class PriorityCmp {
 class AbsTimeCmp {
  public:
   bool operator()(const MidiEvent *a, const MidiEvent *b) const {
-    return (a->AbsTime < b->AbsTime);
+    return (a->absTime < b->absTime);
   }
 };
 
@@ -272,8 +269,8 @@ class NoteEvent
  public:
   NoteEvent
       (MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, bool bNoteDown, uint8_t theKey, uint8_t theVel = 64);
-  MidiEventType GetEventType() override { return MIDIEVENT_NOTEON; }
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  MidiEventType eventType() override { return MIDIEVENT_NOTEON; }
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   bool bNoteDown;
   int8_t key;
@@ -303,8 +300,8 @@ class ControllerEvent
                   uint8_t controllerNum,
                   uint8_t theDataByte,
                   int8_t thePriority = PRIORITY_MIDDLE);
-  MidiEventType GetEventType() override { return MIDIEVENT_UNDEFINED; }
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  MidiEventType eventType() override { return MIDIEVENT_UNDEFINED; }
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   uint8_t controlNum;
   uint8_t dataByte;
@@ -317,8 +314,8 @@ public:
              uint32_t absoluteTime,
              const std::vector<uint8_t>& sysexData,
              int8_t thePriority = PRIORITY_MIDDLE);
-  MidiEventType GetEventType() override { return MIDIEVENT_UNDEFINED; }
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  MidiEventType eventType() override { return MIDIEVENT_UNDEFINED; }
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   std::vector<uint8_t> sysexData;
 };
@@ -328,7 +325,7 @@ class VolumeEvent
  public:
   VolumeEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t volume)
       : ControllerEvent(prntTrk, channel, absoluteTime, 7, volume, PRIORITY_MIDDLE) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_VOLUME; }
+  MidiEventType eventType() override { return MIDIEVENT_VOLUME; }
 };
 
 class VolumeFineEvent
@@ -336,7 +333,7 @@ class VolumeFineEvent
 public:
   VolumeFineEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t volume_lsb)
       : ControllerEvent(prntTrk, channel, absoluteTime, 39, volume_lsb, PRIORITY_MIDDLE) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_VOLUME; }
+  MidiEventType eventType() override { return MIDIEVENT_VOLUME; }
 };
 
 class ExpressionEvent
@@ -344,7 +341,7 @@ class ExpressionEvent
  public:
   ExpressionEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t expression)
       : ControllerEvent(prntTrk, channel, absoluteTime, 11, expression, PRIORITY_MIDDLE) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_EXPRESSION; }
+  MidiEventType eventType() override { return MIDIEVENT_EXPRESSION; }
 };
 
 class SustainEvent
@@ -352,7 +349,7 @@ class SustainEvent
  public:
   SustainEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t depth)
       : ControllerEvent(prntTrk, channel, absoluteTime, 64, depth, PRIORITY_MIDDLE) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_SUSTAIN; }
+  MidiEventType eventType() override { return MIDIEVENT_SUSTAIN; }
 };
 
 class PortamentoEvent
@@ -360,7 +357,7 @@ class PortamentoEvent
  public:
   PortamentoEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t bOn)
       : ControllerEvent(prntTrk, channel, absoluteTime, 65, (bOn) ? 0x7F : 0, PRIORITY_MIDDLE) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_PORTAMENTO; }
+  MidiEventType eventType() override { return MIDIEVENT_PORTAMENTO; }
 };
 
 class PortamentoTimeEvent
@@ -368,7 +365,7 @@ class PortamentoTimeEvent
  public:
   PortamentoTimeEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t time)
       : ControllerEvent(prntTrk, channel, absoluteTime, 5, time, PRIORITY_MIDDLE) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_PORTAMENTOTIME; }
+  MidiEventType eventType() override { return MIDIEVENT_PORTAMENTOTIME; }
 };
 
 class PortamentoTimeFineEvent
@@ -376,7 +373,7 @@ class PortamentoTimeFineEvent
 public:
   PortamentoTimeFineEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t time)
       : ControllerEvent(prntTrk, channel, absoluteTime, 37, time, PRIORITY_MIDDLE) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_PORTAMENTOTIMEFINE; }
+  MidiEventType eventType() override { return MIDIEVENT_PORTAMENTOTIMEFINE; }
 };
 
 class PortamentoControlEvent
@@ -384,7 +381,7 @@ class PortamentoControlEvent
 public:
   PortamentoControlEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t key)
       : ControllerEvent(prntTrk, channel, absoluteTime, 84, key, PRIORITY_MIDDLE) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_PORTAMENTOCONTROL; }
+  MidiEventType eventType() override { return MIDIEVENT_PORTAMENTOCONTROL; }
 };
 
 class PanEvent
@@ -392,7 +389,7 @@ class PanEvent
  public:
   PanEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t pan)
       : ControllerEvent(prntTrk, channel, absoluteTime, 10, pan, PRIORITY_MIDDLE) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_PAN; }
+  MidiEventType eventType() override { return MIDIEVENT_PAN; }
 };
 
 class ModulationEvent
@@ -400,7 +397,7 @@ class ModulationEvent
  public:
   ModulationEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t depth)
       : ControllerEvent(prntTrk, channel, absoluteTime, 1, depth, PRIORITY_MIDDLE) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_MODULATION; }
+  MidiEventType eventType() override { return MIDIEVENT_MODULATION; }
 };
 
 class BreathEvent
@@ -408,7 +405,7 @@ class BreathEvent
  public:
   BreathEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t depth)
       : ControllerEvent(prntTrk, channel, absoluteTime, 2, depth, PRIORITY_MIDDLE) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_BREATH; }
+  MidiEventType eventType() override { return MIDIEVENT_BREATH; }
 };
 
 class BankSelectEvent
@@ -416,7 +413,7 @@ class BankSelectEvent
  public:
   BankSelectEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t bank)
       : ControllerEvent(prntTrk, channel, absoluteTime, 0, bank, PRIORITY_HIGH) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_BANKSELECT; }
+  MidiEventType eventType() override { return MIDIEVENT_BANKSELECT; }
 };
 
 class BankSelectFineEvent
@@ -424,7 +421,7 @@ class BankSelectFineEvent
  public:
   BankSelectFineEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t bank)
       : ControllerEvent(prntTrk, channel, absoluteTime, 32, bank, PRIORITY_HIGH) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_BANKSELECTFINE; }
+  MidiEventType eventType() override { return MIDIEVENT_BANKSELECTFINE; }
 };
 
 /*
@@ -455,7 +452,7 @@ class MasterVolEvent
 public:
   MasterVolEvent(MidiTrack *prntTrk, uint8_t /* channel */, uint32_t absoluteTime, uint8_t msb)
       : SysexEvent(prntTrk, absoluteTime, {0x07, 0x7F, 0x7F, 0x04, 0x01, 0, msb }, PRIORITY_HIGHER) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_MASTERVOL; }
+  MidiEventType eventType() override { return MIDIEVENT_MASTERVOL; }
 };
 
 /*
@@ -475,16 +472,16 @@ class MonoEvent
  public:
   MonoEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime)
       : ControllerEvent(prntTrk, channel, absoluteTime, 126, 0, PRIORITY_HIGHER) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_MONO; }
+  MidiEventType eventType() override { return MIDIEVENT_MONO; }
 };
 
 class ProgChangeEvent
     : public MidiEvent {
  public:
   ProgChangeEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t progNum);
-  MidiEventType GetEventType() override { return MIDIEVENT_PROGRAMCHANGE; }
+  MidiEventType eventType() override { return MIDIEVENT_PROGRAMCHANGE; }
   //virtual ProgChangeEvent* MakeCopy();
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   uint8_t programNum;
 };
@@ -493,9 +490,9 @@ class PitchBendEvent
     : public MidiEvent {
  public:
   PitchBendEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, int16_t bend);
-  MidiEventType GetEventType() override { return MIDIEVENT_PITCHBEND; }
+  MidiEventType eventType() override { return MIDIEVENT_PITCHBEND; }
   //virtual PitchBendEvent* MakeCopy();
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   int16_t bend;
 };
@@ -505,9 +502,9 @@ class TempoEvent
     : public MidiEvent {
  public:
   TempoEvent(MidiTrack *prntTrk, uint32_t absoluteTime, uint32_t microSeconds);
-  MidiEventType GetEventType() override { return MIDIEVENT_TEMPO; }
+  MidiEventType eventType() override { return MIDIEVENT_TEMPO; }
   //virtual TempoEvent* MakeCopy();
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   uint32_t microSecs;
 };
@@ -515,9 +512,9 @@ class TempoEvent
 class MidiPortEvent : public MidiEvent {
 public:
   MidiPortEvent(MidiTrack *prntTrk, uint32_t absoluteTime, uint8_t port);
-  MidiEventType GetEventType() override { return MIDIEVENT_MIDIPORT; }
+  MidiEventType eventType() override { return MIDIEVENT_MIDIPORT; }
   // virtual TimeSigEvent* MakeCopy();
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   uint8_t port;
 };
@@ -527,9 +524,9 @@ class TimeSigEvent
  public:
   TimeSigEvent
       (MidiTrack *prntTrk, uint32_t absoluteTime, uint8_t numerator, uint8_t denominator, uint8_t clicksPerQuarter);
-  MidiEventType GetEventType() override { return MIDIEVENT_TIMESIG; }
+  MidiEventType eventType() override { return MIDIEVENT_TIMESIG; }
   //virtual TimeSigEvent* MakeCopy();
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   uint8_t numer;
   uint8_t denom;
@@ -540,17 +537,17 @@ class EndOfTrackEvent
     : public MidiEvent {
  public:
   EndOfTrackEvent(MidiTrack *prntTrk, uint32_t absoluteTime);
-  MidiEventType GetEventType() override { return MIDIEVENT_ENDOFTRACK; }
+  MidiEventType eventType() override { return MIDIEVENT_ENDOFTRACK; }
   //virtual EndOfTrackEvent* MakeCopy();
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 };
 
 class TextEvent
     : public MidiEvent {
  public:
   TextEvent(MidiTrack *prntTrk, uint32_t absoluteTime, std::string str);
-  MidiEventType GetEventType() override { return MIDIEVENT_TEXT; }
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  MidiEventType eventType() override { return MIDIEVENT_TEXT; }
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   std::string text;
 };
@@ -559,8 +556,8 @@ class SeqNameEvent
     : public MidiEvent {
  public:
   SeqNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, std::string str);
-  MidiEventType GetEventType() override { return MIDIEVENT_TEXT; }
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  MidiEventType eventType() override { return MIDIEVENT_TEXT; }
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   std::string text;
 };
@@ -569,8 +566,8 @@ class TrackNameEvent
     : public MidiEvent {
  public:
   TrackNameEvent(MidiTrack *prntTrk, uint32_t absoluteTime, std::string str);
-  MidiEventType GetEventType() override { return MIDIEVENT_TEXT; }
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  MidiEventType eventType() override { return MIDIEVENT_TEXT; }
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   std::string text;
 };
@@ -580,8 +577,8 @@ class GlobalTransposeEvent
     : public MidiEvent {
  public:
   GlobalTransposeEvent(MidiTrack *prntTrk, uint32_t absoluteTime, int8_t semitones);
-  MidiEventType GetEventType() override { return MIDIEVENT_GLOBALTRANSPOSE; }
-  uint32_t WriteEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+  MidiEventType eventType() override { return MIDIEVENT_GLOBALTRANSPOSE; }
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 
   int8_t semitones;
 };
@@ -598,8 +595,8 @@ class MarkerEvent
               int8_t thePriority = PRIORITY_MIDDLE)
       : MidiEvent(prntTrk, absoluteTime, channel, thePriority), name(name), databyte1(databyte1),
         databyte2(databyte2) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_MARKER; }
-  uint32_t WriteEvent(std::vector<uint8_t>& /*buf*/, uint32_t time) override { return time; }
+  MidiEventType eventType() override { return MIDIEVENT_MARKER; }
+  uint32_t writeEvent(std::vector<uint8_t>& /*buf*/, uint32_t time) override { return time; }
 
   std::string name;
   uint8_t databyte1, databyte2;
@@ -610,7 +607,7 @@ class GMResetEvent
  public:
   GMResetEvent(MidiTrack *prntTrk, uint32_t absoluteTime)
        : SysexEvent(prntTrk, absoluteTime, { 0x05, 0x7E, 0x7F, 0x09, 0x01 }, PRIORITY_HIGHEST) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_RESET; }
+  MidiEventType eventType() override { return MIDIEVENT_RESET; }
 };
 
 class GM2ResetEvent
@@ -618,7 +615,7 @@ class GM2ResetEvent
  public:
   GM2ResetEvent(MidiTrack *prntTrk, uint32_t absoluteTime)
        : SysexEvent(prntTrk, absoluteTime, { 0x05, 0x7E, 0x7F, 0x09, 0x03 }, PRIORITY_HIGHEST) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_RESET; }
+  MidiEventType eventType() override { return MIDIEVENT_RESET; }
 };
 
 class GSResetEvent
@@ -627,7 +624,7 @@ class GSResetEvent
   GSResetEvent(MidiTrack *prntTrk, uint32_t absoluteTime)
        : SysexEvent(prntTrk, absoluteTime, { 0x0A, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7F, 0x00, 0x41 },
                     PRIORITY_HIGHEST) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_RESET; }
+  MidiEventType eventType() override { return MIDIEVENT_RESET; }
 };
 
 class XGResetEvent
@@ -636,7 +633,7 @@ class XGResetEvent
   XGResetEvent(MidiTrack *prntTrk, uint32_t absoluteTime)
        : SysexEvent(prntTrk, absoluteTime,  { 0x08, 0x43, 0x10, 0x4C, 0x00, 0x00, 0x7E, 0x00 },
                     PRIORITY_HIGHEST) { }
-  MidiEventType GetEventType() override { return MIDIEVENT_RESET; }
+  MidiEventType eventType() override { return MIDIEVENT_RESET; }
 };
 
 

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -142,9 +142,9 @@ class SynthWave {
         name(std::move(waveName)) {
     RiffFile::alignName(name);
   }
-  ~SynthWave(void);
+  ~SynthWave();
 
-  SynthSampInfo *addSampInfo(void);
+  SynthSampInfo *addSampInfo();
 
   void convertTo16bitSigned();
 

--- a/src/main/formats/ChunSnes/ChunSnesSeq.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesSeq.cpp
@@ -345,7 +345,7 @@ bool ChunSnesTrack::readEvent() {
         if (prevNoteSlurred && key == prevNoteKey) {
           // slurred note with same key works as tie
           makePrevDurNoteEnd(getTime() + dur);
-          desc = fmt::format("Abs Key: {} ({})   Duration: {}", key, MidiEvent::GetNoteName(key), dur);
+          desc = fmt::format("Abs Key: {} ({})   Duration: {}", key, MidiEvent::getNoteName(key), dur);
           addGenericEvent(beginOffset, curOffset - beginOffset, "Note with Duration", desc, CLR_TIE, ICON_NOTE);
         }
         else {

--- a/src/main/formats/HeartBeatPS1/HeartBeatPS1Seq.cpp
+++ b/src/main/formats/HeartBeatPS1/HeartBeatPS1Seq.cpp
@@ -182,7 +182,7 @@ bool HeartBeatPS1Seq::readEvent() {
         case 1:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
@@ -190,28 +190,28 @@ bool HeartBeatPS1Seq::readEvent() {
         case 2:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Breath Controller?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 4:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Foot Controller?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 5:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Time?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 6 :
           addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
@@ -223,7 +223,7 @@ bool HeartBeatPS1Seq::readEvent() {
         case 9:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control 9", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
@@ -240,147 +240,147 @@ bool HeartBeatPS1Seq::readEvent() {
         case 20:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control 20", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 21:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control 21", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 22:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control 22", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 23:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control 23", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 32:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Bank LSB?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 52:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control 52", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 53:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control 53", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 54:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control 54", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 55:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control 55", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 56:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control 56", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 64:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Hold 1?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 69:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Hold 2?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 71:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Resonance?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 72:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Release Time?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 73:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Attack Time?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 74:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Cut Off Frequency?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 75:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Decay Time?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 76:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Rate?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 77:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Depth?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 78:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Delay?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 79:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control 79", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
@@ -391,7 +391,7 @@ bool HeartBeatPS1Seq::readEvent() {
         case 92:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
@@ -411,7 +411,7 @@ bool HeartBeatPS1Seq::readEvent() {
           }
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
@@ -432,35 +432,35 @@ bool HeartBeatPS1Seq::readEvent() {
           }
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 121:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Reset All Controllers", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 126:
           addGenericEvent(beginOffset, curOffset - beginOffset, "MONO?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 127:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Poly?", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         default:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control Event", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
       }

--- a/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
@@ -176,7 +176,7 @@ bool KonamiPS1Track::readEvent() {
         addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry",
           description.str(), CLR_MISC);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
-          pMidiTrack->AddControllerEvent(channel, command, paramByte);
+          pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
         break;
 
@@ -197,7 +197,7 @@ bool KonamiPS1Track::readEvent() {
         addGenericEvent(beginOffset, curOffset - beginOffset, "Stereo Widening (?)",
                         description.str(), CLR_PAN, ICON_CONTROL);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
-          pMidiTrack->AddControllerEvent(channel, command, paramByte);
+          pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
         break;
 
@@ -211,7 +211,7 @@ bool KonamiPS1Track::readEvent() {
         addGenericEvent(beginOffset, curOffset - beginOffset, "Set Channe", description.str(),
                         CLR_PAN, ICON_CONTROL);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
-          pMidiTrack->AddControllerEvent(channel, command, paramByte);
+          pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
         break;
 
@@ -272,7 +272,7 @@ bool KonamiPS1Track::readEvent() {
         addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN (LSB)", description.str(),
                         CLR_MISC);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
-          pMidiTrack->AddControllerEvent(channel, command, paramByte);
+          pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
         break;
 
@@ -287,7 +287,7 @@ bool KonamiPS1Track::readEvent() {
                           CLR_MISC);
         }
         if (readMode == READMODE_CONVERT_TO_MIDI) {
-          pMidiTrack->AddControllerEvent(channel, command, paramByte);
+          pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
         break;
 
@@ -296,7 +296,7 @@ bool KonamiPS1Track::readEvent() {
         addGenericEvent(beginOffset, curOffset - beginOffset, "Seq Beat", description.str(),
                         CLR_MISC);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
-          pMidiTrack->AddControllerEvent(channel, command, paramByte);
+          pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
         break;
 
@@ -308,7 +308,7 @@ bool KonamiPS1Track::readEvent() {
       default:
         addUnknown(beginOffset, curOffset - beginOffset);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
-          pMidiTrack->AddControllerEvent(channel, command, paramByte);
+          pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
 
         // bContinue = false;

--- a/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
@@ -373,7 +373,7 @@ bool NamcoSnesSeq::readEvent() {
           else {
             key = keyByte;
             noteType = NOTE_MELODY;
-            desc << " [" << (trackIndex + 1) << "] " << key << " (" << MidiEvent::GetNoteName(key + transpose)
+            desc << " [" << (trackIndex + 1) << "] " << key << " (" << MidiEvent::getNoteName(key + transpose)
                 << ")";
           }
 

--- a/src/main/formats/Org/OrgSeq.cpp
+++ b/src/main/formats/Org/OrgSeq.cpp
@@ -41,7 +41,7 @@ OrgTrack::OrgTrack(OrgSeq *parentFile, uint32_t offset, uint32_t length, uint8_t
 }
 
 bool OrgTrack::loadTrack(uint32_t trackNum, uint32_t stopOffset, long stopDelta) {
-  pMidiTrack = parentSeq->midi->AddTrack();
+  pMidiTrack = parentSeq->midi->addTrack();
   //SetChannelAndGroupFromTrkNum(trackNum);
 
   if (realTrkNum > 7)
@@ -49,7 +49,7 @@ bool OrgTrack::loadTrack(uint32_t trackNum, uint32_t stopOffset, long stopDelta)
   else
     channel = trackNum;
   channelGroup = 0;
-  pMidiTrack->SetChannelGroup(channelGroup);
+  pMidiTrack->setChannelGroup(channelGroup);
 
   if (trackNum == 0) {
     addTempo(0, 0, ((OrgSeq *) parentSeq)->waitTime * 4000);

--- a/src/main/formats/PS1/PS1Seq.cpp
+++ b/src/main/formats/PS1/PS1Seq.cpp
@@ -152,7 +152,7 @@ bool PS1Seq::readEvent() {
         case 6 :
           addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
@@ -198,7 +198,7 @@ bool PS1Seq::readEvent() {
           }
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
@@ -219,7 +219,7 @@ bool PS1Seq::readEvent() {
           }
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
@@ -227,7 +227,7 @@ bool PS1Seq::readEvent() {
         case 100 :
           addGenericEvent(beginOffset, curOffset - beginOffset, "RPN 1", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
@@ -235,7 +235,7 @@ bool PS1Seq::readEvent() {
         case 101 :
           addGenericEvent(beginOffset, curOffset - beginOffset, "RPN 2", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
@@ -243,14 +243,14 @@ bool PS1Seq::readEvent() {
         case 121 :
           addGenericEvent(beginOffset, curOffset - beginOffset, "Reset All Controllers", "", CLR_MISC);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         default:
           addGenericEvent(beginOffset, curOffset - beginOffset, "Control Event", "", CLR_UNKNOWN);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            pMidiTrack->AddControllerEvent(channel, controlNum, value);
+            pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
       }

--- a/src/main/formats/PrismSnes/PrismSnesSeq.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesSeq.cpp
@@ -348,7 +348,7 @@ bool PrismSnesTrack::readEvent() {
 
       if (prevNoteSlurred && key == prevNoteKey) {
         makePrevDurNoteEnd(getTime() + dur);
-        desc << "Abs Key: " << key << " (" << MidiEvent::GetNoteName(key) << "  Velocity: " << NOTE_VELOCITY << "  Duration: "
+        desc << "Abs Key: " << key << " (" << MidiEvent::getNoteName(key) << "  Velocity: " << NOTE_VELOCITY << "  Duration: "
             << dur;
         addGenericEvent(beginOffset, curOffset - beginOffset, "Note (Tied)", desc.str(), CLR_DURNOTE, ICON_NOTE);
       }
@@ -387,9 +387,9 @@ bool PrismSnesTrack::readEvent() {
       uint8_t dur = getDuration(curOffset, len, durDelta);
 
       desc << "Note Number (From): " << noteNumberFrom << " ("
-          << ((noteFrom & 0x80) != 0 ? "Noise" : MidiEvent::GetNoteName(noteNumberFrom)) << ")" <<
+          << ((noteFrom & 0x80) != 0 ? "Noise" : MidiEvent::getNoteName(noteNumberFrom)) << ")" <<
           "  Note Number (To): " << noteNumberTo << " ("
-          << ((noteTo & 0x80) != 0 ? "Noise" : MidiEvent::GetNoteName(noteNumberTo)) << ")" <<
+          << ((noteTo & 0x80) != 0 ? "Noise" : MidiEvent::getNoteName(noteNumberTo)) << ")" <<
           "  Length: " << len << "  Duration: " << dur;
       addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc.str(), CLR_PITCHBEND, ICON_CONTROL);
 

--- a/src/ui/qt/MainWindow.cpp
+++ b/src/ui/qt/MainWindow.cpp
@@ -130,7 +130,7 @@ void MainWindow::showEvent(QShowEvent* event) {
 }
 
 void MainWindow::routeSignals() {
-  connect(m_menu_bar, &MenuBar::openFile, this, &MainWindow::OpenFile);
+  connect(m_menu_bar, &MenuBar::openFile, this, &MainWindow::openFile);
   connect(m_menu_bar, &MenuBar::exit, this, &MainWindow::close);
   connect(m_menu_bar, &MenuBar::showAbout, [this]() {
     About about(this);
@@ -169,7 +169,7 @@ void MainWindow::dropEvent(QDropEvent *event) {
   event->acceptProposedAction();
 }
 
-void MainWindow::OpenFile() {
+void MainWindow::openFile() {
   auto filenames = QFileDialog::getOpenFileNames(
       this, "Select a file...", QStandardPaths::writableLocation(QStandardPaths::MusicLocation),
       "All files (*)");

--- a/src/ui/qt/MainWindow.h
+++ b/src/ui/qt/MainWindow.h
@@ -34,7 +34,7 @@ private:
   void createStatusBar();
   void routeSignals();
 
-  void OpenFile();
+  void openFile();
   void openFileInternal(const QString& filename);
 
   QDockWidget *m_rawfile_dock{};

--- a/src/ui/qt/QtVGMRoot.cpp
+++ b/src/ui/qt/QtVGMRoot.cpp
@@ -29,34 +29,25 @@ void QtVGMRoot::UI_setRootPtr(VGMRoot** theRoot) {
 }
 
 void QtVGMRoot::UI_addRawFile(RawFile*) {
-  this->UI_AddedRawFile();
+  this->UI_addedRawFile();
 }
 
 void QtVGMRoot::UI_closeRawFile(RawFile*) {
-  this->UI_RemovedRawFile();
+  this->UI_removedRawFile();
 }
 
 void QtVGMRoot::UI_onBeginLoadRawFile() {
   if (rawFileLoadRecurseStack++ == 0)
-    this->UI_BeganLoadingRawFile();
+    this->UI_beganLoadingRawFile();
 }
 
 void QtVGMRoot::UI_onEndLoadRawFile() {
   if (--rawFileLoadRecurseStack == 0)
-    this->UI_EndedLoadingRawFile();
-}
-
-void QtVGMRoot::UI_OnBeginScan() {
-}
-
-void QtVGMRoot::UI_SetScanInfo() {
-}
-
-void QtVGMRoot::UI_OnEndScan() {
+    this->UI_endedLoadingRawFile();
 }
 
 void QtVGMRoot::UI_addVGMFile(VGMFileVariant file) {
-  this->UI_AddedVGMFile();
+  this->UI_addedVGMFile();
 }
 
 void QtVGMRoot::UI_addVGMSeq(VGMSeq*) {
@@ -72,15 +63,15 @@ void QtVGMRoot::UI_addVGMMisc(VGMMiscFile*) {
 }
 
 void QtVGMRoot::UI_addVGMColl(VGMColl*) {
-  this->UI_AddedVGMColl();
+  this->UI_addedVGMColl();
 }
 
 void QtVGMRoot::UI_beginRemoveVGMFiles() {
-  this->UI_BeganRemovingVGMFiles();
+  this->UI_beganRemovingVGMFiles();
 }
 
 void QtVGMRoot::UI_endRemoveVGMFiles() {
-  this->UI_EndedRemovingVGMFiles();
+  this->UI_endedRemovingVGMFiles();
 }
 
 void QtVGMRoot::UI_addItem(VGMItem* item, VGMItem* parent, const std::string& itemName,
@@ -89,16 +80,11 @@ void QtVGMRoot::UI_addItem(VGMItem* item, VGMItem* parent, const std::string& it
   treeview->addVGMItem(item, parent, itemName);
 }
 
-std::string QtVGMRoot::UI_GetOpenFilePath(const std::string&, const std::string&) {
-  std::string path = "Placeholder";
-  return path;
-}
-
 std::string QtVGMRoot::UI_getSaveFilePath(const std::string& suggested_filename,
                                            const std::string& extension) {
-  return OpenSaveFileDialog(suggested_filename, extension);
+  return openSaveFileDialog(suggested_filename, extension);
 }
 
 std::string QtVGMRoot::UI_getSaveDirPath(const std::string&) {
-  return OpenSaveDirDialog();
+  return openSaveDirDialog();
 }

--- a/src/ui/qt/QtVGMRoot.h
+++ b/src/ui/qt/QtVGMRoot.h
@@ -22,9 +22,6 @@ public:
 
   void UI_onBeginLoadRawFile() override;
   void UI_onEndLoadRawFile() override;
-  void UI_OnBeginScan();
-  void UI_SetScanInfo();
-  void UI_OnEndScan();
   void UI_addVGMFile(VGMFileVariant file) override;
   void UI_addVGMSeq(VGMSeq* theSeq) override;
   void UI_addVGMInstrSet(VGMInstrSet* theInstrSet) override;
@@ -35,25 +32,23 @@ public:
   void UI_endRemoveVGMFiles() override;
   void UI_addItem(VGMItem* item, VGMItem* parent, const std::string& itemName,
                   void* UI_specific) override;
-  std::string UI_GetOpenFilePath(const std::string& suggestedFilename = "",
-                                          const std::string& extension = "");
   std::string UI_getSaveFilePath(const std::string& suggestedFilename,
-                                          const std::string& extension = "") override;
-  std::string UI_getSaveDirPath(const std::string& suggestedDir = "") override;
+                                          const std::string& extension) override;
+  std::string UI_getSaveDirPath(const std::string& suggestedDir) override;
 
 private:
   int rawFileLoadRecurseStack = 0;
 
 signals:
-  void UI_BeganLoadingRawFile();
-  void UI_EndedLoadingRawFile();
-  void UI_BeganRemovingVGMFiles();
-  void UI_EndedRemovingVGMFiles();
-  void UI_AddedRawFile();
-  void UI_RemovedRawFile();
-  void UI_AddedVGMFile();
-  void UI_AddedVGMColl();
-  void UI_RemovedVGMColl();
+  void UI_beganLoadingRawFile();
+  void UI_endedLoadingRawFile();
+  void UI_beganRemovingVGMFiles();
+  void UI_endedRemovingVGMFiles();
+  void UI_addedRawFile();
+  void UI_removedRawFile();
+  void UI_addedVGMFile();
+  void UI_addedVGMColl();
+  void UI_removedVGMColl();
   void UI_removeVGMColl(VGMColl* targColl) override;
   void UI_removeVGMFile(VGMFile* targFile) override;
   void UI_log(LogItem* theLog) override;

--- a/src/ui/qt/SequencePlayer.cpp
+++ b/src/ui/qt/SequencePlayer.cpp
@@ -185,7 +185,7 @@ bool SequencePlayer::playCollection(VGMColl *coll) {
 
   MidiFile *midi = seq->convertToMidi();
   std::vector<uint8_t> raw_midi;
-  midi->WriteMidiToBuffer(raw_midi);
+  midi->writeMidiToBuffer(raw_midi);
   /* Set up the MIDI stream */
   HSTREAM midi_stream =
       BASS_MIDI_StreamCreateFile(true, raw_midi.data(), 0, raw_midi.size(), BASS_MIDI_DECAYEND, 0);

--- a/src/ui/qt/services/MenuManager.cpp
+++ b/src/ui/qt/services/MenuManager.cpp
@@ -9,26 +9,26 @@
 #include "services/commands/SaveCommands.h"
 
 MenuManager::MenuManager() {
-  RegisterCommands<VGMSeq, VGMItem>({
+  registerCommands<VGMSeq, VGMItem>({
       std::make_shared<SaveAsMidiCommand>(),
       std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<CloseVGMFileCommand>(),
   });
-  RegisterCommands<VGMInstrSet, VGMItem>({
+  registerCommands<VGMInstrSet, VGMItem>({
       std::make_shared<SaveAsSF2Command>(),
       std::make_shared<SaveAsDLSCommand>(),
       std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<CloseVGMFileCommand>(),
   });
-  RegisterCommands<VGMSampColl, VGMItem>({
+  registerCommands<VGMSampColl, VGMItem>({
       std::make_shared<SaveWavBatchCommand>(),
       std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<CloseVGMFileCommand>(),
   });
-  RegisterCommands<VGMFile, VGMItem>({
+  registerCommands<VGMFile, VGMItem>({
       std::make_shared<CloseVGMFileCommand>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
@@ -36,13 +36,13 @@ MenuManager::MenuManager() {
       std::make_shared<CloseVGMFileCommand>(),
   });
 
-  RegisterCommands<RawFile>({
+  registerCommands<RawFile>({
       std::make_shared<SaveAsOriginalFormatCommand<RawFile>>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<CloseRawFileCommand>(),
   });
 
-  RegisterCommands<VGMColl>({
+  registerCommands<VGMColl>({
       std::make_shared<SaveCollCommand<conversion::Target::MIDI | conversion::Target::SF2>>(),
       std::make_shared<SaveCollCommand<conversion::Target::MIDI | conversion::Target::DLS>>(),
       std::make_shared<SaveCollCommand<conversion::Target::MIDI | conversion::Target::SF2
@@ -51,7 +51,7 @@ MenuManager::MenuManager() {
 }
 
 template<typename T, typename Base>
-void MenuManager::RegisterCommands(const std::vector<std::shared_ptr<Command>>& commands) {
+void MenuManager::registerCommands(const std::vector<std::shared_ptr<Command>>& commands) {
   commandsForType[typeid(T)] = commands;
 
   if constexpr (std::is_convertible_v<T*, Base*>) {

--- a/src/ui/qt/services/commands/Command.h
+++ b/src/ui/qt/services/commands/Command.h
@@ -78,13 +78,13 @@ public:
    * @param properties A map of properties to be used for context creation.
    * @return A shared pointer to the created CommandContext object.
    */
-  [[nodiscard]] virtual std::shared_ptr<CommandContext> CreateContext(const PropertyMap& properties) const = 0;
+  [[nodiscard]] virtual std::shared_ptr<CommandContext> createContext(const PropertyMap& properties) const = 0;
 
   /**
    * Retrieves the specifications for the properties required to be set in the PropertyMap passed to CreateContext().
    * @return A list of property specifications.
    */
-  [[nodiscard]] virtual PropertySpecifications GetPropertySpecifications() const = 0;
+  [[nodiscard]] virtual PropertySpecifications propertySpecifications() const = 0;
 };
 
 
@@ -100,7 +100,7 @@ public:
    * Executes the command within the given context.
    * @param context A reference to the CommandContext which will provide the data needed to execute the command.
    */
-  virtual void Execute(CommandContext& context) = 0;
+  virtual void execute(CommandContext& context) = 0;
 
   /**
    * Retrieves the name of the command to appear in the UI. Commands must use unique Names, or they will
@@ -108,21 +108,21 @@ public:
    * selecting multiple sequences and executing the "Save to MIDI" command).
    * @return The name of the command.
    */
-  [[nodiscard]] virtual std::string Name() const = 0;
+  [[nodiscard]] virtual std::string name() const = 0;
 
   /**
    * Gets the factory for creating a command context specific to this command.
    * @return A shared pointer to the CommandContextFactory.
    */
-  [[nodiscard]] virtual std::shared_ptr<CommandContextFactory> GetContextFactory() const = 0;
+  [[nodiscard]] virtual std::shared_ptr<CommandContextFactory> contextFactory() const = 0;
 };
 
 class CommandSeparator : public Command {
 public:
   CommandSeparator() = default;
 
-  void Execute(CommandContext&) override {}
+  void execute(CommandContext&) override {}
 
-  [[nodiscard]] std::shared_ptr<CommandContextFactory> GetContextFactory() const override { return nullptr; }
-  [[nodiscard]] std::string Name() const override { return "separator"; }
+  [[nodiscard]] std::shared_ptr<CommandContextFactory> contextFactory() const override { return nullptr; }
+  [[nodiscard]] std::string name() const override { return "separator"; }
 };

--- a/src/ui/qt/util/UIHelpers.cpp
+++ b/src/ui/qt/util/UIHelpers.cpp
@@ -42,7 +42,7 @@ void applyEffectToPixmap(QPixmap &src, QPixmap &tgt, QGraphicsEffect *effect, in
 }
 
 
-std::string OpenSaveDirDialog() {
+std::string openSaveDirDialog() {
   static auto selected_dir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
   QFileDialog dialog(QApplication::activeWindow());
   dialog.setFileMode(QFileDialog::FileMode::Directory);
@@ -58,7 +58,7 @@ std::string OpenSaveDirDialog() {
 }
 
 
-std::string OpenSaveFileDialog(const std::string& suggested_filename, const std::string& extension) {
+std::string openSaveFileDialog(const std::string& suggested_filename, const std::string& extension) {
   static auto selected_dir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
   QFileDialog dialog(QApplication::activeWindow());
   dialog.setFileMode(QFileDialog::AnyFile);

--- a/src/ui/qt/util/UIHelpers.h
+++ b/src/ui/qt/util/UIHelpers.h
@@ -17,5 +17,5 @@ class VGMItem;
 QScrollArea* getContainingScrollArea(QWidget* widget);
 void applyEffectToPixmap(QPixmap &src, QPixmap &tgt, QGraphicsEffect *effect, int extent = 0);
 
-std::string OpenSaveFileDialog(const std::string& suggested_filename, const std::string& extension);
-std::string OpenSaveDirDialog();
+std::string openSaveFileDialog(const std::string& suggested_filename, const std::string& extension);
+std::string openSaveDirDialog();

--- a/src/ui/qt/workarea/RawFileListView.cpp
+++ b/src/ui/qt/workarea/RawFileListView.cpp
@@ -26,8 +26,8 @@ static const QIcon& fileIcon() {
  */
 
 RawFileListViewModel::RawFileListViewModel(QObject *parent) : QAbstractTableModel(parent) {
-  connect(&qtVGMRoot, &QtVGMRoot::UI_AddedRawFile, this, &RawFileListViewModel::AddRawFile);
-  connect(&qtVGMRoot, &QtVGMRoot::UI_RemovedRawFile, this, &RawFileListViewModel::RemoveRawFile);
+  connect(&qtVGMRoot, &QtVGMRoot::UI_addedRawFile, this, &RawFileListViewModel::addRawFile);
+  connect(&qtVGMRoot, &QtVGMRoot::UI_removedRawFile, this, &RawFileListViewModel::removeRawFile);
 }
 
 int RawFileListViewModel::rowCount(const QModelIndex &parent) const {
@@ -44,7 +44,7 @@ int RawFileListViewModel::columnCount(const QModelIndex &parent) const {
   return 2;
 }
 
-void RawFileListViewModel::AddRawFile() {
+void RawFileListViewModel::addRawFile() {
   int position = static_cast<int>(qtVGMRoot.rawFiles().size()) - 1;
   if (position >= 0) {
     beginInsertRows(QModelIndex(), position, position);
@@ -52,7 +52,7 @@ void RawFileListViewModel::AddRawFile() {
   }
 }
 
-void RawFileListViewModel::RemoveRawFile() {
+void RawFileListViewModel::removeRawFile() {
   int position = static_cast<int>(qtVGMRoot.rawFiles().size()) - 1;
   if (position >= 0) {
     beginRemoveRows(QModelIndex(), position, position);
@@ -148,7 +148,7 @@ void RawFileListView::rawFilesMenu(const QPoint &pos) const {
       selectedFiles->push_back(qtVGMRoot.rawFiles()[index.row()]);
     }
   }
-  auto menu = MenuManager::the()->CreateMenuForItems<RawFile>(selectedFiles);
+  auto menu = MenuManager::the()->createMenuForItems<RawFile>(selectedFiles);
   menu->exec(mapToGlobal(pos));
   menu->deleteLater();
 }

--- a/src/ui/qt/workarea/RawFileListView.h
+++ b/src/ui/qt/workarea/RawFileListView.h
@@ -19,8 +19,8 @@ public:
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
 public slots:
-  void AddRawFile();
-  void RemoveRawFile();
+  void addRawFile();
+  void removeRawFile();
 
 private:
   enum Property : uint8_t { Name = 0, ContainedFiles = 1 };

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -32,13 +32,13 @@ VGMCollListViewModel::VGMCollListViewModel(QObject *parent) : QAbstractListModel
     resettingModel = false;
   };
 
-  connect(&qtVGMRoot, &QtVGMRoot::UI_BeganLoadingRawFile, startResettingModel);
-  connect(&qtVGMRoot, &QtVGMRoot::UI_EndedLoadingRawFile, endResettingModel);
-  connect(&qtVGMRoot, &QtVGMRoot::UI_BeganRemovingVGMFiles, startResettingModel);
-  connect(&qtVGMRoot, &QtVGMRoot::UI_EndedRemovingVGMFiles, endResettingModel);
+  connect(&qtVGMRoot, &QtVGMRoot::UI_beganLoadingRawFile, startResettingModel);
+  connect(&qtVGMRoot, &QtVGMRoot::UI_endedLoadingRawFile, endResettingModel);
+  connect(&qtVGMRoot, &QtVGMRoot::UI_beganRemovingVGMFiles, startResettingModel);
+  connect(&qtVGMRoot, &QtVGMRoot::UI_endedRemovingVGMFiles, endResettingModel);
 
 
-  connect(&qtVGMRoot, &QtVGMRoot::UI_AddedVGMColl,
+  connect(&qtVGMRoot, &QtVGMRoot::UI_addedVGMColl,
           [this]() {
             if (!resettingModel)
               dataChanged(index(0, 0), index(rowCount() - 1, 0));
@@ -144,7 +144,7 @@ void VGMCollListView::collectionMenu(const QPoint &pos) const {
       selectedColls->push_back(qtVGMRoot.vgmColls()[index.row()]);
     }
   }
-  auto menu = MenuManager::the()->CreateMenuForItems<VGMColl>(selectedColls);
+  auto menu = MenuManager::the()->createMenuForItems<VGMColl>(selectedColls);
   menu->exec(mapToGlobal(pos));
   menu->deleteLater();
 }

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -25,7 +25,7 @@
  */
 
 VGMFileListModel::VGMFileListModel(QObject *parent) : QAbstractTableModel(parent) {
-  connect(&qtVGMRoot, &QtVGMRoot::UI_AddedVGMFile, this, &VGMFileListModel::AddVGMFile);
+  connect(&qtVGMRoot, &QtVGMRoot::UI_addedVGMFile, this, &VGMFileListModel::addVGMFile);
 }
 
 QVariant VGMFileListModel::data(const QModelIndex &index, int role) const {
@@ -96,13 +96,13 @@ int VGMFileListModel::columnCount(const QModelIndex &parent) const {
   return 2;
 }
 
-void VGMFileListModel::AddVGMFile() {
+void VGMFileListModel::addVGMFile() {
   int position = static_cast<int>(qtVGMRoot.vgmFiles().size()) - 1;
   beginInsertRows(QModelIndex(), position, position);
   endInsertRows();
 }
 
-void VGMFileListModel::RemoveVGMFile() {
+void VGMFileListModel::removeVGMFile() {
   int position = static_cast<int>(qtVGMRoot.vgmFiles().size()) - 1;
   if (position < 0) {
     return;
@@ -145,7 +145,7 @@ void VGMFileListView::itemMenu(const QPoint &pos) {
       selectedFiles->push_back(variantToVGMFile(qtVGMRoot.vgmFiles()[index.row()]));
     }
   }
-  auto menu = MenuManager::the()->CreateMenuForItems<VGMItem>(selectedFiles);
+  auto menu = MenuManager::the()->createMenuForItems<VGMItem>(selectedFiles);
   menu->exec(mapToGlobal(pos));
   menu->deleteLater();
 }
@@ -181,7 +181,7 @@ void VGMFileListView::keyPressEvent(QKeyEvent *input) {
 
 void VGMFileListView::removeVGMFile(const VGMFile *file) const {
   MdiArea::the()->removeView(file);
-  view_model->RemoveVGMFile();
+  view_model->removeVGMFile();
 }
 
 void VGMFileListView::requestVGMFileView(const QModelIndex& index) {

--- a/src/ui/qt/workarea/VGMFileListView.h
+++ b/src/ui/qt/workarea/VGMFileListView.h
@@ -25,8 +25,8 @@ class VGMFileListModel : public QAbstractTableModel {
     int columnCount(const QModelIndex &parent) const override;
 
   public slots:
-    void AddVGMFile();
-    void RemoveVGMFile();
+    void addVGMFile();
+    void removeVGMFile();
 
   private:
     enum Property : uint8_t { Name = 0, Format = 1 };


### PR DESCRIPTION
This also covers MidiFile.cpp and DLSFile.cpp, which I missed in the last PR. That should be everything, knock on wood.

Only thing I did here that wasn't a simple rename was among the MenuManager classes, where I made some fields private and renamed them to allow consistency with the naming scheme (think `name` being made private and changed to `m_name`, for example).

I'll try the "merge" option this time to see if that preserves the commit hash.

## How Has This Been Tested?
Menus seem to be working.