### PR TITLE
minor AkaoMatcher improvements

### DIFF
--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -92,11 +92,11 @@ bool AkaoMatcher::tryCreateCollection(int id) {
 
     std::vector<AkaoSampColl *> sampCollsToCheck;
     // seq->id() represents the associated sample set id
-    if (seq->id() != -1) {
-      auto it = std::find_if(sampColls.begin(), sampColls.end(), [seq](AkaoSampColl *sc) {
+    if (seq->id() > 0) {
+      auto it = std::find_if(sampColls.rbegin(), sampColls.rend(), [seq](AkaoSampColl *sc) {
         return sc->id() == seq->id();
       });
-      if (it != sampColls.end()) {
+      if (it != sampColls.rend()) {
         sampCollsToCheck.push_back(*it);
       } else {
         // PSF files may optimize out the IDs, so be lenient
@@ -106,7 +106,8 @@ bool AkaoMatcher::tryCreateCollection(int id) {
         }
       }
     }
-    // Add the rest of the sample collections that are not already in sampCollsToCheck
+    // Add the rest of the sample collections that are not already in sampCollsToCheck.
+    // Iterate in reverse to prioritize sample collections most recently scanned.
     for (auto* sc : std::ranges::reverse_view(sampColls)) {
       if (std::find(sampCollsToCheck.begin(), sampCollsToCheck.end(), sc) == sampCollsToCheck.end()) {
         sampCollsToCheck.push_back(sc);


### PR DESCRIPTION
A couple small changes:
- prioritize most-recently scanned files when searching for associated sample collection
- ignore associated sample collection id of 0, as this is most likely an invalid, optimized-out value

## Description
This fixes some issues when loading multiple psf sets at a time

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
