### PR TITLE
add CPS1OPMInstrSet and OPM file export

### DIFF
--- a/bin/mame_roms.xml
+++ b/bin/mame_roms.xml
@@ -273,6 +273,10 @@
         <romgroup type="audiocpu" load_method="append" seq_table="0x1100" >
             <rom>kd_9.12a</rom>
         </romgroup>
+        <romgroup type="oki6295" load_method="append">
+            <rom>kd_18.11c</rom>
+            <rom>kd_19.12c</rom>
+        </romgroup>
     </game>
     <game name="mmatrix" format="CPS2" fmt_version="1.80">
         <romgroup type="audiocpu" load_method="append" seq_table="0x9005" instr_table_ptrs="0x3C05" num_instr_banks="9" samp_table="0x6000" samp_table_length="0x828" artic_table="0x8000">
@@ -350,6 +354,10 @@
     <game name="msword" format="CPS1" fmt_version="CPS1_3.50">
         <romgroup type="audiocpu" load_method="append" seq_table="0x1000" >
             <rom>ms_09.12b</rom>
+        </romgroup>
+        <romgroup type="oki6295" load_method="append">
+            <rom>ms_18.11c</rom>
+            <rom>ms_19.12c</rom>
         </romgroup>
     </game>
     <game name="mtwins" format="CPS1" fmt_version="CPS1_4.25">

--- a/src/main/formats/CPS/CPS1Instr.cpp
+++ b/src/main/formats/CPS/CPS1Instr.cpp
@@ -124,10 +124,9 @@ std::string CPS1OPMInstrSet::generateOPMFile() {
   output << header;
 
   for (size_t i = 0; i < aInstrs.size(); ++i) {
-    CPS1OPMInstr* instr = dynamic_cast<CPS1OPMInstr*>(aInstrs[i]);
-    if (instr != nullptr) {
-      output << instr->toOPMString(i) << "\n";
-    }
+        if (auto* instr = dynamic_cast<CPS1OPMInstr*>(aInstrs[i]); instr != nullptr) {
+            output << instr->toOPMString(i) << '\n';
+        }
   }
   return output.str();
 }

--- a/src/main/formats/CPS/CPS1Instr.cpp
+++ b/src/main/formats/CPS/CPS1Instr.cpp
@@ -3,6 +3,8 @@
 #include "CPS2Format.h"
 #include "VGMRgn.h"
 #include "OkiAdpcm.h"
+#include "version.h"
+#include "Root.h"
 
 // ******************
 // CPS1SampleInstrSet
