### PR TITLE
Akao Format improvements

### DIFF
--- a/src/main/formats/Akao/AkaoFormat.h
+++ b/src/main/formats/Akao/AkaoFormat.h
@@ -2,7 +2,7 @@
 #include "Format.h"
 #include "AkaoScanner.h"
 #include "VGMColl.h"
-#include "Matcher.h"
+#include "AkaoMatcher.h"
 
 class AkaoInstrSet;
 
@@ -29,6 +29,6 @@ class AkaoColl final :
 
 BEGIN_FORMAT(Akao)
   USING_SCANNER(AkaoScanner)
-  USING_MATCHER(FilegroupMatcher)
+  USING_MATCHER(AkaoMatcher)
   USING_COLL(AkaoColl)
 END_FORMAT()

--- a/src/main/formats/Akao/AkaoFormat.h
+++ b/src/main/formats/Akao/AkaoFormat.h
@@ -5,6 +5,7 @@
 #include "AkaoMatcher.h"
 
 class AkaoInstrSet;
+class AkaoArt;
 
 // ********
 // AkaoColl
@@ -21,6 +22,9 @@ class AkaoColl final :
 
   AkaoInstrSet *origInstrSet;
   uint32_t numInstrsToAdd;
+
+private:
+  std::tuple<std::map<int, AkaoArt*>, std::map<int, int>, std::map<int, AkaoSampColl*>> mapSampleCollections();
 };
 
 // **********

--- a/src/main/formats/Akao/AkaoFormat.h
+++ b/src/main/formats/Akao/AkaoFormat.h
@@ -11,20 +11,22 @@ class AkaoArt;
 // AkaoColl
 // ********
 
