### PR TITLE
Reorganize Matcher classes

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -57,6 +57,7 @@ target_include_directories(vgmtranscore PUBLIC
         .
         ./components
         ./components/instr
+        ./components/matcher
         ./components/seq
         ./conversion
         ./formats

--- a/src/main/components/matcher/FilegroupMatcher.cpp
+++ b/src/main/components/matcher/FilegroupMatcher.cpp
@@ -1,45 +1,16 @@
 /*
- * VGMTrans (c) 2002-2014
+ * VGMTrans (c) 2002-2024
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
- */
+*/
 
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
+#include "Format.h"
+#include "VGMSeq.h"
+#include "VGMInstrSet.h"
+#include "VGMSampColl.h"
+#include "VGMColl.h"
 #include <regex>
-
-using namespace std;
-
-Matcher::Matcher(Format *format) {
-  fmt = format;
-}
-
-bool Matcher::onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file) {
-  if(auto seq = std::get_if<VGMSeq *>(&file)) {
-    onNewSeq(*seq);
-  } else if(auto instr = std::get_if<VGMInstrSet *>(&file)) {
-    onNewInstrSet(*instr);
-  } else if(auto sampcoll = std::get_if<VGMSampColl *>(&file)) {
-    onNewSampColl(*sampcoll);
-}
-
-  return false;
-}
-
-bool Matcher::onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file) {
-  if(auto seq = std::get_if<VGMSeq *>(&file)) {
-    onCloseSeq(*seq);
-  } else if(auto instr = std::get_if<VGMInstrSet *>(&file)) {
-    onCloseInstrSet(*instr);
-  } else if(auto sampcoll = std::get_if<VGMSampColl *>(&file)) {
-    onCloseSampColl(*sampcoll);
-  }
-  return false;
-}
-
-// ****************
-// FilegroupMatcher
-// ****************
 
 FilegroupMatcher::FilegroupMatcher(Format *format) : Matcher(format) {}
 

--- a/src/main/components/matcher/FilegroupMatcher.h
+++ b/src/main/components/matcher/FilegroupMatcher.h
@@ -1,0 +1,49 @@
+/*
+ * VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+*/
+
+#pragma once
+
+#include "Matcher.h"
+#include <list>
+
+class VGMSeq;
+class VGMInstrSet;
+class VGMSampColl;
+
+// ****************
+// FilegroupMatcher
+// ****************
+
+// FilegroupMatcher handles formats where the only method of associating sequences, instrument sets,
+// and sample collections is that they are loaded together within the same RawFile. When loading is
+// complete, FilegroupMatcher processes the VGMFiles in the order they were added and groups them
+// into collections: thus, it assumes association by order. FilegroupMatcher does not retain
+// state between loads, so it will never create a collection that spans multiple RawFiles, with the
+// exception that FilegroupMatcher processes a psf file and all of its psflib dependencies together
+// as a single load.
+
+class FilegroupMatcher : public Matcher {
+public:
+  explicit FilegroupMatcher(Format *format);
+
+  void onFinishedScan(RawFile *rawfile) override;
+
+protected:
+  bool onNewSeq(VGMSeq *seq) override;
+  bool onNewInstrSet(VGMInstrSet *instrset) override;
+  bool onNewSampColl(VGMSampColl *sampcoll) override;
+
+  bool onCloseSeq(VGMSeq *seq) override;
+  bool onCloseInstrSet(VGMInstrSet *instrset) override;
+  bool onCloseSampColl(VGMSampColl *sampcoll) override;
+
+  virtual void lookForMatch();
+
+protected:
+  std::list<VGMSeq *> seqs;
+  std::list<VGMInstrSet *> instrsets;
+  std::list<VGMSampColl *> sampcolls;
+};

