### PR TITLE
Fix SSEQ file size read

### DIFF
--- a/src/main/formats/NDS/NDSSeq.cpp
+++ b/src/main/formats/NDS/NDSSeq.cpp
@@ -15,7 +15,7 @@ bool NDSSeq::parseHeader(void) {
   SSEQHdr->addChild(dwOffset + 12, 2, "Header Size");
   SSEQHdr->addUnknownChild(dwOffset + 14, 2);
   //SeqChunkHdr->addSimpleChild(dwOffset, 4, "Blah");
-  unLength = readShort(dwOffset + 8);
+  unLength = readWord(dwOffset + 8);
   setPPQN(0x30);
   return true;        //successful
 }


### PR DESCRIPTION
This change adjusts the size read for the actual file interactions to equal the size in the header. Previously this size was read as a short even though the header contains a word field for size.

Dragon Quest VI - Realms of Reverie contains SND_BGM_M30_LULLABY which has a size of 0x1a228 and was previously not parsable.