@@ -11,12 +13,9 @@
 CPS1SampleInstrSet::CPS1SampleInstrSet(RawFile *file,
                                        CPSFormatVer version,
                                        uint32_t offset,
-                                       std::string &name)
+                                       std::string name)
     : VGMInstrSet(CPS1Format::name, file, offset, 0, std::move(name)),
       fmt_version(version) {
-}
-
-CPS1SampleInstrSet::~CPS1SampleInstrSet(void) {
 }
 
 bool CPS1SampleInstrSet::parseInstrPointers() {
@@ -91,4 +90,72 @@ bool CPS1SampColl::parseSampleInfo() {
     samples.push_back(sample);
   }
   return true;
+}
+
+// ******************
+// CPS1SampleInstrSet
+// ******************
+
+CPS1OPMInstrSet::CPS1OPMInstrSet(RawFile *file,
+                               CPSFormatVer version,
+                               uint32_t offset,
+                               const std::string& name)
+    : VGMInstrSet(CPS1Format::name, file, offset, 0, name),
+      fmt_version(version) {
+}
+
+bool CPS1OPMInstrSet::parseInstrPointers() {
+  for (int i = 0; i < 128; ++i) {
+    auto offset = dwOffset + (i * sizeof(CPS1OPMInstrData));
+    if (VGMFile::readWord(offset) == 0 && VGMFile::readWord(offset+4) == 0) {
+      break;
+    }
+
+    auto instr = new CPS1OPMInstr(this, offset, sizeof(CPS1OPMInstrData), 0,
+      i, fmt::format("Instrument {}", i));
+    aInstrs.push_back(instr);
+  }
+  return true;
+}
+
+std::string CPS1OPMInstrSet::generateOPMFile() {
+  std::ostringstream output;
+  std::string header = std::string("// Converted using VGMTrans version: ") + VGMTRANS_VERSION + "\n";
+  output << header;
+
+  for (size_t i = 0; i < aInstrs.size(); ++i) {
+    CPS1OPMInstr* instr = dynamic_cast<CPS1OPMInstr*>(aInstrs[i]);
+    if (instr != nullptr) {
+      output << instr->toOPMString(i) << "\n";
+    }
+  }
+  return output.str();
+}
+
+bool CPS1OPMInstrSet::saveAsOPMFile(const std::string &filepath) {
+  auto content = generateOPMFile();
+  pRoot->UI_writeBufferToFile(filepath, reinterpret_cast<uint8_t*>(const_cast<char*>(content.data())), static_cast<uint32_t>(content.size()));
+}
+
+// ************
+// CPS1OPMInstr
+// ************
+
+CPS1OPMInstr::CPS1OPMInstr(VGMInstrSet *instrSet,
+                     uint32_t offset,
+                     uint32_t length,
+                     uint32_t theBank,
+                     uint32_t theInstrNum,
+                     const std::string &name)
+    : VGMInstr(instrSet, offset, length, theBank, theInstrNum, name) {
+}
+
+bool CPS1OPMInstr::loadInstr() {
+
+  this->readBytes(dwOffset, sizeof(CPS1OPMInstrData), &opmData);
+  return true;
+}
+
+std::string CPS1OPMInstr::toOPMString(int num) {
+  return opmData.convertToOPMData(name()).toOPMString(num);
 }

--- a/src/main/formats/CPS/CPS1Instr.h
+++ b/src/main/formats/CPS/CPS1Instr.h
@@ -3,6 +3,7 @@
 #include "VGMInstrSet.h"
 #include "CPS1Scanner.h"
 #include "VGMSampColl.h"
+#include <sstream>
 
 // ******************
 // CPS1SampleInstrSet
@@ -14,8 +15,8 @@ public:
   CPS1SampleInstrSet(RawFile *file,
                      CPSFormatVer fmt_version,
                      uint32_t offset,
-                     std::string &name);
-  ~CPS1SampleInstrSet() override;
+                     std::string name);
+  ~CPS1SampleInstrSet() override = default;
 
   bool parseInstrPointers() override;
 
@@ -38,4 +39,161 @@ public:
 private:
   std::vector<VGMItem*> samplePointers;
   CPS1SampleInstrSet *instrset;
