### PR TITLE
Fix fallback version string in build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if(GIT_FOUND)
     OUTPUT_VARIABLE VCS_TAG
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 else()
-  set(VCS_TAG "v$(CMAKE_PROJECT_VERSION)")
+  set(VCS_TAG "v${CMAKE_PROJECT_VERSION}")
   set(VCS_HASH "unknown")
   set(VCS_BRANCH "unknown")
 endif()


### PR DESCRIPTION
Replace fallback version string `v$(CMAKE_PROJECT_VERSION)` with `v${CMAKE_PROJECT_VERSION}`.

## Description
If Git is not available, the application version would be set to `v$(CMAKE_PROJECT_VERSION)`. This is a literal string and the version does not get substituted by CMake. It should be `v${CMAKE_PROJECT_VERSION}` instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The version displayed in the Help page is incorrect.
Noticed during packaging in Nixpkgs: https://github.com/NixOS/nixpkgs/pull/321129#issuecomment-2466679937

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Rebuilt the application in Nixpkgs with this patch applied

## Screenshots (if appropriate):

Before:
![Help page](https://scrumplex.rocks/img/1731234911_ESh3qu.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
