### PR TITLE
add hack for Parasite Eve "UB" track

### DIFF
--- a/src/main/formats/Akao/AkaoSeq.cpp
+++ b/src/main/formats/Akao/AkaoSeq.cpp
@@ -34,6 +34,8 @@ void AkaoSeq::resetVars() {
   condition = 0;
   if (rawFile()->tag.album == "Final Fantasy 9" && rawFile()->tag.title == "Final Battle")
     condition = 2;
+  else if (rawFile()->tag.album == "Parasite Eve" && rawFile()->tag.title == "UB")
+    condition = 2;
 }
 
 bool AkaoSeq::isPossibleAkaoSeq(const RawFile *file, uint32_t offset) {


### PR DESCRIPTION
This adds a hack to enable this track to play in entirety, fixing: https://github.com/vgmtrans/vgmtrans/issues/578.
The hack checks PSF meta tags, as we're already doing in a couple other places (not that this is necessarily good practice).

I do wonder if there are any tracks for which we don't want these conditions to be met. Otherwise, we could just always jump on this conditional event type without the need for hacks. Maybe @loveemu has some insight? 

Alternatively, we could just not jump once or twice, then set the condition as met and save the tick offset at sequence level so that every other track can mimic the timing. Since there could be additional condition events with different expected values, we'd have to generate something of a log such that the condition value at any given tick offset can be determined, again for timing consistency across tracks.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