+};
+
+
+// ***************
+// CPS1OPMInstrSet
+// ***************
+
+class CPS1OPMInstrSet
+    : public VGMInstrSet {
+public:
+  CPS1OPMInstrSet(RawFile *file,
+                 CPSFormatVer fmt_version,
+                 uint32_t offset,
+                 const std::string& name);
+  ~CPS1OPMInstrSet() override = default;
+
+  bool parseInstrPointers() override;
+  bool saveAsOPMFile(const std::string &filepath);
+
+public:
+  CPSFormatVer fmt_version;
+
+private:
+  std::string generateOPMFile();
+};
+
+// ************
+// CPS1OPMInstr
+// ************
+
+struct OPMData {
+  struct LFO {
+    uint8_t LFRQ;
+    uint8_t AMD;
+    uint8_t PMD;
+    uint8_t WF;
+    uint8_t NFRQ;
+  };
+
+  struct CH {
+    uint8_t PAN;
+    uint8_t FL;
+    uint8_t CON;
+    uint8_t AMS;
+    uint8_t PMS;
+    uint8_t SLOT_MASK;
+    uint8_t NE;
+  };
+
+  struct OP {
+    uint8_t AR;
+    uint8_t D1R;
+    uint8_t D2R;
+    uint8_t RR;
+    uint8_t D1L;
+    uint8_t TL;
+    uint8_t KS;
+    uint8_t MUL;
+    uint8_t DT1;
+    uint8_t DT2;
+    uint8_t AMS_EN;
+  };
+
+  std::string name;
+  LFO lfo;
+  CH ch;
+  OP op[4];
+
+  std::string toOPMString(int num) const {
+    std::ostringstream ss;
+    ss << "@:" << num << " " << name << "\n";
+    ss << "LFO:" << +lfo.LFRQ << "   " << +lfo.AMD << "   " << +lfo.PMD << "   " << +lfo.WF << "   " << +lfo.NFRQ << "\n";
+    ss << "CH: " << +ch.PAN << "   " << +ch.FL << "   " << +ch.CON << "   " << +ch.AMS << "   " << +ch.PMS << " " << +ch.SLOT_MASK << "   " << +ch.NE << "\n";
+
+    const int opIndex[4] = { 0, 2, 1, 3 };
+    const char* opNames[4] = {"M1", "C1", "M2", "C2"};
+    for (int i = 0; i < 4; ++i) {
+      const OP& op = this->op[opIndex[i]];
+      ss << opNames[i] << ": " << +op.AR << "   " << +op.D1R << "   " << +op.D2R << "   " << +op.RR << "  " << +op.D1L << "  "
+         << +op.TL << "   " << +op.KS << "   " << +op.MUL << "   " << +op.DT1 << "   " << +op.DT2 << " " << +op.AMS_EN << "\n";
+    }
+
+    return ss.str();
+  }
+};
+
+struct CPS1OPMInstrData {
+  int8_t transpose;
+  uint8_t LFO_ENABLE_AND_WF;
+  uint8_t LFRQ;
+  uint8_t PMD;
+  uint8_t AMD;
+  uint8_t FL_CON;
+  uint8_t PMS_AMS;
+  uint8_t SLOT_MASK;
+  uint8_t unknown[12];
+  uint8_t DT1_MUL[4];
+  uint8_t KS_AR[4];
+  uint8_t AMSEN_D1R[4];
+  uint8_t DT2_D2R[4];
+  uint8_t D1L_RR[4];
+
+  OPMData convertToOPMData(const std::string& name) const {
+    // LFO
+    OPMData::LFO lfo{};
+    lfo.WF = (LFO_ENABLE_AND_WF >> 5) & 0b11;
+    lfo.NFRQ = 0;  // the driver doesn't define noise frequency
+
+    // CH
+    OPMData::CH ch{};
+    ch.PAN = 0b11000000; // the driver always sets R/L, ie PAN, to 0xC0 (sf2ce 0xDC0)
+    ch.FL = (FL_CON >> 3) & 0b111;
+    ch.CON = FL_CON & 0b111;
+    ch.AMS = PMS_AMS & 0b11;
+    ch.PMS = (PMS_AMS >> 4) & 0b1111;
+    ch.SLOT_MASK = SLOT_MASK;
+    ch.NE = 0;
+
+    // OP
+    OPMData::OP op[4];
+    for (int i = 0; i < 4; i ++) {
+      auto& opx = op[i];
+      opx.AR = KS_AR[i] & 0b11111;
+      opx.D1R = AMSEN_D1R[i] & 0b11111;
+      opx.D2R = DT2_D2R[i] & 0b11111;
+      opx.RR = D1L_RR[i] & 0b1111;
+      opx.D1L = D1L_RR[i] >> 4;
+      opx.TL = 25; // the driver dynamically calculates TL each note. set to a default for now
+      opx.KS = KS_AR[i] >> 6;
+      opx.MUL = DT1_MUL[i] & 0b1111;
+      opx.DT1 = (DT1_MUL[i] >> 4) & 0b111;
+      opx.DT2 = DT2_D2R[i] >> 6;
+      opx.AMS_EN = AMSEN_D1R[i] & 0b10000000;
+    }
+
+    return {name, lfo, ch, { op[0], op[1], op[2], op[3] }};
+  }
+};
+
+class CPS1OPMInstr : public VGMInstr {
+public:
+  CPS1OPMInstr(VGMInstrSet *instrSet,
+               uint32_t offset,
+               uint32_t length,
+               uint32_t theBank,
+               uint32_t theInstrNum,
+               const std::string& name);
+  ~CPS1OPMInstr() override = default;
+  bool loadInstr() override;
+
+  std::string toOPMString(int num);
+
+protected:
+  CPS1OPMInstrData opmData;
+
+  int info_ptr;        //pointer to start of instrument set block
+  int nNumRegions;
 };

