### PR TITLE
Update .git-blame-ignore-revs for Qt implementation method renaming

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -24,4 +24,4 @@ ed533cd46d853523d184ff1a60f769223ee97845
 6bcd74f826462ed5ea4ff52c28e9f9dad605251c
 
 # Rename the Qt implementation methods
-f21c279c8dbeadda11ee065c0db19473006d8b55
+6a066930d0281c1ddd356baaedf4db3a1c3fada4


### PR DESCRIPTION
Updating the last commit hash after a rebase and merge.