### PR TITLE
Fix FileNameMatcher and VirtFile::extension()

### DIFF
--- a/src/main/components/Matcher.h
+++ b/src/main/components/Matcher.h
@@ -297,19 +297,19 @@ class FilenameMatcher : public SimpleMatcher<std::string> {
 
   bool seqId(VGMSeq *seq, std::string &id) override {
     RawFile *rawfile = seq->rawFile();
-    id = rawfile->path();
+    id = rawfile->path().string();
     return !id.empty();
   }
 
   bool instrSetId(VGMInstrSet *instrset, std::string &id) override {
     RawFile *rawfile = instrset->rawFile();
-    id = rawfile->path();
+    id = rawfile->path().string();
     return !id.empty();
   }
 
   bool sampCollId(VGMSampColl *sampcoll, std::string &id) override {
     RawFile *rawfile = sampcoll->rawFile();
-    id = rawfile->path();
+    id = rawfile->path().string();
     return !id.empty();
   }
 };

--- a/src/main/components/Matcher.h
+++ b/src/main/components/Matcher.h
@@ -297,17 +297,20 @@ class FilenameMatcher : public SimpleMatcher<std::string> {
 
   bool seqId(VGMSeq *seq, std::string &id) override {
     RawFile *rawfile = seq->rawFile();
-    return !rawfile->path().empty();
+    id = rawfile->path();
+    return !id.empty();
   }
 
   bool instrSetId(VGMInstrSet *instrset, std::string &id) override {
     RawFile *rawfile = instrset->rawFile();
-    return !rawfile->path().empty();
+    id = rawfile->path();
+    return !id.empty();
   }
 
   bool sampCollId(VGMSampColl *sampcoll, std::string &id) override {
     RawFile *rawfile = sampcoll->rawFile();
-    return !rawfile->path().empty();
+    id = rawfile->path();
+    return !id.empty();
   }
 };
 

--- a/src/main/components/seq/VGMSeqNoTrks.h
+++ b/src/main/components/seq/VGMSeqNoTrks.h
@@ -24,13 +24,13 @@ public:
   using VGMSeq::readWord;
   using VGMSeq::readShortBE;
   using VGMSeq::readWordBE;
-  inline uint32_t &offset() { return VGMSeq::dwOffset; }
-  inline uint32_t &length() { return VGMSeq::unLength; }
-  inline std::string name() { return VGMSeq::name(); }
+  [[nodiscard]] inline uint32_t &offset() { return VGMSeq::dwOffset; }
+  [[nodiscard]] inline uint32_t &length() { return VGMSeq::unLength; }
+  [[nodiscard]] inline std::string name() { return VGMSeq::name(); }
 
-  inline RawFile* rawFile() { return VGMSeq::rawFile(); }
+  [[nodiscard]] inline RawFile* rawFile() { return VGMSeq::rawFile(); }
 
-  inline uint32_t &eventsOffset() { return dwEventsOffset; }
+  [[nodiscard]] inline uint32_t &eventsOffset() { return dwEventsOffset; }
 
   // this function must be called in GetHeaderInfo or before LoadEvents is called
   inline void setEventsOffset(uint32_t offset) {

--- a/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
@@ -38,7 +38,7 @@ void SonyPS2Scanner::searchForSeq(RawFile *file) {
     if (sig1 != 0x53434549 || sig2 != 0x4D696469)  // "SCEIMidi" in ASCII
       continue;
 
-    SonyPS2Seq *newSeq = new SonyPS2Seq(file, i);
+    SonyPS2Seq *newSeq = new SonyPS2Seq(file, i, "Sony PS2 Seq");
     if (!newSeq->loadVGMFile())
       delete newSeq;
   }

--- a/src/main/formats/SonyPS2/SonyPS2Seq.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Seq.cpp
@@ -8,19 +8,15 @@ using namespace std;
 // BGMSeq
 // ******
 
-SonyPS2Seq::SonyPS2Seq(RawFile *file, uint32_t offset)
-    : VGMSeqNoTrks(SonyPS2Format::name, file, offset),
+SonyPS2Seq::SonyPS2Seq(RawFile *file, uint32_t offset, std::string name)
+    : VGMSeqNoTrks(SonyPS2Format::name, file, offset, std::move(name)),
       compOption(0),
       bSkipDeltaTime(0) {
   usesLinearAmplitudeScale();        // Onimusha: Kaede Theme track 2 for example of linear vol scale.
   useReverb();
 }
 
-SonyPS2Seq::~SonyPS2Seq(void) {
-}
-
-bool SonyPS2Seq::parseHeader(void) {
-  name() = "Sony PS2 Seq";
+bool SonyPS2Seq::parseHeader() {
   uint32_t curOffset = offset();
   //read the version chunk
   readBytes(curOffset, 0x10, &versCk);

--- a/src/main/formats/SonyPS2/SonyPS2Seq.h
+++ b/src/main/formats/SonyPS2/SonyPS2Seq.h
@@ -19,11 +19,11 @@ class SonyPS2Seq:
     uint32_t seSongChunkAddr;
   } HdrCk;
 
-  SonyPS2Seq(RawFile *file, uint32_t offset);
-  virtual ~SonyPS2Seq();
+  SonyPS2Seq(RawFile *file, uint32_t offset, std::string name);
+  ~SonyPS2Seq() override = default;
 
-  virtual bool parseHeader();
-  virtual bool readEvent();
+  bool parseHeader() override;
+  bool readEvent() override;
   uint8_t getDataByte(uint32_t offset);
 
  private:

--- a/src/main/io/RawFile.h
+++ b/src/main/io/RawFile.h
@@ -171,17 +171,15 @@ class VirtFile final : public RawFile {
       return tmp.string();
     };
     [[nodiscard]] std::string extension() const override {
-        auto tmp = m_lpath.extension().string();
-        if (!tmp.empty()) {
-            return toLower(tmp.substr(1, tmp.size() - 1));
-        } else {
-            std::filesystem::path tmp2(m_name);
-            if (tmp2.has_extension()) {
-                return toLower(tmp2.extension().string().substr(1, tmp2.extension().string().size() - 1));
-            }
-        }
-
-        return tmp;
+      std::filesystem::path tmp2(m_name);
+      if (tmp2.has_extension()) {
+        return toLower(tmp2.extension().string().substr(1, tmp2.extension().string().size() - 1));
+      }
+      auto tmp = m_lpath.extension().string();
+      if (!tmp.empty()) {
+        return toLower(tmp.substr(1, tmp.size() - 1));
+      }
+      return "";
     }
 
     const char *data() const override { return m_data.data(); }


### PR DESCRIPTION
A couple issues addressed here:
- FileNameMatcher never sets the id for any of its file types, and is therefore totally broken. 
- VirtFile::extension() returns the extension of its parent raw file by default. This is undesirable, as we would usually prefer to get the extension of the filename of the VirtFile. For example, when extracting a psf2, the SonyPS2 scanner needs to know the extension of the sample collection file.

I've fixed FileNameMatcher and reversed the VirtFile::extension() logic so that it returns the VirtFile name extension first, and if none exists, the parent RawFile's extension.

This fixes detection of SonyPS2 collections.

## How Has This Been Tested?
I tested that every format is still detected correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