--- a/src/main/formats/CPS/CPS2Instr.h
+++ b/src/main/formats/CPS/CPS2Instr.h
@@ -220,9 +220,9 @@ public:
 };
 
 
-// ***********
+// *********
 // CPS2Instr
-// ***********
+// *********
 
 class CPS2Instr : public VGMInstr {
 public:

--- a/src/main/formats/CPS/CPSTrackV1.cpp
+++ b/src/main/formats/CPS/CPSTrackV1.cpp
@@ -212,7 +212,8 @@ bool CPSTrackV1::readEvent() {
             break;
           }
           case YM2151:
-            curOffset++;
+            vol = readByte(curOffset++);
+            vol = convertPercentAmpToStdMidiVal(vol_table[vol] / (double) 0x1FFF);
             this->addVol(beginOffset, curOffset - beginOffset, vol);
             break;
         }

--- a/src/ui/qt/services/MenuManager.cpp
+++ b/src/ui/qt/services/MenuManager.cpp
@@ -22,6 +22,12 @@ MenuManager::MenuManager() {
       std::make_shared<CommandSeparator>(),
       std::make_shared<CloseVGMFileCommand>(),
   });
+  registerCommands<CPS1OPMInstrSet, VGMItem>({
+      std::make_shared<CloseVGMFileCommand>(),
+      std::make_shared<CommandSeparator>(),
+      std::make_shared<SaveAsOPMCommand>(),
+      std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
+  });
   registerCommands<VGMSampColl, VGMItem>({
       std::make_shared<SaveWavBatchCommand>(),
       std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),

--- a/src/ui/qt/services/commands/SaveCommands.h
+++ b/src/ui/qt/services/commands/SaveCommands.h
@@ -12,6 +12,7 @@
 #include "VGMSampColl.h"
 #include "VGMExport.h"
 #include "VGMColl.h"
+#include "formats/CPS/CPS1Instr.h"
 
 namespace fs = std::filesystem;
 
@@ -188,6 +189,17 @@ public:
   }
   [[nodiscard]] std::string name() const override { return "Save as SF2"; }
   [[nodiscard]] std::string extension() const override { return "sf2"; }
+};
+
+class SaveAsOPMCommand : public SaveCommand<CPS1OPMInstrSet, VGMFile> {
+public:
+  SaveAsOPMCommand() : SaveCommand<CPS1OPMInstrSet, VGMFile>(false) {}
+
+  void save(const std::string& path, CPS1OPMInstrSet* instrSet) const override {
+    instrSet->saveAsOPMFile(path);
+  }
+  [[nodiscard]] std::string name() const override { return "Save as OPM"; }
+  [[nodiscard]] std::string extension() const override { return "opm"; }
 };
 
 


### PR DESCRIPTION
## Description
This pulls in some work done on the juce3 branch which converts CPS1 instrument set data for the YM2151 chip into the [OPM file format](https://vgmrips.net/wiki/OPM_File_Format).

## Motivation and Context
I am working on implementing actual YM2151 playback within the juce3 branch, but some necessary work can be done on the master branch. For example, as we support formats beyond sampled instrument sets like SoundFont 2, it seems necessary to refactor our conversion code a little bit. We'll need a way for collections and instrument sets to indicate the formats they can be converted to, and we'll want some abstraction around the the conversion process so that the base classes don't require any specific format knowledge.

I'm planning to work on this refactor next.

## How Has This Been Tested?
Exporting has worked with every CPS1 set I've tried. I also believe it's loading in external software that supports the opm format.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
