### PR TITLE
PS1 / PSF fixes

### DIFF
--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -22,6 +22,12 @@ class VGMSampColl;
 class VGMMiscFile;
 class LogItem;
 
+template <typename T>
+T* variantToType(VGMFileVariant variant) {
+  T* vgmFilePtr = nullptr;
+  std::visit([&vgmFilePtr](auto *vgm) { vgmFilePtr = dynamic_cast<T*>(vgm); }, variant);
+  return vgmFilePtr;
+}
 VGMFile* variantToVGMFile(VGMFileVariant variant);
 VGMFileVariant vgmFileToVariant(VGMFile* vgmfile);
 

--- a/src/main/components/VGMColl.cpp
+++ b/src/main/components/VGMColl.cpp
@@ -485,7 +485,7 @@ SynthFile *VGMColl::createSynthFile() {
         newRgn->setWaveLinkInfo(0, 0, 1, static_cast<uint32_t>(realSampNum));
 
         if (realSampNum >= finalSamps.size()) {
-          L_ERROR("Sample {} does not exist", realSampNum);
+          L_ERROR("Sample {} does not exist. Instr index: {:d}, Instr num: {:d}, Region index: {:d}", realSampNum, i, vgminstr->instrNum, j);
           realSampNum = finalSamps.size() - 1;
         }
 

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -90,16 +90,15 @@ SF2File::SF2File(SynthFile *synthfile)
     memcpy(presetHdr.achPresetName, instr->name.c_str(), std::min(instr->name.length(), static_cast<size_t>(20)));
     presetHdr.wPreset = static_cast<uint16_t>(instr->ulInstrument);
 
-    // Despite being a 16-bit value, SF2 only supports banks up to 127. Since
-    // it's pretty common to have either MSB or LSB be 0, we'll use whatever
-    // one is not zero, with preference for MSB.
+    // Despite being a 16-bit value, SF2 only supports banks up to 128. Since
+    // it's pretty common to have either MSB or LSB be 0, we'll use MSB if the
+    // value is greater than 128
     uint16_t bank16 = static_cast<uint16_t>(instr->ulBank);
 
-    if ((bank16 & 0xFF00) == 0) {
-      presetHdr.wBank = bank16 & 0x7F;
-    }
-    else {
+    if (bank16 > 128) {
       presetHdr.wBank = (bank16 >> 8) & 0x7F;
+    } else {
+      presetHdr.wBank = bank16;
     }
     presetHdr.wPresetBagNdx = static_cast<uint16_t>(i);
     presetHdr.dwLibrary = 0;

--- a/src/main/formats/HOSA/HOSAScanner.cpp
+++ b/src/main/formats/HOSA/HOSAScanner.cpp
@@ -9,6 +9,7 @@
 #include "VGMColl.h"
 #include "PSXSPU.h"
 #include "ScannerManager.h"
+#include "VGMMiscFile.h"
 
 namespace vgmtrans::scanners {
 ScannerRegistration<HOSAScanner> s_hosa("HOSA");
@@ -22,7 +23,11 @@ void HOSAScanner::scan(RawFile *file, void *info) {
     return;
   }
 
-  std::vector<PSXSampColl *> sampcolls = PSXSampColl::searchForPSXADPCMs(file, HOSAFormat::name);
+  // Scan for PSXSampColls if we haven't already
+  std::vector<PSXSampColl *> sampcolls = file->containedVGMFilesOfType<PSXSampColl>();
+  if (sampcolls.empty()) {
+    sampcolls = PSXSampColl::searchForPSXADPCMs(file, HOSAFormat::name);
+  }
 
   PSXSampColl *sampcoll = nullptr;
   HOSAInstrSet *instrset = nullptr;

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -165,7 +165,7 @@ bool PSXSampColl::parseSampleInfo() {
       sampleIndex++;
     }
   }
-  return true;
+  return unLength > 0x20;
 }
 
 

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -221,7 +221,7 @@ std::vector<PSXSampColl *> PSXSampColl::searchForPSXADPCMs(RawFile *file, const 
       for (uint32_t j = 0; j < NUM_CHUNKS_READAHEAD; j++) {
         uint32_t curChunk = firstChunk + 16 + j * 16;
         keyFlagByte = file->readByte(curChunk + 1);
-        if ((keyFlagByte & 0xFC) != 0) {
+        if ((keyFlagByte & 0xF0) != 0) {
           bBad = true;
           break;
         }

--- a/src/main/io/RawFile.h
+++ b/src/main/io/RawFile.h
@@ -14,6 +14,7 @@
 #include <variant>
 #include "mio.hpp"
 
+#include "Root.h"
 #include "util/common.h"
 #include "components/VGMTag.h"
 
@@ -105,6 +106,17 @@ class RawFile {
 
     [[nodiscard]] const auto &containedVGMFiles() const noexcept {
         return m_vgmfiles;
+    }
+
+    template <typename T>
+    [[nodiscard]] const std::vector<T*> containedVGMFilesOfType() const noexcept {
+      std::vector<T*> files = {};
+      for (const auto& vgmfile : m_vgmfiles) {
+        if (T* fileOfType = variantToType<T>(*vgmfile)) {
+          files.emplace_back(fileOfType);
+        }
+      }
+      return files;
     }
     void addContainedVGMFile(std::shared_ptr<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>);
     void removeContainedVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>);

--- a/src/main/loaders/PSFLoader.cpp
+++ b/src/main/loaders/PSFLoader.cpp
@@ -55,7 +55,7 @@ void PSFLoader::psf_read_exe(const RawFile *file, int version) {
         enqueue(newfile);
 
         /* Look for additional libraries in the same folder */
-        int i = 1;
+        int i = 2;
         for (libtag = psf.tags().find(fmt::format("_lib{}", i));
              libtag != psf.tags().end();
              libtag = psf.tags().find(fmt::format("_lib{}", ++i))) {

--- a/src/main/loaders/PSFLoader.cpp
+++ b/src/main/loaders/PSFLoader.cpp
@@ -31,6 +31,8 @@ const std::unordered_map<int, size_t> data_offset = {{PSF1_VERSION, 0x800},
                                                      {NCSF_VERSION, 0x0}};
 
 void PSFLoader::apply(const RawFile *file) {
+  if (file->size() <= 16)
+    return;
   if (std::equal(file->begin(), file->begin() + 3, "PSF")) {
     uint8_t version = file->get<u8>(3);
     if (data_offset.contains(version)) {

--- a/src/main/loaders/RSNLoader.cpp
+++ b/src/main/loaders/RSNLoader.cpp
@@ -19,6 +19,9 @@ LoaderRegistration<RSNLoader> _rsn("RSN");
 
 void RSNLoader::apply(const RawFile *file) {
 
+  if (file->size() < FILE_SIGNATURE_SIZE)
+    return;
+
   // Read header
   uint8_t rarHeader[FILE_SIGNATURE_SIZE];
   file->readBytes(0, FILE_SIGNATURE_SIZE, rarHeader);

--- a/src/main/loaders/SPC2Loader.cpp
+++ b/src/main/loaders/SPC2Loader.cpp
@@ -28,7 +28,7 @@ void SPC2Loader::apply(const RawFile *file) {
   const size_t SPC_FILENAME_SIZE = 28;
 
   // File size sanity check. Max ram block size is 16MB, and we'll add a generous 1MB for everything else.
-  if (file->size() > (65536*256) + (1024*1024)) {
+  if (file->size() > (65536*256) + (1024*1024) || file->size() < HEADER_SIZE) {
     return;
   }
 


### PR DESCRIPTION
This is a collection of fixes for improving detection of PS1 / PSF formats:

- additional psflib file tags start at _lib2 per the spec. we were search for _lib1 and stopping when we couldn't find it
- add file size checks to various Loader classes. Was throwing errors for some PSF collections where the psf files themselves contains no content, but loads multiple psflib files.
- loosened a PSXSampColl detection heuristic that was causing a false negative on Philosoma
- clamp the VAB region pitch tune value to 127. This fixes MegaMan 8, which uses values > 0x7F but apparently expects them to be clamped. Also consistent with gocha's comment.
- reject PSXSampColls size 32 bytes or less. This was allowing more false positives through.
- add Root::variantToType<>() and RawFile::containedVGMFilesOfType<>() so that specific VGMFile types can be retrieved without the hassle of std::variant ugliness 
- HOSAScanner: prevent duplicate PSXSampColl detection

HOSAScanner is making a redundant call to PSXSampColl::searchForPSXADPCMs() between it and the PS1 Scanner. We may want to come up with a solution that ensures it is only called once per RawFile. What I've implemented only ensures it isn't redundantly called if a PSXSampColl was found.

At some point, we should probably revisit the PSXSampColl heuristic logic. That is some of the earliest and ugliest code I wrote, and it doesn't work well. We still get too many false-positive VGMSampColls.

## How Has This Been Tested?
Tried a number of PS1 format PSF files to ensure we're not seeing more false-negative VGMSampColl as a result of the heuristic change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
