### PR TITLE
AkaoMatcher onFinishedScan()

### DIFF
--- a/src/main/formats/Akao/AkaoFormat.cpp
+++ b/src/main/formats/Akao/AkaoFormat.cpp
@@ -21,7 +21,6 @@ AkaoColl::mapSampleCollections() {
   std::unordered_map<int, int> artIdToSampleNumMap;
   std::unordered_map<int, AkaoSampColl *> artIdToSampCollMap;
 
-  // First order the sa
   std::transform(sampColls().begin(), sampColls().end(), std::back_inserter(orderedSampColls),
                  [](VGMSampColl *vgm) { return static_cast<AkaoSampColl *>(vgm); });
 

--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -98,8 +98,12 @@ bool AkaoMatcher::tryCreateCollection(int id) {
       });
       if (it != sampColls.end()) {
         sampCollsToCheck.push_back(*it);
-      } else if (seq->rawFile()->extension() != "psf") {  // PSF files may optimize out the IDs, so be lenient
-        return false;
+      } else {
+        // PSF files may optimize out the IDs, so be lenient
+        auto extension = toLower(seq->rawFile()->extension());
+        if (extension != "psf" && extension != "minipsf") {
+          return false;
+        }
       }
     }
     // Add the rest of the sample collections that are not already in sampCollsToCheck

--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -100,7 +100,7 @@ bool AkaoMatcher::tryCreateCollection(int id) {
         sampCollsToCheck.push_back(*it);
       } else {
         // PSF files may optimize out the IDs, so be lenient
-        auto extension = toLower(seq->rawFile()->extension());
+        auto extension = seq->rawFile()->extension();
         if (extension != "psf" && extension != "minipsf") {
           return false;
         }

--- a/src/main/formats/Akao/AkaoMatcher.h
+++ b/src/main/formats/Akao/AkaoMatcher.h
@@ -15,12 +15,15 @@ class VGMSampColl;
 class AkaoSeq;
 class AkaoInstrSet;
 class AkaoSampColl;
+class RawFile;
 
 class AkaoMatcher : public Matcher {
  public:
   explicit AkaoMatcher(Format *format)
     : Matcher(format) {}
   ~AkaoMatcher() override = default;
+
+  void onFinishedScan(RawFile* rawfile);
 
  protected:
   bool onNewSeq(VGMSeq* seq) override;

--- a/src/main/formats/Akao/AkaoScanner.cpp
+++ b/src/main/formats/Akao/AkaoScanner.cpp
@@ -88,6 +88,10 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
       }
     }
   }
+
+  if (auto akaoMatcher = dynamic_cast<AkaoMatcher*>(format->matcher)) {
+    akaoMatcher->onFinishedScan(file);
+  }
 }
 
 AkaoPs1Version AkaoScanner::determineVersionFromTag(const RawFile *file) noexcept {


### PR DESCRIPTION
This PR is branched off of `akao-matcher` and rebased on top of `scanner-format`. It's probably best to ignore it until those PRs are addressed.

This follows up on #527 and the discussion in #526 to add an onFinishedScan() callback to AkaoMatcher. This vastly improves the efficacy of AkaoMatcher.

## How Has This Been Tested?
This is working with every PSF set I have tested, and is able to match files within ISO images for games that use a single sample collection per song with ID associations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