-class AkaoColl final :
-    public VGMColl {
- public:
-  explicit AkaoColl(std::string name = "Unnamed Collection") : VGMColl(std::move(name)), origInstrSet(nullptr), numInstrsToAdd(0) {}
+class AkaoColl final : public VGMColl {
+public:
+  explicit AkaoColl(std::string name = "Unnamed Collection")
+      : VGMColl(std::move(name)) {}
 
   bool loadMain() override;
   void preSynthFileCreation() override;
   void postSynthFileCreation() override;
 
-  AkaoInstrSet *origInstrSet;
-  uint32_t numInstrsToAdd;
+  AkaoInstrSet *origInstrSet = nullptr;
+  uint32_t numInstrsToAdd = 0;
 
 private:
-  std::tuple<std::map<int, AkaoArt*>, std::map<int, int>, std::map<int, AkaoSampColl*>> mapSampleCollections();
+  std::tuple<std::unordered_map<int, AkaoArt *>, std::unordered_map<int, int>,
+             std::unordered_map<int, AkaoSampColl *>>
+  mapSampleCollections();
 };
 
 // **********

--- a/src/main/formats/Akao/AkaoFormat.h
+++ b/src/main/formats/Akao/AkaoFormat.h
@@ -13,14 +13,14 @@ class AkaoInstrSet;
 class AkaoColl final :
     public VGMColl {
  public:
-  explicit AkaoColl(std::string name = "Unnamed Collection") : VGMColl(std::move(name)), origInstrSet(nullptr), numAddedInstrs(0) {}
+  explicit AkaoColl(std::string name = "Unnamed Collection") : VGMColl(std::move(name)), origInstrSet(nullptr), numInstrsToAdd(0) {}
 
   bool loadMain() override;
   void preSynthFileCreation() override;
   void postSynthFileCreation() override;
 
   AkaoInstrSet *origInstrSet;
-  uint32_t numAddedInstrs;
+  uint32_t numInstrsToAdd;
 };
 
 // **********

--- a/src/main/formats/Akao/AkaoInstr.cpp
+++ b/src/main/formats/Akao/AkaoInstr.cpp
@@ -17,10 +17,10 @@ AkaoInstrSet::AkaoInstrSet(RawFile *file,
                            AkaoPs1Version version,
                            uint32_t instrOff,
                            uint32_t dkitOff,
-                           uint32_t theID,
+                           uint32_t id,
                            std::string name)
     : VGMInstrSet(AkaoFormat::name, file, 0, length, std::move(name)), version_(version) {
-  setId(theID);
+  setId(id);
   instrSetOff = instrOff;
   drumkitOff = dkitOff;
   bMelInstrs = instrSetOff > 0;
@@ -34,10 +34,11 @@ AkaoInstrSet::AkaoInstrSet(RawFile *file,
 
 AkaoInstrSet::AkaoInstrSet(RawFile *file, uint32_t end_boundary_offset,
   AkaoPs1Version version, const std::set<uint32_t>& custom_instrument_addresses,
-  const std::set<uint32_t>& drum_instrument_addresses, std::string name)
+  const std::set<uint32_t>& drum_instrument_addresses, uint32_t id, std::string name)
   : VGMInstrSet(AkaoFormat::name, file, 0, 0, std::move(name)), bMelInstrs(false), bDrumKit(false),
   instrSetOff(0), drumkitOff(0), end_boundary_offset(end_boundary_offset), version_(version)
 {
+  setId(id);
   uint32_t first_instrument_offset = 0;
   if (!custom_instrument_addresses.empty()) {
     first_instrument_offset = *custom_instrument_addresses.begin();
@@ -58,11 +59,13 @@ AkaoInstrSet::AkaoInstrSet(RawFile *file, uint32_t end_boundary_offset,
 }
 
 AkaoInstrSet::AkaoInstrSet(RawFile *file, uint32_t offset,
-  uint32_t end_boundary_offset, AkaoPs1Version version, std::string name)
+  uint32_t end_boundary_offset, AkaoPs1Version version, uint32_t id, std::string name)
     : VGMInstrSet(AkaoFormat::name, file, offset, 0, std::move(name)), bMelInstrs(false),
       bDrumKit(false), instrSetOff(0), drumkitOff(0), end_boundary_offset(end_boundary_offset),
       version_(version)
-{}
+{
+  setId(id);
+}
 
 bool AkaoInstrSet::parseInstrPointers() {
   if (bMelInstrs) {
@@ -360,7 +363,6 @@ bool AkaoSampColl::parseHeader() {
 
     sample_section_size = readWord(0x14 + dwOffset);
     starting_art_id = readWord(0x18 + dwOffset);
-    uint32_t ending_art_id;
     if (version() == AkaoPs1Version::VERSION_1_1)
       ending_art_id = 0x80;
     else {

--- a/src/main/formats/Akao/AkaoInstr.cpp
+++ b/src/main/formats/Akao/AkaoInstr.cpp
@@ -249,7 +249,12 @@ bool AkaoRgn::loadRgn() {
   artNum = readByte(dwOffset + 0); //- first_sample_id;
   addKeyLow(readByte(dwOffset + 1), dwOffset + 1);
   addKeyHigh(readByte(dwOffset + 2), dwOffset + 2);
-  // TODO: ADSR conversion?
+  attackRate = readByte(dwOffset + 3);
+  sustainRate = readByte(dwOffset + 4);
+  sustainMode = readByte(dwOffset + 5);
+  releaseRate = readByte(dwOffset + 6);
+  // TODO: Need to confirm the details of these ADSR values. Sustain Mode values are using 3 bits
+  //  which indicates it's more than sustain mode.
   addGeneralItem(dwOffset + 3, 1, "ADSR Attack Rate");
   addGeneralItem(dwOffset + 4, 1, "ADSR Sustain Rate");
   addGeneralItem(dwOffset + 5, 1, "ADSR Sustain Mode");

--- a/src/main/formats/Akao/AkaoInstr.h
+++ b/src/main/formats/Akao/AkaoInstr.h
@@ -38,9 +38,9 @@ class AkaoInstrSet final : public VGMInstrSet {
                std::string name = "Akao Instrument Bank");
   AkaoInstrSet(RawFile *file, uint32_t end_boundary_offset, AkaoPs1Version version,
     const std::set<uint32_t>& custom_instrument_addresses, const std::set<uint32_t>& drum_instrument_addresses,
-    std::string name = "Akao Instrument Bank");
+    uint32_t id, std::string name = "Akao Instrument Bank");
   AkaoInstrSet(RawFile *file, uint32_t offset, uint32_t end_boundary_offset, AkaoPs1Version version,
-    std::string name = "Akao Instrument Bank (Dummy)");
+    uint32_t id, std::string name = "Akao Instrument Bank (Dummy)");
   bool parseInstrPointers() override;
 
   [[nodiscard]] AkaoPs1Version version() const noexcept { return version_; }
@@ -144,12 +144,13 @@ class AkaoSampColl final :
 
   std::vector<AkaoArt> akArts;
   uint32_t starting_art_id;
+  uint32_t ending_art_id;
+  uint32_t nNumArts;
   uint16_t sample_set_id;
 
  private:
   AkaoPs1Version version_;
   uint32_t sample_section_size;
-  uint32_t nNumArts;
   uint32_t arts_offset;
   uint32_t sample_section_offset;
   AkaoInstrDatLocation file_location;

--- a/src/main/formats/Akao/AkaoInstr.h
+++ b/src/main/formats/Akao/AkaoInstr.h
@@ -107,6 +107,10 @@ class AkaoRgn final :
   unsigned short adsr2;  //raw psx ADSR2 value (articulation data)
   uint8_t artNum;
   uint8_t drumRelUnityKey;
+  uint8_t attackRate;
+  uint8_t sustainRate;
+  uint8_t sustainMode;
+  uint8_t releaseRate;
 };
 
 

--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -141,7 +141,6 @@ bool AkaoMatcher::tryCreateCollection(int id) {
           return false;
         }
 
-        std::cout << "Collection created successfully!" << std::endl;
         return true;
       }
     }

--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -1,0 +1,149 @@
+#include "AkaoMatcher.h"
+#include "AkaoSeq.h"
+#include "AkaoInstr.h"
+
+bool AkaoMatcher::onNewSeq(VGMSeq* seq) {
+  if (auto akaoSeq = dynamic_cast<AkaoSeq *>(seq)) {
+    seqs[akaoSeq->seq_id] = akaoSeq;
+    return tryCreateCollection(akaoSeq->seq_id);
+  }
+  return true;
+}
+
+bool AkaoMatcher::onNewInstrSet(VGMInstrSet* instrSet) {
+  if (auto akaoInstrSet = dynamic_cast<AkaoInstrSet*>(instrSet)) {
+    instrSets[akaoInstrSet->id()] = akaoInstrSet;
+    return tryCreateCollection(akaoInstrSet->id());
+  }
+  return true;
+}
+
+bool AkaoMatcher::onNewSampColl(VGMSampColl* sampColl) {
+  if (auto akaoSampColl = dynamic_cast<AkaoSampColl*>(sampColl)) {
+    sampColls.push_back(akaoSampColl);
+    for (const auto& pair : seqs) {
+      AkaoSeq* seq = pair.second;
+      return tryCreateCollection(seq->seq_id);
+    }
+  }
+  return true;
+}
+
+bool AkaoMatcher::onCloseSeq(VGMSeq* seq) {
+  if (auto akaoSeq = dynamic_cast<AkaoSeq *>(seq)) {
+    seqs.erase(akaoSeq->seq_id);
+  }
+  return true;
+}
+
+bool AkaoMatcher::onCloseInstrSet(VGMInstrSet* instrSet) {
+  if (auto akaoInstrSet = dynamic_cast<AkaoInstrSet *>(instrSet)) {
+    instrSets.erase(akaoInstrSet->id());
+  }
+  return true;
+}
+
+bool AkaoMatcher::onCloseSampColl(VGMSampColl* sampColl) {
+  if (auto akaoSampColl = dynamic_cast<AkaoSampColl *>(sampColl)) {
+    sampColls.erase(std::remove(sampColls.begin(), sampColls.end(), akaoSampColl), sampColls.end());
+  }
+  return true;
+}
+
+bool AkaoMatcher::tryCreateCollection(int id) {
+  auto itSeq = seqs.find(id);
+  auto itInstrSet = instrSets.find(id);
+
+  if (itSeq != seqs.end() && itInstrSet != instrSets.end() && !sampColls.empty()) {
+    AkaoSeq* seq = itSeq->second;
+    AkaoInstrSet* instrSet = itInstrSet->second;
+
+    std::vector<AkaoSampColl *> sampCollsToCheck;
+    // id() represents the associated sample set id
+    if (seq->id() != -1) {
+      auto it = std::find_if(sampColls.begin(), sampColls.end(), [seq](AkaoSampColl *sc) {
+        return sc->id() == seq->id();
+      });
+      if (it != sampColls.end()) {
+        sampCollsToCheck.push_back(*it);
+      } else {
+        return false;
+      }
+    }
+    // Add the rest of the sample collections that are not already in sampCollsToCheck
+    for (auto* sc : std::ranges::reverse_view(sampColls)) {
+      if (std::find(sampCollsToCheck.begin(), sampCollsToCheck.end(), sc) == sampCollsToCheck.end()) {
+        sampCollsToCheck.push_back(sc);
+      }
+    }
+
+    std::vector<int> requiredArtIds;
+    for (const auto &instr : instrSet->aInstrs) {
+      for (const auto &region : instr->regions()) {
+        AkaoRgn* akaoRegion = static_cast<AkaoRgn*>(region);
+        // We will exclude articulation id 0, as it often indicates an unused artic
+        if (akaoRegion->artNum != 0)
+          requiredArtIds.emplace_back(akaoRegion->artNum);
+      }
+    }
+    std::sort(requiredArtIds.begin(), requiredArtIds.end());
+    requiredArtIds.erase(std::unique(requiredArtIds.begin(), requiredArtIds.end()), requiredArtIds.end());
+
+    std::vector<AkaoSampColl *> matchingSampColls;
+
+    for (auto *sc : sampCollsToCheck) {
+      bool matches = std::any_of(requiredArtIds.begin(), requiredArtIds.end(), [sc](int artId) {
+        return artId >= sc->starting_art_id && artId < (sc->starting_art_id + sc->nNumArts);
+      });
+
+      if (matches) {
+        matchingSampColls.push_back(sc);
+
+        // Remove the IDs covered by this sample collection
+        auto end = std::remove_if(requiredArtIds.begin(), requiredArtIds.end(), [sc](int artId) {
+          return artId >= sc->starting_art_id && artId < (sc->starting_art_id + sc->nNumArts);
+        });
+
+        // Erase the removed elements
+        requiredArtIds.erase(end, requiredArtIds.end());
+        if (requiredArtIds.empty())
+          break;
+      }
+    }
+
+    if (matchingSampColls.size() > 0) {
+      if (std::all_of(requiredArtIds.begin(), requiredArtIds.end(), [&matchingSampColls](int artId) {
+            return std::any_of(matchingSampColls.begin(), matchingSampColls.end(), [artId](AkaoSampColl *sc) {
+              return artId >= sc->starting_art_id && artId < (sc->starting_art_id + sc->nNumArts);
+            });
+          })) {
+        auto coll = fmt->newCollection();
+        if (!coll) return false;
+
+        coll->setName(seq->name());
+        coll->useSeq(seq);
+        coll->addInstrSet(instrSet);
+
+        // Sort the vector by starting_art_id in ascending order
+        std::sort(matchingSampColls.begin(), matchingSampColls.end(),
+        [](AkaoSampColl* a, AkaoSampColl* b) {
+            return a->starting_art_id < b->starting_art_id;
+        });
+        for (auto *sc : matchingSampColls) {
+          coll->addSampColl(sc);
+        }
+
+        seqs.erase(seq->seq_id);
+
+        if (!coll->load()) {
+          delete coll;
+          return false;
+        }
+
+        std::cout << "Collection created successfully!" << std::endl;
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -66,7 +66,7 @@ bool AkaoMatcher::tryCreateCollection(int id) {
       });
       if (it != sampColls.end()) {
         sampCollsToCheck.push_back(*it);
-      } else {
+      } else if (seq->rawFile()->extension() != "psf") {
         return false;
       }
     }
@@ -82,7 +82,8 @@ bool AkaoMatcher::tryCreateCollection(int id) {
       for (const auto &region : instr->regions()) {
         AkaoRgn* akaoRegion = static_cast<AkaoRgn*>(region);
         // We will exclude articulation id 0, as it often indicates an unused artic
-        if (akaoRegion->artNum != 0)
+        // Also ignoring values > 0x60 is a hack that allows compatability with many psfs.
+        if (akaoRegion->artNum != 0 && akaoRegion->artNum <= 0x60)
           requiredArtIds.emplace_back(akaoRegion->artNum);
       }
     }

--- a/src/main/formats/Akao/AkaoMatcher.h
+++ b/src/main/formats/Akao/AkaoMatcher.h
@@ -1,0 +1,39 @@
+/*
+* VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+*/
+#pragma once
+#include "Matcher.h"
+#include <vector>
+#include <unordered_map>
+#include <iostream>
+
+class VGMSeq;
+class VGMInstrSet;
+class VGMSampColl;
+class AkaoSeq;
+class AkaoInstrSet;
+class AkaoSampColl;
+
+class AkaoMatcher : public Matcher {
+ public:
+  explicit AkaoMatcher(Format *format)
+    : Matcher(format) {}
+  ~AkaoMatcher() override = default;
+
+ protected:
+  bool onNewSeq(VGMSeq* seq) override;
+  bool onNewInstrSet(VGMInstrSet* instrSet) override;
+  bool onNewSampColl(VGMSampColl* sampColl) override;
+  bool onCloseSeq(VGMSeq* seq) override;
+  bool onCloseInstrSet(VGMInstrSet* instrSet) override;
+  bool onCloseSampColl(VGMSampColl* sampColl) override;
+
+ private:
+  std::unordered_map<int, AkaoSeq*> seqs;
+  std::unordered_map<int, AkaoInstrSet*> instrSets;
+  std::vector<AkaoSampColl*> sampColls;
+
+  bool tryCreateCollection(int id);
+};

--- a/src/main/formats/Akao/AkaoScanner.cpp
+++ b/src/main/formats/Akao/AkaoScanner.cpp
@@ -29,7 +29,11 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
       AkaoPs1Version version = file_version;
       if (version == AkaoPs1Version::UNKNOWN)
         version = AkaoSeq::guessVersion(file, offset);
-      AkaoSeq *seq = new AkaoSeq(file, offset, version);
+
+      u16 id = file->readShort(offset + 4);
+      auto name = fmt::format("Akao Seq {:02X}", id);
+
+      AkaoSeq *seq = new AkaoSeq(file, offset, version, name);
       if (!seq->loadVGMFile()) {
         delete seq;
         continue;
@@ -50,7 +54,10 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
       if (version == AkaoPs1Version::UNKNOWN)
         version = AkaoSampColl::guessVersion(file, offset);
 
-      AkaoSampColl *sampColl = new AkaoSampColl(file, offset, version);
+      u16 id = file->readShort(offset + 4);
+      auto name = fmt::format("Akao Sample Collection {:02X}", id);
+
+      AkaoSampColl *sampColl = new AkaoSampColl(file, offset, version, name);
       if (!sampColl->loadVGMFile())
         delete sampColl;
     }

--- a/src/main/formats/Akao/AkaoSeq.cpp
+++ b/src/main/formats/Akao/AkaoSeq.cpp
@@ -17,8 +17,8 @@ using namespace std;
 static const uint16_t DELTA_TIME_TABLE[] = { 192, 96, 48, 24, 12, 6, 3, 32, 16, 8, 4 };
 static constexpr uint8_t NOTE_VELOCITY = 100;
 
-AkaoSeq::AkaoSeq(RawFile *file, uint32_t offset, AkaoPs1Version version)
-    : VGMSeq(AkaoFormat::name, file, offset, 0, "Akao Seq"), seq_id(0), version_(version),
+AkaoSeq::AkaoSeq(RawFile *file, uint32_t offset, AkaoPs1Version version, std::string name)
+    : VGMSeq(AkaoFormat::name, file, offset, 0, std::move(name)), seq_id(0), version_(version),
       instrument_set_offset_(0), drum_set_offset_(0), condition(0) {
   setUseLinearAmplitudeScale(true);        //I think this applies, but not certain, see FF9 320, track 3 for example of problem
   //UseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kAdjustVolumeController); // disabled, it only changes the volume and the pan slightly, and also its output becomes undefined if pan and volume slides are used at the same time

--- a/src/main/formats/Akao/AkaoSeq.cpp
+++ b/src/main/formats/Akao/AkaoSeq.cpp
@@ -225,10 +225,10 @@ AkaoInstrSet* AkaoSeq::newInstrSet() const {
       length = unLength - (drum_set_offset() - dwOffset);
 
     return length != 0
-      ? new AkaoInstrSet(rawFile(), length, version(), instrument_set_offset(), drum_set_offset(), id(), "Akao Instr Set")
-      : new AkaoInstrSet(rawFile(), dwOffset, dwOffset + unLength, version());
+      ? new AkaoInstrSet(rawFile(), length, version(), instrument_set_offset(), drum_set_offset(), seq_id, "Akao Instr Set")
+      : new AkaoInstrSet(rawFile(), dwOffset, dwOffset + unLength, version(), seq_id);
   } else {
-    return new AkaoInstrSet(rawFile(), dwOffset + unLength, version(), custom_instrument_addresses, drum_instrument_addresses);
+    return new AkaoInstrSet(rawFile(), dwOffset + unLength, version(), custom_instrument_addresses, drum_instrument_addresses, seq_id);
   }
 }
 

--- a/src/main/formats/Akao/AkaoSeq.h
+++ b/src/main/formats/Akao/AkaoSeq.h
@@ -144,7 +144,7 @@ enum AkaoSeqEventType {
 class AkaoSeq final :
     public VGMSeq {
  public:
-  explicit AkaoSeq(RawFile *file, uint32_t offset, AkaoPs1Version version);
+  explicit AkaoSeq(RawFile *file, uint32_t offset, AkaoPs1Version version, std::string name);
 
   void resetVars() override;
   bool parseHeader() override;

--- a/src/main/formats/CPS/CPSSeq.cpp
+++ b/src/main/formats/CPS/CPSSeq.cpp
@@ -20,7 +20,7 @@ DECLARE_FORMAT(CPS2);
 CPSSeq::CPSSeq(RawFile *file, uint32_t offset, CPSFormatVer fmtVersion, std::string name)
     : VGMSeq(CPS2Format::name, file, offset, 0, std::move(name)),
       fmt_version(fmtVersion) {
-  usesMonophonicTracks();
+  setUsesMonophonicTracks();
   setAlwaysWriteInitialVol(127);
   setAlwaysWriteInitialMonoMode(true);
   // Until we add CPS3 vibrato and pitch bend using markers, set the default pitch bend range here


### PR DESCRIPTION
This provides three improvements to the Akao format:

1. Adds support for creating collections that use more than one sample collection (Vagrant Story, FF8, others?)
2. Adds a new AkaoMatcher class that better handles the complicated task of determining what files belong in an Akao collection
3. Combines instrument region ADSR with articulation data ADSR, as opposed to only utilizing the articulation data ADSR. This fixes a lot of tracks with broken-sounding instruments.

## Description
Heads up that the Akao format itself is a complete mess. For the sake of matching, the relevant facts are:

1. Sequences and instrument sets are bundled together effectively as one file in their original format, so they are given the same id when we create them in the scanner.
2. Sequences may contain a byte that indicates the id of an associated sample collection, depending on the version. However, a sequence may utilize a second common sample collection for which no id is provided. Final Fantasy VIII and Vagrant Story are examples of games that do this.
3. PSF sets sometimes exclude the aforementioned sample id association byte or the id byte of the sample collection itself. This is because removing all unread bytes is an optional feature of the PSF creation software, and these bytes are never actually read by the sound driver during playback.
4. Sample collections contain a list of "articulations." Each have an id, point to a sample, and provide ADSR data.
5. Each instrument region, defined in the instrument set, points to an articulation ID.

Therefore, we are limited in terms of guaranteed information. The goal is to ensure that the articulation IDs used in the regions of the instrument set are all present and accounted for, and there may be multiple sample collections that define the used articulation ids even if their articulations are unique from each other - so there is some unavoidable guessing. The implemented strategy is to utilize the associated sample collection if it is detected, but otherwise use any sample collection that covers any referenced articulation ids. 

However, we could get better results if the AkaoMatcher class had a callback informing it that a RawFile has finished loading.  Consider what happens when a PSF is loaded. A sequence may point to an associated sample collection ID, but we have no idea if the sample collection will have its id byte present. We also don't know when we have finished loading all the files of the PSF, so we must assume that each file is the last and check if it can be used in the collection. 

If instead the Matcher were informed when RawFile has finished loading, it could first evaluate if a sample collection with the correct ID was loaded. If not, it could check if the RawFile was a PSF, in which case it would make its best attempt to find the correct sample collection(s) exclusively from the files just loaded.

To solve this, I created #527 to provide the Scanner class with a pointer to its Format. This way, a Scanner can get the Format's Matcher instance and inform the Matcher when it has finished loading files. I have also now posted #528, which puts this into practice in AkaoMatcher, building off of this PR and #527.

## How Has This Been Tested?
I've tested this on a large number of Akao sets. In terms of matching results, it will sometimes perform better or worse compared to FilegroupMatcher, ~but the cons should be addressed in a future PR once we provide the Matcher with a new callback~, but #528 basically fixes everything.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
