### PR TITLE
Refactor FileGroupMatcher

### DIFF
--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -15,6 +15,7 @@
 #include "VGMMiscFile.h"
 #include "Format.h"
 #include "Scanner.h"
+#include "Matcher.h"
 
 #include "FileLoader.h"
 #include "LoaderManager.h"
@@ -96,10 +97,16 @@ bool VGMRoot::setupNewRawFile(RawFile *newRawFile) {
     if (!specific_scanners.empty()) {
       for (const auto &scanner : specific_scanners) {
         scanner->scan(newRawFile);
+        if (auto matcher = scanner->format()->matcher) {
+          matcher->onFinishedScan(newRawFile);
+        }
       }
     } else {
       for (const auto &scanner : ScannerManager::get().scanners()) {
         scanner->scan(newRawFile);
+        if (auto matcher = scanner->format()->matcher) {
+          matcher->onFinishedScan(newRawFile);
+        }
       }
     }
   }

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -25,9 +25,6 @@ class LogItem;
 VGMFile* variantToVGMFile(VGMFileVariant variant);
 VGMFileVariant vgmFileToVariant(VGMFile* vgmfile);
 
-// global switch indicating if we are in CLI mode
-inline bool g_isCliMode = false;
-
 class VGMRoot {
 public:
   VGMRoot() = default;

--- a/src/main/components/Scanner.cpp
+++ b/src/main/components/Scanner.cpp
@@ -5,12 +5,8 @@
  */
 #include "Scanner.h"
 
-VGMScanner::VGMScanner(Format *format): format(format) {}
+VGMScanner::VGMScanner(Format *format): m_format(format) {}
 
 bool VGMScanner::init() {
   return true;
-}
-
-void VGMScanner::initiateScan(RawFile *file, void *offset) {
-  this->scan(file, offset);
 }

--- a/src/main/components/Scanner.h
+++ b/src/main/components/Scanner.h
@@ -14,9 +14,10 @@ class VGMScanner {
   virtual ~VGMScanner() = default;
 
   virtual bool init();
-  void initiateScan(RawFile *file, void *offset = nullptr);
   virtual void scan(RawFile *file, void *offset = nullptr) = 0;
 
+  Format* format() const { return m_format; }
+
 protected:
-  Format* format;
+  Format* m_format;
 };

--- a/src/main/formats/Akao/AkaoMatcher.h
+++ b/src/main/formats/Akao/AkaoMatcher.h
@@ -23,7 +23,7 @@ class AkaoMatcher : public Matcher {
     : Matcher(format) {}
   ~AkaoMatcher() override = default;
 
-  void onFinishedScan(RawFile* rawfile);
+  void onFinishedScan(RawFile* rawfile) override;
 
  protected:
   bool onNewSeq(VGMSeq* seq) override;

--- a/src/main/formats/Akao/AkaoScanner.cpp
+++ b/src/main/formats/Akao/AkaoScanner.cpp
@@ -88,10 +88,6 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
       }
     }
   }
-
-  if (auto akaoMatcher = dynamic_cast<AkaoMatcher*>(format->matcher)) {
-    akaoMatcher->onFinishedScan(file);
-  }
 }
 
 AkaoPs1Version AkaoScanner::determineVersionFromTag(const RawFile *file) noexcept {

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -72,7 +72,6 @@ bool CLIVGMRoot::init() {
     if (!openRawFile(infile.string())) {  // file not found
       return false;
     }
-    numVGMFiles = updateCollections(numVGMFiles);
     size_t numCollsAdded = numCollections() - numColls;
     if (numCollsAdded == 0) {
       cout << "File " << infile.string() << " is not a recognized music file" << endl;
@@ -218,18 +217,6 @@ void CLIVGMRoot::UI_log(LogItem* theLog) {
     string text = theLog->text();
     cerr << "[" << source << "]" << text << endl;
   }
-}
-
-size_t CLIVGMRoot::updateCollections(size_t startOffset) {
-  auto files = vgmFiles();
-  for (int i = startOffset; i < files.size(); ++i) {
-    auto targFile = variantToVGMFile(files[i]);
-    Format *fmt = targFile->format();
-    if (fmt && fmt->matcher) {
-      fmt->matcher->makeCollectionsForFile(targFile);
-    }
-  }
-  return vgmFiles().size();
 }
 
 string CLIVGMRoot::UI_getSaveFilePath(const string& suggestedFilename, const string& extension) {

--- a/src/ui/cli/CLIVGMRoot.h
+++ b/src/ui/cli/CLIVGMRoot.h
@@ -46,8 +46,6 @@ public:
 
   void UI_log(LogItem* theLog) override;
 
-  size_t updateCollections(size_t startOffset);
-
   std::string UI_getSaveFilePath(const std::string& suggestedFilename,
                                  const std::string& extension = "") override;
 

--- a/src/ui/cli/main_cli.cpp
+++ b/src/ui/cli/main_cli.cpp
@@ -14,10 +14,6 @@ using namespace std;
 namespace fs = std::filesystem;
 
 int main(int argc, char *argv[]) {
-
-  // set global switch
-  g_isCliMode = true;
-
   for(int i = 1; i < argc; ++i) {
     string s(argv[i]);
     if ((s == "-h") || (s == "--help")) {


### PR DESCRIPTION
This should vastly improve the reliability of FileGroupMatcher.

- add Matcher::onFinishedScan as virtual method
- Root now calls onFinishedScan after each scan()
- refactor FileGroupMatcher - it now utilizes onFinishedScan() and does not retain state between RawFile loads
- remove obviated code in CLIVGMRoot

## Description
This is an extension of the work I did on AkaoMatcher (#527 and #528), specifically around adding a Format to the Scanner class so it can invoke an `onFinishedScan()` callback on Matcher when a RawFile has finished loading. `onFinishedScan()` is now a virtual method of Matcher, and it is invoked in VGMRoot::setupNewRawFile() after scanning a file.

I've updated the logic of FileGroupMatcher so that it works in the simple way I had originally envisioned - it assumes an association between detected files in a single RawFile. It does not retain state from previous RawFile loads. It is consequently much more reliable and should be less confusing to users.

One thing I removed is the ability for FileGroupMatcher to create sequence-less collections. I think this will confuse users more than it will add value, and it violates how I think of collections as a concept.

## How Has This Been Tested?
I ran a test suite of all the supported formats and saw no regression. I also verified the CLI is working with these changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
