### PR TITLE
Switch tab keyboard shortcuts

### DIFF
--- a/src/ui/qt/workarea/MdiArea.cpp
+++ b/src/ui/qt/workarea/MdiArea.cpp
@@ -8,6 +8,7 @@
 
 #include <QTabBar>
 #include <QApplication>
+#include <QKeyEvent>
 #include <VGMFile.h>
 #include "VGMFileView.h"
 #include "Metrics.h"
@@ -109,6 +110,22 @@ void MdiArea::onVGMFileSelected(const VGMFile *file, QWidget *caller) {
     // Reassert the focus back to the caller
     if (caller && callerHadFocus) {
       caller->setFocus();
+    }
+  }
+}
+
+void MdiArea::keyPressEvent(QKeyEvent* event) {
+  QMdiArea::keyPressEvent(event);
+
+  // Handle MacOS shortcut for switching tabs
+  if ((event->modifiers() & Qt::ShiftModifier) && (event->modifiers() & Qt::ControlModifier)) {
+    switch (event->key()) {
+      case Qt::Key_BracketLeft:
+        this->activatePreviousSubWindow();
+        break;
+      case Qt::Key_BracketRight:
+        this->activateNextSubWindow();
+        break;
     }
   }
 }

--- a/src/ui/qt/workarea/MdiArea.cpp
+++ b/src/ui/qt/workarea/MdiArea.cpp
@@ -36,7 +36,7 @@ MdiArea::MdiArea(QWidget *parent) : QMdiArea(parent) {
   auto addShortcut = [this](const QKeySequence &seq, auto slot)
   {
     auto *sc = new QShortcut(seq, this);
-    sc->setContext(Qt::WindowShortcut);          // active for this window only
+    sc->setContext(Qt::WindowShortcut);
     connect(sc, &QShortcut::activated, this, slot);
   };
 
@@ -53,6 +53,11 @@ MdiArea::MdiArea(QWidget *parent) : QMdiArea(parent) {
   addShortcut(QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_Right),
               &QMdiArea::activateNextSubWindow);
 
+  // Ctrl + PageDown / Ctrl + PageUp
+  addShortcut(QKeySequence(Qt::META | Qt::Key_PageDown),
+              &QMdiArea::activateNextSubWindow);
+  addShortcut(QKeySequence(Qt::META | Qt::Key_PageUp),
+              &QMdiArea::activatePreviousSubWindow);
 #else   // Windows & Linux
   // Ctrl + Tab  /  Ctrl + Shift + Tab
   addShortcut(QKeySequence(Qt::CTRL | Qt::Key_Tab),

--- a/src/ui/qt/workarea/MdiArea.h
+++ b/src/ui/qt/workarea/MdiArea.h
@@ -36,6 +36,7 @@ private:
   MdiArea(QWidget *parent = nullptr);
   void onSubWindowActivated(QMdiSubWindow *window);
   void onVGMFileSelected(const VGMFile *file, QWidget *caller);
+  void keyPressEvent(QKeyEvent *) override;
   static void ensureMaximizedSubWindow(QMdiSubWindow *window);
   std::unordered_map<const VGMFile *, QMdiSubWindow *> fileToWindowMap;
   std::unordered_map<QMdiSubWindow *, VGMFile *> windowToFileMap;

--- a/src/ui/qt/workarea/MdiArea.h
+++ b/src/ui/qt/workarea/MdiArea.h
@@ -36,7 +36,6 @@ private:
   MdiArea(QWidget *parent = nullptr);
   void onSubWindowActivated(QMdiSubWindow *window);
   void onVGMFileSelected(const VGMFile *file, QWidget *caller);
-  void keyPressEvent(QKeyEvent *) override;
   static void ensureMaximizedSubWindow(QMdiSubWindow *window);
   std::unordered_map<const VGMFile *, QMdiSubWindow *> fileToWindowMap;
   std::unordered_map<QMdiSubWindow *, VGMFile *> windowToFileMap;


### PR DESCRIPTION
This adds conventional keyboard shortcuts to switch between VGMFileView tabs.

## Description
On MacOS, I've added Cmd-Shift-BracketLeft/Right, Cmd-Opt-ArrowLeft/Right, and Ctrl+PageUp/Down.
Windows and Linux get Ctrl-Tab/Ctrl-Shift-Tab and Ctrl-PageUp/Down.

## How Has This Been Tested?
Tested on MacOS and Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
