### PR TITLE
Add SPCFile, fix tags for PSFFile

### DIFF
--- a/src/main/components/PSFFile.cpp
+++ b/src/main/components/PSFFile.cpp
@@ -12,7 +12,7 @@
 constexpr auto PSF_TAG_SIG = "[TAG]";
 constexpr auto PSF_TAG_SIG_LEN = 5;
 
-VGMTag tagFromPSFFile(const PSFFile& psf) {
+VGMTag PSFFile::tagFromPSFFile(const PSFFile& psf) {
   auto& psfTags = psf.tags();
   return VGMTag(
     psfTags.contains("title") ? psfTags.at("title") : "",
@@ -21,7 +21,6 @@ VGMTag tagFromPSFFile(const PSFFile& psf) {
     psfTags.contains("comment") ? psfTags.at("comment") : ""
   );
 }
-
 
 PSFFile::PSFFile(const RawFile &file) {
     size_t fileSize = file.size();

--- a/src/main/components/PSFFile.cpp
+++ b/src/main/components/PSFFile.cpp
@@ -12,6 +12,17 @@
 constexpr auto PSF_TAG_SIG = "[TAG]";
 constexpr auto PSF_TAG_SIG_LEN = 5;
 
+VGMTag tagFromPSFFile(const PSFFile& psf) {
+  auto& psfTags = psf.tags();
+  return VGMTag(
+    psfTags.contains("title") ? psfTags.at("title") : "",
+    psfTags.contains("artist") ? psfTags.at("artist") : "",
+    psfTags.contains("game") ? psfTags.at("game") : "",
+    psfTags.contains("comment") ? psfTags.at("comment") : ""
+  );
+}
+
+
 PSFFile::PSFFile(const RawFile &file) {
     size_t fileSize = file.size();
     if (fileSize < 0x10) {

--- a/src/main/components/PSFFile.h
+++ b/src/main/components/PSFFile.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include "VGMTag.h"
 #include <cstdint>
 #include <vector>
 #include <map>
@@ -14,6 +15,9 @@
 #include <climits>
 
 class RawFile;
+class PSFFile;
+
+VGMTag tagFromPSFFile(const PSFFile& psf);
 
 class PSFFile {
    public:

--- a/src/main/components/PSFFile.h
+++ b/src/main/components/PSFFile.h
@@ -17,12 +17,12 @@
 class RawFile;
 class PSFFile;
 
-VGMTag tagFromPSFFile(const PSFFile& psf);
-
 class PSFFile {
    public:
     explicit PSFFile(const RawFile &file);
     ~PSFFile() = default;
+
+    static VGMTag tagFromPSFFile(const PSFFile& psf);
 
     [[nodiscard]] uint8_t version() const noexcept { return m_version; }
     [[nodiscard]] const std::map<std::string, std::string> &tags() const noexcept { return m_tags; }

--- a/src/main/components/SPCFile.cpp
+++ b/src/main/components/SPCFile.cpp
@@ -9,7 +9,7 @@
 #include "VGMTag.h"
 #include <stdexcept>
 
-VGMTag tagFromSPCFile(const SPCFile& spc) {
+VGMTag SPCFile::tagFromSPCFile(const SPCFile& spc) {
   const auto& id666 = spc.id666Tag();
   const auto& dsp = spc.dsp();
 

--- a/src/main/components/SPCFile.cpp
+++ b/src/main/components/SPCFile.cpp
@@ -1,0 +1,130 @@
+/*
+ * VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+#include "SPCFile.h"
+#include "LogManager.h"
+#include "RawFile.h"
+#include "VGMTag.h"
+#include <stdexcept>
+
+VGMTag tagFromSPCFile(const SPCFile& spc) {
+  auto id666 = spc.id666Tag();
+  const auto& dsp = spc.dsp();
+
+  auto tag = VGMTag();
+  tag.title = id666.songTitle;
+  tag.artist = id666.artist;
+  tag.album = id666.gameTitle;
+  tag.comment = id666.comments;
+  tag.binaries["dsp"] = std::vector(dsp.begin(), dsp.end());
+  return tag;
+}
+
+SPCFile::SPCFile(const RawFile& file) {
+  if (file.size() < 0x10180) {
+    throw std::length_error("SPC file is smaller than required length");
+  }
+
+  if (!std::equal(file.begin(), file.begin() + 27, "SNES-SPC700 Sound File Data") ||
+      file.readShort(0x21) != 0x1a1a) {
+    throw std::runtime_error("Invalid SPC signature");
+  }
+
+  m_hasID666Tag = file.readByte(0x23);
+  m_versionMinor = file.readByte(0x24);
+  file.readBytes(0x100, m_ram.size(), m_ram.data());
+  file.readBytes(0x10100, m_dspRegisters.size(), m_dspRegisters.data());
+  file.readBytes(0x101C0, m_extraRam.size(), m_extraRam.data());
+
+  if (m_hasID666Tag) {
+    loadID666Tag(file);
+  }
+  if (file.size() >= 0x10208) {
+    loadExtendedID666Tag(file, 0x10200);
+  }
+}
+
+void SPCFile::loadID666Tag(const RawFile& file) {
+  m_id666Tag.songTitle = file.readNullTerminatedString(0x2E, 32);
+  m_id666Tag.gameTitle = file.readNullTerminatedString(0x4E, 32);
+  m_id666Tag.nameOfDumper = file.readNullTerminatedString(0x6E, 16);
+  m_id666Tag.comments = file.readNullTerminatedString(0x7E, 32);
+  m_id666Tag.dateDumped = file.readNullTerminatedString(0x9E, 11);
+  m_id666Tag.secondsToPlay = std::stoi(file.readNullTerminatedString(0xA9, 3));
+  m_id666Tag.fadeLength = std::stoi(file.readNullTerminatedString(0xAC, 5));
+  m_id666Tag.artist = file.readNullTerminatedString(0xB1, 32);
+  m_id666Tag.defaultChannelDisables = file.readByte(0xD1);
+  m_id666Tag.emulatorUsed = file.readByte(0xD2);
+}
+
+void SPCFile::loadExtendedID666Tag(const RawFile& file, size_t offset) {
+  if (!std::equal(file.begin() + offset, file.begin() + offset + 4, "xid6")) {
+    return; // No extended ID666 chunk found
+  }
+
+  size_t chunkSize = file.readWord(offset + 4);
+  size_t chunkEnd = offset + 8 + chunkSize;
+
+  if (file.size() < chunkEnd) {
+    throw std::length_error("Extended ID666 chunk size exceeds file size");
+  }
+
+  size_t currentOffset = offset + 8;
+  while (currentOffset < chunkEnd) {
+    uint8_t id = file.readByte(currentOffset);
+    uint8_t type = file.readByte(currentOffset + 1);
+    uint16_t headerData = file.readShort(currentOffset + 2);
+
+    switch (type) {
+      case 0:
+        // Data stored in last two bytes of 4 byte header
+        currentOffset += 4;
+        break;
+
+      case 1: {
+        // Data is stored after the header. The two header data bytes are length.
+        size_t dataLength = headerData;
+        switch (id) {
+          case 0x01:
+            m_id666Tag.songTitle = file.readNullTerminatedString(currentOffset + 4, dataLength);
+            break;
+          case 0x02:
+            m_id666Tag.gameTitle = file.readNullTerminatedString(currentOffset + 4, dataLength);
+            break;
+          case 0x03:
+            m_id666Tag.artist = file.readNullTerminatedString(currentOffset + 4, dataLength);
+            break;
+          case 0x04:
+            m_id666Tag.nameOfDumper = file.readNullTerminatedString(currentOffset + 4, dataLength);
+            break;
+          case 0x05:
+            m_id666Tag.dateDumped = std::to_string(file.readWord(currentOffset + 4));
+            break;
+          case 0x06:
+            m_id666Tag.emulatorUsed = file.readByte(currentOffset + 4);
+            break;
+          case 0x07:
+            m_id666Tag.comments = file.readNullTerminatedString(currentOffset + 4, dataLength);
+            break;
+          default:
+            L_WARN("Unknown id6 tag id: {} in SPC", id);
+            break;
+        }
+        currentOffset += 4 + ((dataLength + 3) & ~3); // Align to 32-bit boundary
+        break;
+      }
+
+      case 4:
+        // Integer. Data stored after header as int32.
+        currentOffset += 8;
+        break;
+
+      default:
+        L_WARN("Unknown xid type: {:d} in SPC", type);
+        currentOffset += 4;
+        break;
+    }
+  }
+}

--- a/src/main/components/SPCFile.cpp
+++ b/src/main/components/SPCFile.cpp
@@ -10,14 +10,10 @@
 #include <stdexcept>
 
 VGMTag tagFromSPCFile(const SPCFile& spc) {
-  auto id666 = spc.id666Tag();
+  const auto& id666 = spc.id666Tag();
   const auto& dsp = spc.dsp();
 
-  auto tag = VGMTag();
-  tag.title = id666.songTitle;
-  tag.artist = id666.artist;
-  tag.album = id666.gameTitle;
-  tag.comment = id666.comments;
+  auto tag = VGMTag(id666.songTitle, id666.artist, id666.gameTitle, id666.comments);
   tag.binaries["dsp"] = std::vector(dsp.begin(), dsp.end());
   return tag;
 }

--- a/src/main/components/SPCFile.h
+++ b/src/main/components/SPCFile.h
@@ -39,9 +39,9 @@ public:
 private:
   bool m_hasID666Tag;
   uint8_t m_versionMinor;
-  std::array<u8, 64 * 1024> m_ram; // 64KB RAM
-  std::array<u8, 128> m_dspRegisters; // DSP Registers
-  std::array<u8, 64> m_extraRam; // Extra RAM
+  std::array<u8, 64 * 1024> m_ram;
+  std::array<u8, 128> m_dspRegisters;
+  std::array<u8, 64> m_extraRam;
   ID666Tag m_id666Tag;
 
   void loadID666Tag(const RawFile& file);

--- a/src/main/components/SPCFile.h
+++ b/src/main/components/SPCFile.h
@@ -24,12 +24,12 @@ struct ID666Tag {
   u8 emulatorUsed;
 };
 
-VGMTag tagFromSPCFile(const SPCFile&);
-
 class SPCFile {
 public:
   explicit SPCFile(const RawFile& file);
   ~SPCFile() = default;
+
+  static VGMTag tagFromSPCFile(const SPCFile&);
 
   [[nodiscard]] const std::array<u8, 64 * 1024>& ram() const { return m_ram; }
   [[nodiscard]] const std::array<u8, 128>& dsp() const { return m_dspRegisters; }

--- a/src/main/components/SPCFile.h
+++ b/src/main/components/SPCFile.h
@@ -1,0 +1,49 @@
+/*
+ * VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+#pragma once
+#include "VGMTag.h"
+#include "common.h"
+#include <array>
+
+class RawFile;
+class SPCFile;
+
+struct ID666Tag {
+  std::string songTitle;
+  std::string gameTitle;
+  std::string nameOfDumper;
+  std::string comments;
+  std::string dateDumped;
+  u32 secondsToPlay;
+  u32 fadeLength;
+  std::string artist;
+  u8 defaultChannelDisables;
+  u8 emulatorUsed;
+};
+
+VGMTag tagFromSPCFile(const SPCFile&);
+
+class SPCFile {
+public:
+  explicit SPCFile(const RawFile& file);
+  ~SPCFile() = default;
+
+  [[nodiscard]] const std::array<u8, 64 * 1024>& ram() const { return m_ram; }
+  [[nodiscard]] const std::array<u8, 128>& dsp() const { return m_dspRegisters; }
+  [[nodiscard]] const std::array<u8, 64>& extraRam() const { return m_extraRam; }
+  [[nodiscard]] const ID666Tag& id666Tag() const { return m_id666Tag; }
+
+private:
+  bool m_hasID666Tag;
+  uint8_t m_versionMinor;
+  std::array<u8, 64 * 1024> m_ram; // 64KB RAM
+  std::array<u8, 128> m_dspRegisters; // DSP Registers
+  std::array<u8, 64> m_extraRam; // Extra RAM
+  ID666Tag m_id666Tag;
+
+  void loadID666Tag(const RawFile& file);
+  void loadExtendedID666Tag(const RawFile& file, size_t offset);
+};

--- a/src/main/components/VGMTag.cpp
+++ b/src/main/components/VGMTag.cpp
@@ -6,8 +6,10 @@
 
 #include "VGMTag.h"
 
-VGMTag::VGMTag(std::string _title, std::string _artist, std::string _album)
-    : title(std::move(_title)), artist(std::move(_artist)), album(std::move(_album)) {}
+VGMTag::VGMTag(std::string _title, std::string _artist, std::string _album, std::string _comment)
+    : title(std::move(_title)), artist(std::move(_artist)), album(std::move(_album)),
+      comment(std::move(_comment)) {
+}
 
 bool VGMTag::hasTitle() const {
   return !title.empty();

--- a/src/main/components/VGMTag.h
+++ b/src/main/components/VGMTag.h
@@ -14,7 +14,7 @@
 class VGMTag {
 public:
   VGMTag() = default;
-  VGMTag(std::string _title, std::string _artist = "", std::string _album = "");
+  VGMTag(std::string _title, std::string _artist = "", std::string _album = "", std::string _comment = "");
   ~VGMTag() = default;
 
   bool hasTitle() const;

--- a/src/main/formats/Akao/AkaoSeq.cpp
+++ b/src/main/formats/Akao/AkaoSeq.cpp
@@ -15,7 +15,7 @@ DECLARE_FORMAT(Akao);
 using namespace std;
 
 static const uint16_t DELTA_TIME_TABLE[] = { 192, 96, 48, 24, 12, 6, 3, 32, 16, 8, 4 };
-static constexpr uint8_t NOTE_VELOCITY = 100;
+static constexpr uint8_t NOTE_VELOCITY = 127;
 
 AkaoSeq::AkaoSeq(RawFile *file, uint32_t offset, AkaoPs1Version version, std::string name)
     : VGMSeq(AkaoFormat::name, file, offset, 0, std::move(name)), seq_id(0), version_(version),

--- a/src/main/io/RawFile.cpp
+++ b/src/main/io/RawFile.cpp
@@ -60,6 +60,12 @@ bool RawFile::searchBytePattern(const BytePattern &pattern, uint32_t &nMatchOffs
     return false;
 }
 
+std::string RawFile::readNullTerminatedString(size_t offset, size_t maxLength) const {
+  const char* stringPtr = data() + offset;
+  size_t length = strnlen(stringPtr, maxLength);
+  return std::string(stringPtr, length);
+}
+
 /* DiskFile */
 
 DiskFile::DiskFile(const std::string &path) : m_data(mio::mmap_source(path)), m_path(path) {}

--- a/src/main/io/RawFile.cpp
+++ b/src/main/io/RawFile.cpp
@@ -82,7 +82,8 @@ VirtFile::VirtFile(const RawFile &file, size_t offset, size_t limit)
 }
 
 VirtFile::VirtFile(const uint8_t *data, uint32_t fileSize, std::string name,
-                   std::string parent_fullpath, const VGMTag& /*tag*/)
+                   std::string parent_fullpath, const VGMTag& tag)
     : m_name(std::move(name)), m_lpath(std::move(parent_fullpath)) {
-    std::copy_n(data, fileSize, std::back_inserter(m_data));
+  std::copy_n(data, fileSize, std::back_inserter(m_data));
+  this->tag = tag;
 }

--- a/src/main/io/RawFile.h
+++ b/src/main/io/RawFile.h
@@ -95,6 +95,7 @@ class RawFile {
     virtual uint32_t readWord(size_t offset) const = 0;
     virtual uint16_t readShortBE(size_t offset) const = 0;
     virtual uint32_t readWordBE(size_t offset) const = 0;
+    std::string readNullTerminatedString(size_t offset, size_t maxLength) const;
 
     uint32_t readBytes(size_t offset, uint32_t nCount, void *pBuffer) const;
     bool matchBytes(const uint8_t *pattern, size_t offset, size_t nCount) const;

--- a/src/main/loaders/PSFLoader.cpp
+++ b/src/main/loaders/PSFLoader.cpp
@@ -31,12 +31,12 @@ const std::unordered_map<int, size_t> data_offset = {{PSF1_VERSION, 0x800},
                                                      {NCSF_VERSION, 0x0}};
 
 void PSFLoader::apply(const RawFile *file) {
-    if (std::equal(file->begin(), file->begin() + 3, "PSF")) {
-        uint8_t version = file->get<u8>(3);
-        if (data_offset.contains(version)) {
-            psf_read_exe(file, version);
-        }
+  if (std::equal(file->begin(), file->begin() + 3, "PSF")) {
+    uint8_t version = file->get<u8>(3);
+    if (data_offset.contains(version)) {
+      psf_read_exe(file, version);
     }
+  }
 }
 
 /*
@@ -44,34 +44,34 @@ void PSFLoader::apply(const RawFile *file) {
  * however the following is perfectly fine for our purposes.
  */
 void PSFLoader::psf_read_exe(const RawFile *file, int version) {
-    try {
-        PSFFile psf(*file);
-        std::filesystem::path basepath(file->path());
-        auto libtag = psf.tags().find("_lib");
-        if (libtag != psf.tags().end()) {
-            auto newpath = basepath.replace_filename(libtag->second).string();
-            auto newfile = new DiskFile(newpath);
-            enqueue(newfile);
+  try {
+    PSFFile psf(*file);
+    std::filesystem::path basepath(file->path());
+    auto libtag = psf.tags().find("_lib");
+    if (libtag != psf.tags().end()) {
+      auto newpath = basepath.replace_filename(libtag->second).string();
+      auto newfile = new DiskFile(newpath);
+      enqueue(newfile);
 
-            /* Look for additional libraries in the same folder */
-            int i = 1;
-            for (libtag = psf.tags().find(fmt::format("_lib{}", i));
-                 libtag != psf.tags().end();
-                 libtag = psf.tags().find(fmt::format("_lib{}", ++i))) {
-              newpath = basepath.replace_filename(libtag->second).string();
-              newfile = new DiskFile(newpath);
-              enqueue(newfile);
-         }
-        }
-
-        if (!psf.exe().empty()) {
-            auto newfile = new VirtFile(
-                reinterpret_cast<const u8 *>(psf.exe().data()) + data_offset.at(version),
-                psf.exe().size() - data_offset.at(version), file->name(), file->path().string(), file->tag);
-            enqueue(newfile);
-        }
-    } catch (std::exception e) {
-        L_ERROR(e.what());
-        return;
+      /* Look for additional libraries in the same folder */
+      int i = 1;
+      for (libtag = psf.tags().find(fmt::format("_lib{}", i));
+           libtag != psf.tags().end();
+           libtag = psf.tags().find(fmt::format("_lib{}", ++i))) {
+        newpath = basepath.replace_filename(libtag->second).string();
+        newfile = new DiskFile(newpath);
+        enqueue(newfile);
+      }
     }
+
+    if (!psf.exe().empty()) {
+      auto newfile = new VirtFile(
+      reinterpret_cast<const u8 *>(psf.exe().data()) + data_offset.at(version),
+      psf.exe().size() - data_offset.at(version), file->name(), file->path().string(), file->tag);
+      enqueue(newfile);
+    }
+  } catch (std::exception e) {
+    L_ERROR(e.what());
+    return;
+  }
 }

--- a/src/main/loaders/PSFLoader.cpp
+++ b/src/main/loaders/PSFLoader.cpp
@@ -67,7 +67,7 @@ void PSFLoader::psf_read_exe(const RawFile *file, int version) {
     }
 
     if (!psf.exe().empty()) {
-      auto tag = tagFromPSFFile(psf);
+      auto tag = PSFFile::tagFromPSFFile(psf);
       auto newfile = new VirtFile(
       reinterpret_cast<const u8 *>(psf.exe().data()) + data_offset.at(version),
       psf.exe().size() - data_offset.at(version), file->name(), file->path().string(), tag);

--- a/src/main/loaders/SPCLoader.cpp
+++ b/src/main/loaders/SPCLoader.cpp
@@ -7,6 +7,7 @@
 #include "SPCLoader.h"
 #include "LogManager.h"
 #include "LoaderManager.h"
+#include "SPCFile.h"
 
 namespace vgmtrans::loaders {
 LoaderRegistration<SPCLoader> _spc{"SPC"};
@@ -22,125 +23,14 @@ void SPCLoader::apply(const RawFile *file) {
     return;
   }
 
-  auto spcFile = new VirtFile(*file, 0x100, 0x10000);
+  try {
+    SPCFile spc(*file);
 
-  std::vector<uint8_t> dsp(file->data() + 0x10100, file->data() + 0x10100 + 0x80);
-  spcFile->tag.binaries["dsp"] = dsp;
-
-  // Parse [ID666](http://vspcplay.raphnet.net/spc_file_format.txt) if available.
-  if (file->readByte(0x23) == 0x1a) {
-    char s[256];
-
-    file->readBytes(0x2e, 32, s);
-    s[32] = '\0';
-    std::string s_str = s;
-    spcFile->tag.title = (s_str);
-
-    file->readBytes(0x4e, 32, s);
-    s[32] = '\0';
-    s_str = s;
-    spcFile->tag.album = (s_str);
-
-    file->readBytes(0x7e, 32, s);
-    s[32] = '\0';
-    s_str = s;
-    spcFile->tag.comment = (s_str);
-
-    if (file->readByte(0xd2) < 0x30) {
-      // binary format
-      file->readBytes(0xb0, 32, s);
-      s[32] = '\0';
-      s_str = s;
-      spcFile->tag.artist = (s_str);
-
-      spcFile->tag.length = file->readWord(0xa9) & 0xffffff;
-    } else {
-      // text format
-      file->readBytes(0xb1, 32, s);
-      s[32] = '\0';
-      s_str = s;
-      spcFile->tag.artist = (s_str);
-
-      file->readBytes(0xa9, 3, s);
-      s[3] = '\0';
-      spcFile->tag.length = strtoul(s, nullptr, 10);
-    }
+    auto tag = tagFromSPCFile(spc);
+    std::string name = fmt::format("{} - ram", file->name());
+    auto newfile = new VirtFile(spc.ram().data(), spc.ram().size(), name, file->path().string(), tag);
+    enqueue(newfile);
+  } catch (std::exception e) {
+    L_ERROR(e.what());
   }
-
-  // Parse Extended ID666 if available
-  if (file->size() >= 0x10208) {
-    uint32_t xid6_end_offset = 0x10208 + file->readWord(0x10204);
-    if (std::equal(file->begin() + 0x10200, file->begin() + 0x10204, "xid6") &&
-        file->size() >= xid6_end_offset) {
-      uint32_t xid6_offset = 0x10208;
-      while (xid6_offset + 4 < xid6_end_offset) {
-        uint8_t xid6_id = file->readByte(xid6_offset);
-        uint8_t xid6_type = file->readByte(xid6_offset + 1);
-        uint16_t xid6_data = file->readByte(xid6_offset + 2);
-
-        // get the length of this field
-        uint16_t xid6_length;
-        if (xid6_type == 0) {
-          xid6_length = 0;
-        } else {
-          xid6_length = xid6_data;
-        }
-
-        // check size error
-        if (xid6_end_offset < xid6_offset + 4 + xid6_length) {
-          break;
-        }
-
-        switch (xid6_type) {
-          case 0:
-            // Data
-            break;
-
-          case 1: {
-            // String (data contains null character)
-            std::string s_str =
-                std::string((char *)(file->data() + xid6_offset + 4), xid6_length - 1);
-            std::string xid6_string = (s_str);
-            switch (xid6_id) {
-              case 1:
-                // Song name
-                spcFile->tag.title = xid6_string;
-                break;
-
-              case 2:
-                // Game name
-                spcFile->tag.album = xid6_string;
-                break;
-
-              case 3:
-                // Artist
-                spcFile->tag.artist = xid6_string;
-                break;
-
-              case 7:
-                // Comments
-                spcFile->tag.comment = xid6_string;
-                break;
-
-              default:
-                L_WARN("Unknown id6 tag id: {} in SPC", xid6_id);
-            }
-            break;
-          }
-
-          case 4:
-            // Integer
-            break;
-
-          default:
-            // Unknown
-            break;
-        }
-
-        xid6_offset += 4 + ((xid6_length + 3) / 4 * 4);
-      }
-    }
-  }
-
-  enqueue(spcFile);
 }

--- a/src/main/loaders/SPCLoader.cpp
+++ b/src/main/loaders/SPCLoader.cpp
@@ -26,7 +26,7 @@ void SPCLoader::apply(const RawFile *file) {
   try {
     SPCFile spc(*file);
 
-    auto tag = tagFromSPCFile(spc);
+    auto tag = SPCFile::tagFromSPCFile(spc);
     std::string name = fmt::format("{} - ram", file->name());
     auto newfile = new VirtFile(spc.ram().data(), spc.ram().size(), name, file->path().string(), tag);
     enqueue(newfile);


### PR DESCRIPTION
In light of feedback on #530, I decided to refactor SPCLoader so that it's more consistent with PSFLoader. SPC files are now loaded into an SPCFile class. Thereafter, we generate the VGMTag via tagFromSPCFile(). Likewise, I've added a tagFromPSFFile() function, and per my changes in #530, I've fixed the VirtFile constructor to actually set the RawFile::tag field.

I've also added a RawFile::readNullTerminatedString() method, as this logic was needed for reading the id666 tags, and I figure it might be generally useful.

I still wonder if it would be cleaner to make tagFromXFile() static methods of the PSF/SPCFile classes.

Unrelated: I've updated the Akao note velocity from 100 to 127. 

## How Has This Been Tested?
Verified the PSF tags are being set. Tested on SPC files with regular id666 tags and SPC files with extended id666 tags of all three types and verified it was iterating over subchunks correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
