### PR TITLE
Allow instrument sets with no defined instruments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ VGMTrans converts a music files used in console video games into standard midi a
 - Sony's PS2 sequence and instrument formats (.bq, .hd, .bd)
 - Squaresoft's PS2 sequence and instrument formats (.bgm, .wd)
 - Nintendo's Nintendo DS sequence and instrument formats (SDAT)
-- Late versions of Squaresoft's PS1 format known as AKAO - sequences and instruments
+- Squaresoft's PS1 format known as AKAO - sequences and instruments
 - Sony's PS1 sequence and instrument formats (.seq, .vab)
 - Heartbeat's PS1 sequence format used in PS1 Dragon Quest games (.seqq)
 - Tamsoft's PS1 sequence and instrument formats (.tsq, .tvb)
-- Capcom's QSound sequence and instrument formats used in CPS1/CPS2/CPS3 arcade games
+- Capcom's sequence and sampled instrument formats used in CPS1/CPS2/CPS3 arcade games
 - Squaresoft's PS1 format used in certain PS1 games like Final Fantasy Tactics (smds/dwds)
 - Konami's PS1 sequence format known as KDT1
-- Nintendo's Gameboy Advance sequence format
+- Sega's Sega Saturn sequence format
+- Nintendo's Gameboy Advance sequence and instrument format known as MP2k
 - Nintendo's SNES sequence and instrument format known as N-SPC (.spc)
 - Squaresoft's SNES sequence and instrument format (AKAO/SUZUKI/Itikiti) (.spc)
 - Capcom's SNES sequence and instrument format (.spc)
@@ -42,11 +43,11 @@ This software is released under the zlib/libpng License. See LICENSE.txt.
 How to use it
 -------------
 
-To load a file, drag and drop the file into the application window.  The program will scan any file for contained music files. It knows how to unpack psf, psf2 and certain zipped mame rom sets as specified in the mame_roms.xml file, though this last feature is fairly undeveloped.  For example, drag on an NDS rom file and it will detect SDAT files and their contents.
+To load a file, drag and drop the file into the application window.  The program will scan any file for contained music files. It knows how to unpack psf, psf2 and certain zipped mame rom sets as specified in the mame_roms.xml file.  For example, drag on an NDS rom file and it will detect SDAT files and their contents.
 
 Once loaded, double-clicking a file listed under "Detected Music Files" will bring up a color-coded hexadecimal display of the file with a break-down of each format element.  Click the hexadecimal to highlight an element and see more information.  Right click a detected file to bring up save options.  To remove files from the "Detected Music Files" or "Scanned Files" list, highlight the files and press the delete key.
 
-The "Collections" window displays file groupings that the software was able to infer.  A sequence file will be paired with one or more instrument sets and/or sample collections. A collection can be played by highlighting it and pressing the play button or spacebar.
+The "Collections" window displays file groupings that the software was able to infer.  A sequence file will be paired with one or more instrument sets and/or sample collections. A collection can be played by double-clicking it or by highlighting it and pressing the play button or spacebar.
 
 How to compile it
 -----------------

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -57,9 +57,6 @@ bool VGMInstrSet::load() {
   if (!loadInstrs())
     return false;
 
-  if (aInstrs.empty())
-    return false;
-
   if (m_auto_add_instruments_as_children)
     addChildren(aInstrs);
 

--- a/src/main/formats/Akao/AkaoScanner.cpp
+++ b/src/main/formats/Akao/AkaoScanner.cpp
@@ -65,8 +65,8 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
 
   if (file->size() >= 0x1A8000) {
     // Hard-coded loader for Final Fantasy 7 PSF
-    const AkaoInstrDatLocation instrLocation(0xf0000, 0x166000, 0, 128);
-    const AkaoInstrDatLocation instr2Location(0x168000, 0x1a6000, 53, 75); // One-Winged Angel
+    const AkaoInstrDatLocation instrLocation(0xe0000, 0x156000, 0, 128);
+    const AkaoInstrDatLocation instr2Location(0x158000, 0x196000, 53, 75); // One-Winged Angel
 
     std::vector<AkaoInstrDatLocation> instrLocations;
 
@@ -76,9 +76,9 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
 
     // Add choir samples for One-Winged Angel.
     // It is unlikely that any other song will load this sample collection in actual gameplay.
-    if (file->readWord(instr2Location.instrAllOffset) == 0x38560 &&
-        file->readWord(instr2Location.instrDatOffset) == 0x38560)
-      instrLocations.push_back(instr2Location);
+    // if (file->readWord(instr2Location.instrAllOffset) == 0x38560 &&
+    //     file->readWord(instr2Location.instrDatOffset) == 0x38560)
+    //   instrLocations.push_back(instr2Location);
 
     if (!instrLocations.empty()) {
       for (const auto & loc : instrLocations) {


### PR DESCRIPTION
Some Akao sets have no instruments defined, but instead only use "articulation" based program changes. Those instruments are generated on the fly via AkaoColl::preSynthFileCreation and deleted afterward via AkaoColl::postSynthFileCreation.

VGMInstrSet was deleting all instruments sets that have no instruments defined post-load. Prior to the major refactor, we got around this with a flag. I have instead just removed the condition altogether.

I've also updated the hack that loads FF7 psfs, though I'm not sure how to properly integrate the second sample collection for the final boss music. Its inclusion was causing problems, so I commented it out.

Finally, I updated the README to reflect changes  in supported formats.

## Motivation and Context
Fix the rest of the Akao games.

## How Has This Been Tested?
Aside from relevant Akao games, I ran through a test suite of all supported formats. There was no apparent regression in detected files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
