### PR TITLE
HexView optimizations

### DIFF
--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -22,7 +22,7 @@
 #include <QToolTip>
 #include <QStyle>
 
-constexpr qsizetype NUM_CACHED_LINE_PIXMAPS = 300;
+constexpr qsizetype NUM_CACHED_LINE_PIXMAPS = 600;
 constexpr int BYTES_PER_LINE = 16;
 constexpr int NUM_ADDRESS_NIBBLES = 8;
 constexpr int ADDRESS_SPACING_CHARS = 4;

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -124,13 +124,6 @@ int HexView::getVirtualHeight() const {
   return lineHeight * getTotalLines();
 }
 
-// int HexView::getScrollBarWidth() {
-//   if (m_scrollbar_thickness == -1) {
-//     m_scrollbar_thickness = style()->pixelMetric(QStyle::PM_ScrollBarExtent);
-//
-//   }
-// }
-
 int HexView::getVirtualFullWidth() {
   if (m_virtual_full_width == -1) {
     constexpr int numChars = NUM_ADDRESS_NIBBLES + ADDRESS_SPACING_CHARS + (BYTES_PER_LINE * 3) +

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -20,12 +20,13 @@ public:
   explicit HexView(VGMFile* vgmfile, QWidget *parent = nullptr);
   void setSelectedItem(VGMItem* item);
   void setFont(QFont& font);
-  int getVirtualWidth() const;
-  int getVirtualWidthSansAscii() const;
-  int getVirtualWidthSansAsciiAndAddress() const;
-  int getViewportWidth() const;
-  int getViewportWidthSansAscii() const;
-  int getViewportWidthSansAsciiAndAddress() const;
+  [[nodiscard]] int getVirtualFullWidth();
+  [[nodiscard]] int getVirtualWidthSansAscii();
+  [[nodiscard]] int getVirtualWidthSansAsciiAndAddress();
+  [[nodiscard]] int getActualVirtualWidth();
+  [[nodiscard]] int getViewportFullWidth();
+  [[nodiscard]] int getViewportWidthSansAscii();
+  [[nodiscard]] int getViewportWidthSansAsciiAndAddress();
 
 protected:
   bool event(QEvent *event) override;
@@ -81,10 +82,14 @@ private:
   int lineHeight;
   bool addressAsHex = true;
   bool isDragging = false;
-  bool showOffset = true;
+  bool shouldDrawOffset = true;
   bool shouldDrawAscii = true;
   int prevWidth = 0;
   int prevHeight = 0;
+
+  int m_virtual_full_width{-1};
+  int m_virtual_width_sans_ascii{-1};
+  int m_virtual_width_sans_ascii_and_address{-1};
 
   QCache<int, QPixmap> lineCache;
   QGraphicsOpacityEffect* overlayOpacityEffect = nullptr;

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -74,11 +74,13 @@ private:
                   QColor textColor) const;
   void showOverlay(bool show, bool animate);
   void drawSelectedItem() const;
+  QRect calculateSelectionRectForLine(int startOffset, int length);
 
   VGMFile* vgmfile;
   VGMItem* selectedItem;
   int selectedOffset;
   int charWidth;
+  int charHalfWidth;
   int lineHeight;
   bool addressAsHex = true;
   bool isDragging = false;

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -45,6 +45,7 @@ private:
   int getVirtualHeight() const;
   int getTotalLines() const;
   int getOffsetFromPoint(QPoint pos) const;
+  std::pair<QRect,QRect> calculateSelectionRectsForLine(int startColumn, int length, qreal dpr);
   void resizeOverlays(int height) const;
   void redrawOverlay();
   void printLine(QPainter& painter, int line) const;
@@ -74,7 +75,6 @@ private:
                   QColor textColor) const;
   void showOverlay(bool show, bool animate);
   void drawSelectedItem() const;
-  QRect calculateSelectionRectForLine(int startOffset, int length);
 
   VGMFile* vgmfile;
   VGMItem* selectedItem;

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -45,7 +45,7 @@ private:
   int getVirtualHeight() const;
   int getTotalLines() const;
   int getOffsetFromPoint(QPoint pos) const;
-  std::pair<QRect,QRect> calculateSelectionRectsForLine(int startColumn, int length, qreal dpr);
+  std::pair<QRect,QRect> calculateSelectionRectsForLine(int startColumn, int length, qreal dpr) const;
   void resizeOverlays(int height) const;
   void redrawOverlay();
   void printLine(QPainter& painter, int line) const;

