### PR TITLE
Update ManualCollectionDialog to use Format::newCollection() and VGMColl::load()

### DIFF
--- a/src/main/formats/FFT/FFTSeq.cpp
+++ b/src/main/formats/FFT/FFTSeq.cpp
@@ -42,7 +42,7 @@ bool FFTSeq::parseHeader(void) {
   int titleLength = ptPercussionTbl - ptSongTitle;
   char *songtitle = new char[titleLength];
   readBytes(dwOffset + ptSongTitle, titleLength, songtitle);
-  setName(std::string(songtitle, songtitle + titleLength));
+  setName(std::string(songtitle, songtitle + titleLength - 1));
   delete[] songtitle;
 
   VGMHeader *hdr = addHeader(dwOffset, 0x22);

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -183,6 +183,6 @@ void ManualCollectionDialog::createCollection() {
                           "No sample collections were selected\nThe instrument bank will be silent...");
   }
 
-  qtVGMRoot.addVGMColl(coll);
+  coll->load();
   close();
 }

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "QtVGMRoot.h"
+#include "Format.h"
 
 #include <VGMSeq.h>
 #include <VGMColl.h>
@@ -135,8 +136,6 @@ QListWidget *ManualCollectionDialog::makeSampleCollectionList() {
 }
 
 void ManualCollectionDialog::createCollection() {
-  auto coll = new VGMColl(m_name_field->text().toStdString());
-
   VGMSeq *chosen_seq = nullptr;
   for (int i = 0; i < m_seq_list->count(); i++) {
     auto item = m_seq_list->item(i);
@@ -151,6 +150,10 @@ void ManualCollectionDialog::createCollection() {
     QMessageBox::critical(this, "Error creating collection", "A music sequence must be selected");
     return;
   }
+
+  // Get the VGMColl class for the format of the chosen sequence
+  auto coll = chosen_seq->format()->newCollection();
+  coll->setName(m_name_field->text().toStdString());
   coll->useSeq(chosen_seq);
 
   for (int i = 0; i < m_instr_list->count(); i++) {


### PR DESCRIPTION
* ManualCollectionDialog now uses the newCollection() factory method of the selected sequence's format to construct its collection
* ManualCollectionDialog now calls VGMColl:load() instead of just Root::addVGMColl()
* Fix reading of null byte in FFT sequence filename strings

This allows the ManualCollectionDialog to work with formats that use custom VGMColl classes to load their collections. For now, this is only applicable to AkaoPS1.

## How Has This Been Tested?
Tested manual collection loading on a few different formats. One interesting complication is that multi sample collection Akao collections are sensitive to the order of the sample collections in the sampColls vector. It would be ideal for the UI to allow reordering of VGMFiles within the collection file vectors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
