### PR TITLE
Change the category of log messages causing confusion

### DIFF
--- a/src/main/components/SPCFile.cpp
+++ b/src/main/components/SPCFile.cpp
@@ -105,7 +105,7 @@ void SPCFile::loadExtendedID666Tag(const RawFile& file, size_t offset) {
             m_id666Tag.comments = file.readNullTerminatedString(currentOffset + 4, dataLength);
             break;
           default:
-            L_WARN("Unknown id6 tag id: {} in SPC", id);
+            L_INFO("Ignored id6 tag id: {} in SPC", id);
             break;
         }
         currentOffset += 4 + ((dataLength + 3) & ~3); // Align to 32-bit boundary

--- a/src/main/formats/SegSat/SegSatScanner.cpp
+++ b/src/main/formats/SegSat/SegSatScanner.cpp
@@ -78,8 +78,8 @@ void SegSatScanner::scan(RawFile *file, void *info) {
       u16 loopedTempoEventPtr = file->readShortBE(i + seqPtr + 6);
       if (loopedTempoEventPtr >= firstNonTempoTrkPtr ||
           tempoTrkPtr + (numTempoEvents * 8) != firstNonTempoTrkPtr) {
-        L_ERROR("SegSat sequence had unexpected tempo track pointer");
-        continue;
+        L_DEBUG("Unexpected tempo track pointer in prospective SegSat sequence");
+        break;
       }
 
       SegSatSeq* seq = new SegSatSeq(file, i + seqPtr, "Sega Saturn Sequence");


### PR DESCRIPTION
- change a SegSatScanner error log to debug, also break at that point instead of continuing to scan the potential sequence list
- report unhandled id6 tag type as an info log instead of warning

## Motivation and Context
Reduce user confusion - we had issues reported due to these two log messages.