### PR TITLE
Fix usesLinearAmplitudeScale() regression

### DIFF
--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -48,62 +48,63 @@ class VGMSeq : public VGMFile {
 
   void useReverb() { m_use_reverb = true; }
 
-  bool usesMonophonicTracks() { return m_use_monophonic_tracks; }
+  [[nodiscard]] bool usesMonophonicTracks() const { return m_use_monophonic_tracks; }
   void setUsesMonophonicTracks() { m_use_monophonic_tracks = true; }
 
-  bool usesLinearAmplitudeScale() { return m_use_linear_amplitude_scale; }
+  [[nodiscard]] bool usesLinearAmplitudeScale() const { return m_use_linear_amplitude_scale; }
   void setUseLinearAmplitudeScale(bool set) { m_use_linear_amplitude_scale = set; }
 
-  void useLinearPanAmplitudeScale(PanVolumeCorrectionMode mode) {
+  [[nodiscard]] bool usesLinearPanAmplitudeScale() const { return m_use_linear_pan_amplitude_scale; }
+  void setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode mode) {
     m_use_linear_pan_amplitude_scale = true;
     panVolumeCorrectionMode = mode;
   }
 
-  bool alwaysWriteInitialVol() { return m_always_write_initial_vol; }
+  [[nodiscard]] bool alwaysWriteInitialVol() const { return m_always_write_initial_vol; }
   void setAlwaysWriteInitialVol(uint8_t theVol = 100) {
     m_always_write_initial_vol = true;
     m_initial_volume = theVol;
   }
-  bool alwaysWriteInitialExpression() { return m_always_write_initial_expression; }
+  [[nodiscard]] bool alwaysWriteInitialExpression() const { return m_always_write_initial_expression; }
   void setAlwaysWriteInitialExpression(uint8_t level = 127) {
     m_always_write_initial_expression = true;
     m_initial_expression = level;
   }
 
-  bool alwaysWriteInitialReverb() { return m_always_write_initial_expression; }
+  [[nodiscard]] bool alwaysWriteInitialReverb() const { return m_always_write_initial_expression; }
   void setAlwaysWriteInitialReverb(uint8_t level = 127) {
     m_always_write_initial_reverb = true;
     m_initial_reverb_level = level;
   }
 
-  bool alwaysWriteInitialPitchBendRange() { return m_always_write_initial_pitch_bend_range; }
+  [[nodiscard]] bool alwaysWriteInitialPitchBendRange() const { return m_always_write_initial_pitch_bend_range; }
   void setAlwaysWriteInitialPitchBendRange(uint16_t cents) {
     m_always_write_initial_pitch_bend_range = true;
     m_initial_pitch_bend_range_cents = cents;
   }
 
-  bool alwaysWriteInitialTempo() { return m_always_write_initial_tempo; }
+  [[nodiscard]] bool alwaysWriteInitialTempo() const { return m_always_write_initial_tempo; }
   void setAlwaysWriteInitialTempo(double beatsPerMin) {
     m_always_write_initial_tempo = true;
     initialTempoBPM = beatsPerMin;
   }
 
-  bool alwaysWriteInitialMonoMode() { return m_always_write_initial_mono_mode; }
+  [[nodiscard]] bool alwaysWriteInitialMonoMode() const { return m_always_write_initial_mono_mode; }
   void setAlwaysWriteInitialMonoMode(bool set) { m_always_write_initial_mono_mode = set; }
-  bool allowDiscontinuousTrackData() { return m_allow_discontinuous_track_data; }
+  [[nodiscard]] bool allowDiscontinuousTrackData() const { return m_allow_discontinuous_track_data; }
   void setAllowDiscontinuousTrackData(bool allow) { m_allow_discontinuous_track_data = allow; }
 
   bool saveAsMidi(const std::string &filepath);
 
   void deactivateAllTracks();
 
-  uint8_t initialVolume() { return m_initial_volume; }
+  [[nodiscard]] uint8_t initialVolume() const { return m_initial_volume; }
   void setInitialVolume(uint8_t volume) { m_initial_volume = volume; }
-  uint8_t initialExpression() { return m_initial_expression; }
+  [[nodiscard]] uint8_t initialExpression() const { return m_initial_expression; }
   void setInitialExpression(uint8_t expression) { m_initial_expression = expression; }
-  uint8_t initialReverbLevel() { return m_initial_reverb_level; }
+  [[nodiscard]] uint8_t initialReverbLevel() const { return m_initial_reverb_level; }
   void setInitialReverbLevel(uint8_t reverb_level) { m_initial_reverb_level = reverb_level; }
-  uint16_t initialPitchBendRange() { return m_initial_pitch_bend_range_cents; }
+  [[nodiscard]] uint16_t initialPitchBendRange() const { return m_initial_pitch_bend_range_cents; }
   void setInitialPitchBendRange(uint16_t cents) { m_initial_pitch_bend_range_cents = cents; }
 
  protected:

--- a/src/main/formats/Akao/AkaoSeq.cpp
+++ b/src/main/formats/Akao/AkaoSeq.cpp
@@ -20,7 +20,7 @@ static constexpr uint8_t NOTE_VELOCITY = 100;
 AkaoSeq::AkaoSeq(RawFile *file, uint32_t offset, AkaoPs1Version version)
     : VGMSeq(AkaoFormat::name, file, offset, 0, "Akao Seq"), seq_id(0), version_(version),
       instrument_set_offset_(0), drum_set_offset_(0), condition(0) {
-  usesLinearAmplitudeScale();        //I think this applies, but not certain, see FF9 320, track 3 for example of problem
+  setUseLinearAmplitudeScale(true);        //I think this applies, but not certain, see FF9 320, track 3 for example of problem
   //UseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kAdjustVolumeController); // disabled, it only changes the volume and the pan slightly, and also its output becomes undefined if pan and volume slides are used at the same time
   bUsesIndividualArts = false;
   useReverb();

--- a/src/main/formats/FFT/FFTSeq.cpp
+++ b/src/main/formats/FFT/FFTSeq.cpp
@@ -18,7 +18,7 @@ using namespace std;
 FFTSeq::FFTSeq(RawFile *file, uint32_t offset)
     : VGMSeq(FFTFormat::name, file, offset) {
   setAlwaysWriteInitialVol(127);
-  usesLinearAmplitudeScale();
+  setUseLinearAmplitudeScale(true);
   useReverb();
 }
 

--- a/src/main/formats/HOSA/HOSASeq.cpp
+++ b/src/main/formats/HOSA/HOSASeq.cpp
@@ -13,7 +13,7 @@ DECLARE_FORMAT(HOSA);
 HOSASeq::HOSASeq(RawFile *file, uint32_t offset, const std::string &name)
     : VGMSeq(HOSAFormat::name, file, offset, 0, name) {
   useReverb();
-  usesLinearAmplitudeScale();
+  setUseLinearAmplitudeScale(true);
 }
 
 //==============================================================

--- a/src/main/formats/SonyPS2/SonyPS2Seq.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Seq.cpp
@@ -12,7 +12,7 @@ SonyPS2Seq::SonyPS2Seq(RawFile *file, uint32_t offset)
     : VGMSeqNoTrks(SonyPS2Format::name, file, offset),
       compOption(0),
       bSkipDeltaTime(0) {
-  usesLinearAmplitudeScale();        // Onimusha: Kaede Theme track 2 for example of linear vol scale.
+  setUseLinearAmplitudeScale(true);        // Onimusha: Kaede Theme track 2 for example of linear vol scale.
   useReverb();
 }
 

--- a/src/main/formats/SquarePS2/SquarePS2Seq.cpp
+++ b/src/main/formats/SquarePS2/SquarePS2Seq.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 BGMSeq::BGMSeq(RawFile *file, uint32_t offset)
     : VGMSeq(SquarePS2Format::name, file, offset) {
-  usesLinearAmplitudeScale();
+  setUseLinearAmplitudeScale(true);
   useReverb();
   setAlwaysWriteInitialVol(127);
 }

--- a/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
@@ -13,7 +13,7 @@ DECLARE_FORMAT(TriAcePS1);
 
 TriAcePS1Seq::TriAcePS1Seq(RawFile *file, uint32_t offset, const std::string &name)
     : VGMSeq(TriAcePS1Format::name, file, offset, 0, name) {
-  usesLinearAmplitudeScale();
+  setUseLinearAmplitudeScale(true);
   useReverb();
   setAlwaysWriteInitialPitchBendRange(12 * 100);
 }


### PR DESCRIPTION
In #510, I made a mistake and replaced a few calls to UseLinearAmplitudeScale() with the new getter method `usesLinearAmplitudeScale()` rather than new setter method `setUseLinearAmplitudeScale()`. This screwed up volume on these formats.

I have corrected the mistake, and added [[nodiscard]] to the various VGMSeq methods that get such conversion properties to help prevent any future screwups.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
