### PR TITLE
AsciiShuichiSnesFormat: New SNES format supporting Wizardry VI and Down the World

### DIFF
--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -1334,7 +1334,13 @@ void SeqTrack::addTempoBPMNoItem(double bpm) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     // Some MIDI tool can recognise tempo event only in the first track.
     MidiTrack *pFirstMidiTrack = parentSeq->firstMidiTrack();
-    pFirstMidiTrack->insertTempoBPM(bpm, pMidiTrack->getDelta());
+    if (!pFirstMidiTrack->bHasEndOfTrack) {
+      pFirstMidiTrack->insertTempoBPM(bpm, pMidiTrack->getDelta());
+    } else {
+      // Adding an event after the EOT is even worse. So here's a little workaround.
+      // Test case - SNES Wizardry VI "Rest"
+      pMidiTrack->addTempoBPM(bpm);
+    }
   }
 }
 

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -212,7 +212,7 @@ static std::string logEvent(uint8_t statusByte, spdlog::level::level_enum level 
 
   std::ostringstream description;
   description <<  title << ": 0x" << std::hex << std::setfill('0') << std::setw(2)
-              << std::uppercase << statusByte << std::dec << std::setfill(' ') << std::setw(0);
+              << std::uppercase << static_cast<unsigned>(statusByte) << std::dec << std::setfill(' ') << std::setw(0);
 
   // Use a fold expression to process each argument
   int arg_idx = 1;

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesFormat.h
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesFormat.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "Format.h"
+#include "FilegroupMatcher.h"
+#include "AsciiShuichiSnesScanner.h"
+
+
+// ***************
+// AsciiShuichiSnesFormat
+// ***************
+
+BEGIN_FORMAT(AsciiShuichiSnes)
+  USING_SCANNER(AsciiShuichiSnesScanner)
+  USING_MATCHER(FilegroupMatcher)
+END_FORMAT()

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesInstr.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesInstr.cpp
@@ -1,0 +1,159 @@
+/*
+ * VGMTrans (c) 2002-2019
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#include "AsciiShuichiSnesInstr.h"
+#include <spdlog/fmt/fmt.h>
+#include "SNESDSP.h"
+#include "AsciiShuichiSnesFormat.h"
+#include "LogManager.h"
+
+// ************************
+// AsciiShuichiSnesInstrSet
+// ************************
+
+AsciiShuichiSnesInstrSet::AsciiShuichiSnesInstrSet(RawFile *file, uint32_t offset,
+                                                   uint32_t fineTuningTableAddress,
+                                                   uint32_t spcDirAddress, const std::string &name)
+    :
+    VGMInstrSet(AsciiShuichiSnesFormat::name, file, offset, 0, name),
+    fineTuningTableAddress(fineTuningTableAddress),
+    spcDirAddress(spcDirAddress) {
+}
+
+bool AsciiShuichiSnesInstrSet::parseHeader() {
+  return true;
+}
+
+bool AsciiShuichiSnesInstrSet::parseInstrPointers() {
+  usedSRCNs.clear();
+  for (int instr = 0; instr < 0x40; instr++) {
+    const uint32_t instrHeaderAddress = dwOffset + (4 * instr);
+    if (instrHeaderAddress + 4 > 0x10000) {
+      return false;
+    }
+
+    if (!AsciiShuichiSnesInstr::isValidHeader(this->rawFile(), instrHeaderAddress, spcDirAddress)) {
+      continue;
+    }
+
+    const uint8_t srcn = readByte(instrHeaderAddress);
+    auto itrSRCN = std::ranges::find(usedSRCNs, srcn);
+    if (itrSRCN == usedSRCNs.end()) {
+      usedSRCNs.push_back(srcn);
+    }
+
+    const auto newInstr = new AsciiShuichiSnesInstr(
+      this, instrHeaderAddress, instr >> 7, instr & 0x7f, spcDirAddress, fineTuningTableAddress,
+      fmt::format("Instrument {}", instr));
+    aInstrs.push_back(newInstr);
+  }
+  if (aInstrs.empty()) {
+    return false;
+  }
+
+  std::ranges::sort(usedSRCNs);
+  auto newSampColl = new SNESSampColl(AsciiShuichiSnesFormat::name, this->rawFile(), spcDirAddress, usedSRCNs);
+  if (!newSampColl->loadVGMFile()) {
+    delete newSampColl;
+    return false;
+  }
+
+  return true;
+}
+
+// *********************
+// AsciiShuichiSnesInstr
+// *********************
+
+AsciiShuichiSnesInstr::AsciiShuichiSnesInstr(VGMInstrSet *instrSet,
+                                 uint32_t offset,
+                                 uint32_t theBank,
+                                 uint32_t theInstrNum,
+                                 uint32_t spcDirAddress,
+                                 uint32_t fineTuningTableAddress,
+                                 const std::string &name) :
+    VGMInstr(instrSet, offset, 6, theBank, theInstrNum, name),
+    spcDirAddress(spcDirAddress),
+    fineTuningTableAddress(fineTuningTableAddress) {
+}
+
+bool AsciiShuichiSnesInstr::loadInstr() {
+  const uint8_t srcn = readByte(dwOffset);
+  const uint32_t dirEntryOffset = spcDirAddress + (srcn * 4);
+  if (dirEntryOffset + 4 > 0x10000) {
+    return false;
+  }
+
+  const uint16_t sampleStartAddress = readShort(dirEntryOffset);
+
+  if (fineTuningTableAddress + srcn > 0x10000) {
+    return false;
+  }
+  const auto spcFineTuning = static_cast<int8_t>(readByte(fineTuningTableAddress + srcn));
+
+  const auto rgn = new AsciiShuichiSnesRgn(this, dwOffset, spcFineTuning);
+  rgn->sampOffset = sampleStartAddress - spcDirAddress;
+  addRgn(rgn);
+
+  return true;
+}
+
+bool AsciiShuichiSnesInstr::isValidHeader(const RawFile *file, uint32_t instrHeaderAddress, uint32_t spcDirAddress) {
+  if (instrHeaderAddress + 4 > 0x10000) {
+    return false;
+  }
+
+  const uint8_t srcn = file->readByte(instrHeaderAddress);
+  const uint8_t adsr1 = file->readByte(instrHeaderAddress + 1);
+  const uint8_t gain = file->readByte(instrHeaderAddress + 3);
+
+  if (srcn >= 0x80 || (adsr1 == 0 && gain == 0)) {
+    return false;
+  }
+
+  const uint32_t dirEntryAddress = spcDirAddress + (srcn * 4);
+  if (!SNESSampColl::isValidSampleDir(file, dirEntryAddress, false)) {
+    return false;
+  }
+
+  const uint16_t srcAddress = file->readShort(dirEntryAddress);
+  const uint16_t loopStartAddress = file->readShort(dirEntryAddress + 2);
+  if (srcAddress > loopStartAddress || (loopStartAddress - srcAddress) % 9 != 0) {
+    return false;
+  }
+
+  return true;
+}
+
+// *******************
+// AsciiShuichiSnesRgn
+// *******************
+
+AsciiShuichiSnesRgn::AsciiShuichiSnesRgn(AsciiShuichiSnesInstr *instr, uint32_t offset, int8_t spcFineTuning) :
+    VGMRgn(instr, offset, 4) {
+  const uint8_t srcn = readByte(offset);
+  const uint8_t adsr1 = readByte(offset + 1);
+  const uint8_t adsr2 = readByte(offset + 2);
+  const uint8_t gain = readByte(offset + 3);
+
+  addSampNum(srcn, offset, 1);
+  addChild(offset + 1, 1, "ADSR1");
+  addChild(offset + 2, 1, "ADSR2");
+  addChild(offset + 3, 1, "GAIN");
+
+  // pitchTable[57] is 0x1000 then
+  setUnityKey(57 + 24);
+  setFineTune(static_cast<int16_t>(pitchScaleToCents(1.0 + (spcFineTuning / 4096.0))));
+
+  snesConvADSR<VGMRgn>(this, adsr1, adsr2, gain);
+
+  const uint8_t sl = (adsr2 >> 5);
+  emulateSDSPGAIN(gain, static_cast<int16_t>((sl << 8) | 0xff), 0, nullptr, &release_time);
+}
+
+bool AsciiShuichiSnesRgn::loadRgn() {
+  return true;
+}

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesInstr.h
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesInstr.h
@@ -1,0 +1,58 @@
+#pragma once
+#include "VGMInstrSet.h"
+#include "VGMRgn.h"
+
+// ************************
+// AsciiShuichiSnesInstrSet
+// ************************
+
+class AsciiShuichiSnesInstrSet:
+    public VGMInstrSet {
+ public:
+  AsciiShuichiSnesInstrSet
+      (RawFile *file, uint32_t offset, uint32_t fineTuningTableAddress, uint32_t spcDirAddress, const std::string &name = "AsciiShuichiSnesInstrSet");
+
+  bool parseHeader() override;
+  bool parseInstrPointers() override;
+
+ private:
+  uint32_t fineTuningTableAddress;
+  uint32_t spcDirAddress;
+  std::vector<uint8_t> usedSRCNs;
+};
+
+// *********************
+// AsciiShuichiSnesInstr
+// *********************
+
+class AsciiShuichiSnesInstr
+    : public VGMInstr {
+ public:
+  AsciiShuichiSnesInstr(VGMInstrSet *instrSet,
+                  uint32_t offset,
+                  uint32_t theBank,
+                  uint32_t theInstrNum,
+                  uint32_t spcDirAddress,
+                  uint32_t fineTuningTableAddress,
+                  const std::string &name = "AsciiShuichiSnesInstr");
+
+  bool loadInstr() override;
+
+  static bool isValidHeader(const RawFile *file, uint32_t instrHeaderAddress, uint32_t spcDirAddress);
+
+ private:
+  uint32_t spcDirAddress;
+  uint32_t fineTuningTableAddress;
+};
+
+// *******************
+// AsciiShuichiSnesRgn
+// *******************
+
+class AsciiShuichiSnesRgn
+    : public VGMRgn {
+ public:
+  AsciiShuichiSnesRgn(AsciiShuichiSnesInstr *instr, uint32_t offset, int8_t spcFineTuning);
+
+  bool loadRgn() override;
+};

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesScanner.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesScanner.cpp
@@ -1,0 +1,124 @@
+/*
+ * VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#include "AsciiShuichiSnesSeq.h"
+#include "AsciiShuichiSnesInstr.h"
+#include "ScannerManager.h"
+
+namespace vgmtrans::scanners {
+ScannerRegistration<AsciiShuichiSnesScanner> s_graph_snes("AsciiShuichiSnes", {"spc"});
+}
+
+// Only tested with:
+//     - Wizardry VI - Bane of the Cosmic Forge
+//     - Down the World - Mervil's Ambition
+
+// ; Wizardry VI SPC
+// 0f95: e8 05     mov   a,#$05
+// 0f97: 3f 23 0f  call  $0f23
+// 0f9a: f5 00 12  mov   a,$1200+x         ; read voice pointer (low) from address table
+// 0f9d: d5 00 02  mov   $0200+x,a
+// 0fa0: f5 08 12  mov   a,$1208+x         ; read voice pointer (high) from address table
+// 0fa3: d4 0c     mov   $0c+x,a
+// 0fa5: 1d        dec   x
+// 0fa6: 10 ed     bpl   $0f95
+BytePattern AsciiShuichiSnesScanner::ptnLoadSeq(
+  "\xe8\x05\x3f\x23\x0f\xf5\x00\x12"
+  "\xd5\x00\x02\xf5\x08\x12\xd4\x0c"
+  "\x1d\x10\xed",
+  "xxx??x??"
+  "x??x??x?"
+  "xxx",
+  19);
+
+// ; Wizardry VI SPC
+// ; load instrument
+// 094f: f8 ac     mov   x,$ac
+// 0951: 1c        asl   a
+// 0952: 1c        asl   a
+// 0953: c4 b3     mov   $b3,a
+// 0955: fd        mov   y,a
+// 0956: f4 c8     mov   a,$c8+x           ; get ADSR(1) dsp reg address
+// 0958: c4 b7     mov   $b7,a
+// 095a: f7 bc     mov   a,($bc)+y         ; offset 0: SRCN
+// 095c: eb b7     mov   y,$b7
+// 095e: dc        dec   y
+// 095f: 3f 20 08  call  $0820             ; set SRCN
+// 0962: fd        mov   y,a
+// 0963: f7 be     mov   a,($be)+y         ; ($be) fine tuning per instrument (signed)
+// 0965: d5 d0 02  mov   $02d0+x,a
+BytePattern AsciiShuichiSnesScanner::ptnLoadInstr(
+  "\xf8\xac\x1c\x1c\xc4\xb3\xfd\xf4"
+  "\xc8\xc4\xb7\xf7\xbc\xeb\xb7\xdc"
+  "\x3f\x20\x08\xfd\xf7\xbe\xd5\xd0"
+  "\x02",
+  "x?xxx?xx"
+  "?x?x?x?x"
+  "x??xx?x?"
+  "?",
+  25);
+
+// ; Wizardry VI SPC
+// 056c: 8d 5d     mov   y,#$5d
+// 056e: e8 30     mov   a,#$30
+// 0570: 3f 20 08  call  $0820             ; set DIR ($3000)
+BytePattern AsciiShuichiSnesScanner::ptnLoadDIR(
+  "\x8d\x5d\xe8\x30\x3f\x20\x08",
+  "xxx?x??",
+  7);
+
+void AsciiShuichiSnesScanner::scan(RawFile *file, void *info) {
+  const size_t nFileLength = file->size();
+  if (nFileLength == 0x10000) {
+    scanFromARAM(file);
+  } else {
+    // Search from ROM unimplemented
+  }
+}
+
+void AsciiShuichiSnesScanner::scanFromARAM(RawFile *file) {
+  const std::string name = file->tag.hasTitle() ? file->tag.title : file->stem();
+
+  // search song header
+  uint32_t ofsLoadSeq;
+  if (!file->searchBytePattern(ptnLoadSeq, ofsLoadSeq))
+    return;
+  const uint16_t seqHeaderAddress = file->readShort(ofsLoadSeq + 6);
+
+  const auto newSeq = new AsciiShuichiSnesSeq(file, seqHeaderAddress, name);
+  if (!newSeq->loadVGMFile()) {
+    delete newSeq;
+    return;
+  }
+
+  // search instrument loader
+  uint32_t ofsLoadInstr;
+  if (!file->searchBytePattern(ptnLoadInstr, ofsLoadInstr))
+    return;
+  const uint8_t instrTablePtrAddress = file->readByte(ofsLoadInstr + 12);
+  const uint16_t instrTableAddress = file->readShort(instrTablePtrAddress);
+  L_DEBUG("{}: found instrument table {:#04x} via {:#02x}", "AsciiShuichiSnesScanner",
+          instrTableAddress, instrTablePtrAddress);
+
+  const uint8_t instrTuningTablePtrAddress = file->readByte(ofsLoadInstr + 21);
+  const uint16_t instrTuningTableAddress = file->readShort(instrTuningTablePtrAddress);
+  L_DEBUG("{}: found instrument tuning table {:#04x} via {:#02x}", "AsciiShuichiSnesScanner",
+          instrTuningTableAddress, instrTuningTablePtrAddress);
+
+  // search DIR address
+  uint32_t ofsLoadDIR;
+  if (!file->searchBytePattern(ptnLoadDIR, ofsLoadDIR))
+    return;
+  const auto sampleDirAddress = static_cast<uint16_t>(file->readByte(ofsLoadDIR + 3) << 8);
+  L_DEBUG("{}: found sample DIR address {:#04x}", "AsciiShuichiSnesScanner", sampleDirAddress);
+
+  const auto newInstrSet = new AsciiShuichiSnesInstrSet(file, instrTableAddress,
+                                                        instrTuningTableAddress, sampleDirAddress);
+  if (!newInstrSet->loadVGMFile()) {
+    delete newInstrSet;
+    return;
+  }
+}

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesScanner.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesScanner.cpp
@@ -9,7 +9,7 @@
 #include "ScannerManager.h"
 
 namespace vgmtrans::scanners {
-ScannerRegistration<AsciiShuichiSnesScanner> s_graph_snes("AsciiShuichiSnes", {"spc"});
+ScannerRegistration<AsciiShuichiSnesScanner> s_ascii_shuichi_snes("AsciiShuichiSnes", {"spc"});
 }
 
 // Only tested with:

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesScanner.h
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesScanner.h
@@ -1,0 +1,22 @@
+/*
+ * VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#pragma once
+#include "Scanner.h"
+#include "BytePattern.h"
+
+class AsciiShuichiSnesScanner : public VGMScanner {
+ public:
+  explicit AsciiShuichiSnesScanner(Format* format) : VGMScanner(format) {}
+
+  void scan(RawFile *file, void *info) override;
+  static void scanFromARAM(RawFile *file);
+
+ private:
+  static BytePattern ptnLoadSeq;
+  static BytePattern ptnLoadInstr;
+  static BytePattern ptnLoadDIR;
+};

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
@@ -596,9 +596,11 @@ bool AsciiShuichiSnesTrack::readEvent() {
     case EVENT_MASTER_VOLUME: {
       const auto newVolL = static_cast<int8_t>(readByte(curOffset++));
       const auto newVolR = static_cast<int8_t>(readByte(curOffset++));
-      const auto newVol = static_cast<int8_t>(
-        min(abs(newVolL) + abs(newVolR), 255) / 2);  // workaround: convert to mono
-      addMasterVol(beginOffset, curOffset - beginOffset, newVol, "Master Volume L/R");
+
+
+      const auto desc = fmt::format("Master Volume - left: {:d}, right: {:d}", newVolL, newVolR);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Master Volume L/R", desc, CLR_VOLUME,
+                      ICON_CONTROL);
       break;
     }
 

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
@@ -1,0 +1,745 @@
+/*
+ * VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#include "AsciiShuichiSnesSeq.h"
+#include "ScaleConversion.h"
+#include "SeqEvent.h"
+
+using namespace std;
+
+DECLARE_FORMAT(AsciiShuichiSnes);
+
+static constexpr int MAX_TRACKS = 8;
+static constexpr uint16_t SEQ_PPQN = 48;
+static constexpr int SEQ_KEY_OFFSET = 36;
+
+static constexpr uint8_t panTable[] = {
+  0x80, 0x80, 0x7f, 0x7f, 0x7d, 0x7c, 0x7a, 0x78,
+  0x76, 0x73, 0x70, 0x6d, 0x69, 0x65, 0x61, 0x5d,
+  0x58, 0x54, 0x4f, 0x49, 0x44, 0x3e, 0x39, 0x33,
+  0x2d, 0x27, 0x21, 0x1a, 0x13, 0x0a, 0x00
+};
+
+//  ***************
+//  AsciiShuichiSnesSeq
+//  ***************
+
+AsciiShuichiSnesSeq::AsciiShuichiSnesSeq(RawFile *file, uint32_t seqHeaderOffset, string name)
+    : VGMSeq(AsciiShuichiSnesFormat::name, file, seqHeaderOffset, 0, move(name)) {
+  bLoadTickByTick = true;
+  setAllowDiscontinuousTrackData(true);
+  setUseLinearAmplitudeScale(true);
+
+  useReverb();
+  setAlwaysWriteInitialReverb(0);
+
+  loadEventMap();
+}
+
+void AsciiShuichiSnesSeq::resetVars() {
+  VGMSeq::resetVars();
+
+  tempo = 0x14;
+}
+
+bool AsciiShuichiSnesSeq::parseHeader() {
+  setPPQN(SEQ_PPQN);
+
+  VGMHeader *header = addHeader(dwOffset, 2 * MAX_TRACKS);
+  if (dwOffset + header->unLength > 0x10000) {
+    return false;
+  }
+
+  for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
+    string trackNameLow = fmt::format("Track Pointer {:d} (Low)", trackIndex + 1);
+    string trackNameHigh = fmt::format("Track Pointer {:d} (High)", trackIndex + 1);
+
+    header->addChild(dwOffset + trackIndex, 1, trackNameLow);
+    header->addChild(dwOffset + MAX_TRACKS + trackIndex, 1, trackNameHigh);
+  }
+
+  return true;
+}
+
+
+bool AsciiShuichiSnesSeq::parseTrackPointers() {
+  for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
+    const uint8_t lo = readByte(dwOffset + trackIndex);
+    const uint8_t hi = readByte(dwOffset + MAX_TRACKS + trackIndex);
+    const auto trackStartAddress = static_cast<uint16_t>(lo | (hi << 8));
+
+    const auto track = new AsciiShuichiSnesTrack(this, trackStartAddress);
+    aTracks.push_back(track);
+  }
+
+  return true;
+}
+
+void AsciiShuichiSnesSeq::loadEventMap() {
+  for (int statusByte = 0xac; statusByte <= 0xff; statusByte++) {
+    EventMap[static_cast<uint8_t>(statusByte)] = EVENT_NOTE;
+  }
+
+  EventMap[0x80] = EVENT_END;
+  EventMap[0x81] = EVENT_INFINITE_LOOP_START;
+  EventMap[0x82] = EVENT_INFINITE_LOOP_END;
+  EventMap[0x83] = EVENT_LOOP_START;
+  EventMap[0x84] = EVENT_LOOP_END;
+  EventMap[0x85] = EVENT_LOOP_BREAK;
+  EventMap[0x86] = EVENT_CALL;
+  EventMap[0x87] = EVENT_RET;
+  EventMap[0x88] = EVENT_UNKNOWN0;
+  EventMap[0x89] = EVENT_PROGCHANGE;
+  EventMap[0x8a] = EVENT_RELEASE_ADSR;
+  EventMap[0x8b] = EVENT_TEMPO;
+  EventMap[0x8c] = EVENT_TRANSPOSE_ABS;
+  EventMap[0x8d] = EVENT_TRANSPOSE_REL;
+  EventMap[0x8e] = EVENT_TUNING;
+  EventMap[0x8f] = EVENT_PITCH_BEND_SLIDE;
+  EventMap[0x90] = EVENT_DURATION_RATE;
+  //EventMap[0x91] = (invalid?);
+  EventMap[0x92] = EVENT_VOLUME_AND_PAN;
+  EventMap[0x93] = EVENT_VOLUME;
+  EventMap[0x94] = EVENT_VOLUME_REL;
+  EventMap[0x95] = EVENT_VOLUME_REL_TEMP;
+  EventMap[0x96] = EVENT_PAN;
+  //EventMap[0x97] = (undefined);
+  EventMap[0x98] = EVENT_PAN_FADE;
+  EventMap[0x99] = EVENT_VOLUME_FADE;
+  EventMap[0x9a] = EVENT_MASTER_VOLUME;
+  EventMap[0x9b] = EVENT_ECHO_PARAM;
+  EventMap[0x9c] = EVENT_ECHO_CHANNELS;
+  EventMap[0x9d] = EVENT_VIBRATO;
+  EventMap[0x9e] = EVENT_VIBRATO_OFF;
+  EventMap[0x9f] = EVENT_REST;
+  EventMap[0xa0] = EVENT_NOISE_ON;
+  EventMap[0xa1] = EVENT_NOISE_OFF;
+  //EventMap[0xa2] = (undefined);
+  EventMap[0xa3] = EVENT_MUTE_CHANNELS;
+  EventMap[0xa4] = EVENT_INSTRUMENT_VOLUME_PAN_TRANSPOSE;
+  EventMap[0xa5] = EVENT_DURATION_TICKS;
+  EventMap[0xa6] = EVENT_WRITE_TO_PORT;
+  //EventMap[0xa7] = (undefined);
+  //EventMap[0xa8] = (undefined);
+  //EventMap[0xa9] = (undefined);
+  //EventMap[0xaa] = (undefined);
+  EventMap[0xab] = EVENT_UNKNOWN0;
+}
+
+double AsciiShuichiSnesSeq::getTempoInBPM() const {
+  return getTempoInBPM(tempo);
+}
+
+double AsciiShuichiSnesSeq::getTempoInBPM(uint8_t tempo) {
+  if (tempo == 0) {
+    tempo = 1;
+  }
+
+  return 60000000.0 / (SEQ_PPQN * (125 * 4) * tempo);
+}
+
+
+
+//  *****************
+//  AsciiShuichiSnesTrack
+//  *****************
+
+AsciiShuichiSnesTrack::AsciiShuichiSnesTrack(AsciiShuichiSnesSeq *parentFile, uint32_t offset, uint32_t length)
+    : SeqTrack(parentFile, offset, length) {
+  AsciiShuichiSnesTrack::resetVars();
+  bDetermineTrackLengthEventByEvent = true;
+  bWriteGenericEventAsTextEvent = false;
+}
+
+void AsciiShuichiSnesTrack::resetVars() {
+  SeqTrack::resetVars();
+
+  cKeyCorrection = SEQ_KEY_OFFSET;
+
+  spcVolume = 0;
+  infiniteLoopPoint = 0;
+  lastNoteKey = -1;
+  rawNoteLength = 0;
+  noteDuration = 0;
+  noteDurationRate = 0;
+  slurDeferred = false;
+  useNoteDurationRate = true;
+  reachedRepeatBreakBefore = false;
+  repeatStartNestLevel = 0;
+  repeatEndNestLevel = 0;
+  callNestLevel = 0;
+  ranges::fill(repeatStartAddressStack, 0);
+  ranges::fill(repeatEndAddressStack, 0);
+  ranges::fill(repeatCountStack, 0);
+  ranges::fill(callStack, 0);
+}
+
+bool AsciiShuichiSnesTrack::readEvent() {
+  const auto parentSeq = dynamic_cast<AsciiShuichiSnesSeq*>(this->parentSeq);
+
+  const uint32_t beginOffset = curOffset;
+  if (curOffset >= 0x10000) {
+    return false;
+  }
+
+  const uint8_t statusByte = readByte(curOffset++);
+  bool bContinue = true;
+
+  auto eventType = static_cast<AsciiShuichiSnesSeqEventType>(0);
+  const auto pEventType = parentSeq->EventMap.find(statusByte);
+  if (pEventType != parentSeq->EventMap.end()) {
+    eventType = pEventType->second;
+  }
+
+  switch (eventType) {
+    case EVENT_UNKNOWN0: {
+      const auto desc = describeUnknownEvent(statusByte);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
+      break;
+    }
+
+    case EVENT_UNKNOWN1: {
+      const int arg1 = readByte(curOffset++);
+      const auto desc = describeUnknownEvent(statusByte, arg1);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
+      break;
+    }
+
+    case EVENT_UNKNOWN2: {
+      const int arg1 = readByte(curOffset++);
+      const int arg2 = readByte(curOffset++);
+      const auto desc = describeUnknownEvent(statusByte, arg1, arg2);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
+      break;
+    }
+
+    case EVENT_UNKNOWN3: {
+      const int arg1 = readByte(curOffset++);
+      const int arg2 = readByte(curOffset++);
+      const int arg3 = readByte(curOffset++);
+      const auto desc = describeUnknownEvent(statusByte, arg1, arg2, arg3);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
+      break;
+    }
+
+    case EVENT_UNKNOWN4: {
+      const int arg1 = readByte(curOffset++);
+      const int arg2 = readByte(curOffset++);
+      const int arg3 = readByte(curOffset++);
+      const int arg4 = readByte(curOffset++);
+      const auto desc = describeUnknownEvent(statusByte, arg1, arg2, arg3, arg4);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
+      break;
+    }
+
+    case EVENT_END: {
+      addEndOfTrack(beginOffset, curOffset - beginOffset);
+      bContinue = false;
+      break;
+    }
+
+    case EVENT_NOTE: {
+      const auto key = static_cast<int8_t>(statusByte - 0xac);
+      const bool isSlurEvent = (statusByte == 0xff);  // slur/tie
+
+      const uint8_t maybeLength = readByte(curOffset);
+      if (maybeLength < 0x80) {
+        rawNoteLength = maybeLength;
+        if (useNoteDurationRate) {
+          noteDuration = static_cast<uint8_t>(
+              rawNoteLength * (noteDurationRate == 0 ? 256 : noteDurationRate) / 256);
+        }
+        curOffset++;
+      }
+
+      if (isSlurEvent) {
+        // i.e. combine with next note - omit key-off and just change pitch
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie / Slur", "", CLR_TIE, ICON_NOTE);
+        slurDeferred = true;
+      } else {
+        // note event
+        const auto actualDur = min(static_cast<int>(noteDuration), max(1, rawNoteLength - 3));
+
+        if (slurDeferred && key == lastNoteKey) {
+          // tie
+          makePrevDurNoteEnd(getTime() + actualDur);
+
+          // add event without midi event
+          if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(beginOffset, true))
+            addEvent(new DurNoteSeqEvent(this, key + cKeyCorrection, 100, noteDuration, beginOffset,
+                                         curOffset - beginOffset, "Note with Duration"));
+        } else {
+          if (slurDeferred) {
+            makePrevDurNoteEnd(getTime());
+          }
+          addNoteByDur(beginOffset, curOffset - beginOffset, key, 100, actualDur);
+        }
+
+        slurDeferred = false;
+        lastNoteKey = key;
+
+        addTime(rawNoteLength);
+      }
+      break;
+    }
+
+    case EVENT_INFINITE_LOOP_START: {
+      infiniteLoopPoint = static_cast<uint16_t>(curOffset);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Infinite Loop Point",
+                      "", CLR_LOOP, ICON_STARTREP);
+      break;
+    }
+
+    case EVENT_INFINITE_LOOP_END: {
+      bContinue = addLoopForever(beginOffset, curOffset - beginOffset);
+      curOffset = infiniteLoopPoint;
+      break;
+    }
+
+    case EVENT_LOOP_START:
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", CLR_LOOP,
+                      ICON_STARTREP);
+      repeatStartAddressStack[repeatStartNestLevel] = static_cast<uint16_t>(curOffset);
+      repeatStartNestLevel++;
+      break;
+
+    case EVENT_LOOP_END: {
+      const uint8_t count = readByte(curOffset++);
+      const int realLoopCount = (count == 0) ? 256 : count;
+
+      const auto desc = fmt::format("Loop count: {:d}", realLoopCount);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc, CLR_LOOP,
+                      ICON_ENDREP);
+
+      bool firstTime =
+          repeatEndNestLevel == 0 || curOffset != repeatEndAddressStack[repeatEndNestLevel - 1];
+
+      bool shouldRepeatAgain = false;
+      if (firstTime) {
+        // first time
+        if (count == 1) {
+          // repeat once
+          repeatStartNestLevel--;
+        } else {
+          // repeat N times
+          repeatCountStack[repeatEndNestLevel] = count - 1;
+          repeatEndAddressStack[repeatEndNestLevel] = static_cast<uint16_t>(curOffset);
+          repeatEndNestLevel++;
+          shouldRepeatAgain = true;
+        }
+      } else {
+        // after the first time
+        const auto currentRepeatCount = repeatCountStack[repeatEndNestLevel - 1];
+        if (currentRepeatCount == 1) {
+          // repeat end
+          repeatStartNestLevel--;
+          repeatEndNestLevel--;
+        } else {
+          // repeat again
+          repeatCountStack[repeatEndNestLevel - 1] = currentRepeatCount - 1;
+          shouldRepeatAgain = true;
+        }
+      }
+
+      if (shouldRepeatAgain) {
+        if (repeatStartNestLevel == 0) {
+          L_WARN("Stack overflow in Loop End Event.");
+          bContinue = false;
+        } else {
+          curOffset = repeatStartAddressStack[repeatStartNestLevel - 1];
+        }
+      }
+      break;
+    }
+
+    case EVENT_LOOP_BREAK: {
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", "", CLR_LOOP,
+                      ICON_ENDREP);
+
+      if (!reachedRepeatBreakBefore) {
+        // first time, always skip
+        reachedRepeatBreakBefore = true;
+      } else {
+        if (repeatEndNestLevel == 0) {
+          L_WARN("Stack overflow in Loop Break Event.");
+          bContinue = false;
+        } else {
+          // end the repeat if last time
+          if (repeatCountStack[repeatEndNestLevel - 1] == 1) {
+            repeatEndNestLevel--;
+            repeatStartNestLevel--;
+            reachedRepeatBreakBefore = false;
+            curOffset = repeatEndAddressStack[repeatEndNestLevel];
+          }
+        }
+      }
+
+      break;
+    }
+
+    case EVENT_CALL: {
+      uint16_t dest = readShort(curOffset);
+      curOffset += 2;
+
+      const auto desc = fmt::format("Destination: {:#04x}", dest);
+      addGenericEvent(beginOffset, 3, "Pattern Play", desc, CLR_LOOP, ICON_STARTREP);
+
+      if (callNestLevel >= callStack.size()) {
+        L_WARN("Stack overflow in Pattern Play Event.");
+        bContinue = false;
+        break;
+      }
+
+      // save loop start address and repeat count
+      callStack[callNestLevel++] = static_cast<uint16_t>(curOffset);
+
+      // jump to subroutine address
+      curOffset = dest;
+
+      break;
+    }
+
+    case EVENT_RET: {
+      addGenericEvent(beginOffset, curOffset - beginOffset, "End Pattern", "", CLR_LOOP,
+                      ICON_ENDREP);
+
+      if (callNestLevel == 0) {
+        L_WARN("Stack overflow in Pattern End Event.");
+        bContinue = false;
+        break;
+      }
+
+      curOffset = callStack[--callNestLevel];
+      break;
+    }
+
+    case EVENT_PROGCHANGE: {
+      const uint8_t newProgramNumber = readByte(curOffset++);
+      addProgramChange(beginOffset, curOffset - beginOffset, newProgramNumber, true);
+      break;
+    }
+
+    case EVENT_RELEASE_ADSR: {
+      const uint8_t adsr2 = readByte(curOffset++);
+      const auto desc = fmt::format("ADSR(2): {:#02x}", adsr2);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Release ADSR", desc, CLR_ADSR,
+                      ICON_CONTROL);
+      break;
+    }
+
+    case EVENT_TEMPO: {
+      const uint8_t newTempo = readByte(curOffset++);
+      parentSeq->tempo = newTempo;
+      addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq->getTempoInBPM());
+      break;
+    }
+
+    case EVENT_TRANSPOSE_ABS: {
+      const auto newTranspose = static_cast<int8_t>(readByte(curOffset++));
+      addTranspose(beginOffset, curOffset - beginOffset, newTranspose);
+
+      // use coarse tuning instead
+      transpose = 0;
+      if (readMode == READMODE_CONVERT_TO_MIDI) {
+        pMidiTrack->addCoarseTuning(channel, newTranspose);
+      }
+      break;
+    }
+
+    case EVENT_TRANSPOSE_REL: {
+      const auto transposeDelta = static_cast<int8_t>(readByte(curOffset++));
+      const auto newTranspose = static_cast<int8_t>(transpose + transposeDelta);
+      addTranspose(beginOffset, curOffset - beginOffset, transposeDelta, "Transpose (Relative)");
+
+      // use coarse tuning instead
+      transpose = 0;
+      if (readMode == READMODE_CONVERT_TO_MIDI) {
+        pMidiTrack->addCoarseTuning(channel, newTranspose);
+      }
+      break;
+    }
+
+    case EVENT_TUNING: {
+      const auto newTuning = static_cast<int8_t>(readByte(curOffset++));
+      const double cents = pitchScaleToCents(1.0 + (newTuning / 4096.0));
+      addFineTuning(beginOffset, curOffset - beginOffset, cents);
+      break;
+    }
+
+    case EVENT_PITCH_BEND_SLIDE: {
+      const uint8_t arg1 = readByte(curOffset++);
+      const uint8_t arg2 = readByte(curOffset++);
+
+      const auto desc = logEvent(statusByte, spdlog::level::off, "Event", static_cast<int>(arg1),
+                      static_cast<int>(arg2));
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Bend Slide", desc, CLR_PITCHBEND,
+                      ICON_CONTROL);
+      // TODO: pitch bend slide
+      break;
+    }
+
+    case EVENT_DURATION_RATE: {
+      const uint8_t rate = readByte(curOffset++);
+      useNoteDurationRate = true;
+      noteDurationRate = rate;
+
+      noteDuration = static_cast<uint8_t>(rawNoteLength *
+                                          (noteDurationRate == 0 ? 256 : noteDurationRate) / 256);
+
+      const int actualRate = (rate == 0) ? 256 : rate;
+      const auto desc =
+          fmt::format("Note Length: {:d}/256 ({:.1f}%)", actualRate, actualRate / 256.0);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc, CLR_DURNOTE,
+                      ICON_CONTROL);
+      break;
+    }
+
+    case EVENT_DURATION_TICKS: {
+      const uint8_t ticks = readByte(curOffset++);
+      useNoteDurationRate = false;
+      noteDuration = ticks;
+
+      const auto desc = fmt::format("Note Length: {:d} ticks", ticks);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration", desc, CLR_DURNOTE,
+                      ICON_CONTROL);
+      break;
+    }
+
+    case EVENT_VOLUME_AND_PAN: {
+      const uint8_t volume = readByte(curOffset++);
+      const uint8_t pan = readByte(curOffset++);
+      spcVolume = volume;
+
+      const auto desc = fmt::format("Volume: {:d}, pan: {:d}/{:d}", volume, pan, countof(panTable));
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Volume & Pan", desc, CLR_VOLUME,
+                      ICON_CONTROL);
+
+      addVolNoItem(spcVolume / 2);
+
+      const int8_t midiPan = calcMidiPanValue(pan);
+      addPanNoItem(midiPan); // TODO: apply volume scale
+      break;
+    }
+
+    case EVENT_VOLUME: {
+      const uint8_t volume = readByte(curOffset++);
+      spcVolume = volume;
+
+      const auto desc = fmt::format("Volume: {:d}", volume);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Volume", desc, CLR_VOLUME,
+                      ICON_CONTROL);
+      addVolNoItem(spcVolume / 2);
+      break;
+    }
+
+    case EVENT_VOLUME_REL: {
+      const auto volumeDelta = static_cast<int8_t>(readByte(curOffset++));
+      spcVolume += volumeDelta;
+
+      const auto desc = fmt::format("Volume delta: {:d}", volumeDelta);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Volume (Relative)", desc, CLR_VOLUME,
+                      ICON_CONTROL);
+      addVolNoItem(spcVolume / 2);
+      break;
+    }
+
+    case EVENT_VOLUME_REL_TEMP: {
+      const auto volumeDelta = static_cast<int8_t>(readByte(curOffset++));
+
+      const auto desc = fmt::format("Volume delta: {:d}", volumeDelta);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Volume (One-Shot)", desc, CLR_VOLUME,
+                      ICON_CONTROL);
+      // TODO: volume MIDI CC
+      break;
+    }
+
+    case EVENT_PAN: {
+      const uint8_t pan = readByte(curOffset++);
+
+      const auto desc = fmt::format("Pan: {:d}/{:d}", pan, countof(panTable));
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan", desc, CLR_PAN, ICON_CONTROL);
+
+      const int8_t midiPan = calcMidiPanValue(pan);
+      addPanNoItem(midiPan);  // TODO: apply volume scale
+      break;
+    }
+
+    case EVENT_PAN_FADE: {
+      const uint8_t arg1 = readByte(curOffset++);
+      const uint8_t arg2 = readByte(curOffset++);
+      const uint8_t arg3 = readByte(curOffset++);
+
+      const auto desc = logEvent(statusByte, spdlog::level::off, "Event", static_cast<int>(arg1),
+                      static_cast<int>(arg2), static_cast<int>(arg3));
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc, CLR_PAN, ICON_CONTROL);
+      break;
+    }
+
+    case EVENT_VOLUME_FADE: {
+      const uint8_t delay = readByte(curOffset++);
+      const uint8_t rate = readByte(curOffset++);
+      const uint8_t depth = readByte(curOffset++);
+      const uint8_t stepLength = readByte(curOffset++);
+
+      const auto desc =
+          fmt::format("Volume Fade - delay: {:d}, rate: {:d}, depth: {:d}, step length: {:d}",
+                      delay, rate, depth, stepLength);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Volume Fade", desc, CLR_VOLUME,
+                      ICON_CONTROL);
+      // TODO: volume MIDI CC
+      break;
+    }
+
+    case EVENT_MASTER_VOLUME: {
+      const auto newVolL = static_cast<int8_t>(readByte(curOffset++));
+      const auto newVolR = static_cast<int8_t>(readByte(curOffset++));
+      const auto newVol = static_cast<int8_t>(
+        min(abs(newVolL) + abs(newVolR), 255) / 2);  // workaround: convert to mono
+      addMasterVol(beginOffset, curOffset - beginOffset, newVol, "Master Volume L/R");
+      break;
+    }
+
+    case EVENT_ECHO_PARAM: {
+      const uint8_t delay = readByte(curOffset++);
+      const uint8_t feedback = readByte(curOffset++);
+      const uint8_t arg3 = readByte(curOffset++);
+      
+      const auto desc = fmt::format("Echo delay: {:d}, feedback: {:d}, arg3: {:d}", delay, feedback, arg3);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Delay & Feedback", desc,
+                      CLR_REVERB, ICON_CONTROL);
+      break;
+    }
+
+    case EVENT_ECHO_CHANNELS: {
+      const uint8_t dspEchoOn = readByte(curOffset++);
+
+      const auto desc = fmt::format("Echo channels: {:#02x}", dspEchoOn);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Channels", desc, CLR_REVERB,
+                      ICON_CONTROL);
+
+      // TODO: output MIDI reverb
+      break;
+    }
+
+    case EVENT_VIBRATO: {
+      const uint8_t delay = readByte(curOffset++);
+      const uint8_t rate = readByte(curOffset++);
+      const uint8_t depth = readByte(curOffset++);
+      const uint8_t stepLength = readByte(curOffset++);
+
+      const auto desc =
+          fmt::format("Vibrato delay: {:d}, rate: {:d}, depth: {:d}, step length: {:d}", delay,
+                      rate, depth, stepLength);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, CLR_MODULATION,
+                      ICON_CONTROL);
+      break;
+    }
+
+    case EVENT_VIBRATO_OFF: {
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Off", "", CLR_MODULATION,
+                      ICON_CONTROL);
+      break;
+    }
+
+    case EVENT_REST: {
+      const uint8_t maybeLength = readByte(curOffset);
+      if (maybeLength < 0x80) {
+        rawNoteLength = maybeLength;
+        if (useNoteDurationRate) {
+          noteDuration = static_cast<uint8_t>(
+              rawNoteLength * (noteDurationRate == 0 ? 256 : noteDurationRate) / 256);
+        }
+        curOffset++;
+      }
+      addRest(beginOffset, curOffset - beginOffset, rawNoteLength);
+      break;
+    }
+
+    case EVENT_NOISE_ON:
+      lastNoteKey = -1;
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise On", "", CLR_PROGCHANGE,
+                      ICON_CONTROL);
+      break;
+
+    case EVENT_NOISE_OFF:
+      lastNoteKey = -1;
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Off", "", CLR_PROGCHANGE,
+                      ICON_CONTROL);
+      break;
+
+    case EVENT_MUTE_CHANNELS: {
+      const uint8_t channels = readByte(curOffset++);
+
+      const auto desc = fmt::format("Mute channels: {:#02x}", channels);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Mute Channels", desc, CLR_REVERB,
+                      ICON_CONTROL);
+      break;
+    }
+
+    case EVENT_INSTRUMENT_VOLUME_PAN_TRANSPOSE: {
+      const uint8_t newProgramNumber = readByte(curOffset++);
+      const uint8_t volume = readByte(curOffset++);
+      const uint8_t pan = readByte(curOffset++);
+      const auto newTranspose = static_cast<int8_t>(readByte(curOffset++));
+
+      const auto desc =
+          fmt::format("Instrument: {:d}, volume: {:d}, pan: {:d}/{:d}, transpose: {:d}",
+                      newProgramNumber, volume, pan, countof(panTable), newTranspose);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Instrument, Volume, Pan, Transpose",
+                      desc, CLR_PROGCHANGE, ICON_CONTROL);
+
+      addProgramChangeNoItem(newProgramNumber, true);
+
+      spcVolume = volume;
+      addVolNoItem(spcVolume / 2);
+
+      const int8_t midiPan = calcMidiPanValue(pan);
+      addPanNoItem(midiPan);  // TODO: apply volume scale
+
+      if (readMode == READMODE_CONVERT_TO_MIDI) {
+        pMidiTrack->addCoarseTuning(channel, newTranspose);
+      }
+      break;
+    }
+
+    case EVENT_WRITE_TO_PORT: {
+      const uint8_t value = readByte(curOffset++);
+      const auto desc = fmt::format("APUI02: {:d} ({:#02x})", value, value);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Write to I/O Port", desc, CLR_MISC,
+                      ICON_CONTROL);
+      break;
+    }
+
+    default: {
+      const auto desc = logEvent(statusByte);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
+      bContinue = false;
+      break;
+    }
+  }
+
+  return bContinue;
+}
+
+void AsciiShuichiSnesTrack::getVolumeBalance(uint8_t pan, double &volumeLeft, double &volumeRight) {
+  if (pan < countof(panTable)) {
+    const uint8_t vl = panTable[pan];
+    const uint8_t vr = panTable[30 - pan];
+    volumeLeft = vl / 256.0;
+    volumeRight = vr / 256.0;
+  } else {
+    L_WARN("Panpot is out of range. Value must be in the range 0 to 30.");
+    volumeLeft = 1.0;
+    volumeRight = 1.0;
+  }
+}
+
+int8_t AsciiShuichiSnesTrack::calcMidiPanValue(uint8_t pan) {
+  double volumeLeft;
+  double volumeRight;
+  getVolumeBalance(pan, volumeLeft, volumeRight);
+  return static_cast<int8_t>(convertVolumeBalanceToStdMidiPan(volumeLeft, volumeRight));
+}

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.h
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <array>
+
+#include "VGMSeq.h"
+#include "SeqTrack.h"
+#include "AsciiShuichiSnesFormat.h"
+
+enum AsciiShuichiSnesSeqEventType {
+  //start enum at 1 because if map[] look up fails, it returns 0, and we don't want that to get confused with a legit event
+  EVENT_UNKNOWN0 = 1,
+  EVENT_UNKNOWN1,
+  EVENT_UNKNOWN2,
+  EVENT_UNKNOWN3,
+  EVENT_UNKNOWN4,
+  EVENT_NOTE,
+  EVENT_END,
+  EVENT_INFINITE_LOOP_START,
+  EVENT_INFINITE_LOOP_END,
+  EVENT_LOOP_START,
+  EVENT_LOOP_END,
+  EVENT_LOOP_BREAK,
+  EVENT_CALL,
+  EVENT_RET,
+  EVENT_PROGCHANGE,
+  EVENT_RELEASE_ADSR,
+  EVENT_TEMPO,
+  EVENT_TRANSPOSE_ABS,
+  EVENT_TRANSPOSE_REL,
+  EVENT_TUNING,
+  EVENT_PITCH_BEND_SLIDE,
+  EVENT_DURATION_RATE,
+  EVENT_VOLUME_AND_PAN,
+  EVENT_VOLUME,
+  EVENT_VOLUME_REL,
+  EVENT_VOLUME_REL_TEMP,
+  EVENT_PAN,
+  EVENT_PAN_FADE,
+  EVENT_VOLUME_FADE,
+  EVENT_MASTER_VOLUME,
+  EVENT_ECHO_PARAM,
+  EVENT_ECHO_CHANNELS,
+  EVENT_VIBRATO,
+  EVENT_VIBRATO_OFF,
+  EVENT_REST,
+  EVENT_NOISE_ON,
+  EVENT_NOISE_OFF,
+  EVENT_MUTE_CHANNELS,
+  EVENT_INSTRUMENT_VOLUME_PAN_TRANSPOSE,
+  EVENT_DURATION_TICKS,
+  EVENT_WRITE_TO_PORT,
+};
+
+class AsciiShuichiSnesSeq
+    : public VGMSeq {
+ public:
+  AsciiShuichiSnesSeq
+      (RawFile *file, uint32_t seqHeaderOffset, std::string newName = "ASCII Shuichi Ukai SNES Seq");
+
+  bool parseHeader() override;
+  bool parseTrackPointers() override;
+  void resetVars() override;
+
+  std::map<uint8_t, AsciiShuichiSnesSeqEventType> EventMap;
+
+  uint8_t tempo;
+
+  [[nodiscard]] double getTempoInBPM() const;
+  static double getTempoInBPM(uint8_t tempo);
+
+ private:
+  void loadEventMap();
+};
+
+
+class AsciiShuichiSnesTrack
+    : public SeqTrack {
+ public:
+  AsciiShuichiSnesTrack(AsciiShuichiSnesSeq *parentFile, uint32_t offset = 0, uint32_t length = 0);
+  void resetVars() override;
+  bool readEvent() override;
+
+  static void getVolumeBalance(uint8_t pan, double &volumeLeft, double &volumeRight);
+  static int8_t calcMidiPanValue(uint8_t pan);
+
+ private:
+  uint8_t spcVolume;
+  uint16_t infiniteLoopPoint;
+  int8_t lastNoteKey;
+  uint8_t rawNoteLength;
+  uint8_t noteDuration;
+  uint8_t noteDurationRate;
+  bool slurDeferred;
+  bool useNoteDurationRate;
+  bool reachedRepeatBreakBefore;
+  uint8_t repeatStartNestLevel;
+  uint8_t repeatEndNestLevel;
+  uint8_t callNestLevel;
+  std::array<uint16_t, 3> repeatStartAddressStack;
+  std::array<uint16_t, 3> repeatEndAddressStack;
+  std::array<uint8_t, 3> repeatCountStack;
+  std::array<uint16_t, 3> callStack;
+};

--- a/src/main/formats/CPS/CPS1Instr.cpp
+++ b/src/main/formats/CPS/CPS1Instr.cpp
@@ -231,4 +231,5 @@ std::string CPS1OPMInstrSet::generateOPMFile() {
 bool CPS1OPMInstrSet::saveAsOPMFile(const std::string &filepath) {
   auto content = generateOPMFile();
   pRoot->UI_writeBufferToFile(filepath, reinterpret_cast<uint8_t*>(const_cast<char*>(content.data())), static_cast<uint32_t>(content.size()));
+  return true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds support for SNES music drivers by ASCII corporation, designed by Shuichi Ukai.
Specifically, music from Wizardry VI and Down the World (#365) will now be supported.
There should be other game titles that use the same drivers, but I have not tested those so far.

In the process, I have fixed a very small problems with vgmtrans core. (see commit log).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed that Wizardry VI and Down the World music can be played.

Not tested on anything other than Windows 11, Visual Studio 2022.

I haven't done much regression testing because I haven't made aggressive changes other than adding code.

**Supported**:

* Wizardry VI: Bane of the Cosmic Forge
* Down the World: Mervil's Ambition

**No Support Guaranteed (it may or may not work)**:

* Ardy Lightfoot
* Derby Stallion II
* Sanrio Shanghai
* Derby Stallion III
* Derby Stallion '96
* Derby Stallion '98
* Ganpuru: Gunman's Proof
* Wizardry Gaiden IV: Throb of the Demon's Heart

### List of Commands

The following is a list of commands in the sequence.

I have tried to parse these events accurately. On the other hand, only partial support is provided for the conversion to MIDI events.

|Value     |Event Name                                 |Parameters                      |MIDI Conversion|
|----------|-------------------------------------------|--------------------------------|----|
|0x80      |End of Track                               |(none)                          |Good|
|0x81      |Infinite Loop Start                        |(none)                          |Good|
|0x82      |Infinite Loop End                          |(none)                          |Good|
|0x83      |Repeat Start                               |(none)                          |Good|
|0x84      |Repeat End                                 |count                           |Good|
|0x85      |Repeat Break                               |(none)                          |Good|
|0x86      |Pattern Play                               |address: u16                    |Good|
|0x87      |End Pattern                                |(none)                          |Good|
|0x88      |(Unknown)                                  |(none)                          |Ignored|
|0x89      |Instrument                                 |instrument                      |Good|
|0x8a      |Release GAIN                               |gain                            |Ignored|
|0x8b      |Tempo                                      |tempo                           |Good|
|0x8c      |Coarse Tuning (Absolute)                   |key: s8                         |Good (RPN Coarse Tuning used)|
|0x8d      |Coarse Tuning (Relative)                   |key: s8                         |Good (RPN Coarse Tuning used)|
|0x8e      |Tuning                                     |tuning: s8                      |Good (RPN Fine Tuning used)|
|0x8f      |Pitch Bend Slide                           |arg1, arg2                      |**Ignored**|
|0x90      |Note Duration (Rate)                       |rate                            |Good|
|0x92      |Volume & Pan                               |vol, pan                        |Good (*)|
|0x93      |Volume                                     |vol                             |Good|
|0x94      |Volume (Relative)                          |delta: s8                       |Good|
|0x95      |Volume (One-Shot)                          |delta: s8                       |Good|
|0x96      |Pan                                        |pan (0..30)                     |Good (*The L/R volume ratio is adjusted to match the MIDI one, but not the loudness)|
|0x98      |Pan Fade                                   |arg1, arg2, arg3                |**Ignored** (*)|
|0x99      |Volume Fade                                |delay, rate, depth, step_length |**Ignored**|
|0x9a      |Master Volume                              |mvol_l: s8, mvol_r: s8          |**Ignored**|
|0x9b      |Echo Delay / Feedback                      |delay, feedback, arg3           |Good|
|0x9c      |Echo Channels                              |channel_bits                    |**Ignored**|
|0x9d      |Vibrato                                    |delay, rate, depth, step_length |**Ignored**|
|0x9e      |Vibrato Off                                |(none)                          |**Ignored**|
|0x9f      |Rest                                       |[length]                        |Good|
|0xa0      |Noise On                                   |(none)                          |Ignored|
|0xa1      |Noise Off                                  |(none)                          |Ignored|
|0xa3      |Mute Channels                              |channel_bits                    |**Ignored**|
|0xa4      |Instrument w/ Volume & Pan & Coarse Tuning |instrument, vol, pan, key: s8   |Good (*)|
|0xa5      |Note Duration (Tick)                       |length                          |Good|
|0xa6      |Write to I/O Port                          |value                           |Ignored|
|0xab      |(Unknown)                                  |(none)                          |Ignored|
|0xac-0xfe |Note                                       |[length]                        |Good|
|0xff      |Slur/Tie                                   |[length]                        |Good (note duration is adjusted, but no further control is added)|

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