--- a/src/main/components/matcher/FilenameMatcher.h
+++ b/src/main/components/matcher/FilenameMatcher.h
@@ -1,0 +1,33 @@
+/*
+ * VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+*/
+
+#pragma once
+
+#include "SimpleMatcher.h"
+
+class FilenameMatcher : public SimpleMatcher<std::string> {
+public:
+  explicit FilenameMatcher(Format *format, bool bRequiresSampColl = false)
+      : SimpleMatcher(format, bRequiresSampColl) {}
+
+  bool seqId(VGMSeq *seq, std::string &id) override {
+    RawFile *rawfile = seq->rawFile();
+    id = rawfile->path().string();
+    return !id.empty();
+  }
+
+  bool instrSetId(VGMInstrSet *instrset, std::string &id) override {
+    RawFile *rawfile = instrset->rawFile();
+    id = rawfile->path().string();
+    return !id.empty();
+  }
+
+  bool sampCollId(VGMSampColl *sampcoll, std::string &id) override {
+    RawFile *rawfile = sampcoll->rawFile();
+    id = rawfile->path().string();
+    return !id.empty();
+  }
+};

--- a/src/main/components/matcher/GetIdMatcher.h
+++ b/src/main/components/matcher/GetIdMatcher.h
@@ -1,0 +1,30 @@
+/*
+ * VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+*/
+
+#pragma once
+
+#include "SimpleMatcher.h"
+
+class GetIdMatcher : public SimpleMatcher<uint32_t> {
+public:
+  explicit GetIdMatcher(Format *format, bool bRequiresSampColl = false)
+      : SimpleMatcher(format, bRequiresSampColl) {}
+
+  bool seqId(VGMSeq *seq, uint32_t &id) override {
+    id = seq->id();
+    return (id != -1u);
+  }
+
+  bool instrSetId(VGMInstrSet *instrset, uint32_t &id) override {
+    id = instrset->id();
+    return (id != -1u);
+  }
+
+  bool sampCollId(VGMSampColl *sampcoll, uint32_t &id) override {
+    id = sampcoll->id();
+    return (id != -1u);
+  }
+};

--- a/src/main/components/matcher/Matcher.cpp
+++ b/src/main/components/matcher/Matcher.cpp
@@ -1,0 +1,34 @@
+/*
+ * VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#include "Matcher.h"
+
+Matcher::Matcher(Format *format) {
+  fmt = format;
+}
+
+bool Matcher::onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file) {
+  if(auto seq = std::get_if<VGMSeq *>(&file)) {
+    onNewSeq(*seq);
+  } else if(auto instr = std::get_if<VGMInstrSet *>(&file)) {
+    onNewInstrSet(*instr);
+  } else if(auto sampcoll = std::get_if<VGMSampColl *>(&file)) {
+    onNewSampColl(*sampcoll);
+}
+
+  return false;
+}
+
+bool Matcher::onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file) {
+  if(auto seq = std::get_if<VGMSeq *>(&file)) {
+    onCloseSeq(*seq);
+  } else if(auto instr = std::get_if<VGMInstrSet *>(&file)) {
+    onCloseInstrSet(*instr);
+  } else if(auto sampcoll = std::get_if<VGMSampColl *>(&file)) {
+    onCloseSampColl(*sampcoll);
+  }
+  return false;
+}

--- a/src/main/components/matcher/Matcher.h
+++ b/src/main/components/matcher/Matcher.h
@@ -1,0 +1,41 @@
+/*
+ * VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#pragma once
+
+#include <variant>
+
+class Format;
+class RawFile;
+class VGMSeq;
+class VGMInstrSet;
+class VGMSampColl;
+class VGMMiscFile;
+
+// *******
+// Matcher
+// *******
+
+class Matcher {
+public:
+  explicit Matcher(Format *format);
+  virtual ~Matcher() = default;
+
+  virtual void onFinishedScan(RawFile *rawfile) {}
+
+  virtual bool onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file);
+  virtual bool onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file);
+
+protected:
+  virtual bool onNewSeq(VGMSeq *) { return false; }
+  virtual bool onNewInstrSet(VGMInstrSet *) { return false; }
+  virtual bool onNewSampColl(VGMSampColl *) { return false; }
+  virtual bool onCloseSeq(VGMSeq *) { return false; }
+  virtual bool onCloseInstrSet(VGMInstrSet *) { return false; }
+  virtual bool onCloseSampColl(VGMSampColl *) { return false; }
+
+  Format *fmt;
+};

--- a/src/main/formats/Akao/AkaoInstr.h
+++ b/src/main/formats/Akao/AkaoInstr.h
@@ -9,7 +9,6 @@
 #include "VGMSampColl.h"
 #include "VGMRgn.h"
 #include "AkaoFormat.h"
-#include "Matcher.h"
 
 struct AkaoInstrDatLocation {
   uint32_t instrAllOffset;

--- a/src/main/formats/Akao/AkaoMatcher.h
+++ b/src/main/formats/Akao/AkaoMatcher.h
@@ -7,7 +7,6 @@
 #include "Matcher.h"
 #include <vector>
 #include <unordered_map>
-#include <iostream>
 
 class VGMSeq;
 class VGMInstrSet;

--- a/src/main/formats/Akao/AkaoSeq.h
+++ b/src/main/formats/Akao/AkaoSeq.h
@@ -11,7 +11,6 @@
 #include "VGMSeq.h"
 #include "SeqTrack.h"
 #include "AkaoFormatVersion.h"
-#include "Matcher.h"
 
 class AkaoSeq;
 class AkaoTrack;

--- a/src/main/formats/AkaoSnes/AkaoSnesFormat.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesFormat.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
+#include "FilegroupMatcher.h"
 #include "AkaoSnesScanner.h"
 
 

--- a/src/main/formats/CPS/CPS1Scanner.cpp
+++ b/src/main/formats/CPS/CPS1Scanner.cpp
@@ -3,7 +3,7 @@
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
  */
