### PR TITLE
AkaoPS1 pitch events

### DIFF
--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -962,7 +962,7 @@ void SeqTrack::addPitchBendAsPercent(uint32_t offset, uint32_t length, double pe
   const s16 minVal = -8192;
   const s16 maxVal = 8191;
   const s16 bendVal = static_cast<s16>(percent * 8192);
-  s16 bend = std::max(std::min(bendVal, maxVal), minVal);
+  s16 bend = std::clamp(bendVal, minVal, maxVal);
   addPitchBend(offset, length, bend, sEventName);
 }
 

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -958,6 +958,14 @@ void SeqTrack::addPitchBend(uint32_t offset, uint32_t length, int16_t bend, cons
     pMidiTrack->addPitchBend(channel, bend);
 }
 
+void SeqTrack::addPitchBendAsPercent(uint32_t offset, uint32_t length, double percent, const std::string &sEventName) {
+  const s16 minVal = -8192;
+  const s16 maxVal = 8191;
+  const s16 bendVal = static_cast<s16>(percent * 8192);
+  s16 bend = std::max(std::min(bendVal, maxVal), minVal);
+  addPitchBend(offset, length, bend, sEventName);
+}
+
 void SeqTrack::addPitchBendRange(uint32_t offset, uint32_t length, uint16_t cents, const std::string &sEventName) {
   onEvent(offset, length);
 

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -110,6 +110,7 @@ class SeqTrack : public VGMItem {
   void addMonoNoItem() const;
   void insertReverb(uint32_t offset, uint32_t length, uint8_t reverb, uint32_t absTime, const std::string &sEventName = "Reverb");
   void addPitchBend(uint32_t offset, uint32_t length, int16_t bend, const std::string &sEventName = "Pitch Bend");
+  void addPitchBendAsPercent(uint32_t offset, uint32_t length, double percent, const std::string &sEventName = "Pitch Bend");
   void addPitchBendRange(uint32_t offset, uint32_t length, uint16_t cents, const std::string &sEventName = "Pitch Bend Range");
   void addPitchBendRangeNoItem(uint16_t cents) const;
   void addFineTuning(uint32_t offset, uint32_t length, double cents, const std::string &sEventName = "Fine Tuning");

--- a/src/main/formats/Akao/AkaoSeq.cpp
+++ b/src/main/formats/Akao/AkaoSeq.cpp
@@ -1069,8 +1069,7 @@ bool AkaoTrack::readEvent() {
 
       const int div = tuning >= 0 ? 128 : 256;
       const double scale = tuning / static_cast<double>(div);
-      s16 bend = std::min(static_cast<s16>((scale / log(2.0)) * 8192), static_cast<s16>(8191));
-      addPitchBend(beginOffset, curOffset-beginOffset, bend);
+      addPitchBendAsPercent(beginOffset, curOffset-beginOffset, scale / log(2.0));
       break;
     }
 

--- a/src/main/formats/Akao/AkaoSeq.h
+++ b/src/main/formats/Akao/AkaoSeq.h
@@ -221,6 +221,7 @@ class AkaoTrack final
  protected:
   bool slur;
   bool legato;
+  bool portamento;
   bool drum;
   uint32_t pattern_return_offset;
   std::array<uint32_t, 4> loop_begin_loc;


### PR DESCRIPTION
- AkaoPS1: add proper portamento support
- AkaoPS1: reinterpret the absolute fine tuning event as pitch bend, as multiple games use it this way (Racing Lagoon, Saga Frontier 2, for ex)
- AkaoPS1: add a fix for malformed key low / high regions in split-key instruments (affects Saga Frontier 2, Racing Lagoon, maybe others)
- AkaoPS1: use drumkit instrument ADSR overrides like we added for melodic instruments
- SeqTrack:: add SeqTrack::addPitchBendAsPercent() method 

## Description
MIDI Fine Tune events don't change the pitch of active notes, but a lot of tracks use the events we've named "EVENT_TUNING_ABS" as a pitch bend affecting active notes.

We should probably also change the relative fine tuning event to be pitch bend, but I didn't find any games that use this event so I couldn't test a change. I didn't look super thoroughly, though.

Unfortunately, portamento is a little bit broken with BASS audio as it doesn't support LSB pitch bend range. I'm seeing tracks that use sub 128 millisecond pitch bend times, which therefore register as 0 seconds. I'm tempted to force a min portamento time of 128ms, but I lean toward producing accurate midi files. I confirmed these play correctly using fluidsynth in the juce3 branch.

Also note that I'm using the Portamento Control event (cc 84) to force portamento slides. CC 84 indicates that the next note played should use a portamento slide starting from the note specified in the CC 84 value. I probably should have taken this approach for the CPS portamento implementation as well. Broadly speaking, it seems a lot of MIDI implementations will only trigger portamento when notes are played legato (ie they overlap) unless CC 84 is used. In AkaoPS1, notes do not overlap, and portamento notes can have gaps of time between them. To solve this, we track the portamento state. If a new note is to be played when portamento is on, we first send a CC 84 with the value of the previous note.

Some things that remain to be implemented:
- Pitch slides
- Vibrato

## How Has This Been Tested?
Tested for regression on a bunch of AkaoPS1 games.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
