### PR TITLE
More PS1 scanning improvements

### DIFF
--- a/src/main/formats/PS1/PS1Seq.cpp
+++ b/src/main/formats/PS1/PS1Seq.cpp
@@ -65,7 +65,7 @@ void PS1Seq::resetVars() {
   uint8_t numer = readByte(offset() + 0x0D);
   uint8_t denom = readByte(offset() + 0x0E);
   addTimeSig(offset() + 0x0D, 2, numer, 1 << denom, (uint8_t) ppqn());
-  std::ranges::fill(m_hasSetProgramForChannel, u8{0});
+  std::ranges::fill(m_hasSetProgramForChannel, false);
 }
 
 bool PS1Seq::readEvent() {

--- a/src/main/formats/PS1/PS1Seq.h
+++ b/src/main/formats/PS1/PS1Seq.h
@@ -12,5 +12,8 @@ class PS1Seq:
   virtual bool readEvent();
 
  private:
-  uint8_t runningStatus;
+  u8 m_runningStatus;
+  u8 m_hasSetProgramForChannel[16]{};  // It seems the program assignment defaults to channel number,
+                                       // (example: Umihara Kawase: Shun). We use these flags to track if
+                                       // a default program change event is necessary for each channel
 };

--- a/src/main/formats/PS1/PS1Seq.h
+++ b/src/main/formats/PS1/PS1Seq.h
@@ -13,7 +13,7 @@ class PS1Seq:
 
  private:
   u8 m_runningStatus;
-  u8 m_hasSetProgramForChannel[16]{};  // It seems the program assignment defaults to channel number,
-                                       // (example: Umihara Kawase: Shun). We use these flags to track if
-                                       // a default program change event is necessary for each channel
+  bool m_hasSetProgramForChannel[16]{};  // It seems the program assignment defaults to channel number,
+                                         // (example: Umihara Kawase: Shun). We use these flags to track if
+                                         // a default program change event is necessary for each channel
 };

--- a/src/main/formats/PS1/PS1SeqScanner.cpp
+++ b/src/main/formats/PS1/PS1SeqScanner.cpp
@@ -27,7 +27,7 @@ void PS1SeqScanner::scan(RawFile* file, void* /*info*/) {
   );
   // skip sample collection search if we found vabs and every one had an associated sample collection
   if (vabs.empty() || vabsDontOwnSampColls) {
-    PSXSampColl::searchForPSXADPCM(file, PS1Format::name);
+    PSXSampColl::searchForPSXADPCMs(file, PS1Format::name);
   }
 }
 

--- a/src/main/formats/PS1/PS1SeqScanner.cpp
+++ b/src/main/formats/PS1/PS1SeqScanner.cpp
@@ -21,14 +21,7 @@ constexpr int SRCH_BUF_SIZE = 0x20000;
 void PS1SeqScanner::scan(RawFile* file, void* /*info*/) {
   auto seqs = searchForPS1Seq(file);
   auto vabs = searchForVab(file);
-  bool vabsDontOwnSampColls = std::ranges::any_of(
-    vabs,
-    [](Vab* vab) { return vab->sampColl == nullptr; }
-  );
-  // skip sample collection search if we found vabs and every one had an associated sample collection
-  if (vabs.empty() || vabsDontOwnSampColls) {
-    PSXSampColl::searchForPSXADPCMs(file, PS1Format::name);
-  }
+  PSXSampColl::searchForPSXADPCMs(file, PS1Format::name);
 }
 
 std::vector<PS1Seq *> PS1SeqScanner::searchForPS1Seq(RawFile *file) {

--- a/src/main/formats/PS1/Vab.cpp
+++ b/src/main/formats/PS1/Vab.cpp
@@ -139,22 +139,6 @@ bool Vab::parseInstrPointers() {
       vagOffset += vagSize;
     }
     unLength = vagStartOffset - dwOffset;
-
-    if (rawFile()->size() < vagStartOffset + 0x20)
-      return true;
-
-    // Check if samples are appended at the end, preceded by a size value
-    const u32 sampCollSize = rawFile()->readWord(vagStartOffset);
-    if (m_vagLocations.size() != 0 && sampCollSize == totalVAGSize) {
-      PSXSampColl *newSampColl = new PSXSampColl(formatName(), this, vagStartOffset + 4, totalVAGSize, m_vagLocations);
-      if (newSampColl->loadVGMFile()) {
-        pRoot->addVGMFile(newSampColl);
-        this->sampColl = newSampColl;
-      }
-      else {
-        delete newSampColl;
-      }
-    }
   }
 
   return true;

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -8,6 +8,10 @@
 using namespace std;
 
 
