### PR TITLE
FilegroupMatcher and Vab improvements

### DIFF
--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -25,6 +25,7 @@ public:
   virtual bool parseHeader();
   virtual bool parseInstrPointers();
   virtual bool loadInstrs();
+  virtual bool isViableSampCollMatch(VGMSampColl*) { return true; }
 
   VGMInstr *addInstr(uint32_t offset, uint32_t length, uint32_t bank, uint32_t instrNum,
                      const std::string &instrName = "");

--- a/src/main/components/matcher/FilegroupMatcher.cpp
+++ b/src/main/components/matcher/FilegroupMatcher.cpp
@@ -76,8 +76,8 @@ void FilegroupMatcher::lookForMatch() {
 
   // An instrument set plus an optional extra sample collection to add to the VGMColl
   struct InstrAssoc {
-    VGMInstrSet* instr;
-    VGMSampColl* extraSamp;   // nullptr when no extra sample collection is needed
+    VGMInstrSet* instrSet;
+    VGMSampColl* sampColl;
   };
 
   std::vector<InstrAssoc> instrAssocs;
@@ -133,9 +133,9 @@ void FilegroupMatcher::lookForMatch() {
     VGMColl* coll = fmt->newCollection();
     coll->setName(seq->name());
     coll->useSeq(seq);
-    coll->addInstrSet(assoc.instr);
-    if (assoc.extraSamp) {
-      coll->addSampColl(assoc.extraSamp);
+    coll->addInstrSet(assoc.instrSet);
+    if (assoc.sampColl) {
+      coll->addSampColl(assoc.sampColl);
     }
 
     if (!coll->load()) {

--- a/src/main/components/matcher/FilegroupMatcher.cpp
+++ b/src/main/components/matcher/FilegroupMatcher.cpp
@@ -68,46 +68,83 @@ bool FilegroupMatcher::onCloseSampColl(VGMSampColl *sampcoll) {
 }
 
 void FilegroupMatcher::lookForMatch() {
-  while (!seqs.empty() && !instrsets.empty()) {
-    // If there's only 1 of any collection type left, match to largest size.
-    if (seqs.size() == 1 && sampcolls.size() > 1) {
-      sampcolls.sort([](const VGMSampColl* a, const VGMSampColl* b) {
-        return a->size() > b->size();
-      });
-    }
-    else if (seqs.size() == 1 && instrsets.size() > 1) {
-      instrsets.sort([](const VGMInstrSet* a, const VGMInstrSet* b) {
-        return a->size() > b->size();
-      });
-    }
-    else if (instrsets.size() == 1 && seqs.size() > 1) {
-      seqs.sort([](const VGMSeq* a, const VGMSeq* b) {
-        return a->size() > b->size();
-      });
-    }
+  // 1. Sort all three containers by descending file‑offset
+  auto byOffsetDesc = [](auto* a, auto* b) { return a->dwOffset > b->dwOffset; };
+  seqs.sort(byOffsetDesc);
+  instrsets.sort(byOffsetDesc);
+  sampcolls.sort(byOffsetDesc);
 
-    VGMSeq* seq = seqs.front();
-    seqs.pop_front();
-    VGMInstrSet* instrset = instrsets.front();
-    instrsets.pop_front();
-    VGMSampColl* sampcoll = nullptr;
-    if (instrset->sampColl == nullptr) {
-      if (sampcolls.empty()) {
-        continue;
+  // An instrument set plus an optional extra sample collection to add to the VGMColl
+  struct InstrAssoc {
+    VGMInstrSet* instr;
+    VGMSampColl* extraSamp;   // nullptr when no extra sample collection is needed
+  };
+
+  std::vector<InstrAssoc> instrAssocs;
+  instrAssocs.reserve(instrsets.size());
+
+  bool forcePairSingle = (instrsets.size() == 1 && sampcolls.size() == 1);
+  VGMSampColl* lastValidSamp = nullptr;
+
+  // 2. Build the list of usable (instrset, extraSamp) associations
+  for (VGMInstrSet* instr : instrsets) {
+    VGMSampColl* extraSamp = nullptr;
+
+    if (instr->sampColl == nullptr) {
+      if (forcePairSingle) {                     // exactly one‑and‑one: pair regardless
+        extraSamp = sampcolls.front();
+        sampcolls.clear();
+        lastValidSamp = extraSamp;
+      } else {
+        // look for an unused compatible sample collection
+        for (auto scIt = sampcolls.begin(); scIt != sampcolls.end(); ++scIt) {
+          VGMSampColl* sampleColl = *scIt;
+          if (instr->isViableSampCollMatch(sampleColl)) {
+            extraSamp = sampleColl;
+            lastValidSamp = sampleColl;
+            sampcolls.erase(scIt);         // consume it
+            break;
+          }
+        }
+        // none left → reuse the last compatible one if still valid
+        if (!extraSamp && lastValidSamp && instr->isViableSampCollMatch(lastValidSamp)) {
+          extraSamp = lastValidSamp;
+        }
       }
-      sampcoll = sampcolls.front();
-      sampcolls.pop_front();
+    } else {
+      extraSamp = instr->sampColl;                // use the existing sample collection
     }
 
-    VGMColl *coll = fmt->newCollection();
+    // keep only instrsets that actually have a sample collection to work with
+    if (extraSamp != nullptr) {
+      instrAssocs.push_back({instr, extraSamp});
+    }
+  }
+
+  if (instrAssocs.empty()) {
+    return;                                        // nothing left to match
+  }
+
+  // 3. For every sequence, build a VGMColl with the next instrument association
+  auto assocIt = instrAssocs.begin();
+  for (VGMSeq* seq : seqs) {
+    const InstrAssoc& assoc = *assocIt;
+
+    VGMColl* coll = fmt->newCollection();
     coll->setName(seq->name());
     coll->useSeq(seq);
-    coll->addInstrSet(instrset);
-    if (sampcoll != nullptr) {
-      coll->addSampColl(sampcoll);
+    coll->addInstrSet(assoc.instr);
+    if (assoc.extraSamp) {
+      coll->addSampColl(assoc.extraSamp);
     }
+
     if (!coll->load()) {
       delete coll;
+    }
+
+    // advance through the association list; keep using the last one once we run out
+    if (std::next(assocIt) != instrAssocs.end()) {
+      ++assocIt;
     }
   }
 }

--- a/src/main/components/matcher/FilegroupMatcher.h
+++ b/src/main/components/matcher/FilegroupMatcher.h
@@ -17,13 +17,25 @@ class VGMSampColl;
 // FilegroupMatcher
 // ****************
 
-// FilegroupMatcher handles formats where the only method of associating sequences, instrument sets,
-// and sample collections is that they are loaded together within the same RawFile. When loading is
-// complete, FilegroupMatcher processes the VGMFiles in the order they were added and groups them
-// into collections: thus, it assumes association by order. FilegroupMatcher does not retain
-// state between loads, so it will never create a collection that spans multiple RawFiles, with the
-// exception that FilegroupMatcher processes a psf file and all of its psflib dependencies together
-// as a single load.
+// FilegroupMatcher handles formats where the primary method of associating sequences, instrument
+// sets, and sample collections is that they are loaded together within the same RawFile. When
+// loading is complete, FilegroupMatcher processes the VGMFiles in the order they were added and
+// groups them into collections: thus, it assumes association by order. FilegroupMatcher does not
+// retain state between loads, so it will never create a collection that spans multiple RawFiles,
+// with the exception that FilegroupMatcher processes a psf file and all of its psflib dependencies
+// together as a single load.
+
+// When loading is complete, FilegroupMatcher:
+// 1) Sorts sequences, instrument sets, and sample collections by their offsets.
+// 2) Attempts to pair each instrument set with a sample collection. It calls
+// VGMInstrSet::isViableSampCollMatch() to filter out non-viable sample collections. If the file
+// contains a single instrument set and sample collection, they are always paired. After pairing, a
+// sample collection is removed from the pool for matching, unless it is the last one.
+// 3) Creates a new collection for each sequence by iterating over the instrument set / sample
+// collection pairs. If that list is exhausted before the sequence list, it reuses the last
+// instrument set / sample collection pair.
+
+
 
 class FilegroupMatcher : public Matcher {
 public:

--- a/src/main/formats/PS1/PS1Seq.cpp
+++ b/src/main/formats/PS1/PS1Seq.cpp
@@ -35,8 +35,13 @@ bool PS1Seq::parseHeader() {
   seqHeader->addSig(offset() + 0x0D, 2); // Rhythm (Numerator) and Rhythm (Denominator) (2^n)
 
   if (readByte(offset() + 0xF) == 0 && readByte(offset() + 0x10) == 0) {
+    u32 newSeqOffset = offset() + readShortBE(offset() + 0x11) + 0x13 - 6;
+    // Check that there's a plausible amount of space for the sequence
+    if (newSeqOffset > rawFile()->size() - 100)
+      return false;
+
     setEventsOffset(offset() + 0x0F + 4);
-    PS1Seq *newPS1Seq = new PS1Seq(rawFile(), offset() + readShortBE(offset() + 0x11) + 0x13 - 6);
+    PS1Seq *newPS1Seq = new PS1Seq(rawFile(), newSeqOffset);
     if (!newPS1Seq->loadVGMFile()) {
       delete newPS1Seq;
     }

--- a/src/main/formats/PS1/PS1SeqScanner.cpp
+++ b/src/main/formats/PS1/PS1SeqScanner.cpp
@@ -21,7 +21,12 @@ constexpr int SRCH_BUF_SIZE = 0x20000;
 void PS1SeqScanner::scan(RawFile* file, void* /*info*/) {
   auto seqs = searchForPS1Seq(file);
   auto vabs = searchForVab(file);
-  if (vabs.empty() || vabs[0]->dwOffset != 0) {
+  bool vabsDontOwnSampColls = std::ranges::any_of(
+    vabs,
+    [](Vab* vab) { return vab->sampColl == nullptr; }
+  );
+  // skip sample collection search if we found vabs and every one had an associated sample collection
+  if (vabs.empty() || vabsDontOwnSampColls) {
     PSXSampColl::searchForPSXADPCM(file, PS1Format::name);
   }
 }

--- a/src/main/formats/PS1/Vab.h
+++ b/src/main/formats/PS1/Vab.h
@@ -2,8 +2,9 @@
 #include "VGMInstrSet.h"
 #include "VGMSampColl.h"
 #include "VGMRgn.h"
+#include "VGMSamp.h"
 
-//VAB Header
+// VAB Header
 struct VabHdr {
   int32_t form;
   /*always "VABp"*/
@@ -109,9 +110,13 @@ class Vab:
 
   virtual bool parseHeader();
   virtual bool parseInstrPointers();
+  bool isViableSampCollMatch(VGMSampColl* sampColl) override;
 
  public:
   VabHdr hdr;
+
+private:
+  std::vector<SizeOffsetPair> m_vagLocations;
 };
 
 


### PR DESCRIPTION
This improve FilegroupMatcher and updates Vab to take advantage of the changes.

## Description

FilegroupMatcher works fine for files that contain a single sequence, instrument set, and sample collection. It doesn't do a good job when there are more than one of a given file type.

This attempts to improve how we handle these cases. Part of this is the addition of a new VGMInstrSet::isViableSampCollMatch() virtual function. It returns true by default, but a subclass can override it to help filter out sample collections for matching. In the case of VAB, we now keep track of the list of VAG sizes (inspired PS1 speak for "sample"), which allows us to compare the size of a prospective sample collection with what the instrument set expects.

This doesn't fix matching entirely for PS1 games: when there are multiple instrument set / sample collection pairs, there's still no way to know which belongs to a given sequence. But it does fix a lot of cases.

The new algorithm is summed up in the code comment I added to FilegroupMatcher.h:

> FilegroupMatcher handles formats where the primary method of associating sequences, instrument sets, and sample collections is that they are loaded together within the same RawFile. When loading is complete, FilegroupMatcher processes the VGMFiles in the order they were added and groups them into collections: thus, it assumes association by order. FilegroupMatcher does not retain state between loads, so it will never create a collection that spans multiple RawFiles, with the exception that FilegroupMatcher processes a psf file and all of its psflib dependencies together as a single load.
> 
> When loading is complete, FilegroupMatcher:
> 
> 1. Sorts sequences, instrument sets, and sample collections by their offset, ascending.
> 2. Attempts to pair each instrument set with a sample collection. It calls VGMInstrSet::isViableSampCollMatch() to filter out non-viable sample collections. If the file contains a single instrument set and sample collection, they are always paired. After pairing, a sample collection is removed from the pool for matching, unless it is the last one. 
> 3. Creates a new collection for each sequence by iterating over the instrument set / sample collection pairs. If that list is exhausted before the sequence list, it reuses the last instrument set / sample collection pair.


This PR also changes the logic for loading VAB files with bundled sample collections. The prior code assumed that if a VAB was discovered at offset 0, it would be bundled with a sample collection. This wasn't necessarily true, and there are counter examples in PSF collections. The older code also assumed an older version of the bundled VAB format. In newer revisions (I believe it's tied to the format), the attached sample collection is preceded by a 32 bit size value. Since I found more instances of this bundled format, and since we can validate by comparing the total VAG sizes against the size value, I've removed the old logic and added support for this bundled format. The old format should still be detected via the searchForPSXADPCM() function. Really, the only time this bundle load logic makes a difference is when a sample collection has been partially zeroed out via PSF optimization.

## Motivation and Context
Get PS1 SEQ/VAB loading working more reliably.

## How Has This Been Tested?
A lot of formats use this Matcher, so I am going to to run a test suite of every supported format.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
