### PR TITLE
Hexview: improve animation and performance

### DIFF
--- a/src/ui/qt/main_ui.cpp
+++ b/src/ui/qt/main_ui.cpp
@@ -16,6 +16,10 @@ int main(int argc, char *argv[]) {
   QCoreApplication::setOrganizationDomain("vgmtrans.com");
   QCoreApplication::setApplicationName("VGMTrans");
 
+#ifdef Q_OS_LINUX
+  QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor);
+#endif
+
   QApplication app(argc, argv);
   #ifdef _WIN32
   app.setStyle(QStyleFactory::create("fusion"));

--- a/src/ui/qt/main_ui.cpp
+++ b/src/ui/qt/main_ui.cpp
@@ -16,9 +16,7 @@ int main(int argc, char *argv[]) {
   QCoreApplication::setOrganizationDomain("vgmtrans.com");
   QCoreApplication::setApplicationName("VGMTrans");
 
-#ifdef Q_OS_LINUX
-  QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor);
-#endif
+  QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::Round);
 
   QApplication app(argc, argv);
   #ifdef _WIN32

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -201,7 +201,6 @@ void HexView::setSelectedItem(VGMItem *item) {
 
   if (selectedItem == nullptr) {
     showOverlay(false, true);
-    // selectionView->hide();
     prevSelectedItem = nullptr;
     return;
   }
@@ -418,12 +417,15 @@ bool HexView::handleOverlayPaintEvent(QObject* obj, const QEvent* event) const {
 
 bool HexView::handleSelectedItemPaintEvent(QObject* obj, QEvent* event) {
   auto widget = static_cast<QWidget*>(obj);
+
+  // When no item is selected, paint using the cached pixmap. This is necessary because the
+  // selected item is still visible during the deselection animation, after which it will be hidden
   if (!selectedItem) {
     QPainter painter(widget);
     painter.drawPixmap(0, 0, selectionViewPixmap);
     return true;
   }
-  // auto widget = static_cast<QWidget*>(obj);
+
   if (prevSelectedItem != selectedItem) {
 
     prevSelectedItem = selectedItem;
@@ -497,26 +499,9 @@ bool HexView::handleSelectedItemPaintEvent(QObject* obj, QEvent* event) {
       }
       pixmapPainter.restore();
     }
-    // auto glowEffect = new QGraphicsDropShadowEffect();
-    // glowEffect->setBlurRadius(SHADOW_BLUR_RADIUS);
-    // glowEffect->setColor(SHADOW_COLOR);
-    // glowEffect->setOffset(SHADOW_OFFSET_X, SHADOW_OFFSET_Y);
-
-
-    // selectedItemShadowEffect = new QGraphicsDropShadowEffect();
-    // selectedItemShadowEffect->setBlurRadius(SHADOW_BLUR_RADIUS);
-    // selectedItemShadowEffect->setColor(SHADOW_COLOR);
-    // selectedItemShadowEffect->setOffset(SHADOW_OFFSET_X, SHADOW_OFFSET_Y);
-
-
     selectionViewPixmap = QPixmap(pixmap.width(), pixmap.height());
     selectionViewPixmap.setDevicePixelRatio(dpr);
-    // selectionViewPixmap.fill(Qt::transparent);
     selectionViewPixmap = pixmap;
-
-    // applyEffectToPixmap(pixmap, selectionViewPixmap, selectedItemShadowEffect, 0);
-    // selectionView->setGraphicsEffect(selectedItemShadowEffect);
-
   }
   QPainter painter(widget);
   painter.drawPixmap(0, 0, selectionViewPixmap);

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -791,8 +791,8 @@ void HexView::initAnimations() {
       selectionViewPixmap = QPixmap();
       selectionViewPixmapWithShadow = QPixmap();
     }
-    auto quadCurve = selectionAnimation->direction() == QAbstractAnimation::Backward ? QEasingCurve::OutQuad : QEasingCurve::InQuad;
-    auto expoCurve = selectionAnimation->direction() == QAbstractAnimation::Backward ? QEasingCurve::OutExpo : QEasingCurve::InExpo;
+    auto quadCurve = selectionAnimation->direction() == QAbstractAnimation::Forward ? QEasingCurve::InQuad : QEasingCurve::OutQuad;
+    auto expoCurve = selectionAnimation->direction() == QAbstractAnimation::Forward ? QEasingCurve::InExpo : QEasingCurve::OutExpo;
     overlayOpacityAnimation->setEasingCurve(quadCurve);
     selectedItemShadowBlurAnimation->setEasingCurve(quadCurve);
     selectedItemShadowOffsetAnimation->setEasingCurve(expoCurve);

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -777,14 +777,8 @@ void HexView::initAnimations() {
   selectedItemShadowOffsetAnimation->setEasingCurve(QEasingCurve::OutQuad);
 
   selectionAnimation->addAnimation(overlayOpacityAnimation);
-
-  // Qt shadow animations don't play well with non-integer DPRs. There can be jitter, depending
-  // on the y offset of the widget being animated. Easiest solution is to not animate in this case.
-  auto dpr = devicePixelRatioF();
-  if (dpr == std::floor(dpr)) {
-    selectionAnimation->addAnimation(selectedItemShadowOffsetAnimation);
-    selectionAnimation->addAnimation(selectedItemShadowBlurAnimation);
-  }
+  selectionAnimation->addAnimation(selectedItemShadowOffsetAnimation);
+  selectionAnimation->addAnimation(selectedItemShadowBlurAnimation);
 
   QObject::connect(selectionAnimation, &QPropertyAnimation::finished,
     [this, overlayOpacityAnimation, selectedItemShadowBlurAnimation, selectedItemShadowOffsetAnimation]() {

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -777,8 +777,14 @@ void HexView::initAnimations() {
   selectedItemShadowOffsetAnimation->setEasingCurve(QEasingCurve::OutQuad);
 
   selectionAnimation->addAnimation(overlayOpacityAnimation);
-  selectionAnimation->addAnimation(selectedItemShadowBlurAnimation);
-  selectionAnimation->addAnimation(selectedItemShadowOffsetAnimation);
+
+  // Qt shadow animations don't play well with non-integer DPRs. There can be jitter, depending
+  // on the y offset of the widget being animated. Easiest solution is to not animate in this case.
+  auto dpr = devicePixelRatioF();
+  if (dpr == std::floor(dpr)) {
+    selectionAnimation->addAnimation(selectedItemShadowOffsetAnimation);
+    selectionAnimation->addAnimation(selectedItemShadowBlurAnimation);
+  }
 
   QObject::connect(selectionAnimation, &QPropertyAnimation::finished,
     [this, overlayOpacityAnimation, selectedItemShadowBlurAnimation, selectedItemShadowOffsetAnimation]() {

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -411,6 +411,7 @@ bool HexView::handleOverlayPaintEvent(QObject* obj, QPaintEvent* event) const {
   int drawHeight = eventRect.height();
   int drawYPos = eventRect.y();
 
+  // Sometimes the entire view is invalidated. We only need to draw the portion inside the viewport.
   if (eventRect.height() > scrollArea->viewport()->height()) {
     drawHeight = scrollArea->viewport()->height();
     drawYPos = scrollArea->verticalScrollBar()->value() - overlay->y();
@@ -448,7 +449,6 @@ bool HexView::handleSelectedItemPaintEvent(QObject* obj, QPaintEvent* event) {
 
   if (shouldDrawNonShadowedItem) {
     auto widgetSize = widget->size();
-    // auto pixmap = QPixmap(widgetSize.width() * dpr, widgetSize.height() * dpr);
     selectionViewPixmap = QPixmap(widgetSize.width() * dpr, widgetSize.height() * dpr);
     selectionViewPixmap.setDevicePixelRatio(dpr);
     selectionViewPixmap.fill(Qt::transparent);

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -76,6 +76,7 @@ private:
                   int length,
                   QColor bgColor,
                   QColor textColor) const;
+  void initAnimations();
   void showOverlay(bool show, bool animate);
   void drawSelectedItem() const;
 
@@ -99,10 +100,7 @@ private:
   QCache<int, QPixmap> lineCache;
   QGraphicsOpacityEffect* overlayOpacityEffect = nullptr;
   QGraphicsDropShadowEffect* selectedItemShadowEffect = nullptr;
-  QParallelAnimationGroup* overlayAnimation = nullptr;
-  QPropertyAnimation* overlayOpacityAnimation = nullptr;
-  QPropertyAnimation* selectedItemShadowBlurAnimation = nullptr;
-  QPropertyAnimation* selectedItemShadowOffsetAnimation = nullptr;
+  QParallelAnimationGroup* selectionAnimation = nullptr;
   QWidget* overlay;
   QWidget* selectionView = nullptr;
   VGMItem* prevSelectedItem = nullptr;

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -9,6 +9,8 @@
 #include <QWidget>
 #include <QCache>
 
+class QParallelAnimationGroup;
+class QGraphicsDropShadowEffect;
 class VGMFile;
 class VGMItem;
 class QGraphicsOpacityEffect;
@@ -96,7 +98,11 @@ private:
 
   QCache<int, QPixmap> lineCache;
   QGraphicsOpacityEffect* overlayOpacityEffect = nullptr;
-  QPropertyAnimation* overlayAnimation = nullptr;
+  QGraphicsDropShadowEffect* selectedItemShadowEffect = nullptr;
+  QParallelAnimationGroup* overlayAnimation = nullptr;
+  QPropertyAnimation* overlayOpacityAnimation = nullptr;
+  QPropertyAnimation* selectedItemShadowBlurAnimation = nullptr;
+  QPropertyAnimation* selectedItemShadowOffsetAnimation = nullptr;
   QWidget* overlay;
   QWidget* selectionView = nullptr;
   VGMItem* prevSelectedItem = nullptr;

--- a/src/ui/qt/workarea/HexView.h
+++ b/src/ui/qt/workarea/HexView.h
@@ -34,8 +34,8 @@ protected:
   bool event(QEvent *event) override;
   void changeEvent(QEvent *event) override;
   void keyPressEvent(QKeyEvent *event) override;
-  bool handleOverlayPaintEvent(QObject* obj, const QEvent* event) const;
-  bool handleSelectedItemPaintEvent(QObject* obj, QEvent* event);
+  bool handleOverlayPaintEvent(QObject* obj, QPaintEvent* event) const;
+  bool handleSelectedItemPaintEvent(QObject* obj, QPaintEvent* event);
   void paintEvent(QPaintEvent *event) override;
   void mousePressEvent(QMouseEvent *event) override;
   void mouseMoveEvent(QMouseEvent *event) override;
@@ -77,7 +77,7 @@ private:
                   QColor bgColor,
                   QColor textColor) const;
   void initAnimations();
-  void showOverlay(bool show, bool animate);
+  void showSelectedItem(bool show, bool animate);
   void drawSelectedItem() const;
 
   VGMFile* vgmfile;
@@ -103,8 +103,8 @@ private:
   QParallelAnimationGroup* selectionAnimation = nullptr;
   QWidget* overlay;
   QWidget* selectionView = nullptr;
-  VGMItem* prevSelectedItem = nullptr;
   QPixmap selectionViewPixmap;
+  QPixmap selectionViewPixmapWithShadow;
 
 signals:
   void selectionChanged(VGMItem* item);


### PR DESCRIPTION
On the animation side:
- Animate the `blurRadius` and `offset` properties of the selectionView's QGraphicsDropShadowEffect, which is now applied to the widget instead of exclusively used at draw time
- On deselection, instead of immediately hiding the selected item view (which can cause a sort of flash effect), keep it visible and reverse animate its shadow effect alongside the overlay fade in, then hide it afterward.
- I also deepened the shadow by increasing the offset.

On the performance side:
- I refactored the animation code. It's much simpler now. Instead of deleting and recreating animations, it now uses pause() and setDirection() for animation interruption and reversal. The three QPropertyAnimations are bucketed into a QParallelAnimationGroup.
-  Both the `overlay` and `selectionView` have added logic to only draw the portions of their views that were invalidated (the event->rect() property). Before, if the selectionView was at all visible, it would be drawn in entirety. Likewise, now that I've expanded the size of the overlay to be larger than the viewport (for performance reasons explained in #516), resize events and the fade animations were causing it to redraw itself in entirety. Now we just redraw the portion inside the viewport.

## Details
You may be wondering why I didn't have the paintEvent handlers behave this way in the first place. I was confused. When I first designed my implementation, I assumed Qt would render like a compositor where each widget would retain its own bitmap buffer - thus we would draw the widgets (selectionView, overlay) once, move them where they need to be on top of other widgets, and expect Qt to composite them efficiently. Turns out, it doesn't keep a buffer, and everything needs to be redrawn constantly. It's unfortunate, because this paradigm is less intuitive and would render much more efficiently if it utilized the native compositor of MacOS (can't speak for Windows or Linux).

Back to the nitty gritty:  In order to apply an animation to the selectionView's shadow, we now must apply a QGraphicsDropShadowEffect to the selectionView, whereas before we would only create the shadow effect within the paintEvent rendering itself (which was then saved to a pixmap cache). To prevent a degradation in performance, we now cache two QPixmap's: one for the raw text rendering, and one for the text rendering with full shadow effect (as we did before). During the fade in and fade out animations, we enable the shadow effect on the view and draw the raw pixmap. In the "finished" animation callback, we disable the effect and draw the shadowed pixmap from thereon, as this saves performance over keeping the effect enabled.



## How Has This Been Tested?
Trying to break it as best I can on MacOS, soon Windows as well.

## Video:
Old:

https://github.com/vgmtrans/vgmtrans/assets/1659535/31483ddc-6502-4e12-a5c7-43be3dcdffa1

New:

https://github.com/vgmtrans/vgmtrans/assets/1659535/c7b5b040-935e-4ec7-a841-d8b9a757a48d



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
