### PR TITLE
Format fixes / PSX ADPCM detection rewrite

### DIFF
--- a/src/main/components/Matcher.cpp
+++ b/src/main/components/Matcher.cpp
@@ -45,14 +45,6 @@ FilegroupMatcher::FilegroupMatcher(Format *format) : Matcher(format) {}
 
 
 void FilegroupMatcher::onFinishedScan(RawFile* rawfile) {
-
-  if (seqs.empty() || instrsets.empty()) {
-    seqs.clear();
-    instrsets.clear();
-    sampcolls.clear();
-    return;
-  }
-
   // xsflib files are loaded recursively with xsf files. We want to scan the xsflib and the xsf
   // files together as if they're one file, so ignore this callback and wait for the xsf to finish.
   if (std::regex_match(rawfile->extension(), std::regex(R"(\w*sf\w?lib$)")))
@@ -106,6 +98,23 @@ bool FilegroupMatcher::onCloseSampColl(VGMSampColl *sampcoll) {
 
 void FilegroupMatcher::lookForMatch() {
   while (!seqs.empty() && !instrsets.empty()) {
+    // If there's only 1 of any collection type left, match to largest size.
+    if (seqs.size() == 1 && sampcolls.size() > 1) {
+      sampcolls.sort([](const VGMSampColl* a, const VGMSampColl* b) {
+        return a->size() > b->size();
+      });
+    }
+    else if (seqs.size() == 1 && instrsets.size() > 1) {
+      instrsets.sort([](const VGMInstrSet* a, const VGMInstrSet* b) {
+        return a->size() > b->size();
+      });
+    }
+    else if (instrsets.size() == 1 && seqs.size() > 1) {
+      seqs.sort([](const VGMSeq* a, const VGMSeq* b) {
+        return a->size() > b->size();
+      });
+    }
+
     VGMSeq* seq = seqs.front();
     seqs.pop_front();
     VGMInstrSet* instrset = instrsets.front();

--- a/src/main/components/Matcher.cpp
+++ b/src/main/components/Matcher.cpp
@@ -45,6 +45,14 @@ FilegroupMatcher::FilegroupMatcher(Format *format) : Matcher(format) {}
 
 
 void FilegroupMatcher::onFinishedScan(RawFile* rawfile) {
+
+  if (seqs.empty() || instrsets.empty()) {
+    seqs.clear();
+    instrsets.clear();
+    sampcolls.clear();
+    return;
+  }
+
   // xsflib files are loaded recursively with xsf files. We want to scan the xsflib and the xsf
   // files together as if they're one file, so ignore this callback and wait for the xsf to finish.
   if (std::regex_match(rawfile->extension(), std::regex(R"(\w*sf\w?lib$)")))

--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -23,7 +23,7 @@ void AkaoMatcher::onFinishedScan(RawFile* rawfile) {
 
   // We assume psf files contain all of the files necessary to form a collection. Therefore, we
   // treat each one as a one-off and remove all of its detected files from future match consideration.
-  if (rawfile->extension() == "psf") {
+  if (rawfile->extension() == "psf" || rawfile->extension() == "minipsf") {
     auto eraseByRawFile = [rawfile](auto& map) {
       std::erase_if(map, [rawfile](const auto& pair) {
           return pair.second->rawFile() == rawfile;
@@ -120,7 +120,7 @@ bool AkaoMatcher::tryCreateCollection(int id) {
         AkaoRgn* akaoRegion = static_cast<AkaoRgn*>(region);
         // We will exclude articulation id 0, as it often indicates an unused artic
         // Also ignoring values > 0x60 is a hack that allows compatability with many psfs.
-        if (akaoRegion->artNum != 0 && akaoRegion->artNum <= 0x60)
+        if (akaoRegion->artNum != 0)// && akaoRegion->artNum <= 0x60)
           requiredArtIds.emplace_back(akaoRegion->artNum);
       }
     }
@@ -154,36 +154,30 @@ bool AkaoMatcher::tryCreateCollection(int id) {
     }
 
     if (matchingSampColls.size() > 0) {
-      if (std::all_of(requiredArtIds.begin(), requiredArtIds.end(), [&matchingSampColls](int artId) {
-            return std::any_of(matchingSampColls.begin(), matchingSampColls.end(), [artId](AkaoSampColl *sc) {
-              return artId >= sc->starting_art_id && artId < (sc->starting_art_id + sc->nNumArts);
-            });
-          })) {
-        auto coll = fmt->newCollection();
-        if (!coll) return false;
+      auto coll = fmt->newCollection();
+      if (!coll) return false;
 
-        coll->setName(seq->name());
-        coll->useSeq(seq);
-        coll->addInstrSet(instrSet);
+      coll->setName(seq->name());
+      coll->useSeq(seq);
+      coll->addInstrSet(instrSet);
 
-        // Sort the vector by starting_art_id in ascending order
-        std::sort(matchingSampColls.begin(), matchingSampColls.end(),
-        [](AkaoSampColl* a, AkaoSampColl* b) {
-            return a->starting_art_id < b->starting_art_id;
-        });
-        for (auto *sc : matchingSampColls) {
-          coll->addSampColl(sc);
-        }
-
-        seqs.erase(seq->seq_id);
-
-        if (!coll->load()) {
-          delete coll;
-          return false;
-        }
-
-        return true;
+      // Sort the vector by starting_art_id in ascending order
+      std::sort(matchingSampColls.begin(), matchingSampColls.end(),
+      [](AkaoSampColl* a, AkaoSampColl* b) {
+          return a->starting_art_id < b->starting_art_id;
+      });
+      for (auto *sc : matchingSampColls) {
+        coll->addSampColl(sc);
       }
+
+      seqs.erase(seq->seq_id);
+
+      if (!coll->load()) {
+        delete coll;
+        return false;
+      }
+
+      return true;
     }
   }
   return false;

--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -118,9 +118,8 @@ bool AkaoMatcher::tryCreateCollection(int id) {
     for (const auto &instr : instrSet->aInstrs) {
       for (const auto &region : instr->regions()) {
         AkaoRgn* akaoRegion = static_cast<AkaoRgn*>(region);
-        // We will exclude articulation id 0, as it often indicates an unused artic
-        // Also ignoring values > 0x60 is a hack that allows compatability with many psfs.
-        if (akaoRegion->artNum != 0)// && akaoRegion->artNum <= 0x60)
+        // We will exclude articulation id 0, as it often just indicates an unused region
+        if (akaoRegion->artNum != 0)
           requiredArtIds.emplace_back(akaoRegion->artNum);
       }
     }

--- a/src/main/formats/Akao/AkaoSeq.cpp
+++ b/src/main/formats/Akao/AkaoSeq.cpp
@@ -20,6 +20,7 @@ static constexpr uint8_t NOTE_VELOCITY = 127;
 AkaoSeq::AkaoSeq(RawFile *file, uint32_t offset, AkaoPs1Version version, std::string name)
     : VGMSeq(AkaoFormat::name, file, offset, 0, std::move(name)), seq_id(0), version_(version),
       instrument_set_offset_(0), drum_set_offset_(0), condition(0) {
+  setAlwaysWriteInitialVol(127);
   setAlwaysWriteInitialPitchBendRange(12 * 100);
   setUseLinearAmplitudeScale(true);        //I think this applies, but not certain, see FF9 320, track 3 for example of problem
   //UseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kAdjustVolumeController); // disabled, it only changes the volume and the pan slightly, and also its output becomes undefined if pan and volume slides are used at the same time

--- a/src/main/formats/CPS/CPSTrackV1.cpp
+++ b/src/main/formats/CPS/CPSTrackV1.cpp
@@ -213,7 +213,6 @@ bool CPSTrackV1::readEvent() {
           }
           case YM2151:
             curOffset++;
-            vol = 0;
             this->addVol(beginOffset, curOffset - beginOffset, vol);
             break;
         }

--- a/src/main/formats/SquarePS2/WD.cpp
+++ b/src/main/formats/SquarePS2/WD.cpp
@@ -39,7 +39,7 @@ static constexpr int finetune_table[] = {
 
 static constexpr double finetune_coeff = 0.025766555011594949755217727389848;
 
-static constexpr float defaultWDReverbPercent = 0.75;
+static constexpr float defaultWDReverbPercent = 0.5;
 
 // **********
 // WDInstrSet
@@ -121,7 +121,7 @@ bool WDInstr::loadInstr() {
     rgn->addChild(k * 0x20 + 0x12 + dwOffset, 1, "Finetune");
     rgn->addChild(k * 0x20 + 0x13 + dwOffset, 1, "UnityKey");
     rgn->addChild(k * 0x20 + 0x14 + dwOffset, 1, "Key High");
-    rgn->addChild(k * 0x20 + 0x15 + dwOffset, 1, "Velocity High");
+    rgn->addChild(k * 0x20 + 0x15 + dwOffset, 1, "Unknown");
     rgn->addChild(k * 0x20 + 0x16 + dwOffset, 1, "Attenuation");
     rgn->addChild(k * 0x20 + 0x17 + dwOffset, 1, "Pan");
 
@@ -136,7 +136,6 @@ bool WDInstr::loadInstr() {
     rgn->fineTune = readByte(k * 0x20 + 0x12 + dwOffset);
     rgn->unityKey = 0x3A - readByte(k * 0x20 + 0x13 + dwOffset);
     rgn->keyHigh = readByte(k * 0x20 + 0x14 + dwOffset);
-    rgn->velHigh = convert7bitPercentVolValToStdMidiVal(readByte(k * 0x20 + 0x15 + dwOffset));
 
     uint8_t vol = readByte(k * 0x20 + 0x16 + dwOffset);
     rgn->setVolume(vol / 127.0);

--- a/src/main/formats/SquarePS2/WD.cpp
+++ b/src/main/formats/SquarePS2/WD.cpp
@@ -161,8 +161,6 @@ bool WDInstr::loadInstr() {
   }
 
   // First, do key and velocity ranges
-  uint8_t prevKeyHigh = 0;
-  uint8_t prevVelHigh = 0;
   for (size_t k = 0; k < regions().size(); k++) {
     auto region = dynamic_cast<WDRgn*>(regions()[k]);
     auto prevRegion = k > 0 ? regions()[k-1] : nullptr;
@@ -181,25 +179,6 @@ bool WDInstr::loadInstr() {
 
     if (region->bLastRegion)
       region->keyHigh = 0x7F;
-
-    // Velocity ranges
-    if (region->velHigh == prevVelHigh && prevRegion)
-      region->velLow = prevRegion->velLow;
-    else
-      region->velLow = prevVelHigh + 1;
-    prevVelHigh = region->velHigh;
-
-    if (k == 0) //if it's the first region of the instrument
-      region->velLow = 0;
-    else if (region->velHigh == prevRegion->velHigh) {
-      region->velLow = prevRegion->velLow;
-      region->velHigh = 0x7F;     // FFX 0022, aka sight of spira, was giving me problems, hence this
-      prevRegion->velHigh = 0x7F; // hDLSFile.aInstrs.back()->aRgns.back()->usVelHigh = 0x7F;
-    }
-    else if (prevRegion->velHigh == 0x7F)
-     region->velLow = 0;
-    else
-      region->velLow = prevRegion->velHigh + 1;
   }
   return true;
 }

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -208,8 +208,6 @@ std::vector<PSXSampColl *> PSXSampColl::searchForPSXADPCMs(RawFile *file, const 
 
       if (filterRangeByte == 0 && keyFlagByte == 0)
         continue;
-      //if ((keyFlagByte & 0x04) == 0)
-      //	continue;
       if ((keyFlagByte & 0xF8) != 0)
         continue;
 

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -169,11 +169,11 @@ bool PSXSampColl::parseSampleInfo() {
 }
 
 
-#define NUM_CHUNKS_READAHEAD 10
-#define MAX_ALLOWED_RANGE_DIFF 10
-#define MAX_ALLOWED_FILTER_DIFF 5
-#define MIN_ALLOWED_RANGE_DIFF 0
-#define MIN_ALLOWED_FILTER_DIFF 0
+constexpr u32 NUM_CHUNKS_READAHEAD = 10;
+constexpr int MAX_FILTER_DIFF_SUM = NUM_CHUNKS_READAHEAD * 2.5;
+constexpr int MAX_RANGE_FILTER_DIFF_SUM = NUM_CHUNKS_READAHEAD * 2.5;
+constexpr int MIN_UNIQUE_BYTES = NUM_CHUNKS_READAHEAD * 4.5;
+constexpr int MAX_BYTE_REPETITION = NUM_CHUNKS_READAHEAD * 5.5;
 
 // GENERIC FUNCTION USED FOR SCANNERS
 PSXSampColl *PSXSampColl::searchForPSXADPCM(RawFile *file, const string &format) {
@@ -198,63 +198,129 @@ PSXSampColl *PSXSampColl::searchForPSXADPCM(RawFile *file, const string &format)
 std::vector<PSXSampColl *> PSXSampColl::searchForPSXADPCMs(RawFile *file, const string &format) {
   std::vector<PSXSampColl *> sampColls;
   size_t nFileLength = file->size();
-  for (uint32_t i = 0; i + 16 + NUM_CHUNKS_READAHEAD * 16 < nFileLength; i++) {
-    // if we have 16 0s in a row.
-    if (file->readWord(i) == 0 && file->readWord(i + 4) == 0 && file->readWord(i + 8) == 0 && file->readWord(i + 12) == 0) {
-      bool bBad = false;
-      uint32_t firstChunk = i + 16;
-      uint8_t filterRangeByte = file->readByte(firstChunk);
-      uint8_t keyFlagByte = file->readByte(firstChunk + 1);
 
-      if (filterRangeByte == 0 && keyFlagByte == 0)
-        continue;
-      if ((keyFlagByte & 0xF8) != 0)
-        continue;
+  for (u32 i = 0; i + 16 + NUM_CHUNKS_READAHEAD * 16 < nFileLength; i++) {
+    // Search for 16 consecutive null bytes.
+    u8 chunk[16];
+    file->readBytes(i, 16, &chunk);
 
-      uint8_t maxRangeChange = 0;
-      uint8_t maxFilterChange = 0;
-      int prevRange = file->readByte(firstChunk + 16)
-          & 0xF;                    //+16 because we're skipping the first chunk for uncertain reasons
-      int prevFilter = (file->readByte(firstChunk + 16) & 0xF0) >> 4;
-      for (uint32_t j = 0; j < NUM_CHUNKS_READAHEAD; j++) {
-        uint32_t curChunk = firstChunk + 16 + j * 16;
-        keyFlagByte = file->readByte(curChunk + 1);
-        if ((keyFlagByte & 0xF0) != 0) {
-          bBad = true;
-          break;
-        }
-        if ((file->readWord(curChunk) == 0
-            && ((file->readWord(curChunk + 4) == 0) || file->readWord(curChunk + 8) == 0))) {
-          bBad = true;
-          break;
-        }
-
-        //do range and filter value comparison
-        const int range = file->readByte(firstChunk + 16 + j * 16) & 0xF;
-        int diff = abs(range - prevRange);
-        if (diff > maxRangeChange)
-          maxRangeChange = diff;
-        prevRange = range;
-        const int filter = (file->readByte(firstChunk + 16 + j * 16) & 0xF0) >> 4;
-        diff = abs(filter - prevFilter);
-        if (diff > maxFilterChange)
-          maxFilterChange = diff;
-        prevFilter = filter;
+    const u64* block64 = reinterpret_cast<const u64*>(chunk);
+    if (block64[0] != 0 || block64[1] != 0) {
+      // Find the last non-zero byte (if any)
+      int nonZeroIndex = 15;
+      while (nonZeroIndex > 0 && chunk[nonZeroIndex] == 0) {
+        --nonZeroIndex;
       }
-      if ((maxRangeChange > MAX_ALLOWED_RANGE_DIFF || maxFilterChange > MAX_ALLOWED_FILTER_DIFF) ||
-          (maxRangeChange < MIN_ALLOWED_RANGE_DIFF || maxFilterChange < MIN_ALLOWED_FILTER_DIFF))
-        continue;
-      else if (bBad)
-        continue;
-
-      PSXSampColl *newSampColl = new PSXSampColl(PS1Format::name, file, i);
-      if (!newSampColl->loadVGMFile()) {
-        delete newSampColl;
-        continue;
-      }
-      sampColls.push_back(newSampColl);
-      i += newSampColl->unLength - 1;
+      i += nonZeroIndex;
+      continue;
     }
+
+
+    // We found 16 consecutive null bytes. Do further testing for a positive match.
+    bool isValid = true;
+    u32 firstChunkOffset = i + 16;
+
+    // Expect first byte of first chunk to be non-zero
+    if (file->readByte(firstChunkOffset + 0) == 0)
+      continue;
+
+    // Inspect Flag Bytes
+    for (u32 j = 0; j < NUM_CHUNKS_READAHEAD; ++j) {
+      u32 flagByteOffset = firstChunkOffset + (j * 16) + 1;
+      u8 flagByte = file->readByte(flagByteOffset);
+      if (flagByte != 0x00 && flagByte != 0x02 && !(j <= 1 && flagByte == 0x04)) {
+        isValid = false;
+        break;
+      }
+    }
+    if (!isValid) {
+      continue;
+    }
+
+    int byteCount[256] = {};
+    int uniqueBytes = 0;
+    int sumFilterIndexDiff = 0;
+    int sumRangeFilterDiff = 0;
+
+    // Process each chunk.
+    for (u32 j = 0; j < NUM_CHUNKS_READAHEAD; ++j) {
+      u32 curChunkOffset = firstChunkOffset + j * 16;
+
+      file->readBytes(curChunkOffset, 16, &chunk);
+
+      // Check for 16 null bytes. While this is valid (and indicates the beginning of a new sample)
+      // it is extremely unlikely that the first sample is so short, and this will weed out many
+      // false positives
+      const u64* block64 = reinterpret_cast<const u64*>(chunk);
+      if (block64[0] == 0 && block64[1] == 0) {
+        isValid = false;
+        break;
+      }
+
+      // For the sample region, add to the byte count table and unique byte counter
+      for (int k = 2; k < 16; ++k) {
+        byteCount[chunk[k]] += 1;
+        if (byteCount[chunk[k]] == 1) {
+          uniqueBytes += 1;
+        }
+      }
+
+      // It is extremely improbable that the first chunk will have null filter/range and flag bytes
+      // and also contain at least ten null bytes amongst the samples. This Weeds out another common
+      // false positive pattern.
+      if (j == 0 && chunk[0] == 0 && chunk[1] == 0 && byteCount[0] >= 10) {
+        isValid = false;
+        break;
+      }
+
+      // Read the filter and range nibbles from the first byte.
+      u8 firstByte = chunk[0];
+      int filterIndex = (firstByte & 0xF0) >> 4;
+      int rangeFilter = firstByte & 0x0F;
+
+      // Sum the marginal difference of each filter index nibble and range filter nibble between
+      // each chunk and its predecessor. These typically remain close in value. We skip the first
+      // chunk as there's no previous chunk to compare it against.
+      if (j > 0) {
+        u8 prevFirstByte = file->readByte(firstChunkOffset + (j - 1) * 16);
+        int prevFilterIndex = (prevFirstByte & 0xF0) >> 4;
+        int prevRangeFilter = prevFirstByte & 0x0F;
+
+        // Calculate the absolute differences.
+        sumFilterIndexDiff += abs(filterIndex - prevFilterIndex);
+        sumRangeFilterDiff += abs(rangeFilter - prevRangeFilter);
+      }
+    }
+
+    // Validate the cumulative differences against the thresholds
+    if (!isValid || sumFilterIndexDiff > MAX_FILTER_DIFF_SUM || sumRangeFilterDiff > MAX_RANGE_FILTER_DIFF_SUM) {
+      continue;
+    }
+
+    // Expect a wide range of unique byte values among sample bytes
+    if (uniqueBytes < MIN_UNIQUE_BYTES) {
+      continue;
+    }
+
+    // Expect that there won't be excessive repetition of specific byte values among sample bytes
+    for (int k = 0; k < 256; ++k) {
+      if (byteCount[k] > MAX_BYTE_REPETITION) {
+        isValid = false;
+        break;
+      }
+    }
+    if (!isValid) {
+      continue;
+    }
+
+    // Create and load the sample collection if the match passes all checks.
+    PSXSampColl *newSampColl = new PSXSampColl(PS1Format::name, file, i);
+    if (!newSampColl->loadVGMFile()) {
+      delete newSampColl;
+      continue;
+    }
+    sampColls.push_back(newSampColl);
+    i += newSampColl->unLength - 1;
   }
   return sampColls;
 }
@@ -279,7 +345,7 @@ PSXSamp::~PSXSamp() {
 }
 
 double PSXSamp::compressionRatio() {
-  return ((28.0 / 16.0) * 2); //aka 3.5;
+  return ((28.0 / 16.0) * 2);
 }
 
 void PSXSamp::convertToStdWave(uint8_t *buf) {
@@ -322,8 +388,8 @@ void PSXSamp::convertToStdWave(uint8_t *buf) {
 
     rawFile()->readBytes(dwOffset + k + 2, 14, theBlock.brr);
 
-    //each decompressed pcm block is 52 bytes   EDIT: (wait, isn't it 56 bytes? or is it 28?)
-    decompVAGBlk(uncompBuf + ((k * 28) / 16),
+    //each decompressed pcm block is 56 bytes (28 samples, 16-bit each)
+    decompVAGBlk(uncompBuf + ((k / 16) * 28),
                  &theBlock,
                  &prev1,
                  &prev2);


### PR DESCRIPTION
- Rewrite PSX (and PS2) ADPCM sample collection detection
- CPS1: remove debug line that set FM track volumes to 0
- AkaoPS1: add a default volume, set it to max
- SquarePS2: remove totally wrong velocity region stuff
- AkaoMatcher: no longer require that every articulation id be accounted for to create a collection
- FilegroupMatcher: prioritize for size when matching the last of any collection type. Helps match PSFs that contain dummy files.

## How Has This Been Tested?
PSX ADPCM detection: tested extensively against PSF sets and CD images.
AkaoMatcher: tested against most AKAO sets.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
