### PR TITLE
Add samples to instrument sets with internal sample collection, fix TamSoftPS1 issue #547

### DIFF
--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -115,6 +115,11 @@ VGMHeader* VGMItem::addHeader(uint32_t offset, uint32_t length, const std::strin
   return header;
 }
 
+void VGMItem::transferChildren(VGMItem* destination) {
+  destination->addChildren(m_children);
+  m_children.clear();
+}
+
 void VGMItem::sortChildrenByOffset() {
   std::ranges::sort(m_children, [](const VGMItem *a, const VGMItem *b) {
     return a->dwOffset < b->dwOffset;

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -105,6 +105,7 @@ public:
   VGMItem* addChild(uint32_t offset, uint32_t length, const std::string &name);
   VGMItem* addUnknownChild(uint32_t offset, uint32_t length);
   VGMHeader* addHeader(uint32_t offset, uint32_t length, const std::string &name = "Header");
+  void transferChildren(VGMItem* destination);
 
   template <std::ranges::input_range Range>
   requires std::convertible_to<std::ranges::range_value_t<Range>, VGMItem*>
@@ -123,7 +124,6 @@ protected:
   [[nodiscard]] uint32_t getWordBE(uint32_t offset) const;
   bool isValidOffset(uint32_t offset) const;
   // FIXME: clearChildren() is a workaround for VGMSeqNoTrks' multiple inheritance diamond problem
-  void clearChildren() { m_children.clear(); }
 
 public:
   uint32_t dwOffset;  // offset in the pDoc data buffer

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -7,6 +7,7 @@
 #include "VGMInstrSet.h"
 #include <spdlog/fmt/fmt.h>
 #include "VGMSampColl.h"
+#include "VGMSamp.h"
 #include "VGMRgn.h"
 #include "VGMColl.h"
 #include "Root.h"
@@ -67,6 +68,8 @@ bool VGMInstrSet::load() {
   if (sampColl != nullptr) {
     if (!sampColl->load()) {
       L_WARN("Failed to load VGMSampColl");
+    } else {
+      sampColl->transferChildren(this);
     }
   }
 

--- a/src/main/components/seq/VGMSeqNoTrks.cpp
+++ b/src/main/components/seq/VGMSeqNoTrks.cpp
@@ -38,8 +38,7 @@ bool VGMSeqNoTrks::loadMain() {
   // SeqTrack have their own m_children fields. VGMSeq is the one we care about. We need to transfer
   // SeqTrack::m_children into VGMSeq::m_children and then clear it from SeqTrack so that their
   // destructors don't doubly delete the children.
-  VGMSeq::addChildren(SeqTrack::children());
-  SeqTrack::clearChildren();
+  SeqTrack::transferChildren(static_cast<VGMSeq*>(this));
 
   if (length() == 0) {
     VGMSeq::setGuessedLength();

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
@@ -46,12 +46,7 @@ bool TamSoftPS1InstrSet::parseInstrPointers() {
     return false;
   }
 
-  PSXSampColl *newSampColl = new PSXSampColl(TamSoftPS1Format::name, this, dwOffset + 0x800, unLength - 0x800, vagLocations);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
-    return false;
-  }
-
+  sampColl = new PSXSampColl(TamSoftPS1Format::name, this, dwOffset + 0x800, unLength - 0x800, vagLocations);
   return true;
 }
 


### PR DESCRIPTION
* add VGMItem::transferChildren()
* VGMInstrSet: transfer child items of internal sample collections to the instrument set so they appear in the file structure view
* TamSoftPS1: fix the instrument set prematurely loading the internal sample collection and not assigning it to the sampColl property instead.

## Motivation and Context
In conjunction with PR #548, this will fix #547 . 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
