### PR TITLE
HexView optimizations part 2

### DIFF
--- a/src/ui/qt/util/UIHelpers.cpp
+++ b/src/ui/qt/util/UIHelpers.cpp
@@ -14,7 +14,7 @@
 #include <QStandardPaths>
 #include <QApplication>
 
-QScrollArea* getContainingScrollArea(QWidget* widget) {
+QScrollArea* getContainingScrollArea(const QWidget* widget) {
   QWidget* viewport = widget->parentWidget();
   if (viewport) {
     auto* scrollArea = qobject_cast<QScrollArea*>(viewport->parentWidget());

--- a/src/ui/qt/util/UIHelpers.h
+++ b/src/ui/qt/util/UIHelpers.h
@@ -14,7 +14,7 @@ class QPixmap;
 class QGraphicsEffect;
 class VGMItem;
 
-QScrollArea* getContainingScrollArea(QWidget* widget);
+QScrollArea* getContainingScrollArea(const QWidget* widget);
 void applyEffectToPixmap(QPixmap &src, QPixmap &tgt, QGraphicsEffect *effect, int extent = 0);
 
 std::string openSaveFileDialog(const std::string& suggested_filename, const std::string& extension);

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -53,7 +53,6 @@ HexView::HexView(VGMFile* vgmfile, QWidget *parent) :
   overlay = new QWidget(this);
   overlay->setAttribute(Qt::WA_NoSystemBackground);
   overlay->setAttribute(Qt::WA_TranslucentBackground);
-  // overlay->setAttribute(Qt::WA_OpaquePaintEvent);
   overlay->hide();
 
   overlay->installEventFilter(

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -478,9 +478,8 @@ bool HexView::handleSelectedItemPaintEvent(QObject* obj, QEvent* event) {
           translateAndPrintAscii(pixmapPainter, itemData.data() + offsetIntoEvent, col, bytesToPrint, bgColor, textColor);
           translateAndPrintHex(pixmapPainter, itemData.data() + offsetIntoEvent, col, bytesToPrint, bgColor, textColor);
 
-            offsetIntoEvent += bytesToPrint;
-            col = 0;
-          }
+          offsetIntoEvent += bytesToPrint;
+          col = 0;
         }
       }
       pixmapPainter.restore();
@@ -498,20 +497,6 @@ bool HexView::handleSelectedItemPaintEvent(QObject* obj, QEvent* event) {
   QPainter painter(widget);
   painter.drawPixmap(0, 0, selectionViewPixmap);
   return true;
-}
-
-std::pair<QRect,QRect> HexView::calculateSelectionRectsForLine(int startColumn, int length, qreal dpr) const {
-  int hexCharsStartOffsetInChars = shouldDrawOffset ? NUM_ADDRESS_NIBBLES + ADDRESS_SPACING_CHARS : 0;
-  int asciiStartOffsetInChars = hexCharsStartOffsetInChars + (BYTES_PER_LINE * 3) + HEX_TO_ASCII_SPACING_CHARS;
-  int left = (hexCharsStartOffsetInChars + (startColumn * 3)) * charWidth - charHalfWidth;
-  int width = length * 3 * charWidth;
-  QRect hexRect = QRect(left * dpr, 0, width * dpr, lineHeight * dpr);
-
-  left = (asciiStartOffsetInChars + startColumn) * charWidth;
-  width = length * charWidth;
-  QRect asciiRect = QRect(left * dpr, 0, width * dpr, lineHeight * dpr);
-
-  return { hexRect, asciiRect };
 }
 
 std::pair<QRect,QRect> HexView::calculateSelectionRectsForLine(int startColumn, int length, qreal dpr) const {

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -27,14 +27,14 @@ constexpr int BYTES_PER_LINE = 16;
 constexpr int NUM_ADDRESS_NIBBLES = 8;
 constexpr int ADDRESS_SPACING_CHARS = 4;
 constexpr int HEX_TO_ASCII_SPACING_CHARS = 4;
-constexpr int SELECTION_PADDING = 20;
+constexpr int SELECTION_PADDING = 18;
 constexpr int VIEWPORT_PADDING = 10;
 constexpr int DIM_DURATION_MS = 200;
 constexpr int OVERLAY_ALPHA = 80;
 const QColor SHADOW_COLOR = Qt::black;
 constexpr int SHADOW_OFFSET_X = 1;
 constexpr int SHADOW_OFFSET_Y = 2;
-constexpr int SHADOW_BLUR_RADIUS = SELECTION_PADDING;
+constexpr int SHADOW_BLUR_RADIUS = SELECTION_PADDING * 2;
 constexpr int OVERLAY_HEIGHT_IN_SCREENS = 5;
 
 HexView::HexView(VGMFile* vgmfile, QWidget *parent) :
@@ -230,12 +230,11 @@ void HexView::setSelectedItem(VGMItem *item) {
 }
 
 void HexView::resizeOverlays(int y, int viewportHeight) const {
-  auto xStart = hexXOffset() - charHalfWidth;
   const int overlayHeight = viewportHeight * OVERLAY_HEIGHT_IN_SCREENS;
   overlay->setGeometry(
-      xStart,
+      hexXOffset() - charHalfWidth,
       std::max(0, y - ((overlayHeight - viewportHeight) / 2)),
-      width() - xStart,
+      width(),
       overlayHeight
   );
 }

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -30,11 +30,12 @@ constexpr int HEX_TO_ASCII_SPACING_CHARS = 4;
 constexpr int SELECTION_PADDING = 20;
 constexpr int VIEWPORT_PADDING = 10;
 constexpr int DIM_DURATION_MS = 200;
-constexpr qreal OVERLAY_OPACITY_LEVEL = 0.8;
+constexpr int OVERLAY_ALPHA = 80;
 const QColor SHADOW_COLOR = Qt::black;
 constexpr int SHADOW_OFFSET_X = 1;
 constexpr int SHADOW_OFFSET_Y = 2;
-constexpr int SHADOW_BLUR_RADIUS = 20;
+constexpr int SHADOW_BLUR_RADIUS = SELECTION_PADDING;
+constexpr int OVERLAY_HEIGHT_IN_SCREENS = 5;
 
 HexView::HexView(VGMFile* vgmfile, QWidget *parent) :
       QWidget(parent), vgmfile(vgmfile), selectedItem(nullptr) {
@@ -52,6 +53,7 @@ HexView::HexView(VGMFile* vgmfile, QWidget *parent) :
   overlay = new QWidget(this);
   overlay->setAttribute(Qt::WA_NoSystemBackground);
   overlay->setAttribute(Qt::WA_TranslucentBackground);
+  // overlay->setAttribute(Qt::WA_OpaquePaintEvent);
   overlay->hide();
 
   overlay->installEventFilter(
@@ -97,10 +99,10 @@ void HexView::setFont(QFont& font) {
   this->charWidth = static_cast<int>(std::round(fontMetrics.horizontalAdvance("A")));
   this->charHalfWidth = static_cast<int>(std::round(fontMetrics.horizontalAdvance("A") / 2));
   this->lineHeight = static_cast<int>(std::round(fontMetrics.height()));
+  this->lineHeight = static_cast<int>(std::round(fontMetrics.height()));
 
   QWidget::setFont(font);
-  this->setMinimumWidth(getVirtualFullWidth());
-  this->setFixedHeight(getVirtualHeight());
+  updateSize();
 
   // Force everything to redraw
   prevSelectedItem = nullptr;
@@ -171,6 +173,16 @@ int HexView::getViewportWidthSansAsciiAndAddress() {
   return getVirtualWidthSansAsciiAndAddress() + VIEWPORT_PADDING;
 }
 
+void HexView::updateSize() {
+  const QScrollArea* scrollArea = getContainingScrollArea(this);
+  const int scrollBarThickness = style()->pixelMetric(QStyle::PM_ScrollBarExtent);
+  const int scrollAreaWidth = scrollArea ? scrollArea->width() : getVirtualFullWidth();
+  // It is important that the width is not greater than its container. If it is greater, scrolling
+  // will invalidate the entire viewport rather than just the area scrolled into view
+  const int hexViewWidth = scrollAreaWidth - scrollBarThickness - 2;
+  setFixedSize({hexViewWidth, getVirtualHeight()});
+}
+
 int HexView::getTotalLines() const {
   return (vgmfile->unLength + BYTES_PER_LINE - 1) / BYTES_PER_LINE;
 }
@@ -218,18 +230,21 @@ void HexView::setSelectedItem(VGMItem *item) {
   }
 }
 
-void HexView::resizeOverlays(int height) const {
+void HexView::resizeOverlays(int y, int viewportHeight) const {
+  auto xStart = hexXOffset() - charHalfWidth;
+  const int overlayHeight = viewportHeight * OVERLAY_HEIGHT_IN_SCREENS;
   overlay->setGeometry(
-      hexXOffset() - charHalfWidth,
-      overlay->y(),
-      ((BYTES_PER_LINE * 3 + HEX_TO_ASCII_SPACING_CHARS + BYTES_PER_LINE) * charWidth) + charHalfWidth,
-      height
+      xStart,
+      std::max(0, y - ((overlayHeight - viewportHeight) / 2)),
+      width() - xStart,
+      overlayHeight
   );
 }
 
 void HexView::redrawOverlay() {
   if (QScrollArea* scrollArea = getContainingScrollArea(this)) {
-    resizeOverlays(scrollArea->height());
+    int y = scrollArea->verticalScrollBar()->value();
+    resizeOverlays(y, scrollArea->height());
   }
 }
 
@@ -267,7 +282,9 @@ void HexView::changeEvent(QEvent *event) {
             int scrollAreaWidth = scrollArea->width();
             int scrollAreaHeight = scrollArea->height();
 
-            if (scrollAreaHeight > prevHeight) {
+            updateSize();
+
+            if (scrollAreaHeight * (OVERLAY_HEIGHT_IN_SCREENS - 1) > overlay->height()) {
               redrawOverlay();
             }
             prevHeight = scrollAreaHeight;
@@ -306,7 +323,14 @@ void HexView::changeEvent(QEvent *event) {
     );
 
     connect(scrollArea->verticalScrollBar(), &QScrollBar::valueChanged, this, [this, scrollArea](int value) {
-      overlay->move(overlay->x(), value);
+      // If the overlay has moved out of frame, center it back into frame
+      if (value < overlay->geometry().top() || value + scrollArea->height() > overlay->geometry().bottom()) {
+        overlay->move(
+          overlay->x(),
+          std::max(0, value - ((overlay->height() - scrollArea->height()) / 2))
+        );
+      }
+
       if (selectedItem != nullptr) {
         int startLine = value / lineHeight;
         int endLine = (value + scrollArea->height()) / lineHeight;
@@ -371,7 +395,7 @@ bool HexView::handleOverlayPaintEvent(QObject* obj, const QEvent* event) const {
 
   QPainter painter(static_cast<QWidget*>(obj));
   painter.fillRect(QRect(0, 0, BYTES_PER_LINE * 3 * charWidth, overlay->height()),
-                   QColor(0, 0, 0, 100));
+                   QColor(0, 0, 0, OVERLAY_ALPHA));
 
   if (shouldDrawAscii) {
     painter.fillRect(
@@ -464,10 +488,9 @@ bool HexView::handleSelectedItemPaintEvent(QObject* obj, QEvent* event) {
       pixmapPainter.restore();
     }
     auto glowEffect = new QGraphicsDropShadowEffect();
-    glowEffect->setBlurRadius(SELECTION_PADDING);
+    glowEffect->setBlurRadius(SHADOW_BLUR_RADIUS);
     glowEffect->setColor(SHADOW_COLOR);
     glowEffect->setOffset(SHADOW_OFFSET_X, SHADOW_OFFSET_Y);
-    glowEffect->setBlurRadius(SHADOW_BLUR_RADIUS);
 
     selectionViewPixmap = QPixmap(pixmap.width(), pixmap.height());
     selectionViewPixmap.setDevicePixelRatio(dpr);
@@ -523,7 +546,7 @@ void HexView::paintEvent(QPaintEvent *e) {
 #endif
 
   int startLine = paintRect.top() / lineHeight;
-  int endLine = (paintRect.bottom() + lineHeight - 1) / lineHeight;
+  int endLine = paintRect.bottom() / lineHeight;
 
   qreal dpr = devicePixelRatioF();
 
@@ -741,7 +764,7 @@ void HexView::showOverlay(bool show, bool animate) {
     overlayAnimation = new QPropertyAnimation(overlayOpacityEffect, "opacity");
     overlayAnimation->setDuration(DIM_DURATION_MS);
     overlayAnimation->setStartValue(overlayOpacityEffect == nullptr ? 0 : overlayOpacityEffect->opacity());
-    overlayAnimation->setEndValue(OVERLAY_OPACITY_LEVEL);
+    overlayAnimation->setEndValue(1.0);
     overlayAnimation->setEasingCurve(QEasingCurve::OutQuad);
 
     QObject::connect(overlayAnimation, &QPropertyAnimation::finished, [this]() {
@@ -760,7 +783,7 @@ void HexView::showOverlay(bool show, bool animate) {
 
     overlayAnimation = new QPropertyAnimation(overlayOpacityEffect, "opacity");
     overlayAnimation->setDuration(DIM_DURATION_MS);
-    overlayAnimation->setStartValue(overlayOpacityEffect == nullptr ? OVERLAY_OPACITY_LEVEL : overlayOpacityEffect->opacity());
+    overlayAnimation->setStartValue(overlayOpacityEffect == nullptr ? 1.0 : overlayOpacityEffect->opacity());
     overlayAnimation->setEndValue(0.0);
 
     // Connect the finished signal of the animation to a lambda function

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -456,8 +456,9 @@ bool HexView::handleSelectedItemPaintEvent(QObject* obj, QEvent* event) {
           translateAndPrintAscii(pixmapPainter, itemData.data() + offsetIntoEvent, col, bytesToPrint, bgColor, textColor);
           translateAndPrintHex(pixmapPainter, itemData.data() + offsetIntoEvent, col, bytesToPrint, bgColor, textColor);
 
-          offsetIntoEvent += bytesToPrint;
-          col = 0;
+            offsetIntoEvent += bytesToPrint;
+            col = 0;
+          }
         }
       }
       pixmapPainter.restore();
@@ -490,6 +491,18 @@ std::pair<QRect,QRect> HexView::calculateSelectionRectsForLine(int startColumn, 
   QRect asciiRect = QRect(left * dpr, 0, width * dpr, lineHeight * dpr);
 
   return { hexRect, asciiRect };
+}
+
+QRect HexView::calculateSelectionRectForLine(int startColumn, int length) {
+  qreal dpr = devicePixelRatioF();
+
+  int hexCharsStartOffsetInChars = shouldDrawOffset ? NUM_ADDRESS_NIBBLES + ADDRESS_SPACING_CHARS : 0;
+  int left = (hexCharsStartOffsetInChars + (startColumn * 3)) * charWidth;
+  // left = 0;
+  left -= charWidth / 2;
+  // int right = left + (length * 3 * charWidth);
+  int width = length * 3 * charWidth;
+  return QRect(left * dpr, 0, width * dpr, lineHeight * dpr);
 }
 
 void HexView::paintEvent(QPaintEvent *e) {

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -499,7 +499,7 @@ QRect HexView::calculateSelectionRectForLine(int startColumn, int length) {
   int hexCharsStartOffsetInChars = shouldDrawOffset ? NUM_ADDRESS_NIBBLES + ADDRESS_SPACING_CHARS : 0;
   int left = (hexCharsStartOffsetInChars + (startColumn * 3)) * charWidth;
   // left = 0;
-  left -= charWidth / 2;
+  left -= charHalfWidth;
   // int right = left + (length * 3 * charWidth);
   int width = length * 3 * charWidth;
   return QRect(left * dpr, 0, width * dpr, lineHeight * dpr);

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -493,16 +493,18 @@ std::pair<QRect,QRect> HexView::calculateSelectionRectsForLine(int startColumn, 
   return { hexRect, asciiRect };
 }
 
-QRect HexView::calculateSelectionRectForLine(int startColumn, int length) {
-  qreal dpr = devicePixelRatioF();
-
+std::pair<QRect,QRect> HexView::calculateSelectionRectsForLine(int startColumn, int length, qreal dpr) {
   int hexCharsStartOffsetInChars = shouldDrawOffset ? NUM_ADDRESS_NIBBLES + ADDRESS_SPACING_CHARS : 0;
-  int left = (hexCharsStartOffsetInChars + (startColumn * 3)) * charWidth;
-  // left = 0;
-  left -= charHalfWidth;
-  // int right = left + (length * 3 * charWidth);
+  int asciiStartOffsetInChars = hexCharsStartOffsetInChars + (BYTES_PER_LINE * 3) + HEX_TO_ASCII_SPACING_CHARS;
+  int left = (hexCharsStartOffsetInChars + (startColumn * 3)) * charWidth - charHalfWidth;
   int width = length * 3 * charWidth;
-  return QRect(left * dpr, 0, width * dpr, lineHeight * dpr);
+  QRect hexRect = QRect(left * dpr, 0, width * dpr, lineHeight * dpr);
+
+  left = (asciiStartOffsetInChars + startColumn) * charWidth;
+  width = length * charWidth;
+  QRect asciiRect = QRect(left * dpr, 0, width * dpr, lineHeight * dpr);
+
+  return { hexRect, asciiRect };
 }
 
 void HexView::paintEvent(QPaintEvent *e) {

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -493,7 +493,7 @@ std::pair<QRect,QRect> HexView::calculateSelectionRectsForLine(int startColumn, 
   return { hexRect, asciiRect };
 }
 
-std::pair<QRect,QRect> HexView::calculateSelectionRectsForLine(int startColumn, int length, qreal dpr) {
+std::pair<QRect,QRect> HexView::calculateSelectionRectsForLine(int startColumn, int length, qreal dpr) const {
   int hexCharsStartOffsetInChars = shouldDrawOffset ? NUM_ADDRESS_NIBBLES + ADDRESS_SPACING_CHARS : 0;
   int asciiStartOffsetInChars = hexCharsStartOffsetInChars + (BYTES_PER_LINE * 3) + HEX_TO_ASCII_SPACING_CHARS;
   int left = (hexCharsStartOffsetInChars + (startColumn * 3)) * charWidth - charHalfWidth;

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -75,6 +75,7 @@ private:
                   QColor textColor) const;
   void showOverlay(bool show, bool animate);
   void drawSelectedItem() const;
+  QRect calculateSelectionRectForLine(int startOffset, int length);
 
   VGMFile* vgmfile;
   VGMItem* selectedItem;

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -75,7 +75,6 @@ private:
                   QColor textColor) const;
   void showOverlay(bool show, bool animate);
   void drawSelectedItem() const;
-  QRect calculateSelectionRectForLine(int startOffset, int length);
 
   VGMFile* vgmfile;
   VGMItem* selectedItem;

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -43,10 +43,11 @@ protected:
 private:
   int hexXOffset() const;
   int getVirtualHeight() const;
+  void updateSize();
   int getTotalLines() const;
   int getOffsetFromPoint(QPoint pos) const;
   std::pair<QRect,QRect> calculateSelectionRectsForLine(int startColumn, int length, qreal dpr) const;
-  void resizeOverlays(int height) const;
+  void resizeOverlays(int y, int viewportHeight) const;
   void redrawOverlay();
   void printLine(QPainter& painter, int line) const;
   void printAddress(QPainter& painter, int line) const;


### PR DESCRIPTION
This is a follow up to the previous PR #514. I will merge them together, because...

#514 added a regression. One thing I tacked on was brightening the selection overlay by reducing the final opacity of the animated QGraphicsOpacityEffect.  It turns out that an overlaid widget using a QGraphicsOpacityEffect with an opacity value between 0 and 1 (exclusive) hurts draw performance. The solution is to animate to a full 1.0 opacity (as before), and instead reduce the alpha of the fill color that we use to paint the overlay. This is the cleaner solution anyway.

Other changes:

- Solved a bug that was causing the full QScrollArea viewport to be invalidated on a scroll - ie. HexView was redrawing every visible line (albeit with pixmap caches) on each draw pass. The bug is that we're setting the width of HexView greater than its QScrollArea's viewport. A little odd that it results in this behavior.
- The overlay is now sized (arbitrarily) 5 times taller than the viewport and moved only when it is scrolled out of view. The reason is to reduce the need to constantly move it on scroll. Before, when an item was selected and the overlay was therefore visible, we would move the overlay on every scroll event. However, this invalidates the entire area that it is moved to, and thus every line needed to be redrawn on every frame. This problem was shadowed by the previous issue.
- The endLine value, used to determine which lines to redraw, was over-calculated. We were always drawing an extra line on each draw pass.

Happy to say that this has all adds up to noticeably more fluid HexView.

## How Has This Been Tested?
Thoroughly tested on Mac. Will test it on Windows soon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