--- a/src/ui/qt/workarea/MdiArea.cpp
+++ b/src/ui/qt/workarea/MdiArea.cpp
@@ -71,9 +71,23 @@ void MdiArea::removeView(const VGMFile *file) {
 }
 
 void MdiArea::onSubWindowActivated(QMdiSubWindow *window) {
+  if (!window)
+    return;
+
   // For some reason, if multiple documents are open, closing one document causes the others
   // to become windowed instead of maximized. This fixes the problem.
   ensureMaximizedSubWindow(window);
+
+  // Another quirk: paintEvents for all subWindows, not just the active one, are fired
+  // unless we manually hide them.
+  for (auto subWindow : subWindowList()) {
+    if (subWindow == window) {
+      qDebug() << "skipping this window";
+      subWindow->widget()->setHidden(false);
+    } else {
+      subWindow->widget()->setHidden(true);
+    }
+  }
 
   if (window) {
     auto it = windowToFileMap.find(window);

--- a/src/ui/qt/workarea/MdiArea.cpp
+++ b/src/ui/qt/workarea/MdiArea.cpp
@@ -81,11 +81,7 @@ void MdiArea::onSubWindowActivated(QMdiSubWindow *window) {
   // Another quirk: paintEvents for all subWindows, not just the active one, are fired
   // unless we manually hide them.
   for (auto subWindow : subWindowList()) {
-    if (subWindow == window) {
-      subWindow->widget()->setHidden(false);
-    } else {
-      subWindow->widget()->setHidden(true);
-    }
+    subWindow->widget()->setHidden(subWindow != window);
   }
 
   if (window) {

--- a/src/ui/qt/workarea/MdiArea.cpp
+++ b/src/ui/qt/workarea/MdiArea.cpp
@@ -82,7 +82,6 @@ void MdiArea::onSubWindowActivated(QMdiSubWindow *window) {
   // unless we manually hide them.
   for (auto subWindow : subWindowList()) {
     if (subWindow == window) {
-      qDebug() << "skipping this window";
       subWindow->widget()->setHidden(false);
     } else {
       subWindow->widget()->setHidden(true);

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -35,12 +35,12 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
 
   m_splitter->addWidget(m_hexScrollArea);
   m_splitter->addWidget(m_treeview);
-  m_splitter->setSizes(QList<int>{hexViewWidth(), treeViewMinimumWidth});
+  m_splitter->setSizes(QList<int>{hexViewFullWidth(), treeViewMinimumWidth});
   m_splitter->setStretchFactor(0, 0);
   m_splitter->setStretchFactor(1, 1);
   m_splitter->persistState();
   resetSnapRanges();
-  m_hexScrollArea->setMaximumWidth(hexViewWidth());
+  m_hexScrollArea->setMaximumWidth(hexViewFullWidth());
   m_treeview->setMinimumWidth(treeViewMinimumWidth);
 
   connect(m_hexview, &HexView::selectionChanged, this, &VGMFileView::onSelectionChange);
@@ -81,11 +81,11 @@ void VGMFileView::focusInEvent(QFocusEvent* event) {
 void VGMFileView::resetSnapRanges() const {
   m_splitter->clearSnapRanges();
   m_splitter->addSnapRange(0, hexViewWidthSansAsciiAndAddress(), hexViewWidthSansAscii());
-  m_splitter->addSnapRange(0, hexViewWidthSansAscii(), hexViewWidth());
+  m_splitter->addSnapRange(0, hexViewWidthSansAscii(), hexViewFullWidth());
 }
 
-int VGMFileView::hexViewWidth() const {
-  return m_hexview->getViewportWidth();
+int VGMFileView::hexViewFullWidth() const {
+  return m_hexview->getViewportFullWidth();
 }
 
 int VGMFileView::hexViewWidthSansAscii() const {
@@ -113,14 +113,14 @@ void VGMFileView::updateHexViewFont(qreal sizeIncrement) const {
 
   // Updating the font will shrink or expand the maximum possible width of the hex view
   int actualWidthBeforeResize = m_splitter->sizes()[0];
-  int fullWidthBeforeResize = hexViewWidth();
+  int fullWidthBeforeResize = hexViewFullWidth();
 
   m_hexview->setFont(font);
-  m_hexScrollArea->setMaximumWidth(hexViewWidth());
+  m_hexScrollArea->setMaximumWidth(hexViewFullWidth());
 
   // We'll scale the hex view size such that approximately the same portion of text will be visible
   float percentHexViewVisible = static_cast<float>(actualWidthBeforeResize) / static_cast<float>(fullWidthBeforeResize);
-  int fullWidthAfterResize = hexViewWidth();
+  int fullWidthAfterResize = hexViewFullWidth();
   int widthChange = fullWidthAfterResize - fullWidthBeforeResize;
   int newWidth = actualWidthBeforeResize + static_cast<int>(round(static_cast<float>(widthChange) * percentHexViewVisible));
   resetSnapRanges();

--- a/src/ui/qt/workarea/VGMFileView.h
+++ b/src/ui/qt/workarea/VGMFileView.h
@@ -26,7 +26,7 @@ private:
   void resetSnapRanges() const;
   void focusInEvent(QFocusEvent* event) override;
   void closeEvent(QCloseEvent *closeEvent) override;
-  int hexViewWidth() const;
+  int hexViewFullWidth() const;
   int hexViewWidthSansAscii() const;
   int hexViewWidthSansAsciiAndAddress() const;
   void updateHexViewFont(qreal sizeIncrement) const;


### PR DESCRIPTION
A lot of little performance optimizations for HexView:
- hack fix for paintEvents being called for all open subwindows of the MDI, not just the active one
- draw the selected item pixmap by copying segments of cached line pixmaps when possible (virtually, always) instead of calling the various print() methods to draw from scratch
- optimize paintEvent for happy path - construct a QPixmap and QPainter only when a line isn't in cache.
- memoize getVirtualWidth() methods calculated values. They are invalidated on font change
- memoize a new charHalfWidth() value, also invalidated on font change
- only redraw the overlay when window height expands beyond its current height (don't redraw when window height shrinks)
- skip drawing lines that are totally eclipsed by the selected item
- MacOS: detect paint events intended to draw the scroll bar which don't overlap with our draw area. Don't redraw lines when this happens.
- check that event type is Paint before calling `handleOverlayPaintEvent()` and `handleSelectedItemPaintEvent()` instead of checking in the methods.

Also:
- brighten the selection overlay a wee bit (the dark background)
- define drop shadow constants and tweak them to give the selected item a little more pop

I may run some benchmarks on `handleSelectedItemPaintEvent()` to see if the new method of drawing the selected item is truly improving performance. Best I can tell, it does, marginally.

## How Has This Been Tested?
Tried my best to break it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