+static bool isValidSampleStart(const RawFile* file, u32 offset, bool allowShort);
+static bool isZero16(const RawFile* f, u32 ofs);
+static bool isValidFilterShiftByte(u8 b);
+static bool isValidFlagByte(u8 b);
 
 // ***********
 // PSXSampColl
@@ -36,11 +40,11 @@ bool PSXSampColl::parseSampleInfo() {
     //We do this by searching for series of 16 0x00 value bytes.  These indicate the beginning of a sample,
     //and they will never be found at any other point within the adpcm sample data.
 
-    uint32_t nEndOffset = dwOffset + unLength;
+    u32 nEndOffset = dwOffset + unLength;
     if (unLength == 0)
       nEndOffset = endOffset();
 
-    uint32_t i = dwOffset;
+    u32 i = dwOffset;
     while (i + 32 <= nEndOffset) {
       bool isSample = false;
 
@@ -83,57 +87,82 @@ bool PSXSampColl::parseSampleInfo() {
         }
       }
 
-      if (isSample) {
-        uint32_t extraGunkLength = 0;
-        uint8_t filterRangeByte = readByte(i + 16);
-        uint8_t keyFlagByte = readByte(i + 16 + 1);
-        if ((keyFlagByte & 0xF8) != 0)
-          break;
+      if (!isSample)
+        break;
 
-        //if (filterRangeByte == 0 && keyFlagByte == 0)	// Breaking on FFXII 309 - Eruyt Village at 61D50 of the WD
-        if (readWord(i + 16) == 0 && readWord(i + 20) == 0 && readWord(i + 24) == 0 && readWord(i + 28) == 0)
-          break;
+      // We've found the start of a sample. Now we determine its length and add it.
 
-        uint32_t beginOffset = i;
+      u32 extraGunkLength = 0;
+      u8 filterRangeByte = readByte(i + 16);
+      u8 keyFlagByte = readByte(i + 16 + 1);
+
+      if (!isValidFlagByte(keyFlagByte) || !isValidFilterShiftByte(filterRangeByte))
+        break;
+
+      if (isZero16(rawFile(), i + 16))
+        break;
+
+      u32 beginOffset = i;
+      i += 16;
+
+      //skip through until we reach the chunk with the end flag set
+      u32 endLoopOffset = 0;  // This will mark the end of the first frame that has an end flag set.
+                              // Occasionally, the data for a given sample may extend beyond this point
+                              // for some reason. For conversion, we treat this as the end of the sample.
+      while (i + 16 <= nEndOffset) {
+        u8 flagByte = readByte(i + 1);
+        u8 endFlag = ((flagByte & 1) != 0);
         i += 16;
 
-        //skip through until we reach the chunk with the end flag set
-        bool loopEnd = false;
-        while (i + 16 <= nEndOffset && !loopEnd) {
-          loopEnd = ((readByte(i + 1) & 1) != 0);
-          i += 16;
-        }
+        if (endFlag) {
+          endLoopOffset = endLoopOffset == 0 ? i : endLoopOffset;
 
-        //deal with exceptional cases where we see 00 07 77 77 77 77 77 etc.
-        while (i + 16 <= nEndOffset) {
-          loopEnd = ((readByte(i + 1) & 1) != 0);
-          if (!loopEnd) {
+          // We found an end flag. Check for vestigial ADPCM frames beyond it
+          if (i + 16 < nEndOffset) {
+            u8 nextFilterShiftByte = readByte(i);
+            u8 nextFlagByte = readByte(i + 1);
+            if (nextFlagByte < 1 || nextFlagByte > 3 || !isValidFilterShiftByte(nextFilterShiftByte)) {
+              break;
+            }
+          } else {
             break;
           }
+        }
+      }
+
+      // Handle the case of an end frame using the format 00 07 77 77 77 77 77 etc
+      while (i + 16 <= nEndOffset) {
+        u8 filterShiftByte = readByte(i);
+        u8 flagByte = readByte(i + 1);
+        if (filterShiftByte == 0 && flagByte == 7) {
           extraGunkLength += 16;
           i += 16;
+        } else {
+          break;
         }
-
-        ostringstream name;
-        name << "Sample " << samples.size();
-        PSXSamp *samp = new PSXSamp(this,
-                                    beginOffset,
-                                    i - beginOffset,
-                                    beginOffset,
-                                    i - beginOffset - extraGunkLength,
-                                    1,
-                                    16,
-                                    44100,
-                                    name.str());
-        samples.push_back(samp);
       }
-      else
-        break;
+
+      ostringstream name;
+      name << "Sample " << samples.size();
+      PSXSamp *samp = new PSXSamp(this,
+                                  beginOffset,
+                                  i - beginOffset,
+                                  beginOffset,
+                                  endLoopOffset - beginOffset - extraGunkLength,
+                                  1,
+                                  16,
+                                  44100,
+                                  name.str());
+      samples.push_back(samp);
     }
     unLength = i - dwOffset;
   }
   else {
     uint32_t sampleIndex = 0;
+
+    if (!isValidSampleStart(rawFile(), dwOffset, true))
+      return false;
+
     for (std::vector<SizeOffsetPair>::iterator it = vagLocations.begin(); it != vagLocations.end(); ++it) {
       if (it->offset == 0 && it->size == 0)
         continue;
@@ -170,26 +199,6 @@ bool PSXSampColl::parseSampleInfo() {
     }
   }
   return unLength > 0x20;
-}
-
-// GENERIC FUNCTION USED FOR SCANNERS
-PSXSampColl *PSXSampColl::searchForPSXADPCM(RawFile *file, const string &format) {
-  const std::vector<PSXSampColl *> &sampColls = searchForPSXADPCMs(file, format);
-  if (sampColls.size() != 0) {
-    // pick up one of the SampColls
-    size_t bestSampleCount = 0;
-    PSXSampColl *bestSampColl = sampColls[0];
-    for (size_t i = 0; i < sampColls.size(); i++) {
-      if (sampColls[i]->samples.size() > bestSampleCount) {
-        bestSampleCount = sampColls[i]->samples.size();
-        bestSampColl = sampColls[i];
-      }
-    }
-    return bestSampColl;
-  }
-  else {
-    return nullptr;
-  }
 }
 
 constexpr u32 NUM_CHUNKS_READAHEAD      = 10;
@@ -314,7 +323,7 @@ static bool isValidSampleStart(const RawFile* file, u32 offset, bool allowShort)
 }
 
 std::vector<PSXSampColl*> PSXSampColl::searchForPSXADPCMs(RawFile* file, const std::string&) {
-  std::vector<PSXSampColl*> out;
+  std::vector<PSXSampColl*> sampColls;
   const size_t len = file->size();
 
   for (u32 i = 0; i + 16 + NUM_CHUNKS_READAHEAD * 16 < len; ++i)
@@ -333,6 +342,7 @@ std::vector<PSXSampColl*> PSXSampColl::searchForPSXADPCMs(RawFile* file, const s
       continue;
 
     // We found a valid sample. Now back scan to check for shorter samples we might have skipped
+    u32 origOffset = i;
     u32 start   = i;
     u32 scanned = 16;
     while (start - scanned >= 16 && scanned < BACK_SCAN_LIMIT)
@@ -341,8 +351,15 @@ std::vector<PSXSampColl*> PSXSampColl::searchForPSXADPCMs(RawFile* file, const s
       scanned += 16;
 
       // Look for a 16 null byte frame which usually prefixes a sample
-      if (!isZero16(file, offset))
+      if (!isZero16(file, offset)) {
+        // Make sure the data we scan past is still potentially valid frames
+        u8 filterShiftByte = file->readByte(offset);
+        u8 flagByte = file->readByte(offset + 1);
+        if (!isValidFilterShiftByte(filterShiftByte) || !isValidFlagByte(flagByte)) {
+          break;
+        }
         continue;
+      }
 
       if (!isValidSampleStart(file, offset, true))
         break;
@@ -353,10 +370,16 @@ std::vector<PSXSampColl*> PSXSampColl::searchForPSXADPCMs(RawFile* file, const s
     auto* coll = new PSXSampColl(PS1Format::name, file, start);
     if (!coll->loadVGMFile()) { delete coll; continue; }
 
-    out.push_back(coll);
-    i = start + coll->unLength - 1;                      // skip parsed area
+    sampColls.push_back(coll);
+
+    // Sanity check that the detected sampcoll isn't smaller than the back scanned distance
+    if ((start + coll->unLength - 1) < origOffset) {
+      i = origOffset + 32;
+    } else {
+      i = start + coll->unLength - 1;                      // skip parsed area
+    }
   }
-  return out;
+  return sampColls;
 }
 
 //  *******

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -110,6 +110,12 @@ bool PSXSampColl::parseSampleInfo() {
                               // Occasionally, the data for a given sample may extend beyond this point
                               // for some reason. For conversion, we treat this as the end of the sample.
       while (i + 16 <= nEndOffset) {
+
+        // This is uncommon, but seen in poorly-ripped PSFs
+        if (isZero16(rawFile(), i)) {
+          break;
+        }
+
         u8 flagByte = readByte(i + 1);
         u8 endFlag = ((flagByte & 1) != 0);
         i += 16;

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -147,9 +147,6 @@ bool PSXSampColl::parseSampleInfo() {
           break;
         }
       }
-
-      ostringstream name;
-      name << "Sample " << samples.size();
       PSXSamp *samp = new PSXSamp(this,
                                   beginOffset,
                                   i - beginOffset,
@@ -158,7 +155,7 @@ bool PSXSampColl::parseSampleInfo() {
                                   1,
                                   16,
                                   44100,
-                                  name.str());
+                                  fmt::format("Sample {:d}", samples.size()));
       samples.push_back(samp);
     }
     unLength = i - dwOffset;
@@ -189,8 +186,6 @@ bool PSXSampColl::parseSampleInfo() {
         offSampEnd += 16;
       } while (!lastBlock);
 
-      ostringstream name;
-      name << "Sample " << sampleIndex;
       PSXSamp *samp = new PSXSamp(this,
                                   dwOffset + it->offset,
                                   it->size,
@@ -199,7 +194,8 @@ bool PSXSampColl::parseSampleInfo() {
                                   1,
                                   16,
                                   44100,
-                                  name.str());
+                                  fmt::format("Sample {:d}", sampleIndex));
+
       samples.push_back(samp);
       sampleIndex++;
     }


### PR DESCRIPTION
Improvements to PSX ADPCM scanning:
- handle case where frame data for a given sample extends beyond the first frame with end flag set
- do frame header byte validation at every iteration of back scan
- add check to ensure loaded sample collections are greater than the number of bytes back-scanned

PS1Seq:
- default program assignment to channel number

VAB:
- remove loading of bundled VAGS. Was proving unreliable

## How Has This Been Tested?
Ran it against a large swath of games, mostly PSF

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
