### PR TITLE
Vab: VAG locations should be relative to the start of the sample data

### DIFF
--- a/src/main/formats/PS1/Vab.cpp
+++ b/src/main/formats/PS1/Vab.cpp
@@ -120,7 +120,7 @@ bool Vab::parseInstrPointers() {
     VGMHeader *vagOffsetHdr = addHeader(offVAGOffsets, 2 * 256, "VAG Pointer Table");
 
     uint32_t vagStartOffset = offVAGOffsets + 2 * 256;
-    uint32_t vagOffset = vagStartOffset;
+    uint32_t vagOffset = 0;
 
     for (uint32_t i = 0; i < numVAGs; i++) {
       uint32_t vagSize = readShort(offVAGOffsets + i * 2) * 8;
@@ -128,12 +128,13 @@ bool Vab::parseInstrPointers() {
       snprintf(name, 256, "VAG Size /8 #%u", i);
       vagOffsetHdr->addChild(offVAGOffsets + i * 2, 2, name);
 
-      if (vagOffset + vagSize <= nEndOffset) {
+      auto absoluteVagOffset = vagStartOffset + vagOffset;
+      if (absoluteVagOffset + vagSize <= nEndOffset) {
         vagLocations.emplace_back(vagOffset, vagSize);
         totalVAGSize += vagSize;
       }
       else {
-        L_WARN("VAG #{} pointer (offset=0x{:08X}, size={}) is invalid.", i, vagOffset, vagSize);
+        L_WARN("VAG #{} pointer (offset=0x{:08X}, size={}) is invalid.", i, absoluteVagOffset, vagSize);
       }
 
       vagOffset += vagSize;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes parsing of the sample data in PS1 VAB files (i.e. VH and VB combined into one file).

## Motivation and Context
When the `Vab` class reads the VAB header, it creates a vector `vagLocations` with the offset and size of each VAG audio sample. It then creates a `PSXSampColl` and passes it the `vagLocations` so that it can read the samples. The base (`dwOffset`) of the `PSXSampColl` is the start of the sample data (the VB portion of the VAB file), but the offsets in `vagLocations` are relative to the beginning of the file (the VH portion of the VAB file), so all the reads of the sample data are offset by one header length and the samples are cut off at the beginning. This PR changes `vagLocations` to be relative to the start of the VB data.

## How Has This Been Tested?
I tested this with VAB files from two different games and verified that the samples were cut off before the PR and correct after the PR. I also tested loading VB files and verified that the behavior was not affected. Finally, I tested loading a SEP file once with a VAB file and making collections from the SEQs, VAB, and samples before and after the PR and verified that it sounded correct after the PR.

I do want to mention a few caveats with this testing:

- I tried the SEP file both with a combined VAB file (by loading the VAB, then the SEP, then making a collection out of a sequence from the SEP, the VAB, and the samples from the VAB), and with split VH and VB files (by loading the VB, then the VH, then the SEP, then making a collection the same way). Playing the resulting collections did not sound the same. However, when I exported the individual samples, they weren't in the same order, but the ones I matched up did sound the same. I *think* that's because the way `PSXSampColl` scans a VB for samples when it doesn't have a header can miss certain small/dummy samples and result in samples being out of order. For example, one of my VAB files, according to the header, has 4 samples, the first of which is only 48 bytes. When I load the VAB file, I see all 4 samples. But when I load only the VB file, I only see 3 samples; the 48-byte one doesn't seem to be detected. So I suspect that the collection is being played incorrectly in the VB case due to limitations of the scanner.
- I don't have access to a game that comes with pre-combined .VAB files. I created the files I used for testing by manually concatenating VH and VB files. As I understand it, this is exactly what a .VAB file is anyway (and I was motivated to do this due to the issue in the previous bullet), but I thought it was worth mentioning.
- When loading the SEP file in a debug build, the application crashed with the error ``vgmtrans/src/main/io/RawFile.h:73: T RawFile::getBE(size_t) const [with T = short unsigned int; size_t = long unsigned int]: Assertion `ind + sizeof(T) <= size()' failed.``. However, I confirmed that this also occurs without my changes in place, so I believe this is an unrelated issue. In a release build, I didn't notice any issues working with the SEP file.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
