### PR TITLE
Add context menus to VGMCollView

### DIFF
--- a/src/ui/qt/workarea/MdiArea.cpp
+++ b/src/ui/qt/workarea/MdiArea.cpp
@@ -7,6 +7,7 @@
 #include "MdiArea.h"
 
 #include <QTabBar>
+#include <QApplication>
 #include <VGMFile.h>
 #include "VGMFileView.h"
 #include "Metrics.h"
@@ -100,9 +101,10 @@ void MdiArea::onVGMFileSelected(const VGMFile *file, QWidget *caller) {
   auto it = fileToWindowMap.find(file);
   if (it != fileToWindowMap.end()) {
 
-    bool callerHadFocus = caller && caller->hasFocus();
+    QWidget* focusedWidget = QApplication::focusWidget();
+    bool callerHadFocus = focusedWidget && caller && caller->isAncestorOf(focusedWidget);
     QMdiSubWindow *window = it->second;
-    window->setFocus();
+    setActiveSubWindow(window);
 
     // Reassert the focus back to the caller
     if (caller && callerHadFocus) {

--- a/src/ui/qt/workarea/VGMCollView.h
+++ b/src/ui/qt/workarea/VGMCollView.h
@@ -43,11 +43,12 @@ public:
 
 private:
   void keyPressEvent(QKeyEvent *e) override;
+  void itemMenu(const QPoint &pos);
 
 private slots:
   void removeVGMColl(const VGMColl *coll) const;
   void doubleClickedSlot(const QModelIndex&) const;
-  void handleSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
+  void handleCurrentChanged(const QModelIndex &current, const QModelIndex &previous);
   void onVGMFileSelected(const VGMFile *file, const QWidget* caller) const;
 
 private:

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -251,7 +251,11 @@ void VGMFileListView::onVGMFileSelected(VGMFile* file, const QWidget* caller) {
 
   QItemSelection selection(firstIndex, lastIndex);
   selectionModel()->select(selection, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+  // Prevent the currentChanged callback from triggering so that we don't recursively
+  // call NotificationCenter::selectVGMFile()
+  selectionModel()->blockSignals(true);
   setCurrentIndex(firstIndex);
+  selectionModel()->blockSignals(false);
 
   scrollTo(firstIndex, QAbstractItemView::EnsureVisible);
 }


### PR DESCRIPTION
- VGMCollView: support context menus for files
- VGMCollView: allow multiple file selection
- Update MDIArea to return focus to the caller of a VGM file selection notification if a descendant of the caller has focus
- VGMFileListView: prevent a recursive call to Notification::selectVGMFile() within onVGMFileSelected()

## Description
This enables context menus for files in the "Selected Collection" view, and makes its selection behavior consistent with VGMFileListView.

## Motivation and Context
Since all conversion must happen via right-click context menus at the moment, it's best we eliminate any barriers to discoverability or potential sources of confusion.

This is the last UI feature I want to get in before a release.

## How Has This Been Tested?
General attempts to break it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