-#include "Root.h"
+#include "common.h"
 #include "CPS1Scanner.h"
 #include "CPSSeq.h"
 #include "CPS1Instr.h"

--- a/src/main/formats/CPS/CPS2Instr.h
+++ b/src/main/formats/CPS/CPS2Instr.h
@@ -2,7 +2,6 @@
 #include "VGMInstrSet.h"
 #include "VGMSampColl.h"
 #include "VGMMiscFile.h"
-#include "CPS2Format.h"
 
 class CPS2Instr;
 

--- a/src/main/formats/CapcomSnes/CapcomSnesFormat.h
+++ b/src/main/formats/CapcomSnes/CapcomSnesFormat.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
+#include "FilegroupMatcher.h"
 #include "CapcomSnesScanner.h"
 
 

--- a/src/main/formats/ChunSnes/ChunSnesFormat.h
+++ b/src/main/formats/ChunSnes/ChunSnesFormat.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
+#include "FilegroupMatcher.h"
 #include "ChunSnesScanner.h"
 
 

--- a/src/main/formats/CompileSnes/CompileSnesFormat.h
+++ b/src/main/formats/CompileSnes/CompileSnesFormat.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
+#include "FilegroupMatcher.h"
 #include "CompileSnesScanner.h"
 
 

--- a/src/main/formats/FFT/FFTFormat.h
+++ b/src/main/formats/FFT/FFTFormat.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
+#include "GetIdMatcher.h"
 #include "FFTScanner.h"
 
 BEGIN_FORMAT(FFT)

--- a/src/main/formats/FalcomSnes/FalcomSnesFormat.h
+++ b/src/main/formats/FalcomSnes/FalcomSnesFormat.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "FalcomSnesScanner.h"
 
 

--- a/src/main/formats/Format.cpp
+++ b/src/main/formats/Format.cpp
@@ -7,6 +7,7 @@
 #include "Format.h"
 #include "Scanner.h"
 #include "Matcher.h"
+#include "VGMColl.h"
 
 FormatMap &Format::registry() {
   static FormatMap registry;

--- a/src/main/formats/GraphResSnes/GraphResSnesFormat.h
+++ b/src/main/formats/GraphResSnes/GraphResSnesFormat.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "GraphResSnesScanner.h"
 
 

--- a/src/main/formats/HOSA/HOSAFormat.h
+++ b/src/main/formats/HOSA/HOSAFormat.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "Format.h"
-#include "Root.h"
 #include "HOSAScanner.h"
 
 

--- a/src/main/formats/HeartBeatPS1/HeartBeatPS1Format.h
+++ b/src/main/formats/HeartBeatPS1/HeartBeatPS1Format.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Format.h"
 #include "HeartBeatPS1Scanner.h"
-#include "Matcher.h"
+#include "FilegroupMatcher.h"
 
 #define HEARTBEATPS1_SND_HEADER_SIZE 0x3C
 

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesFormat.h
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesFormat.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
+#include "FilegroupMatcher.h"
 #include "HeartBeatSnesScanner.h"
 
 

--- a/src/main/formats/HudsonSnes/HudsonSnesFormat.h
+++ b/src/main/formats/HudsonSnes/HudsonSnesFormat.h
@@ -5,8 +5,7 @@
  */
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "HudsonSnesScanner.h"
 
 // ****************

--- a/src/main/formats/ItikitiSnes/ItikitiSnesFormat.h
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesFormat.h
@@ -5,8 +5,7 @@
  */
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "ItikitiSnesScanner.h"
 
 constexpr uint8_t kItikitiSnesSeqNoteKeyBias = 24;

--- a/src/main/formats/KonamiGX/KonamiGXFormat.h
+++ b/src/main/formats/KonamiGX/KonamiGXFormat.h
@@ -1,7 +1,5 @@
 #pragma once
 #include "Format.h"
-#include "Root.h"
-#include "VGMColl.h"
 #include "KonamiGXScanner.h"
 
 

--- a/src/main/formats/KonamiPS1/KonamiPS1Format.h
+++ b/src/main/formats/KonamiPS1/KonamiPS1Format.h
@@ -5,8 +5,7 @@
  */
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "KonamiPS1Scanner.h"
 
 // ***************

--- a/src/main/formats/KonamiSnes/KonamiSnesFormat.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesFormat.h
@@ -5,8 +5,7 @@
  */
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "KonamiSnesScanner.h"
 
 

--- a/src/main/formats/MoriSnes/MoriSnesFormat.h
+++ b/src/main/formats/MoriSnes/MoriSnesFormat.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "MoriSnesScanner.h"
 
 

--- a/src/main/formats/NDS/NDSFormat.h
+++ b/src/main/formats/NDS/NDSFormat.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "Format.h"
-#include "Root.h"
 #include "NDSScanner.h"
 #include "VGMColl.h"
 

--- a/src/main/formats/NamcoSnes/NamcoSnesFormat.h
+++ b/src/main/formats/NamcoSnes/NamcoSnesFormat.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "NamcoSnesScanner.h"
 
 

--- a/src/main/formats/NeverlandSnes/NeverlandSnesFormat.h
+++ b/src/main/formats/NeverlandSnes/NeverlandSnesFormat.h
@@ -1,9 +1,7 @@
 #pragma once
 #include "Format.h"
-#include "Root.h"
 #include "NeverlandSnesScanner.h"
-#include "Matcher.h"
-#include "VGMColl.h"
+#include "FilegroupMatcher.h"
 
 // *************
 // NeverlandSnesFormat

--- a/src/main/formats/NinSnes/NinSnesFormat.h
+++ b/src/main/formats/NinSnes/NinSnesFormat.h
@@ -1,9 +1,7 @@
 #pragma once
 #include "Format.h"
-#include "Root.h"
 #include "NinSnesScanner.h"
-#include "Matcher.h"
-#include "VGMColl.h"
+#include "FilegroupMatcher.h"
 
 // *************
 // NinSnesFormat

--- a/src/main/formats/Org/OrgFormat.h
+++ b/src/main/formats/Org/OrgFormat.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "Format.h"
-#include "Root.h"
 #include "OrgScanner.h"
 
 

--- a/src/main/formats/PS1/PS1Format.h
+++ b/src/main/formats/PS1/PS1Format.h
@@ -5,9 +5,7 @@
  */
 #pragma once
 #include "Format.h"
-#include "Root.h"
-#include "Matcher.h"
-#include "VGMColl.h"
+#include "FilegroupMatcher.h"
 #include "PS1Seq.h"
 #include "formats/PS1/Vab.h"
 #include "PS1SeqScanner.h"
@@ -18,6 +16,5 @@
 
 BEGIN_FORMAT(PS1)
   USING_SCANNER(PS1SeqScanner)
-  //USING_MATCHER_WITH_ARG(SimpleMatcher, true)
   USING_MATCHER(FilegroupMatcher)
 END_FORMAT()

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesFormat.h
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesFormat.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "PandoraBoxSnesScanner.h"
 
 

--- a/src/main/formats/PrismSnes/PrismSnesFormat.h
+++ b/src/main/formats/PrismSnes/PrismSnesFormat.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "PrismSnesScanner.h"
 
 

--- a/src/main/formats/RareSnes/RareSnesFormat.h
+++ b/src/main/formats/RareSnes/RareSnesFormat.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "RareSnesScanner.h"
 
 

--- a/src/main/formats/SegSat/SegSatFormat.h
+++ b/src/main/formats/SegSat/SegSatFormat.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "Format.h"
-#include "Root.h"
 #include "SegSatScanner.h"
 
 

--- a/src/main/formats/SoftCreatSnes/SoftCreatSnesFormat.h
+++ b/src/main/formats/SoftCreatSnes/SoftCreatSnesFormat.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "SoftCreatSnesScanner.h"
 
 // ******************************

--- a/src/main/formats/SonyPS2/SonyPS2Format.h
+++ b/src/main/formats/SonyPS2/SonyPS2Format.h
@@ -1,8 +1,7 @@
 #pragma once
 #include "Format.h"
-#include "Root.h"
 #include "SonyPS2Scanner.h"
-#include "Matcher.h"
+#include "FilenameMatcher.h"
 #include "VGMColl.h"
 
 typedef struct _VersCk {

--- a/src/main/formats/SquarePS2/SquarePS2Format.h
+++ b/src/main/formats/SquarePS2/SquarePS2Format.h
@@ -1,9 +1,7 @@
 #pragma once
 #include "Format.h"
-#include "Root.h"
 #include "SquarePS2Scanner.h"
-#include "Matcher.h"
-#include "VGMColl.h"
+#include "GetIdMatcher.h"
 
 // ***************
 // SquarePS2Format
@@ -12,7 +10,6 @@
 BEGIN_FORMAT(SquarePS2)
   USING_SCANNER(SquarePS2Scanner)
   USING_MATCHER(GetIdMatcher)
-  //USING_MATCHER(SimpleMatcher)
 END_FORMAT()
 
 

--- a/src/main/formats/SuzukiSnes/SuzukiSnesFormat.h
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesFormat.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "SuzukiSnesScanner.h"
 
 

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Format.h
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Format.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Format.h"
-#include "Matcher.h"
-#include "Root.h"
+#include "FilegroupMatcher.h"
 #include "TamSoftPS1Scanner.h"
 
 

--- a/src/main/formats/TriAcePS1/TriAcePS1Format.h
+++ b/src/main/formats/TriAcePS1/TriAcePS1Format.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "Format.h"
-#include "Root.h"
 #include "TriAcePS1Scanner.h"
 
 BEGIN_FORMAT(TriAcePS1)

--- a/src/main/formats/common/PSXSPU.h
+++ b/src/main/formats/common/PSXSPU.h
@@ -3,7 +3,6 @@
 #include "VGMSamp.h"
 #include "VGMItem.h"
 #include "ScaleConversion.h"
-#include "Root.h"
 #include "LogManager.h"
 
 // All of the ADSR calculations herein (except where inaccurate) are derived from Neill Corlett's work in

--- a/src/main/loaders/PSF2Loader.cpp
+++ b/src/main/loaders/PSF2Loader.cpp
@@ -6,7 +6,6 @@
 
 #include "PSF2Loader.h"
 #include <zlib-ng.h>
-#include "Root.h"
 #include "LogManager.h"
 #include "components/PSFFile.h"
 

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -9,7 +9,6 @@
 
 #include <version.h>
 #include "Format.h"
-#include "Matcher.h"
 #include "CLIVGMRoot.h"
 #include "DLSFile.h"
 #include "LogManager.h"

--- a/src/ui/qt/SequencePlayer.cpp
+++ b/src/ui/qt/SequencePlayer.cpp
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <cstddef>
 
-#include "Root.h"
 #include "bass.h"
 #include "bassmidi.h"
 #include "VGMColl.h"


### PR DESCRIPTION
This PR simply moves Matcher.h and Matcher.cpp into a new folder and breaks out much of its content into separate files. I have also removed a number of unnecessary #include directives. This PR does not change any logic.

I will add this commit to .git-blame-ignore-revs in my next PR (since the commit hash always changes after a rebase/squash).

## Motivation and Context
Matcher.h and Matcher.cpp were becoming unmanageably large.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
