### PR TITLE
Rename VGMItem::EventColor enum to Type

### DIFF
--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -94,7 +94,7 @@ void VGMHeader::addSig(uint32_t offset, uint32_t length, const std::string &name
 
 VGMHeaderItem::VGMHeaderItem(const VGMHeader *hdr, HdrItemType theType, uint32_t offset, uint32_t length,
                              const std::string &name)
-    : VGMItem(hdr->vgmFile(), offset, length, name, CLR_HEADER), type(theType) {}
+    : VGMItem(hdr->vgmFile(), offset, length, name, Type::Header), type(theType) {}
 
 VGMItem::Icon VGMHeaderItem::icon() {
   switch (type) {

--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -4,11 +4,11 @@
 #include "Root.h"
 #include "helper.h"
 
-VGMItem::VGMItem() : m_vgmfile(nullptr), dwOffset(0), unLength(0), color(CLR_UNKNOWN) {
+VGMItem::VGMItem() : m_vgmfile(nullptr), dwOffset(0), unLength(0), type(Type::Unknown) {
 }
 
-VGMItem::VGMItem(VGMFile *vgmfile, uint32_t offset, uint32_t length, std::string name, EventColor color)
-    : m_vgmfile(vgmfile), m_name(std::move(name)), dwOffset(offset), unLength(length), color(color) {
+VGMItem::VGMItem(VGMFile *vgmfile, uint32_t offset, uint32_t length, std::string name, Type type)
+    : m_vgmfile(vgmfile), m_name(std::move(name)), dwOffset(offset), unLength(length), type(type) {
 }
 
 VGMItem::~VGMItem() {
@@ -98,7 +98,7 @@ VGMItem* VGMItem::addChild(VGMItem *item) {
 }
 
 VGMItem* VGMItem::addChild(uint32_t offset, uint32_t length, const std::string &name) {
-  auto child = new VGMItem(vgmFile(), offset, length, name, CLR_HEADER);
+  auto child = new VGMItem(vgmFile(), offset, length, name, Type::Header);
   m_children.emplace_back(child);
   return child;
 }

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -13,7 +13,6 @@ class VGMHeader;
 
 class VGMItem {
 public:
-  enum ItemType { ITEMTYPE_UNDEFINED, ITEMTYPE_VGMFILE, ITEMTYPE_SEQEVENT };
   enum Icon {
     ICON_SEQ,
     ICON_INSTRSET,
@@ -104,7 +103,6 @@ public:
   virtual uint32_t guessLength();
   virtual void setGuessedLength();
   virtual std::string description() { return ""; }
-  [[nodiscard]] virtual ItemType type() const { return ITEMTYPE_UNDEFINED; }
   virtual Icon icon() { return ICON_BINARY; }
   virtual void addToUI(VGMItem *parent, void *UI_specific);
 

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -33,7 +33,6 @@ public:
     ICON_INSTR,
     ICON_SAMP,
     ICON_BINARY,
-    ICON_MAX,
     ICON_LOOP,
     ICON_LOOP_FOREVER,
     ICON_VOLUME,
@@ -42,39 +41,40 @@ public:
     ICON_PITCHBEND,
     ICON_JUMP,
   };
-  enum EventColor {
-    CLR_UNKNOWN,
-    CLR_UNRECOGNIZED,
-    CLR_HEADER,
-    CLR_MISC,
-    CLR_MARKER,
-    CLR_TIMESIG,
-    CLR_TEMPO,
-    CLR_PROGCHANGE,
-    CLR_BANKSELECT,
-    CLR_TRANSPOSE,
-    CLR_PRIORITY,
-    CLR_VOLUME,
-    CLR_EXPRESSION,
-    CLR_PAN,
-    CLR_NOTEON,
-    CLR_NOTEOFF,
-    CLR_DURNOTE,
-    CLR_TIE,
-    CLR_REST,
-    CLR_PITCHBEND,
-    CLR_PITCHBENDRANGE,
-    CLR_MODULATION,
-    CLR_PORTAMENTO,
-    CLR_PORTAMENTOTIME,
-    CLR_CHANGESTATE,
-    CLR_ADSR,
-    CLR_LFO,
-    CLR_REVERB,
-    CLR_SUSTAIN,
-    CLR_LOOP,
-    CLR_LOOPFOREVER,
-    CLR_TRACKEND,
+  enum class Type {
+    Unknown,
+    Unrecognized,
+    Header,
+    Misc,
+    Marker,
+    TimeSignature,
+    Tempo,
+    ProgramChange,
+    BankSelect,
+    Transpose,
+    Priority,
+    MasterVolume,
+    Volume,
+    Expression,
+    Pan,
+    NoteOn,
+    NoteOff,
+    DurationNote,
+    Tie,
+    Rest,
+    PitchBend,
+    PitchBendRange,
+    Modulation,
+    Portamento,
+    PortamentoTime,
+    ChangeState,
+    Adsr,
+    Lfo,
+    Reverb,
+    Sustain,
+    Loop,
+    LoopForever,
+    TrackEnd,
   };
 
 public:
@@ -83,7 +83,7 @@ public:
           uint32_t offset,
           uint32_t length = 0,
           std::string name = "",
-          EventColor color = CLR_UNKNOWN);
+          Type type = Type::Unknown);
   virtual ~VGMItem();
 
   friend bool operator>(VGMItem &item1, VGMItem &item2);
@@ -134,7 +134,7 @@ protected:
 public:
   uint32_t dwOffset;  // offset in the pDoc data buffer
   uint32_t unLength;  // num of bytes the event engulfs
-  EventColor color;
+  Type type;
 
 private:
   std::vector<VGMItem *> m_children;

--- a/src/main/components/seq/SeqEvent.cpp
+++ b/src/main/components/seq/SeqEvent.cpp
@@ -14,10 +14,10 @@ SeqEvent::SeqEvent(SeqTrack *pTrack,
                    uint32_t offset,
                    uint32_t length,
                    const std::string &name,
-                   EventColor color,
+                   Type type,
                    Icon icon,
                    const std::string &desc)
-    : VGMItem(pTrack->parentSeq, offset, length, name, color), channel(0),
+    : VGMItem(pTrack->parentSeq, offset, length, name, type), channel(0),
       parentTrack(pTrack), m_icon(icon), m_description(desc) {}
 
 // ***************
@@ -31,7 +31,7 @@ DurNoteSeqEvent::DurNoteSeqEvent(SeqTrack *pTrack,
                                  uint32_t offset,
                                  uint32_t length,
                                  const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_DURNOTE), absKey(absoluteKey), vel(velocity), dur(duration) { }
+    : SeqEvent(pTrack, offset, length, name, Type::DurationNote), absKey(absoluteKey), vel(velocity), dur(duration) { }
 
 
 // ************
@@ -44,7 +44,7 @@ NoteOnSeqEvent::NoteOnSeqEvent(SeqTrack *pTrack,
                                uint32_t offset,
                                uint32_t length,
                                const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_NOTEON), absKey(absoluteKey), vel(velocity) { }
+    : SeqEvent(pTrack, offset, length, name, Type::NoteOn), absKey(absoluteKey), vel(velocity) { }
 
 
 
@@ -57,7 +57,7 @@ NoteOffSeqEvent::NoteOffSeqEvent(SeqTrack *pTrack,
                                  uint32_t offset,
                                  uint32_t length,
                                  const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_NOTEOFF), absKey(absoluteKey) { }
+    : SeqEvent(pTrack, offset, length, name, Type::NoteOff), absKey(absoluteKey) { }
 
 // ************
 // RestSeqEvent
@@ -68,7 +68,7 @@ RestSeqEvent::RestSeqEvent(SeqTrack *pTrack,
                            uint32_t offset,
                            uint32_t length,
                            const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_REST), dur(duration) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Rest), dur(duration) { }
 
 // *****************
 // SetOctaveSeqEvent
@@ -79,21 +79,21 @@ SetOctaveSeqEvent::SetOctaveSeqEvent(SeqTrack *pTrack,
                                      uint32_t offset,
                                      uint32_t length,
                                      const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_CHANGESTATE), octave(theOctave) { }
+    : SeqEvent(pTrack, offset, length, name, Type::ChangeState), octave(theOctave) { }
 
 // ***********
 // VolSeqEvent
 // ***********
 
 VolSeqEvent::VolSeqEvent(SeqTrack *pTrack, uint8_t volume, uint32_t offset, uint32_t length, const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_VOLUME), vol(volume) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Volume), vol(volume) { }
 
 // ***********
 // Volume14BitSeqEvent
 // ***********
 
 Volume14BitSeqEvent::Volume14BitSeqEvent(SeqTrack *pTrack, uint16_t volume, uint32_t offset, uint32_t length, const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_VOLUME), m_volume(volume) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Volume), m_volume(volume) { }
 
 // ****************
 // VolSlideSeqEvent
@@ -105,7 +105,7 @@ VolSlideSeqEvent::VolSlideSeqEvent(SeqTrack *pTrack,
                                    uint32_t offset,
                                    uint32_t length,
                                    const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_VOLUME), targVol(targetVolume), dur(duration) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Volume), targVol(targetVolume), dur(duration) { }
 
 // ***********
 // MastVolSeqEvent
@@ -116,7 +116,7 @@ MastVolSeqEvent::MastVolSeqEvent(SeqTrack *pTrack,
                                  uint32_t offset,
                                  uint32_t length,
                                  const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_VOLUME), vol(volume) { }
+    : SeqEvent(pTrack, offset, length, name, Type::MasterVolume), vol(volume) { }
 
 // ****************
 // MastVolSlideSeqEvent
@@ -128,7 +128,7 @@ MastVolSlideSeqEvent::MastVolSlideSeqEvent(SeqTrack *pTrack,
                                            uint32_t offset,
                                            uint32_t length,
                                            const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_VOLUME), targVol(targetVolume), dur(duration) { }
+    : SeqEvent(pTrack, offset, length, name, Type::MasterVolume), targVol(targetVolume), dur(duration) { }
 
 // ******************
 // ExpressionSeqEvent
@@ -139,7 +139,7 @@ ExpressionSeqEvent::ExpressionSeqEvent(SeqTrack *pTrack,
                                        uint32_t offset,
                                        uint32_t length,
                                        const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_EXPRESSION), level(theLevel) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Expression), level(theLevel) { }
 
 // ***********************
 // ExpressionSlideSeqEvent
@@ -151,7 +151,7 @@ ExpressionSlideSeqEvent::ExpressionSlideSeqEvent(SeqTrack *pTrack,
                                                  uint32_t offset,
                                                  uint32_t length,
                                                  const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_EXPRESSION), targExpr(targetExpression), dur(duration) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Expression), targExpr(targetExpression), dur(duration) { }
 
 
 
@@ -160,7 +160,7 @@ ExpressionSlideSeqEvent::ExpressionSlideSeqEvent(SeqTrack *pTrack,
 // ***********
 
 PanSeqEvent::PanSeqEvent(SeqTrack *pTrack, uint8_t thePan, uint32_t offset, uint32_t length, const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_PAN), pan(thePan) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Pan), pan(thePan) { }
 
 // ****************
 // PanSlideSeqEvent
@@ -172,7 +172,7 @@ PanSlideSeqEvent::PanSlideSeqEvent(SeqTrack *pTrack,
                                    uint32_t offset,
                                    uint32_t length,
                                    const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_PAN), targPan(targetPan), dur(duration) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Pan), targPan(targetPan), dur(duration) { }
 
 // **************
 // ReverbSeqEvent
@@ -183,7 +183,7 @@ ReverbSeqEvent::ReverbSeqEvent(SeqTrack *pTrack,
                                uint32_t offset,
                                uint32_t length,
                                const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_REVERB), reverb(theReverb) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Reverb), reverb(theReverb) { }
 
 // *****************
 // PitchBendSeqEvent
@@ -194,7 +194,7 @@ PitchBendSeqEvent::PitchBendSeqEvent(SeqTrack *pTrack,
                                      uint32_t offset,
                                      uint32_t length,
                                      const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_PITCHBEND), pitchbend(thePitchBend) { }
+    : SeqEvent(pTrack, offset, length, name, Type::PitchBend), pitchbend(thePitchBend) { }
 
 // **********************
 // PitchBendRangeSeqEvent
@@ -202,7 +202,7 @@ PitchBendSeqEvent::PitchBendSeqEvent(SeqTrack *pTrack,
 
 PitchBendRangeSeqEvent::PitchBendRangeSeqEvent(SeqTrack *pTrack, uint16_t cents,
                                                uint32_t offset, uint32_t length, const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_PITCHBENDRANGE), m_cents(cents) { }
+    : SeqEvent(pTrack, offset, length, name, Type::PitchBendRange), m_cents(cents) { }
 
 // ******************
 // FineTuningSeqEvent
@@ -210,7 +210,7 @@ PitchBendRangeSeqEvent::PitchBendRangeSeqEvent(SeqTrack *pTrack, uint16_t cents,
 
 FineTuningSeqEvent::FineTuningSeqEvent(SeqTrack *pTrack, double cents,
                                        uint32_t offset, uint32_t length, const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_MISC), m_cents(cents) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Misc), m_cents(cents) { }
 
 // ****************************
 // ModulationDepthRangeSeqEvent
@@ -218,7 +218,7 @@ FineTuningSeqEvent::FineTuningSeqEvent(SeqTrack *pTrack, double cents,
 
 ModulationDepthRangeSeqEvent::ModulationDepthRangeSeqEvent(SeqTrack *pTrack, double semitones,
                                                            uint32_t offset, uint32_t length, const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_MISC), m_semitones(semitones) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Misc), m_semitones(semitones) { }
 
 // *****************
 // TransposeSeqEvent
@@ -229,7 +229,7 @@ TransposeSeqEvent::TransposeSeqEvent(SeqTrack *pTrack,
                                      uint32_t offset,
                                      uint32_t length,
                                      const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_TRANSPOSE), m_transpose(theTranspose) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Transpose), m_transpose(theTranspose) { }
 
 // ******************
 // ModulationSeqEvent
@@ -240,7 +240,7 @@ ModulationSeqEvent::ModulationSeqEvent(SeqTrack *pTrack,
                                        uint32_t offset,
                                        uint32_t length,
                                        const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_MODULATION), depth(theDepth) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Modulation), depth(theDepth) { }
 
 // **************
 // BreathSeqEvent
@@ -251,7 +251,7 @@ BreathSeqEvent::BreathSeqEvent(SeqTrack *pTrack,
                                uint32_t offset,
                                uint32_t length,
                                const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_MODULATION), depth(theDepth) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Modulation), depth(theDepth) { }
 
 // ***************
 // SustainSeqEvent
@@ -262,7 +262,7 @@ SustainSeqEvent::SustainSeqEvent(SeqTrack *pTrack,
                                  uint32_t offset,
                                  uint32_t length,
                                  const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_SUSTAIN), depth(theDepth) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Sustain), depth(theDepth) { }
 
 // ******************
 // PortamentoSeqEvent
@@ -273,7 +273,7 @@ PortamentoSeqEvent::PortamentoSeqEvent(SeqTrack *pTrack,
                                        uint32_t offset,
                                        uint32_t length,
                                        const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_PORTAMENTO), bOn(bPortamento) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Portamento), bOn(bPortamento) { }
 
 // **********************
 // PortamentoTimeSeqEvent
@@ -284,7 +284,7 @@ PortamentoTimeSeqEvent::PortamentoTimeSeqEvent(SeqTrack *pTrack,
                                                uint32_t offset,
                                                uint32_t length,
                                                const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_PORTAMENTO), time(theTime) { }
+    : SeqEvent(pTrack, offset, length, name, Type::PortamentoTime), time(theTime) { }
 
 // ******************
 // ProgChangeSeqEvent
@@ -295,7 +295,7 @@ ProgChangeSeqEvent::ProgChangeSeqEvent(SeqTrack *pTrack,
                                        uint32_t offset,
                                        uint32_t length,
                                        const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_PROGCHANGE), progNum(programNumber) { }
+    : SeqEvent(pTrack, offset, length, name, Type::ProgramChange), progNum(programNumber) { }
 
 // ******************
 // BankSelectSeqEvent
@@ -306,7 +306,7 @@ BankSelectSeqEvent::BankSelectSeqEvent(SeqTrack *pTrack,
                                        uint32_t offset,
                                        uint32_t length,
                                        const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_BANKSELECT), bank(bank) { }
+    : SeqEvent(pTrack, offset, length, name, Type::BankSelect), bank(bank) { }
 
 // *************
 // TempoSeqEvent
@@ -317,7 +317,7 @@ TempoSeqEvent::TempoSeqEvent(SeqTrack *pTrack,
                              uint32_t offset,
                              uint32_t length,
                              const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_TEMPO), bpm(beatsperminute) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Tempo), bpm(beatsperminute) { }
 
 // ******************
 // TempoSlideSeqEvent
@@ -329,7 +329,7 @@ TempoSlideSeqEvent::TempoSlideSeqEvent(SeqTrack *pTrack,
                                        uint32_t offset,
                                        uint32_t length,
                                        const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_TEMPO), targbpm(targBPM), dur(duration) { }
+    : SeqEvent(pTrack, offset, length, name, Type::Tempo), targbpm(targBPM), dur(duration) { }
 
 // ***************
 // TimeSigSeqEvent
@@ -342,7 +342,7 @@ TimeSigSeqEvent::TimeSigSeqEvent(SeqTrack *pTrack,
                                  uint32_t offset,
                                  uint32_t length,
                                  const std::string &name)
-    : SeqEvent(pTrack, offset, length, name, CLR_TIMESIG), numer(numerator), denom(denominator),
+    : SeqEvent(pTrack, offset, length, name, Type::TimeSignature), numer(numerator), denom(denominator),
       ticksPerQuarter(theTicksPerQuarter) { }
 
 

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -48,7 +48,7 @@ class SeqEvent:
                     uint32_t offset = 0,
                     uint32_t length = 0,
                     const std::string &name = "",
-                    EventColor color = CLR_UNKNOWN,
+                    Type type = Type::Unknown,
                     Icon icon = ICON_BINARY,
                     const std::string &desc = "");
   ~SeqEvent() override = default;
@@ -644,8 +644,8 @@ class MarkerSeqEvent : public SeqEvent {
                  uint32_t offset = 0,
                  uint32_t length = 0,
                  const std::string &name = "",
-                 EventColor color = CLR_MARKER)
-      : SeqEvent(pTrack, offset, length, name, color), databyte1(databyte1), databyte2(databyte2),
+                 Type type = Type::Marker)
+      : SeqEvent(pTrack, offset, length, name, type), databyte1(databyte1), databyte2(databyte2),
         markerName(markername) {}
   EventType eventType() override { return EVENTTYPE_MARKER; }
 
@@ -680,7 +680,7 @@ class TrackEndSeqEvent : public SeqEvent {
  public:
   explicit TrackEndSeqEvent(SeqTrack *pTrack, uint32_t offset = 0, uint32_t length = 0,
                    const std::string &name = "")
-      : SeqEvent(pTrack, offset, length, name, CLR_TRACKEND) {}
+      : SeqEvent(pTrack, offset, length, name, Type::TrackEnd) {}
   EventType eventType() override { return EVENTTYPE_TRACKEND; }
   Icon icon() override { return ICON_TRACKEND; }
 };
@@ -693,7 +693,7 @@ class LoopForeverSeqEvent : public SeqEvent {
  public:
   explicit LoopForeverSeqEvent(SeqTrack *pTrack, uint32_t offset = 0, uint32_t length = 0,
                       const std::string &name = "", const std::string &descr = "")
-      : SeqEvent(pTrack, offset, length, name, CLR_LOOPFOREVER) {}
+      : SeqEvent(pTrack, offset, length, name, Type::LoopForever) {}
   EventType eventType() override { return EVENTTYPE_LOOPFOREVER; }
   Icon icon() override { return ICON_LOOP_FOREVER; }
 };

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -55,7 +55,6 @@ class SeqEvent:
   std::string description() override {
     return m_description;
   }
-  [[nodiscard]] ItemType type() const override { return ITEMTYPE_SEQEVENT; }
   virtual EventType eventType() { return EVENTTYPE_UNDEFINED; }
   Icon icon() override { return m_icon; }
 

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -279,12 +279,12 @@ void SeqTrack::addGenericEvent(uint32_t offset,
                                uint32_t length,
                                const std::string &sEventName,
                                const std::string &sEventDesc,
-                               EventColor color,
+                               Type type,
                                Icon icon) {
   onEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true)) {
-    addEvent(new SeqEvent(this, offset, length, sEventName, color, icon, sEventDesc));
+    addEvent(new SeqEvent(this, offset, length, sEventName, type, icon, sEventDesc));
   }
   else if (readMode == READMODE_CONVERT_TO_MIDI) {
     if (bWriteGenericEventAsTextEvent) {
@@ -306,7 +306,7 @@ void SeqTrack::addUnknown(uint32_t offset,
   onEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true)) {
-    addEvent(new SeqEvent(this, offset, length, sEventName, CLR_UNKNOWN, ICON_BINARY, sEventDesc));
+    addEvent(new SeqEvent(this, offset, length, sEventName, Type::Unknown, ICON_BINARY, sEventDesc));
   }
   else if (readMode == READMODE_CONVERT_TO_MIDI) {
     if (bWriteGenericEventAsTextEvent) {
@@ -333,7 +333,7 @@ void SeqTrack::addIncrementOctave(uint32_t offset, uint32_t length, const std::s
 
   octave++;
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
-    addEvent(new SeqEvent(this, offset, length, sEventName, CLR_CHANGESTATE));
+    addEvent(new SeqEvent(this, offset, length, sEventName, Type::ChangeState));
 }
 
 void SeqTrack::addDecrementOctave(uint32_t offset, uint32_t length, const std::string &sEventName) {
@@ -341,7 +341,7 @@ void SeqTrack::addDecrementOctave(uint32_t offset, uint32_t length, const std::s
 
   octave--;
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
-    addEvent(new SeqEvent(this, offset, length, sEventName, CLR_CHANGESTATE));
+    addEvent(new SeqEvent(this, offset, length, sEventName, Type::ChangeState));
 }
 
 void SeqTrack::addRest(uint32_t offset, uint32_t length, uint32_t restTime, const std::string &sEventName) {
@@ -360,7 +360,7 @@ void SeqTrack::addHold(uint32_t offset, uint32_t length, const std::string &sEve
   onEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
-    addEvent(new SeqEvent(this, offset, length, sEventName, CLR_TIE));
+    addEvent(new SeqEvent(this, offset, length, sEventName, Type::Tie));
 }
 
 void SeqTrack::addNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t vel, const std::string &sEventName) {
@@ -1441,11 +1441,11 @@ void SeqTrack::addMarker(uint32_t offset,
                          uint8_t databyte2,
                          const std::string &sEventName,
                          int8_t priority,
-                         EventColor color) {
+                         Type type) {
   onEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
-    addEvent(new MarkerSeqEvent(this, markername, databyte1, databyte2, offset, length, sEventName, color));
+    addEvent(new MarkerSeqEvent(this, markername, databyte1, databyte2, offset, length, sEventName, type));
   addMarkerNoItem(markername, databyte1, databyte2, priority);
 }
 

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -55,7 +55,7 @@ class SeqTrack : public VGMItem {
   virtual void addEvent(SeqEvent *pSeqEvent);
   void addControllerSlide(uint32_t dur, uint8_t &prevVal, uint8_t targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t)) const;
  public:
-  void addGenericEvent(uint32_t offset, uint32_t length, const std::string &sEventName, const std::string &sEventDesc, EventColor color, Icon icon = ICON_BINARY);
+  void addGenericEvent(uint32_t offset, uint32_t length, const std::string &sEventName, const std::string &sEventDesc, Type type, Icon icon = ICON_BINARY);
   void addSetOctave(uint32_t offset, uint32_t length, uint8_t newOctave, const std::string &sEventName = "Set Octave");
   void addIncrementOctave(uint32_t offset, uint32_t length, const std::string &sEventName = "Increment Octave");    // 1,Sep.2009 revise
   void addDecrementOctave(uint32_t offset, uint32_t length, const std::string &sEventName = "Decrement Octave");    // 1,Sep.2009 revise
@@ -161,7 +161,7 @@ class SeqTrack : public VGMItem {
   void addControllerEventNoItem(uint8_t controllerType, uint8_t controllerValue) const;
 
   void addGlobalTranspose(uint32_t offset, uint32_t length, int8_t semitones, const std::string &sEventName = "Global Transpose");
-  void addMarker(uint32_t offset, uint32_t length, const std::string &markername, uint8_t databyte1, uint8_t databyte2, const std::string &sEventName, int8_t priority = 0, EventColor color = CLR_MISC);
+  void addMarker(uint32_t offset, uint32_t length, const std::string &markername, uint8_t databyte1, uint8_t databyte2, const std::string &sEventName, int8_t priority = 0, Type type = Type::Misc);
   void addMarkerNoItem(const std::string &markername, uint8_t databyte1, uint8_t databyte2, int8_t priority) const;
   void insertMarkerNoItem(uint32_t absTime, const std::string &markername, uint8_t databyte1, uint8_t databyte2, int8_t priority) const;
 

--- a/src/main/components/seq/VGMSeqSection.cpp
+++ b/src/main/components/seq/VGMSeqSection.cpp
@@ -13,8 +13,8 @@ VGMSeqSection::VGMSeqSection(VGMMultiSectionSeq *parentFile,
                              uint32_t theOffset,
                              uint32_t theLength,
                              const std::string& name,
-                             EventColor color)
-    : VGMItem(parentFile, theOffset, theLength, name, color),
+                             Type type)
+    : VGMItem(parentFile, theOffset, theLength, name, type),
       parentSeq(parentFile) {
 }
 

--- a/src/main/components/seq/VGMSeqSection.h
+++ b/src/main/components/seq/VGMSeqSection.h
@@ -12,7 +12,7 @@ class VGMSeqSection
                 uint32_t theOffset,
                 uint32_t theLength = 0,
                 const std::string& name = "Section",
-                EventColor color = CLR_HEADER);
+                Type type = Type::Header);
 
   virtual bool load();
   virtual bool parseTrackPointers();

--- a/src/main/formats/Akao/AkaoSeq.cpp
+++ b/src/main/formats/Akao/AkaoSeq.cpp
@@ -617,7 +617,7 @@ bool AkaoTrack::readEvent() {
       makePrevDurNoteEnd(getTime() + dur);
       addTime(delta_time);
       desc << "Length: " << delta_time << "  Duration: " << dur;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str(), CLR_TIE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str(), Type::Tie);
     }
     else // rest
     {
@@ -677,7 +677,7 @@ bool AkaoTrack::readEvent() {
       last_delta_time = one_time_delta_time = delta_time;
       use_one_time_delta_time = true;
       desc << "Length: " << delta_time;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Next Note Length", desc.str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Next Note Length", desc.str(), Type::ChangeState);
       break;
     }
 
@@ -700,7 +700,7 @@ bool AkaoTrack::readEvent() {
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const int8_t semitones = readByte(curOffset++);
       desc << "Length: " << length << "  Key: " << semitones << " semitones";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc.str(), CLR_PITCHBEND, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc.str(), Type::PitchBend, ICON_CONTROL);
       break;
     }
 
@@ -741,7 +741,7 @@ bool AkaoTrack::readEvent() {
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t expression = readByte(curOffset++);
       desc << "Target Expression: " << expression << "  Duration: " << length;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Expression Slide Per Note", desc.str(), CLR_VOLUME, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Expression Slide Per Note", desc.str(), Type::Volume, ICON_CONTROL);
       break;
     }
 
@@ -775,28 +775,28 @@ bool AkaoTrack::readEvent() {
         const uint8_t clock = raw_clock & 0x3f;
         desc << "Clock: " << clock;
       }
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Clock", desc.str(), CLR_CHANGESTATE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Clock", desc.str(), Type::ChangeState, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR_ATTACK_RATE: {
       const uint8_t ar = readByte(curOffset++); // 0-127
       desc << "AR: " << ar;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Attack Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Attack Rate", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR_DECAY_RATE: {
       const uint8_t dr = readByte(curOffset++); // 0-15
       desc << "DR: " << dr;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Decay Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Decay Rate", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR_SUSTAIN_LEVEL: {
       const uint8_t sl = readByte(curOffset++); // 0-15
       desc << "SL: " << sl;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Sustain Level", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Sustain Level", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -804,26 +804,26 @@ bool AkaoTrack::readEvent() {
       const uint8_t dr = readByte(curOffset++); // 0-15
       const uint8_t sl = readByte(curOffset++); // 0-15
       desc << "DR: " << dr << "  SL: " << sl;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Decay Rate & Sustain Level", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Decay Rate & Sustain Level", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR_SUSTAIN_RATE: {
       const uint8_t sr = readByte(curOffset++); // 0-127
       desc << "SR: " << sr;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Sustain Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Sustain Rate", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR_RELEASE_RATE: {
       const uint8_t rr = readByte(curOffset++); // 0-127
       desc << "RR: " << rr;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Release Rate", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Release Rate", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
     case EVENT_RESET_ADSR:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Reset ADSR", "", CLR_ADSR);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Reset ADSR", "", Type::Adsr);
       break;
 
     case EVENT_VIBRATO: {
@@ -832,7 +832,7 @@ bool AkaoTrack::readEvent() {
       const uint16_t rate = raw_rate == 0 ? 256 : raw_rate;
       const uint8_t type = readByte(curOffset++); // 0-15
       desc << "Delay: " << delay << "  Rate: " << rate << "  LFO Type: " << type;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc.str(), CLR_LFO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc.str(), Type::Lfo, ICON_CONTROL);
       break;
     }
 
@@ -847,18 +847,18 @@ bool AkaoTrack::readEvent() {
       else {
         desc << " (1/1 scale, approx 700 cents at maximum)";
       }
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Depth", desc.str(), CLR_LFO);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Depth", desc.str(), Type::Lfo);
       break;
     }
 
     case EVENT_VIBRATO_OFF:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Off", "", CLR_LFO);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Off", "", Type::Lfo);
       break;
 
     case EVENT_ADSR_ATTACK_MODE: {
       const uint8_t ar_mode = readByte(curOffset++);
       desc << "Mode: " << ar_mode;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Attack Rate Mode", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Attack Rate Mode", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -868,25 +868,25 @@ bool AkaoTrack::readEvent() {
       const uint16_t rate = raw_rate == 0 ? 256 : raw_rate;
       const uint8_t type = readByte(curOffset++); // 0-15
       desc << "Delay: " << delay << "  Rate: " << rate << "  LFO Type: " << type;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo", desc.str(), CLR_LFO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo", desc.str(), Type::Lfo, ICON_CONTROL);
       break;
     }
 
     case EVENT_TREMOLO_DEPTH: {
       const uint8_t depth = readByte(curOffset++);
       desc << "Depth: " << depth;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth", desc.str(), CLR_LFO);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth", desc.str(), Type::Lfo);
       break;
     }
 
     case EVENT_TREMOLO_OFF:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Off", "", CLR_LFO);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Off", "", Type::Lfo);
       break;
 
     case EVENT_ADSR_SUSTAIN_MODE: {
       const uint8_t sr_mode = readByte(curOffset++);
       desc << "Mode: " << sr_mode;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Sustain Rate Mode", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Sustain Rate Mode", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -895,25 +895,25 @@ bool AkaoTrack::readEvent() {
       const uint16_t rate = raw_rate == 0 ? 256 : raw_rate;
       const uint8_t type = readByte(curOffset++); // 0-15
       desc << "Rate: " << rate << "  LFO Type: " << type;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO", desc.str(), CLR_LFO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO", desc.str(), Type::Lfo, ICON_CONTROL);
       break;
     }
 
     case EVENT_PAN_LFO_DEPTH: {
       const uint8_t depth = readByte(curOffset++);
       desc << "Depth: " << depth;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Depth", desc.str(), CLR_LFO);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Depth", desc.str(), Type::Lfo);
       break;
     }
 
     case EVENT_PAN_LFO_OFF:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Off", "", CLR_LFO);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Off", "", Type::Lfo);
       break;
 
     case EVENT_ADSR_RELEASE_MODE: {
       const uint8_t rr_mode = readByte(curOffset++);
       desc << "Mode: " << rr_mode;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Release Rate Mode", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Release Rate Mode", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -931,32 +931,32 @@ bool AkaoTrack::readEvent() {
 
     case EVENT_REVERB_ON:
       // TODO: reverb control
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb On", "", CLR_REVERB);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb On", "", Type::Reverb);
       break;
 
     case EVENT_REVERB_OFF:
       // TODO: reverb control
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Off", "", CLR_REVERB);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Off", "", Type::Reverb);
       break;
 
     case EVENT_NOISE_ON:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise On", "", CLR_PROGCHANGE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise On", "", Type::ProgramChange, ICON_CONTROL);
       break;
 
     case EVENT_NOISE_OFF:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Off", "", CLR_PROGCHANGE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Off", "", Type::ProgramChange, ICON_CONTROL);
       break;
 
     case EVENT_PITCH_MOD_ON:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) On", "", CLR_PROGCHANGE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) On", "", Type::ProgramChange, ICON_CONTROL);
       break;
 
     case EVENT_PITCH_MOD_OFF:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) Off", "", CLR_PROGCHANGE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) Off", "", Type::ProgramChange, ICON_CONTROL);
       break;
 
     case EVENT_LOOP_START:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Start", "", CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Start", "", Type::Loop, ICON_STARTREP);
 
       loop_layer = (loop_layer + 1) & 3;
       loop_begin_loc[loop_layer] = curOffset;
@@ -968,7 +968,7 @@ bool AkaoTrack::readEvent() {
       const uint16_t count = raw_count == 0 ? 256 : raw_count;
 
       desc << "Count: " << count;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Until", desc.str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Until", desc.str(), Type::Loop, ICON_ENDREP);
 
       loop_counter[loop_layer]++;
       if (loop_counter[loop_layer] == count)
@@ -983,7 +983,7 @@ bool AkaoTrack::readEvent() {
     }
 
     case EVENT_LOOP_AGAIN: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Again", "", CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Again", "", Type::Loop, ICON_ENDREP);
 
       loop_counter[loop_layer]++;
       curOffset = loop_begin_loc[loop_layer];
@@ -992,16 +992,16 @@ bool AkaoTrack::readEvent() {
 
     case EVENT_RESET_VOICE_EFFECTS:
       // Reset noise, FM modulation, reverb, etc.
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Reset Voice Effects", "", CLR_CHANGESTATE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Reset Voice Effects", "", Type::ChangeState, ICON_CONTROL);
       break;
 
     case EVENT_SLUR_ON:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Slur On (No Key Off, No Retrigger)", "", CLR_CHANGESTATE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Slur On (No Key Off, No Retrigger)", "", Type::ChangeState, ICON_CONTROL);
       slur = true;
       break;
 
     case EVENT_SLUR_OFF:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Slur Off", "", CLR_CHANGESTATE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Slur Off", "", Type::ChangeState, ICON_CONTROL);
       slur = false;
       break;
 
@@ -1009,7 +1009,7 @@ bool AkaoTrack::readEvent() {
       const uint8_t raw_delay = readByte(curOffset++);
       const uint16_t delay = raw_delay == 0 ? 1 : raw_delay + 1;
       desc << "Delay: " << delay;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise On & Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise On & Delay Switching", desc.str(), Type::ProgramChange, ICON_PROGCHANGE);
       break;
     }
 
@@ -1017,17 +1017,17 @@ bool AkaoTrack::readEvent() {
       const uint8_t raw_delay = readByte(curOffset++);
       const uint16_t delay = raw_delay == 0 ? 1 : raw_delay + 1;
       desc << "Delay: " << delay;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise On/Off Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise On/Off Delay Switching", desc.str(), Type::ProgramChange, ICON_PROGCHANGE);
       break;
     }
 
     case EVENT_LEGATO_ON:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato On (No Key Off)", "", CLR_CHANGESTATE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato On (No Key Off)", "", Type::ChangeState, ICON_CONTROL);
       legato = true;
       break;
 
     case EVENT_LEGATO_OFF:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato Off", "", CLR_CHANGESTATE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato Off", "", Type::ChangeState, ICON_CONTROL);
       legato = false;
       break;
 
@@ -1035,7 +1035,7 @@ bool AkaoTrack::readEvent() {
       const uint8_t raw_delay = readByte(curOffset++);
       const uint16_t delay = raw_delay == 0 ? 1 : raw_delay + 1;
       desc << "Delay: " << delay;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) On & Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) On & Delay Switching", desc.str(), Type::ProgramChange, ICON_PROGCHANGE);
       break;
     }
 
@@ -1043,24 +1043,24 @@ bool AkaoTrack::readEvent() {
       const uint8_t raw_delay = readByte(curOffset++);
       const uint16_t delay = raw_delay == 0 ? 1 : raw_delay + 1;
       desc << "Delay: " << delay;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) On/Off Delay Switching", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "FM (Pitch LFO) On/Off Delay Switching", desc.str(), Type::ProgramChange, ICON_PROGCHANGE);
       break;
     }
 
     case EVENT_PITCH_SIDE_CHAIN_ON:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Side Chain On", "", CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Side Chain On", "", Type::Misc);
       break;
 
     case EVENT_PITCH_SIDE_CHAIN_OFF:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Side Chain Off", "", CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Side Chain Off", "", Type::Misc);
       break;
 
     case EVENT_PITCH_TO_VOLUME_SIDE_CHAIN_ON:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch-Volume Side Chain On", "", CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch-Volume Side Chain On", "", Type::Misc);
       break;
 
     case EVENT_PITCH_TO_VOLUME_SIDE_CHAIN_OFF:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch-Volume Side Chain Off", "", CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch-Volume Side Chain Off", "", Type::Misc);
       break;
 
     case EVENT_TUNING_ABS:
@@ -1082,7 +1082,7 @@ bool AkaoTrack::readEvent() {
       const double scale = tuning / static_cast<double>(div);
       const double cents = (scale / log(2.0)) * 1200.0;
       desc << "Amount: " << relative_tuning <<  "  Tuning: " << cents << " cents (" << tuning << "/" << div << ")";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tuning (Relative)", desc.str(), CLR_MISC, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tuning (Relative)", desc.str(), Type::Misc, ICON_CONTROL);
       addFineTuningNoItem(cents);
       break;
     }
@@ -1091,7 +1091,7 @@ bool AkaoTrack::readEvent() {
       const uint8_t raw_speed = readByte(curOffset++);
       const uint16_t speed = raw_speed == 0 ? 256 : raw_speed;
       desc << "Time: " << speed << " tick(s)";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento", desc.str(), Type::Portamento, ICON_CONTROL);
       double millisPerTick = 60000.0 / (parentSeq->tempoBPM * parentSeq->ppqn());
       addPortamentoTime14BitNoItem(millisPerTick * speed);
       addPortamentoNoItem(true);
@@ -1100,7 +1100,7 @@ bool AkaoTrack::readEvent() {
     }
 
     case EVENT_PORTAMENTO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Off", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Off", desc.str(), Type::Portamento, ICON_CONTROL);
       addPortamentoNoItem(false);
       portamento = false;
       break;
@@ -1111,7 +1111,7 @@ bool AkaoTrack::readEvent() {
       const int16_t length = std::min(std::max(last_delta_time + relative_length, 1), 255);
       delta_time_overwrite = length;
       desc << "Duration (Relative Amount): " << relative_length;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Fixed Note Length", desc.str(), CLR_MISC, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Fixed Note Length", desc.str(), Type::Misc, ICON_CONTROL);
       break;
     }
 
@@ -1128,7 +1128,7 @@ bool AkaoTrack::readEvent() {
       else {
         desc << " (1/1 scale, approx 700 cents at maximum)";
       }
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Depth Slide", desc.str(), CLR_LFO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Depth Slide", desc.str(), Type::Lfo, ICON_CONTROL);
       break;
     }
 
@@ -1137,7 +1137,7 @@ bool AkaoTrack::readEvent() {
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t depth = readByte(curOffset++);
       desc << "Duration: " << length << "  Target Depth: " << depth;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth Slide", desc.str(), CLR_LFO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth Slide", desc.str(), Type::Lfo, ICON_CONTROL);
       break;
     }
 
@@ -1146,7 +1146,7 @@ bool AkaoTrack::readEvent() {
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t depth = readByte(curOffset++);
       desc << "Duration: " << length << "  Target Depth: " << depth;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Depth Slide", desc.str(), CLR_LFO);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Depth Slide", desc.str(), Type::Lfo);
       break;
     }
 
@@ -1155,7 +1155,7 @@ bool AkaoTrack::readEvent() {
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t rate = readByte(curOffset++);
       desc << "Duration: " << length << "  Target Rate: " << rate;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Rate Slide", desc.str(), CLR_LFO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Rate Slide", desc.str(), Type::Lfo, ICON_CONTROL);
       break;
     }
 
@@ -1164,7 +1164,7 @@ bool AkaoTrack::readEvent() {
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t rate = readByte(curOffset++);
       desc << "Duration: " << length << "  Target Rate: " << rate;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Rate Slide", desc.str(), CLR_LFO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Rate Slide", desc.str(), Type::Lfo, ICON_CONTROL);
       break;
     }
 
@@ -1173,7 +1173,7 @@ bool AkaoTrack::readEvent() {
       const uint16_t length = raw_length == 0 ? 256 : raw_length;
       const uint8_t rate = readByte(curOffset++);
       desc << "Duration: " << length << "  Target Rate: " << rate;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Rate Slide", desc.str(), CLR_LFO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Rate Slide", desc.str(), Type::Lfo, ICON_CONTROL);
       break;
     }
 
@@ -1221,7 +1221,7 @@ bool AkaoTrack::readEvent() {
       curOffset += 2;
 
       desc << "Depth: " << depth;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", desc.str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", desc.str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -1232,7 +1232,7 @@ bool AkaoTrack::readEvent() {
       curOffset += 2;
 
       desc << "Duration: " << length << "  Target Depth: " << depth;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth Slide", desc.str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth Slide", desc.str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -1242,7 +1242,7 @@ bool AkaoTrack::readEvent() {
       const uint32_t drum_instrset_offset = curOffset + relative_drum_offset;
 
       desc << "Offset: 0x" << std::hex << std::setfill('0') << std::uppercase << drum_instrset_offset;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Drum Kit On", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Drum Kit On", desc.str(), Type::ProgramChange, ICON_PROGCHANGE);
 
       if (readMode == READMODE_ADD_TO_UI) {
         parentSeq->drum_instrument_addresses.insert(drum_instrset_offset);
@@ -1261,7 +1261,7 @@ bool AkaoTrack::readEvent() {
     }
 
     case EVENT_DRUM_ON_V2: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Drum Kit On", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Drum Kit On", desc.str(), Type::ProgramChange, ICON_PROGCHANGE);
       addBankSelectNoItem(127);
       addProgramChangeNoItem(127, false);
       drum = true;
@@ -1271,7 +1271,7 @@ bool AkaoTrack::readEvent() {
 
     case EVENT_DRUM_OFF:
       // TODO: restore program change for regular instrument
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Drum Kit Off", "", CLR_PROGCHANGE, ICON_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Drum Kit Off", "", Type::ProgramChange, ICON_PROGCHANGE);
       drum = false;
       break;
 
@@ -1285,7 +1285,7 @@ bool AkaoTrack::readEvent() {
       curOffset = dest;
 
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc.str(), CLR_LOOPFOREVER);
+        addGenericEvent(beginOffset, length, "Jump", desc.str(), Type::LoopForever);
       }
       else {
         if (!addLoopForever(beginOffset, length, "Jump"))
@@ -1321,7 +1321,7 @@ bool AkaoTrack::readEvent() {
           curOffset = dest;
       }
 
-      addGenericEvent(beginOffset, length, "CPU-Conditional Jump", desc.str(), CLR_LOOP);
+      addGenericEvent(beginOffset, length, "CPU-Conditional Jump", desc.str(), Type::Loop);
       break;
     }
 
@@ -1334,7 +1334,7 @@ bool AkaoTrack::readEvent() {
       const uint32_t length = curOffset - beginOffset;
 
       desc << "Count: " << count << "  Destination: 0x" << std::hex << std::setfill('0') << std::uppercase << dest;
-      addGenericEvent(beginOffset, length, "Repeat Branch", desc.str(), CLR_MISC);
+      addGenericEvent(beginOffset, length, "Repeat Branch", desc.str(), Type::Misc);
 
       if (loop_counter[loop_layer] + 1 == count)
         curOffset = dest;
@@ -1351,7 +1351,7 @@ bool AkaoTrack::readEvent() {
       const uint32_t length = curOffset - beginOffset;
 
       desc << "Count: " << count << "  Destination: 0x" << std::hex << std::setfill('0') << std::uppercase << dest;
-      addGenericEvent(beginOffset, length, "Repeat Break", desc.str(), CLR_MISC);
+      addGenericEvent(beginOffset, length, "Repeat Break", desc.str(), Type::Misc);
 
       if (loop_counter[loop_layer] + 1 == count)
         curOffset = dest;
@@ -1386,14 +1386,14 @@ bool AkaoTrack::readEvent() {
       const uint8_t artNum2 = readByte(curOffset++);
 
       desc << "Program Number for Primary Voice: " << artNum << "  Program Number for Secondary Voice: " << artNum2;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Voice On (With Program Change)", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Voice On (With Program Change)", desc.str(), Type::ProgramChange, ICON_PROGCHANGE);
       addBankSelectNoItem(0);
       addProgramChangeNoItem(artNum, false);
       break;
     }
 
     case EVENT_OVERLAY_VOICE_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Voice Off", "", CLR_MISC, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Voice Off", "", Type::Misc, ICON_CONTROL);
       break;
     }
 
@@ -1402,7 +1402,7 @@ bool AkaoTrack::readEvent() {
       const int primary_percent = (127 - balance) * 100 / 256;
       const int secondary_percent = balance * 100 / 256;
       desc << "Balance: " << balance << " (Primary Voice Volume " << primary_percent << "%, Secondary Voice Volume " << secondary_percent << "%)";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Volume Balance", desc.str(), CLR_VOLUME, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Volume Balance", desc.str(), Type::Volume, ICON_CONTROL);
       break;
     }
 
@@ -1413,19 +1413,19 @@ bool AkaoTrack::readEvent() {
       const int primary_percent = (127 - balance) * 100 / 256;
       const int secondary_percent = balance * 100 / 256;
       desc << "Duration: " << length << "  Target Balance: " << balance << " (Primary Voice Volume " << primary_percent << "%, Secondary Voice Volume " << secondary_percent << "%)";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Volume Balance Fade", desc.str(), CLR_VOLUME, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Overlay Volume Balance Fade", desc.str(), Type::Volume, ICON_CONTROL);
       break;
     }
 
     case EVENT_ALTERNATE_VOICE_ON: {
       const uint8_t rr = readByte(curOffset++); // 0-127
       desc << "Release Rate: " << rr;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Alternate Voice On", desc.str(), CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Alternate Voice On", desc.str(), Type::Misc);
       break;
     }
 
     case EVENT_ALTERNATE_VOICE_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Alternate Voice Off", "", CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Alternate Voice Off", "", Type::Misc);
       break;
     }
 
@@ -1476,7 +1476,7 @@ bool AkaoTrack::readEvent() {
       const uint32_t length = curOffset - beginOffset;
 
       desc << "Destination: 0x" << std::hex << std::setfill('0') << std::uppercase << dest;
-      addGenericEvent(beginOffset, length, "Play Pattern", desc.str(), CLR_MISC);
+      addGenericEvent(beginOffset, length, "Play Pattern", desc.str(), Type::Misc);
 
       pattern_return_offset = curOffset;
       curOffset = dest;
@@ -1484,7 +1484,7 @@ bool AkaoTrack::readEvent() {
     }
 
     case EVENT_END_PATTERN: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "End Pattern", "", CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "End Pattern", "", Type::Misc);
       curOffset = pattern_return_offset;
       break;
     }
@@ -1492,14 +1492,14 @@ bool AkaoTrack::readEvent() {
     case EVENT_ALLOC_RESERVED_VOICES: {
       const uint8_t count = readByte(curOffset++);
       desc << "Number of Voices: " << count;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Allocate Reserved Voices", desc.str(), CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Allocate Reserved Voices", desc.str(), Type::Misc);
       break;
     }
 
     case EVENT_FREE_RESERVED_VOICES: {
       constexpr uint8_t count = 0;
       desc << "Number of Voices: " << count;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Free Reserved Voices", desc.str(), CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Free Reserved Voices", desc.str(), Type::Misc);
       break;
     }
 
@@ -1511,7 +1511,7 @@ bool AkaoTrack::readEvent() {
         const uint8_t denom = static_cast<uint8_t>((parentSeq->ppqn() * 4) / ticksPerBeat); // or should it always be 4? no idea
         addTimeSig(beginOffset, curOffset - beginOffset, beatsPerMeasure, denom, ticksPerBeat);
       } else {
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Time Signature", "", CLR_TIMESIG, ICON_TIMESIG);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Time Signature", "", Type::TimeSignature, ICON_TIMESIG);
       }
       break;
     }
@@ -1520,7 +1520,7 @@ bool AkaoTrack::readEvent() {
       const uint16_t measure = readShort(curOffset);
       curOffset += 2;
       desc << "Measure: " << measure;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Marker (Measure Number)", desc.str(), CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Marker (Measure Number)", desc.str(), Type::Misc);
       // TODO: write midi marker event
       break;
     }
@@ -1540,7 +1540,7 @@ bool AkaoTrack::readEvent() {
       const uint32_t key_split_regions_offset = curOffset + relative_key_split_regions_offset;
 
       desc << "Offset: 0x" << std::hex << std::setfill('0') << std::uppercase << key_split_regions_offset;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Program Change (Key-Split Instrument)", desc.str(), CLR_PROGCHANGE, ICON_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Program Change (Key-Split Instrument)", desc.str(), Type::ProgramChange, ICON_PROGCHANGE);
 
       if (readMode == READMODE_ADD_TO_UI) {
         parentSeq->custom_instrument_addresses.insert(key_split_regions_offset);
@@ -1570,11 +1570,11 @@ bool AkaoTrack::readEvent() {
     }
 
     case EVENT_USE_RESERVED_VOICES:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Use Reserved Voices", "", CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Use Reserved Voices", "", Type::Misc);
       break;
 
     case EVENT_USE_NO_RESERVED_VOICES:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Use No Reserved Voices", "", CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Use No Reserved Voices", "", Type::Misc);
       break;
 
     default:

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -677,7 +677,7 @@ bool AkaoSnesTrack::readEvent(void) {
       }
       else if (noteIndex == parentSeq->STATUS_NOTEINDEX_TIE) {
         makePrevDurNoteEnd(getTime() + dur);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, CLR_TIE, ICON_NOTE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, Type::Tie, ICON_NOTE);
         addTime(len);
       }
       else {
@@ -688,13 +688,13 @@ bool AkaoSnesTrack::readEvent(void) {
     }
 
     case EVENT_NOP: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc, CLR_MISC, ICON_BINARY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc, Type::Misc, ICON_BINARY);
       break;
     }
 
     case EVENT_NOP1: {
       curOffset++;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc, CLR_MISC, ICON_BINARY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc, Type::Misc, ICON_BINARY);
       break;
     }
 
@@ -722,7 +722,7 @@ bool AkaoSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Volume Fade",
                         fmt::format("Fade Length: {}  Volume: {}", fadeLength, vol),
-                        CLR_VOLUME,
+                        Type::Volume,
                         ICON_CONTROL);
       }
       else {
@@ -757,7 +757,7 @@ bool AkaoSnesTrack::readEvent(void) {
       // TODO: apply volume scale
       if (fadeLength != 0) {
         desc = fmt::format("Fade Length: {}  Pan: {}", fadeLength, pan);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc, CLR_PAN, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc, Type::Pan, ICON_CONTROL);
       }
       else {
         addPan(beginOffset, curOffset - beginOffset, midiPan);
@@ -789,7 +789,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Slide On",
                       desc,
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -799,7 +799,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Slide Off",
                       desc,
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -811,7 +811,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Slide",
                       fmt::format("Length: {}  Key: {} semitones", pitchSlideLength, pitchSlideSemitones),
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -824,7 +824,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Vibrato",
                       fmt::format("Delay: {}  Rate: {}  Depth: {}", lfoDelay, lfoRate, lfoDepth),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -834,7 +834,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Vibrato Off",
                       desc,
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -847,7 +847,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Tremolo",
                       fmt::format("Delay {}  Rate: {}  Depth {}", lfoDelay, lfoRate, lfoDepth),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -857,7 +857,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Tremolo Off",
                       desc,
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -869,7 +869,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pan LFO",
                       fmt::format("Depth: {}  Rate: {}", lfoDepth, lfoRate),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -882,7 +882,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pan LFO",
                       fmt::format("Delay: {}  Rate: {}  Depth: {}", lfoDelay, lfoRate, lfoDepth),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -892,7 +892,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pan LFO Off",
                       desc,
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -903,7 +903,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Noise Frequency",
                       fmt::format("Noise Frequency (NCK): {}", newNCK),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -913,7 +913,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Noise On",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -923,7 +923,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Noise Off",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -933,7 +933,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Modulation On",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -943,18 +943,18 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Modulation Off",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_ON: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc, CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc, Type::Reverb, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc, CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc, Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -1015,7 +1015,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Volume Envelope",
                       fmt::format("Envelope: {}", envelopeIndex),
-                      CLR_VOLUME,
+                      Type::Volume,
                       ICON_CONTROL);
       break;
     }
@@ -1026,7 +1026,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Release Rate (GAIN)",
                       fmt::format("GAIN: {}", gain),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -1041,7 +1041,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Duration Rate",
                       fmt::format("Note Length: {} %", rate),
-                      CLR_DURNOTE,
+                      Type::DurationNote,
                       ICON_CONTROL);
       break;
     }
@@ -1052,7 +1052,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "ADSR Attack Rate",
                       fmt::format("AR: {}", newAR),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -1063,7 +1063,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "ADSR Decay Rate",
                       fmt::format("DR: {}", newDR),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -1074,7 +1074,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "ADSR Sustain Level",
                       fmt::format("SL: {}", newSL),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -1085,7 +1085,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "ADSR Sustain Rate",
                       fmt::format("SR: {}", newSR),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -1095,7 +1095,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Default ADSR",
                       desc,
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -1107,7 +1107,7 @@ bool AkaoSnesTrack::readEvent(void) {
       }
 
       desc = fmt::format("Loop Count: {}", count);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc, CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc, Type::Loop, ICON_STARTREP);
 
       loopStart[loopLevel] = curOffset;
       if (parentSeq->version == AKAOSNES_V4) {
@@ -1133,7 +1133,7 @@ bool AkaoSnesTrack::readEvent(void) {
         curOffset = loopStart[prevLoopLevel];
       }
       else {
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc, CLR_LOOP, ICON_ENDREP);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc, Type::Loop, ICON_ENDREP);
 
         if (loopDecCount[prevLoopLevel] - 1 == 0) {
           // repeat end
@@ -1163,7 +1163,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Slur On (No Key Off/On)",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       slur = true;
       break;
@@ -1174,7 +1174,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Slur Off",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       slur = false;
       break;
@@ -1185,7 +1185,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Legato On (No Key Off)",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       legato = true;
       break;
@@ -1196,7 +1196,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Legato Off",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       legato = false;
       break;
@@ -1206,7 +1206,7 @@ bool AkaoSnesTrack::readEvent(void) {
       uint8_t dur = readByte(curOffset++);
       onetimeDuration = dur;
       desc = fmt::format("Duration: {}", dur);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration (One-Time)", desc, CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration (One-Time)", desc, Type::DurationNote);
       break;
     }
 
@@ -1268,7 +1268,7 @@ bool AkaoSnesTrack::readEvent(void) {
 
       if (fadeLength != 0) {
         desc = fmt::format("Fade Length: {}  BPM: {}", fadeLength, parentSeq->getTempoInBPM(newTempo));
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tempo Fade", desc, CLR_TEMPO, ICON_TEMPO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tempo Fade", desc, Type::Tempo, ICON_TEMPO);
       }
       else {
         addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq->getTempoInBPM(newTempo));
@@ -1282,7 +1282,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Echo Volume",
                       fmt::format("Volume: {}", vol),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -1295,7 +1295,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Echo Volume Fade",
                       fmt::format("Fade Length: {}  Volume {}", fadeLength, vol),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -1307,7 +1307,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Echo Feedback & FIR",
                       fmt::format("Feedback: {},  FIR: {}", feedback, filterIndex),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -1327,7 +1327,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Loop Break / Jump to Volta",
                       fmt::format("Count: {}  Destination: ${:04X}", count, dest),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_ENDREP);
 
       uint8_t prevLoopLevel = (loopLevel != 0 ? loopLevel : AKAOSNES_LOOP_LEVEL_MAX) - 1;
@@ -1371,7 +1371,7 @@ bool AkaoSnesTrack::readEvent(void) {
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc, CLR_LOOPFOREVER);
+        addGenericEvent(beginOffset, length, "Jump", desc, Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -1397,7 +1397,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Echo Feedback Fade",
                       fmt::format("Fade Length: {}  Feedback: {}", fadeLength, feedback),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -1410,7 +1410,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Echo FIR Fade",
                       fmt::format("Fade Length: {}  FIR: {}", fadeLength, vol),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -1421,7 +1421,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Echo Feedback",
                       fmt::format("Feedback: {}", feedback),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -1432,7 +1432,7 @@ bool AkaoSnesTrack::readEvent(void) {
         curOffset - beginOffset,
         "Echo FIR",
         fmt::format("FIR: {}", vol),
-        CLR_REVERB,
+        Type::Reverb,
         ICON_CONTROL);
       break;
     }
@@ -1448,7 +1448,7 @@ bool AkaoSnesTrack::readEvent(void) {
       curOffset += 2;
       desc = fmt::format("Destination: ${:04X}", dest);
       addGenericEvent(beginOffset, curOffset - beginOffset, "CPU-Controlled Jump", desc,
-                      CLR_LOOP);
+                      Type::Loop);
 
       if (jumpActivatedByMainCpu) {
         curOffset = dest;
@@ -1475,7 +1475,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Percussion On",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       percussion = true;
       addProgramChangeNoItem(AkaoSnesInstrSet::DRUMKIT_PROGRAM, true);
@@ -1487,7 +1487,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Percussion Off",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       percussion = false;
       addProgramChangeNoItem(nonPercussionProgram, true);
@@ -1501,7 +1501,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Ignore Master Volume (Broken)",
                       desc,
-                      CLR_VOLUME,
+                      Type::Volume,
                       ICON_CONTROL);
       break;
     }
@@ -1511,7 +1511,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Ignore Master Volume",
                       desc,
-                      CLR_VOLUME,
+                      Type::Volume,
                       ICON_CONTROL);
       break;
     }
@@ -1522,7 +1522,7 @@ bool AkaoSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Ignore Master Volume By Program Number",
                       fmt::format("Program Number: {}", ignoreMasterVolumeProgNum),
-                      CLR_VOLUME,
+                      Type::Volume,
                       ICON_CONTROL);
       break;
     }

--- a/src/main/formats/CPS/CPS1TrackV1.cpp
+++ b/src/main/formats/CPS/CPS1TrackV1.cpp
@@ -83,7 +83,7 @@ bool CPS1TrackV1::readEvent() {
           addNoteOn(beginOffset, curOffset - beginOffset, key, masterVol, "Note On (tied)");
         }
         else
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", "", CLR_NOTEON);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", "", Type::NoteOn);
         bPrevNoteTie = true;
         prevTieNote = key;
         tieNoteCounter--;
@@ -117,12 +117,12 @@ bool CPS1TrackV1::readEvent() {
     if (statusByte >= 0x30) {
       shortenDeltaCounter = statusByte & 0xf;
       std::string desc = fmt::format("Shorten next {:d} events", shortenDeltaCounter);
-      addGenericEvent(beginOffset, curOffset-beginOffset, desc, "", CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset-beginOffset, desc, "", Type::ChangeState);
     } else {
       tieNoteCounter = (statusByte & 0xf) + 1;
       tieNoteFlag = true;
       std::string desc = fmt::format("Tie next {:d} notes", tieNoteCounter);
-      addGenericEvent(beginOffset, curOffset-beginOffset, desc, "", CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset-beginOffset, desc, "", Type::ChangeState);
     }
     return true;
   }
@@ -147,7 +147,7 @@ bool CPS1TrackV1::readEvent() {
     }
     case 0x01: {
       noteDuration = readByte(curOffset++);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Set Duration", "", CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Set Duration", "", Type::ChangeState);
       break;
     }
     case 0x02: { // loop break
@@ -181,7 +181,7 @@ bool CPS1TrackV1::readEvent() {
         loop[loopNum] = numLoops;
         std::string name = fmt::format("Loop #{:d}", loopNum);
         std::string desc = fmt::format("Loop count: {:d}. Offset: {:X}", numLoops, offset);
-        addGenericEvent(beginOffset, 4, name, desc, CLR_LOOP);
+        addGenericEvent(beginOffset, 4, name, desc, Type::Loop);
       } else {
         // The loop counter was previously set: decrement the counter
         loop[loopNum]--;
@@ -204,19 +204,19 @@ bool CPS1TrackV1::readEvent() {
         break;
       }
       curOffset += 2;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop break", "", CLR_LOOP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop break", "", Type::Loop);
       break;
     }
 
     case 0x06:        // set dotted note flag
       extendDeltaFlag = true;
-      addGenericEvent(beginOffset, curOffset-beginOffset, "Extend next event", "", CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset-beginOffset, "Extend next event", "", Type::ChangeState);
       break;
 
     case 0x07: {      // transpose
       cps0transpose = readByte(curOffset++);
       std::string desc = fmt::format("{:+d} semitones", cps0transpose);
-      addGenericEvent(beginOffset, curOffset-beginOffset, "Transpose", desc, CLR_TRANSPOSE);
+      addGenericEvent(beginOffset, curOffset-beginOffset, "Transpose", desc, Type::Transpose);
       break;
     }
 
@@ -237,7 +237,7 @@ bool CPS1TrackV1::readEvent() {
 
     case 0x0A:        // NOP
       curOffset++;
-      addGenericEvent(beginOffset, curOffset-beginOffset, "NOP", "", CLR_MISC);
+      addGenericEvent(beginOffset, curOffset-beginOffset, "NOP", "", Type::Misc);
       break;
 
     case 0x0B:        // NOP

--- a/src/main/formats/CPS/CPS1TrackV2.cpp
+++ b/src/main/formats/CPS/CPS1TrackV2.cpp
@@ -103,7 +103,7 @@ bool CPS1TrackV2::readEvent() {
           addNoteOn(beginOffset, curOffset - beginOffset, key, masterVol, "Note On (tied)");
         }
         else
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", "", CLR_NOTEON);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", "", Type::NoteOn);
         bPrevNoteTie = true;
         prevTieNote = key;
       }
@@ -129,7 +129,7 @@ bool CPS1TrackV2::readEvent() {
       }
     }
     else {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Rest", "", CLR_REST);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Rest", "", Type::Rest);
     }
     addTime(delta);
   }
@@ -142,7 +142,7 @@ bool CPS1TrackV2::readEvent() {
                         curOffset - beginOffset,
                         "Note State xor 0x20 (change duration table)",
                         "",
-                        CLR_CHANGESTATE);
+                        Type::ChangeState);
         break;
       case 0x01 :
         noteState ^= 0x40;
@@ -150,7 +150,7 @@ bool CPS1TrackV2::readEvent() {
                         curOffset - beginOffset,
                         "Note State xor 0x40 (Toggle tie)",
                         "",
-                        CLR_CHANGESTATE);
+                        Type::ChangeState);
         break;
       case 0x02 :
         noteState |= (1 << 4);
@@ -158,7 +158,7 @@ bool CPS1TrackV2::readEvent() {
                         curOffset - beginOffset,
                         "Note State |= 0x10 (change duration table)",
                         "",
-                        CLR_CHANGESTATE);
+                        Type::ChangeState);
         break;
       case 0x03 :
         noteState ^= 8;
@@ -166,13 +166,13 @@ bool CPS1TrackV2::readEvent() {
                         curOffset - beginOffset,
                         "Note State xor 8 (change octave)",
                         "",
-                        CLR_CHANGESTATE);
+                        Type::ChangeState);
         break;
 
       case 0x04 :
         noteState &= 0x97;
         noteState |= readByte(curOffset++);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Change Note State (& 0x97)", "", CLR_CHANGESTATE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Change Note State (& 0x97)", "", Type::ChangeState);
         break;
 
       case 0x05 : {
@@ -188,7 +188,7 @@ bool CPS1TrackV2::readEvent() {
 
       case 0x06 :
         noteDuration = readByte(curOffset++);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Duration", "", CLR_CHANGESTATE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Duration", "", Type::ChangeState);
         break;
 
       case 0x07 :
@@ -221,7 +221,7 @@ bool CPS1TrackV2::readEvent() {
       case 0x09 :
         noteState &= 0xF8;
         noteState |= readByte(curOffset++);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Octave", "", CLR_CHANGESTATE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Octave", "", Type::ChangeState);
         break;
 
       // Global Transpose
@@ -250,7 +250,7 @@ bool CPS1TrackV2::readEvent() {
       }
       case 0x0D : {
         uint8_t portamentoRate = readByte(curOffset++);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Time", "", CLR_PORTAMENTOTIME);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Time", "", Type::PortamentoTime);
         break;
       }
 
@@ -311,7 +311,7 @@ bool CPS1TrackV2::readEvent() {
             }
           }
 
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", CLR_LOOP);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", Type::Loop);
 
           if (loop[loopNum] == 0) {
             bInLoop = false;
@@ -348,7 +348,7 @@ bool CPS1TrackV2::readEvent() {
           {
             uint16_t jump = getShortBE(curOffset);
             curOffset += 2;
-            addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", "", CLR_LOOP);
+            addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", "", Type::Loop);
 
             if (version() <= CPS1_V425) {
               curOffset = jump;
@@ -403,7 +403,7 @@ bool CPS1TrackV2::readEvent() {
 
       case 0x1A : {
         uint8_t masterVol = readByte(curOffset++);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Master Volume", "", CLR_UNKNOWN);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Master Volume", "", Type::Unknown);
         cpsSeq->setMasterVolume(masterVol);
         break;
       }
@@ -438,7 +438,7 @@ bool CPS1TrackV2::readEvent() {
         break;
 
       default :
-        addGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", CLR_UNRECOGNIZED);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", Type::Unrecognized);
     }
   }
   return true;

--- a/src/main/formats/CPS/CPS2Instr.cpp
+++ b/src/main/formats/CPS/CPS2Instr.cpp
@@ -232,7 +232,7 @@ bool CPS2InstrSet::parseInstrPointers() {
         uint32_t bankOff = instr_table_ptrs[bank] - 0x6000000;
 
         auto pointersName = fmt::format("Bank {:d} Instrument Pointers", bank);
-        auto instrPointersItem = new VGMItem(vgmFile(), bankOff, 128*2, pointersName, CLR_HEADER);
+        auto instrPointersItem = new VGMItem(vgmFile(), bankOff, 128*2, pointersName, Type::Header);
 
         // For each bank, iterate over all instr ptrs and create instruments
         for (uint8_t j = 0; j < 128; j++) {

--- a/src/main/formats/CPS/CPS2TrackV1.cpp
+++ b/src/main/formats/CPS/CPS2TrackV1.cpp
@@ -105,7 +105,7 @@ bool CPS2TrackV1::readEvent() {
           addNoteOffNoItem(prevTieNote);
         }
         else
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", "", CLR_NOTEON);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", "", Type::NoteOn);
         bPrevNoteTie = true;
         prevTieNote = key;
       }
@@ -131,7 +131,7 @@ bool CPS2TrackV1::readEvent() {
       }
     }
     else {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Rest", "", CLR_REST);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Rest", "", Type::Rest);
     }
     addTime(delta);
   }
@@ -144,7 +144,7 @@ bool CPS2TrackV1::readEvent() {
                         curOffset - beginOffset,
                         "Note State xor 0x20 (change duration table)",
                         "",
-                        CLR_CHANGESTATE);
+                        Type::ChangeState);
         break;
       case 0x01 :
         noteState ^= 0x40;
@@ -152,7 +152,7 @@ bool CPS2TrackV1::readEvent() {
                         curOffset - beginOffset,
                         "Note State xor 0x40 (Toggle tie)",
                         "",
-                        CLR_CHANGESTATE);
+                        Type::ChangeState);
         break;
       case 0x02 :
         noteState |= (1 << 4);
@@ -160,7 +160,7 @@ bool CPS2TrackV1::readEvent() {
                         curOffset - beginOffset,
                         "Note State |= 0x10 (change duration table)",
                         "",
-                        CLR_CHANGESTATE);
+                        Type::ChangeState);
         break;
       case 0x03 :
         noteState ^= 8;
@@ -168,13 +168,13 @@ bool CPS2TrackV1::readEvent() {
                         curOffset - beginOffset,
                         "Note State xor 8 (change octave)",
                         "",
-                        CLR_CHANGESTATE);
+                        Type::ChangeState);
         break;
 
       case 0x04 :
         noteState &= 0x97;
         noteState |= readByte(curOffset++);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Change Note State (& 0x97)", "", CLR_CHANGESTATE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Change Note State (& 0x97)", "", Type::ChangeState);
         break;
 
       case 0x05 : {
@@ -207,7 +207,7 @@ bool CPS2TrackV1::readEvent() {
 
       case 0x06 :
         noteDuration = readByte(curOffset++);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Duration", "", CLR_CHANGESTATE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Duration", "", Type::ChangeState);
         break;
 
       case 0x07 :
@@ -227,7 +227,7 @@ bool CPS2TrackV1::readEvent() {
       case 0x09 :
         noteState &= 0xF8;
         noteState |= readByte(curOffset++);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Octave", "", CLR_CHANGESTATE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Octave", "", Type::ChangeState);
         break;
 
       // Global Transpose
@@ -254,7 +254,7 @@ bool CPS2TrackV1::readEvent() {
                   0,
                   "Pitch Bend",
                   PRIORITY_MIDDLE,
-                  CLR_PITCHBEND);
+                  Type::PitchBend);
       }
       break;
       case 0x0D : {
@@ -267,7 +267,7 @@ bool CPS2TrackV1::readEvent() {
         } else {
           portamentoCentsPerSec = 0;
         }
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Time", "", CLR_PORTAMENTOTIME);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Time", "", Type::PortamentoTime);
         break;
       }
 
@@ -320,7 +320,7 @@ bool CPS2TrackV1::readEvent() {
             curOffset += 2;
           }
 
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", CLR_LOOP);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", Type::Loop);
 
           if (loop[loopNum] == 0) {
             bInLoop = false;
@@ -357,7 +357,7 @@ bool CPS2TrackV1::readEvent() {
           {
             u16 jump = getShortBE(curOffset);
             curOffset += 2;
-            addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", "", CLR_LOOP);
+            addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", "", Type::Loop);
             curOffset += static_cast<int16_t>(jump);
           }
         }
@@ -401,7 +401,7 @@ bool CPS2TrackV1::readEvent() {
 
       case 0x1A : {
         uint8_t masterVol = readByte(curOffset++);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Master Volume", "", CLR_UNKNOWN);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Master Volume", "", Type::Unknown);
         // addMasterVol(beginOffset, curOffset-beginOffset, masterVol);
         break;
       }
@@ -417,7 +417,7 @@ bool CPS2TrackV1::readEvent() {
                     0,
                     "Vibrato",
                     PRIORITY_HIGH,
-                    CLR_PITCHBEND);
+                    Type::PitchBend);
         }
         else {
           // First data byte defines behavior 0-3
@@ -433,7 +433,7 @@ bool CPS2TrackV1::readEvent() {
                         0,
                         "Vibrato",
                         PRIORITY_HIGH,
-                        CLR_PITCHBEND);
+                        Type::PitchBend);
               break;
 
             // tremelo
@@ -445,7 +445,7 @@ bool CPS2TrackV1::readEvent() {
                         0,
                         "Tremelo",
                         PRIORITY_MIDDLE,
-                        CLR_EXPRESSION);
+                        Type::Expression);
               break;
 
             // LFO rate
@@ -457,7 +457,7 @@ bool CPS2TrackV1::readEvent() {
                         0,
                         "LFO Rate",
                         PRIORITY_MIDDLE,
-                        CLR_LFO);
+                        Type::Lfo);
               break;
 
             // LFO reset
@@ -469,7 +469,7 @@ bool CPS2TrackV1::readEvent() {
                         0,
                         "LFO Reset",
                         PRIORITY_MIDDLE,
-                        CLR_LFO);
+                        Type::Lfo);
               break;
             default:
               break;
@@ -486,7 +486,7 @@ bool CPS2TrackV1::readEvent() {
                     0,
                     "Tremelo",
                     PRIORITY_MIDDLE,
-                    CLR_EXPRESSION);
+                    Type::Expression);
         }
         else {
           // I'm not sure at all about the behavior here, need to test
@@ -506,7 +506,7 @@ bool CPS2TrackV1::readEvent() {
                     0,
                     "LFO Rate",
                     PRIORITY_MIDDLE,
-                    CLR_LFO);
+                    Type::Lfo);
         else
           addUnknown(beginOffset, curOffset - beginOffset, "NOP");
         break;
@@ -523,7 +523,7 @@ bool CPS2TrackV1::readEvent() {
                     0,
                     "LFO Reset",
                     PRIORITY_MIDDLE,
-                    CLR_LFO);
+                    Type::Lfo);
         else
           addUnknown(beginOffset, curOffset - beginOffset, "NOP");
       }
@@ -537,7 +537,7 @@ bool CPS2TrackV1::readEvent() {
         else {
           bank = value;
           addBankSelectNoItem(bank * 2);
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Bank Change", "", CLR_PROGCHANGE);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Bank Change", "", Type::ProgramChange);
         }
         break;
       }
@@ -563,7 +563,7 @@ bool CPS2TrackV1::readEvent() {
         break;
 
       default :
-        addGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", CLR_UNRECOGNIZED);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", Type::Unrecognized);
     }
   }
   return true;

--- a/src/main/formats/CPS/CPS2TrackV2.cpp
+++ b/src/main/formats/CPS/CPS2TrackV2.cpp
@@ -85,7 +85,7 @@ bool CPS2TrackV2::readEvent() {
 
     case C2_SETBANK:
       addBankSelectNoItem(readByte(curOffset++) * 2);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Bank Change", "", CLR_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Bank Change", "", Type::ProgramChange);
       break;
 
     case C3_PITCHBEND: {
@@ -97,7 +97,7 @@ bool CPS2TrackV2::readEvent() {
                 0,
                 "Pitch Bend",
                 PRIORITY_MIDDLE,
-                CLR_PITCHBEND);
+                Type::PitchBend);
       break;
     }
 
@@ -116,7 +116,7 @@ bool CPS2TrackV2::readEvent() {
                 0,
                 "Vibrato",
                 PRIORITY_HIGH,
-                CLR_PITCHBEND);
+                Type::PitchBend);
       break;
     }
 
@@ -183,22 +183,22 @@ bool CPS2TrackV2::readEvent() {
 
     case D0_LOOP_1_START:
       loopOffset[0] = curOffset;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop 1 Start", "", CLR_LOOP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop 1 Start", "", Type::Loop);
       break;
 
     case D1_LOOP_2_START:
       loopOffset[1] = curOffset;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop 2 Start", "", CLR_LOOP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop 2 Start", "", Type::Loop);
       break;
 
     case D2_LOOP_3_START:
       loopOffset[2] = curOffset;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop 3 Start", "", CLR_LOOP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop 3 Start", "", Type::Loop);
       break;
 
     case D3_LOOP_4_START:
       loopOffset[3] = curOffset;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop 4 Start", "", CLR_LOOP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop 4 Start", "", Type::Loop);
       break;
 
     case D4_LOOP_1: loopNum = 0; goto handleLoop;
@@ -226,7 +226,7 @@ bool CPS2TrackV2::readEvent() {
         curOffset = loopOffset[loopNum];
       }
       else {
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", CLR_LOOP);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", Type::Loop);
         loopCounter[loopNum] = loopCount; //start loop
         curOffset = loopOffset[loopNum];
       }
@@ -241,7 +241,7 @@ bool CPS2TrackV2::readEvent() {
       if (loopCounter[loopNum] - 1 == 0) {
         loopCounter[loopNum] = 0;
         uint16_t jump = getShortBE(curOffset);
-        addGenericEvent(beginOffset, (curOffset+2) - beginOffset, "Loop Break", "", CLR_LOOP);
+        addGenericEvent(beginOffset, (curOffset+2) - beginOffset, "Loop Break", "", Type::Loop);
         curOffset += jump + 2;
       }
       else {
@@ -256,7 +256,7 @@ bool CPS2TrackV2::readEvent() {
 
     case DD_TRANSPOSE:
       transpose += static_cast<int8_t>(readByte(curOffset++));
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Transpose", "", CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Transpose", "", Type::ChangeState);
       break;
 
     case EVENT_DE:
@@ -279,7 +279,7 @@ bool CPS2TrackV2::readEvent() {
                 0,
                 "LFO Reset",
                 PRIORITY_MIDDLE,
-                CLR_LFO);
+                Type::Lfo);
       break;
     }
 
@@ -292,7 +292,7 @@ bool CPS2TrackV2::readEvent() {
                 0,
                 "LFO Rate",
                 PRIORITY_MIDDLE,
-                CLR_LFO);
+                Type::Lfo);
       break;
     }
 
@@ -305,7 +305,7 @@ bool CPS2TrackV2::readEvent() {
                 0,
                 "Tremelo",
                 PRIORITY_MIDDLE,
-                CLR_EXPRESSION);
+                Type::Expression);
       break;
     }
 
@@ -345,7 +345,7 @@ bool CPS2TrackV2::readEvent() {
       uint8_t slot = readByte(curOffset++);
       uint8_t value = readByte(curOffset++);
       auto description = fmt::format("Slot: {:d} Value: {:d}", slot, value);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Meta Event", description, CLR_MARKER);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Meta Event", description, Type::Marker);
       break;
     }
 
@@ -354,7 +354,7 @@ bool CPS2TrackV2::readEvent() {
       return false;
 
     default :
-      addGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", CLR_UNRECOGNIZED);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", Type::Unrecognized);
       break;
   }
 

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -303,7 +303,7 @@ bool CapcomSnesTrack::readEvent() {
         addTime(dur);
         makePrevDurNoteEnd();
         addTime(len - dur);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, CLR_TIE, ICON_NOTE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, Type::Tie, ICON_NOTE);
       }
       else {
         addNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur);
@@ -363,22 +363,22 @@ bool CapcomSnesTrack::readEvent() {
 
       case EVENT_TOGGLE_TRIPLET:
         setNoteTriplet(!isNoteTriplet());
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Toggle Triplet", "", CLR_DURNOTE, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Toggle Triplet", "", Type::DurationNote, ICON_CONTROL);
         break;
 
       case EVENT_TOGGLE_SLUR:
         setNoteSlurred(!isNoteSlurred());
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Toggle Slur/Tie", "", CLR_DURNOTE, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Toggle Slur/Tie", "", Type::DurationNote, ICON_CONTROL);
         break;
 
       case EVENT_DOTTED_NOTE_ON:
         setNoteDotted(true);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Dotted Note On", "", CLR_DURNOTE, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Dotted Note On", "", Type::DurationNote, ICON_CONTROL);
         break;
 
       case EVENT_TOGGLE_OCTAVE_UP:
         setNoteOctaveUp(!isNoteOctaveUp());
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Toggle 2-Octave Up", "", CLR_DURNOTE, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Toggle 2-Octave Up", "", Type::DurationNote, ICON_CONTROL);
         break;
 
       case EVENT_NOTE_ATTRIBUTES: {
@@ -393,7 +393,7 @@ bool CapcomSnesTrack::readEvent() {
                         curOffset - beginOffset,
                         "Note Attributes",
                         desc,
-                        CLR_DURNOTE,
+                        Type::DurationNote,
                         ICON_CONTROL);
         break;
       }
@@ -413,7 +413,7 @@ bool CapcomSnesTrack::readEvent() {
                         curOffset - beginOffset,
                         "Duration",
                         fmt::format("Duration: {:d}/256", newDurationRate),
-                        CLR_DURNOTE,
+                        Type::DurationNote,
                         ICON_CONTROL);
         break;
       }
@@ -448,7 +448,7 @@ bool CapcomSnesTrack::readEvent() {
         uint8_t newOctave = readByte(curOffset++);
         desc = fmt::format("Octave: {}", newOctave);
         setNoteOctave(newOctave);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Octave", desc, CLR_DURNOTE, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Octave", desc, Type::DurationNote, ICON_CONTROL);
         break;
       }
 
@@ -478,7 +478,7 @@ bool CapcomSnesTrack::readEvent() {
                         curOffset - beginOffset,
                         "Portamento Time",
                         fmt::format("Time: {:d}", newPortamentoTime),
-                        CLR_PORTAMENTOTIME,
+                        Type::PortamentoTime,
                         ICON_CONTROL);
         addPortamentoTimeNoItem(newPortamentoTime >> 1);
         addPortamentoNoItem(newPortamentoTime != 0);
@@ -519,7 +519,7 @@ bool CapcomSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           repeatEventName,
                           desc,
-                          CLR_LOOP,
+                          Type::Loop,
                           ICON_STARTREP);
         }
 
@@ -563,7 +563,7 @@ bool CapcomSnesTrack::readEvent() {
                         curOffset - beginOffset,
                         repeatEventName,
                         desc,
-                        CLR_LOOP,
+                        Type::Loop,
                         ICON_STARTREP);
 
         if (repeatCount[repeatSlot] == 1) {
@@ -583,7 +583,7 @@ bool CapcomSnesTrack::readEvent() {
         uint32_t length = curOffset - beginOffset;
 
         if (!isOffsetUsed(dest)) {
-          addGenericEvent(beginOffset, length, "Jump", desc, CLR_LOOPFOREVER);
+          addGenericEvent(beginOffset, length, "Jump", desc, Type::LoopForever);
         }
         else {
           bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -649,7 +649,7 @@ bool CapcomSnesTrack::readEvent() {
         uint8_t lfoType = readByte(curOffset++);
         uint8_t lfoAmount = readByte(curOffset++);
         desc = fmt::format("Type: {:d}  Amount: {:d}", lfoType, lfoAmount);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Param", desc, CLR_LFO, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Param", desc, Type::Lfo, ICON_CONTROL);
         break;
       }
 
@@ -661,7 +661,7 @@ bool CapcomSnesTrack::readEvent() {
                         curOffset - beginOffset,
                         "Echo Param",
                         desc,
-                        CLR_REVERB,
+                        Type::Reverb,
                         ICON_CONTROL);
         break;
       }
@@ -682,7 +682,7 @@ bool CapcomSnesTrack::readEvent() {
                         curOffset - beginOffset,
                         "Release Rate",
                         fmt::format("GAIN: ${:02X}", gain),
-                        CLR_SUSTAIN,
+                        Type::Sustain,
                         ICON_CONTROL);
         break;
       }

--- a/src/main/formats/ChunSnes/ChunSnesSeq.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesSeq.cpp
@@ -293,7 +293,7 @@ bool ChunSnesTrack::readEvent() {
     }
 
     case EVENT_NOP: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc, CLR_MISC, ICON_BINARY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc, Type::Misc, ICON_BINARY);
       break;
     }
 
@@ -337,7 +337,7 @@ bool ChunSnesTrack::readEvent() {
       }
       else if (tie) {
         // update note duration without changing note pitch
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, CLR_TIE, ICON_NOTE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, Type::Tie, ICON_NOTE);
         makePrevDurNoteEnd(getTime() + dur);
         addTime(noteLength);
       }
@@ -346,7 +346,7 @@ bool ChunSnesTrack::readEvent() {
           // slurred note with same key works as tie
           makePrevDurNoteEnd(getTime() + dur);
           desc = fmt::format("Abs Key: {} ({})   Duration: {}", key, MidiEvent::getNoteName(key), dur);
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Note with Duration", desc, CLR_TIE, ICON_NOTE);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Note with Duration", desc, Type::Tie, ICON_NOTE);
         }
         else {
           addNoteByDur(beginOffset, curOffset - beginOffset, key, NOTE_VELOCITY, dur);
@@ -377,7 +377,7 @@ bool ChunSnesTrack::readEvent() {
       else {
         desc = fmt::format("Duration Rate: {}/256", noteDurationRate+1);
       }
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate from Table", desc, CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate from Table", desc, Type::DurationNote);
       break;
     }
 
@@ -386,7 +386,7 @@ bool ChunSnesTrack::readEvent() {
       curOffset += 2;
       uint16_t dest = curOffset + destOffset;
       desc = fmt::format("Destination: ${:04X}", dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break (Alt)", desc, CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break (Alt)", desc, Type::Loop, ICON_ENDREP);
 
       if (loopCountAlt != 0) {
         curOffset = dest;
@@ -400,7 +400,7 @@ bool ChunSnesTrack::readEvent() {
       curOffset += 2;
       uint16_t dest = curOffset + destOffset;
       desc = fmt::format("Destination: ${:04X}", dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again (Alt)", desc, CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again (Alt)", desc, Type::Loop, ICON_ENDREP);
 
       if (loopCountAlt == 0) {
         loopCountAlt = 2;
@@ -417,7 +417,7 @@ bool ChunSnesTrack::readEvent() {
     case EVENT_ADSR_RELEASE_SR: {
       uint8_t release_sr = readByte(curOffset++) & 31;
       desc = fmt::format("SR (Release): {}", release_sr);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Release Rate", desc, CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Release Rate", desc, Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -432,7 +432,7 @@ bool ChunSnesTrack::readEvent() {
       uint8_t sr = adsr2 & 0x1f;
       desc = fmt::format("AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}  SR (Release): {:d}",
                           ar, dr, sl, sr, release_sr);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR & Release Rate", desc, CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR & Release Rate", desc, Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -443,7 +443,7 @@ bool ChunSnesTrack::readEvent() {
       desc = fmt::format("Invert Left: {}  Invert Right: {}",
                                 invertLeft ? "On" : "Off",
                                 invertRight ? "On" : "Off");
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Surround", desc, CLR_PAN, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Surround", desc, Type::Pan, ICON_CONTROL);
       break;
     }
 
@@ -453,7 +453,7 @@ bool ChunSnesTrack::readEvent() {
       uint8_t condValue = readByte(curOffset++);
       uint16_t dest = curOffset + destOffset;
       desc = fmt::format("Destination: ${:04X}", dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump", desc, CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump", desc, Type::Misc);
 
       if ((parentSeq->conditionVar & 0x7f) == condValue) {
         // repeat again
@@ -469,7 +469,7 @@ bool ChunSnesTrack::readEvent() {
 
     case EVENT_INC_COUNTER: {
       // increment a counter value, which will be sent to main CPU
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Increment Counter", desc, CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Increment Counter", desc, Type::Misc);
       break;
     }
 
@@ -481,17 +481,17 @@ bool ChunSnesTrack::readEvent() {
       else {
         desc = fmt::format("Envelope: {:d}", envelopeIndex);
       }
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope", desc, CLR_LFO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope", desc, Type::Lfo, ICON_CONTROL);
       break;
     }
 
     case EVENT_NOISE_ON: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise On", desc, CLR_PROGCHANGE, ICON_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise On", desc, Type::ProgramChange, ICON_PROGCHANGE);
       break;
     }
 
     case EVENT_NOISE_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Off", desc, CLR_PROGCHANGE, ICON_PROGCHANGE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Off", desc, Type::ProgramChange, ICON_PROGCHANGE);
       break;
     }
 
@@ -518,7 +518,7 @@ bool ChunSnesTrack::readEvent() {
       // fade channel volume to zero or full, do not know where it is used
       uint8_t arg1 = readByte(curOffset++);
       desc = fmt::format("Arg1: {:d}", arg1);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Fade", desc, CLR_VOLUME, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Fade", desc, Type::Volume, ICON_CONTROL);
       break;
     }
 
@@ -551,7 +551,7 @@ bool ChunSnesTrack::readEvent() {
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc, CLR_LOOPFOREVER);
+        addGenericEvent(beginOffset, length, "Jump", desc, Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -582,7 +582,7 @@ bool ChunSnesTrack::readEvent() {
       else {
         desc = fmt::format("Duration Rate: {:d}/256", noteDurationRate);
       }
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc, CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc, Type::DurationNote);
       break;
     }
 
@@ -612,7 +612,7 @@ bool ChunSnesTrack::readEvent() {
       uint8_t sr = adsr2 & 0x1f;
 
       desc = fmt::format("AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}", ar, dr, sl, sr);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -628,13 +628,13 @@ bool ChunSnesTrack::readEvent() {
       // refresh duration info promptly
       syncNoteLengthWithPriorTrack();
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Sync Note Length On", desc, CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Sync Note Length On", desc, Type::DurationNote);
       break;
     }
 
     case EVENT_SYNC_NOTE_LEN_OFF: {
       syncNoteLen = false;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Sync Note Length Off", desc, CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Sync Note Length Off", desc, Type::DurationNote);
       break;
     }
 
@@ -643,7 +643,7 @@ bool ChunSnesTrack::readEvent() {
       curOffset += 2;
       uint16_t dest = curOffset + destOffset;
       desc = fmt::format("Destination: ${:04X}", dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again", desc, CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again", desc, Type::Loop, ICON_ENDREP);
 
       if (loopCount == 0) {
         loopCount = 2;
@@ -663,7 +663,7 @@ bool ChunSnesTrack::readEvent() {
       curOffset += 2;
       uint16_t dest = curOffset + destOffset;
       desc = fmt::format("Times: {:d}  Destination: ${:04X}", times, dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Until", desc, CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Until", desc, Type::Loop, ICON_ENDREP);
 
       if (loopCount == 0) {
         loopCount = times;
@@ -689,7 +689,7 @@ bool ChunSnesTrack::readEvent() {
       uint16_t dest = curOffset + destOffset;
       desc = fmt::format("Destination: ${:04X}", dest);
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern Play", desc, CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern Play", desc, Type::Loop, ICON_STARTREP);
 
       if (subNestLevel >= CHUNSNES_SUBLEVEL_MAX) {
         // stack overflow
@@ -705,7 +705,7 @@ bool ChunSnesTrack::readEvent() {
     }
 
     case EVENT_RET: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern End", desc, CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern End", desc, Type::Loop, ICON_ENDREP);
 
       if (subNestLevel > 0) {
         curOffset = subReturnAddr[subNestLevel - 1];
@@ -729,7 +729,7 @@ bool ChunSnesTrack::readEvent() {
                       semitones,
                       length);
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc, CLR_PITCHBEND, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc, Type::PitchBend, ICON_CONTROL);
       break;
     }
 
@@ -759,12 +759,12 @@ bool ChunSnesTrack::readEvent() {
         case PRESET_CONDITION:
           desc = fmt::format("Value: {:d}", presetIndex);
           parentSeq->conditionVar = presetIndex; // luckily those preset starts from preset 0 :)
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Set Condition Value", desc, CLR_CHANGESTATE);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Set Condition Value", desc, Type::ChangeState);
           break;
 
         default:
           desc = fmt::format("Preset: {:d}", presetIndex);
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Load Preset", desc, CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Load Preset", desc, Type::Misc);
           break;
       }
 
@@ -774,7 +774,7 @@ bool ChunSnesTrack::readEvent() {
     case EVENT_END: {
       if (subNestLevel > 0) {
         // return from subroutine (normally not used)
-        addGenericEvent(beginOffset, curOffset - beginOffset, "End of Track", desc, CLR_TRACKEND, ICON_TRACKEND);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "End of Track", desc, Type::TrackEnd, ICON_TRACKEND);
         curOffset = subReturnAddr[subNestLevel - 1];
         subNestLevel--;
       }

--- a/src/main/formats/CompileSnes/CompileSnesSeq.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesSeq.cpp
@@ -301,7 +301,7 @@ bool CompileSnesTrack::readEvent() {
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc, CLR_LOOPFOREVER);
+        addGenericEvent(beginOffset, length, "Jump", desc, Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -315,7 +315,7 @@ bool CompileSnesTrack::readEvent() {
       curOffset += 2;
 
       desc = fmt::format("Nest Level: {:d}  Destination: ${:04X}", repeatNest, dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat End", desc, CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat End", desc, Type::Loop, ICON_ENDREP);
 
       repeatCount[repeatNest]--;
       if (repeatCount[repeatNest] != 0) {
@@ -337,7 +337,7 @@ bool CompileSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Vibrato",
                       desc,
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -349,7 +349,7 @@ bool CompileSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Portamento Time",
                       desc,
-                      CLR_PORTAMENTOTIME,
+                      Type::PortamentoTime,
                       ICON_CONTROL);
       break;
     }
@@ -369,7 +369,7 @@ bool CompileSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Volume Envelope",
                       desc,
-                      CLR_VOLUME,
+                      Type::Volume,
                       ICON_CONTROL);
       break;
     }
@@ -416,7 +416,7 @@ bool CompileSnesTrack::readEvent() {
       int actualTimes = (times == 0) ? 256 : times;
 
       desc = fmt::format("Nest Level: {:d}  Times: {:d}", repeatNest, actualTimes);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Count", desc, CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Count", desc, Type::Loop, ICON_STARTREP);
 
       repeatCount[repeatNest] = times;
       break;
@@ -429,7 +429,7 @@ bool CompileSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Flags",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -455,7 +455,7 @@ bool CompileSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Tuning",
                       fmt::format("Pitch Register Delta: {:d}", newTuning),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -469,7 +469,7 @@ bool CompileSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Pattern Play",
                       desc,
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
 
       subReturnAddress = curOffset;
@@ -482,7 +482,7 @@ bool CompileSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "End Pattern",
                       desc,
-                      CLR_TRACKEND,
+                      Type::TrackEnd,
                       ICON_ENDREP);
       curOffset = subReturnAddress;
       break;
@@ -497,7 +497,7 @@ bool CompileSnesTrack::readEvent() {
     case EVENT_ADSR: {
       uint8_t envelopeIndex = readByte(curOffset++);
       desc = fmt::format("Envelope Index: {:d}", envelopeIndex);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, CLR_VOLUME, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, Type::Volume, ICON_CONTROL);
       break;
     }
 
@@ -507,7 +507,7 @@ bool CompileSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Portamento On",
                       desc,
-                      CLR_PORTAMENTO,
+                      Type::Portamento,
                       ICON_CONTROL);
       break;
     }
@@ -518,7 +518,7 @@ bool CompileSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Portamento Off",
                       desc,
-                      CLR_PORTAMENTO,
+                      Type::Portamento,
                       ICON_CONTROL);
       break;
     }
@@ -530,7 +530,7 @@ bool CompileSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Panpot Envelope",
                       desc,
-                      CLR_PAN,
+                      Type::Pan,
                       ICON_CONTROL);
       break;
     }
@@ -552,7 +552,7 @@ bool CompileSnesTrack::readEvent() {
       curOffset += 2;
 
       desc = fmt::format("Nest Level: {:d}  Destination: ${:04X}", repeatNest, dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Break", desc, CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Break", desc, Type::Loop, ICON_ENDREP);
 
       repeatCount[repeatNest]--;
       if (repeatCount[repeatNest] == 0) {
@@ -574,7 +574,7 @@ bool CompileSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Duration (Direct)",
                       desc,
-                      CLR_DURNOTE,
+                      Type::DurationNote,
                       ICON_CONTROL);
       break;
     }
@@ -588,7 +588,7 @@ bool CompileSnesTrack::readEvent() {
       spcNoteDuration = duration;
 
       desc = fmt::format("Duration: {:d}", duration);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration", desc, CLR_DURNOTE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration", desc, Type::DurationNote, ICON_CONTROL);
       break;
     }
 

--- a/src/main/formats/FFT/FFTSeq.cpp
+++ b/src/main/formats/FFT/FFTSeq.cpp
@@ -181,7 +181,7 @@ bool FFTTrack::readEvent() {
       case 0x91:
         infiniteLoopPt = curOffset;
         infiniteLoopOctave = octave;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Track Repeat Point", "", CLR_LOOP);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Track Repeat Point", "", Type::Loop);
         //AddEventItem(_T("Repeat"), ICON_STARTREP, beginOffset, curOffset-beginOffset, BG_CLR_WHEAT);
         break;
 
@@ -226,14 +226,14 @@ bool FFTTrack::readEvent() {
         loop_counter[loop_layer] = 0;
         loop_repeats[loop_layer] = loopCount - 1;
         loop_octave[loop_layer] = octave;            //1,Sep.2009 revise
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Begin", "", CLR_LOOP);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Begin", "", Type::Loop);
         //AddEventItem("Loop Begin", ICON_STARTREP, beginOffset, curOffset-beginOffset, BG_CLR_WHEAT);
         break;
       }
 
         //Repeat End
       case 0x99:
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat End", "", CLR_LOOP);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat End", "", Type::Loop);
         //AddEventItem("Loop End", ICON_ENDREP, beginOffset, curOffset-beginOffset, BG_CLR_WHEAT);
 
         // hitting loop end for first time
@@ -263,7 +263,7 @@ bool FFTTrack::readEvent() {
 
         //Repeat break on last repeat
       case 0x9A:
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Break", "", CLR_LOOP);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Repeat Break", "", Type::Loop);
         //AddEventItem("Loop Break", ICON_ENDREP, beginOffset, curOffset-beginOffset, BG_CLR_WHEAT);
 
         // if this is the last run of the loop, we break
@@ -323,22 +323,22 @@ bool FFTTrack::readEvent() {
 
         //Percussion On
       case 0xAE :
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion On", "", CLR_CHANGESTATE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion On", "", Type::ChangeState);
         break;
 
         //Percussion Off
       case 0xAF:
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion Off", "", CLR_CHANGESTATE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion Off", "", Type::ChangeState);
         break;
 
         //Slur On
       case 0xB0:
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Slur On", "", CLR_PORTAMENTO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Slur On", "", Type::Portamento);
         break;
 
         //Slur Off
       case 0xB1:
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Slur Off", "", CLR_PORTAMENTO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Slur Off", "", Type::Portamento);
         break;
 
         //unknown
@@ -358,12 +358,12 @@ bool FFTTrack::readEvent() {
 
         //Reverb On
       case 0xBA :
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb On", "", CLR_REVERB);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb On", "", Type::Reverb);
         break;
 
         //Reverb Off
       case 0xBB :
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Off", "", CLR_REVERB);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Off", "", Type::Reverb);
         break;
 
         //--------
@@ -371,27 +371,27 @@ bool FFTTrack::readEvent() {
 
         //ADSR Reset
       case 0xC0:
-        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Reset", "", CLR_ADSR);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Reset", "", Type::Adsr);
         break;
 
       case 0xC2: {
         const auto arg1 = readByte(curOffset++);
         desc = describeUnknownEvent(status_byte, arg1);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Attack Rate?", desc, CLR_ADSR);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Attack Rate?", desc, Type::Adsr);
         break;
       }
 
       case 0xC4: {
         const auto arg1 = readByte(curOffset++);
         desc = describeUnknownEvent(status_byte, arg1);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Sustain Rate?", desc, CLR_ADSR);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Sustain Rate?", desc, Type::Adsr);
         break;
       }
 
       case 0xC5: {
         const auto arg1 = readByte(curOffset++);
         desc = describeUnknownEvent(status_byte, arg1);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Release Rate?", desc, CLR_ADSR);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Release Rate?", desc, Type::Adsr);
         break;
       }
 
@@ -420,14 +420,14 @@ bool FFTTrack::readEvent() {
       case 0xC9: {
         const auto arg1 = readByte(curOffset++);
         desc = describeUnknownEvent(status_byte, arg1);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Decay Rate?", desc, CLR_ADSR);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Decay Rate?", desc, Type::Adsr);
         break;
       }
 
       case 0xCA: {
         const auto arg1 = readByte(curOffset++);
         desc = describeUnknownEvent(status_byte, arg1);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Sustain Level?", desc, CLR_ADSR);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR: Sustain Level?", desc, Type::Adsr);
         break;
       }
 
@@ -454,7 +454,7 @@ bool FFTTrack::readEvent() {
       case 0xD2: {
         const auto arg1 = readByte(curOffset++);
         desc = describeUnknownEvent(status_byte, arg1);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Bend?", desc, CLR_PITCHBEND);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Bend?", desc, Type::PitchBend);
         break;
       }
 
@@ -463,7 +463,7 @@ bool FFTTrack::readEvent() {
         uint8_t cPitchSlideTimes = readByte(curOffset++);        //slide times [ticks]
         uint8_t cPitchSlideDepth = readByte(curOffset++);        //Target Panpot
         desc = fmt::format("Duration: {:d} ticks  Target: {:d}", cPitchSlideTimes, cPitchSlideDepth);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento", desc, CLR_PORTAMENTO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento", desc, Type::Portamento);
         break;
       }
 
@@ -471,7 +471,7 @@ bool FFTTrack::readEvent() {
       case 0xD6: {
         const auto arg1 = readByte(curOffset++);
         desc = describeUnknownEvent(status_byte, arg1);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Detune?", desc, CLR_PITCHBEND);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Detune?", desc, Type::PitchBend);
         break;
       }
 
@@ -479,7 +479,7 @@ bool FFTTrack::readEvent() {
       case 0xD7: {
         uint8_t cPitchLFO_Depth = readByte(curOffset++);        //slide times [ticks]
         desc = fmt::format("Depth: {:d}", cPitchLFO_Depth);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Depth (Pitch bend)", desc, CLR_LFO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Depth (Pitch bend)", desc, Type::Lfo);
         break;
       }
 
@@ -489,7 +489,7 @@ bool FFTTrack::readEvent() {
         uint8_t cPitchLFO_Cycle = readByte(curOffset++);
         uint8_t cPitchLFO_Decay1 = readByte(curOffset++);
         desc = fmt::format("decay2: {:d}  cycle: {:d}  decay1: {:d}", cPitchLFO_Decay2, cPitchLFO_Cycle, cPitchLFO_Decay1);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Length (Pitch bend)", desc, CLR_LFO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Length (Pitch bend)", desc, Type::Lfo);
         break;
       }
 
@@ -499,7 +499,7 @@ bool FFTTrack::readEvent() {
         const auto arg2 = readByte(curOffset++);
         const auto arg3 = readByte(curOffset++);
         desc = describeUnknownEvent(status_byte, arg1, arg2, arg3);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO ? (Pitch bend)", desc, CLR_LFO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO ? (Pitch bend)", desc, Type::Lfo);
         break;
       }
 
@@ -538,7 +538,7 @@ bool FFTTrack::readEvent() {
       case 0xE3: {
         uint8_t cVolLFO_Depth = readByte(curOffset++);        //
         desc = fmt::format("Depth: {:d}", cVolLFO_Depth);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Depth (Volume)", desc, CLR_LFO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Depth (Volume)", desc, Type::Lfo);
         break;
       }
 
@@ -548,7 +548,7 @@ bool FFTTrack::readEvent() {
         uint8_t cVolLFO_Cycle = readByte(curOffset++);
         uint8_t cVolLFO_Decay1 = readByte(curOffset++);
         desc = fmt::format("decay2: {:d}  cycle: {:d}  decay1: {:d}", cVolLFO_Decay2, cVolLFO_Cycle, cVolLFO_Decay1);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Length (Volume)", desc, CLR_LFO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Length (Volume)", desc, Type::Lfo);
         break;
       }
 
@@ -558,7 +558,7 @@ bool FFTTrack::readEvent() {
         const auto arg2 = readByte(curOffset++);
         const auto arg3 = readByte(curOffset++);
         desc = describeUnknownEvent(status_byte, arg1, arg2, arg3);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO ? (Volume)", desc, CLR_LFO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO ? (Volume)", desc, Type::Lfo);
         break;
       }
 
@@ -597,7 +597,7 @@ bool FFTTrack::readEvent() {
       case 0xEB: {
         uint8_t cPanLFO_Depth = readByte(curOffset++);
         desc = fmt::format("Depth: {:d}", cPanLFO_Depth);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Depth (Panpot)", desc, CLR_LFO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Depth (Panpot)", desc, Type::Lfo);
         break;
       }
 
@@ -607,7 +607,7 @@ bool FFTTrack::readEvent() {
         uint8_t cPanLFO_Cycle = readByte(curOffset++);
         uint8_t cPanLFO_Decay1 = readByte(curOffset++);
         desc = fmt::format("decay2: {:d}  cycle: {:d}  decay1: {:d}", cPanLFO_Decay2, cPanLFO_Cycle, cPanLFO_Decay1);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Length (Panpot)", desc, CLR_LFO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Length (Panpot)", desc, Type::Lfo);
         break;
       }
 
@@ -617,7 +617,7 @@ bool FFTTrack::readEvent() {
         const auto arg2 = readByte(curOffset++);
         const auto arg3 = readByte(curOffset++);
         desc = describeUnknownEvent(status_byte, arg1, arg2, arg3);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO ? (Panpot)", desc, CLR_LFO);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO ? (Panpot)", desc, Type::Lfo);
         break;
       }
 
@@ -678,7 +678,7 @@ bool FFTTrack::readEvent() {
       case 0xFE: {
         uint8_t cProgBankNum = readByte(curOffset++);        //Bank Number [ticks]
         desc = fmt::format(" Bank: {:d}", cProgBankNum);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Program bank select", desc, CLR_PROGCHANGE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Program bank select", desc, Type::ProgramChange);
         break;
       }
 

--- a/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
@@ -263,7 +263,7 @@ bool FalcomSnesTrack::readEvent() {
     case EVENT_NOP1: {
       uint8_t arg1 = readByte(curOffset++);
       desc = describeUnknownEvent(statusByte, arg1);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP.1", desc, CLR_MISC, ICON_BINARY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP.1", desc, Type::Misc, ICON_BINARY);
       break;
     }
 
@@ -313,7 +313,7 @@ bool FalcomSnesTrack::readEvent() {
         if (prevNoteSlurred && key == prevNoteKey) {
           // tie
           makePrevDurNoteEnd(getTime() + dur);
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, CLR_TIE, ICON_NOTE);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, Type::Tie, ICON_NOTE);
         }
         else {
           // note
@@ -353,7 +353,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t vibratoRate = readByte(curOffset++);
 
       desc = fmt::format("Delay: {:d}  Depth: {:d}  Rate: {:d}", vibratoDelay, vibratoDepth, vibratoRate);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, CLR_MODULATION, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, Type::Modulation, ICON_CONTROL);
       break;
     }
 
@@ -361,7 +361,7 @@ bool FalcomSnesTrack::readEvent() {
       bool vibratoOn = readByte(curOffset++) != 0;
 
       desc = fmt::format("Vibrato: {}", vibratoOn ? "On" : "Off");
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato On/Off", desc, CLR_MODULATION, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato On/Off", desc, Type::Modulation, ICON_CONTROL);
       break;
     }
 
@@ -369,7 +369,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t newQuantize = readByte(curOffset++);
 
       desc = fmt::format("Duration Rate: 1.0 - {:d}/256", newQuantize);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc, CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc, Type::DurationNote);
       spcNoteQuantize = newQuantize;
       break;
     }
@@ -390,7 +390,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t amount = amounts[statusByte - 0xdf];
 
       desc = fmt::format("Decrease Volume by : {:d}", amount);
-      addGenericEvent(beginOffset, curOffset - beginOffset, desc, "", CLR_VOLUME, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, desc, "", Type::Volume, ICON_CONTROL);
 
       // add MIDI events only if updated
       uint8_t newVolume = static_cast<uint8_t>(std::max(static_cast<int8_t>(spcVolume) - amount, 0));
@@ -406,7 +406,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t amount = amounts[statusByte - 0xe3];
 
       desc = fmt::format("Increase Volume by : {:d}", amount);
-      addGenericEvent(beginOffset, curOffset - beginOffset, desc, "", CLR_VOLUME, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, desc, "", Type::Volume, ICON_CONTROL);
 
       // add MIDI events only if updated
       uint8_t newVolume = static_cast<uint8_t>(std::min(spcVolume + amount, 0x7f));
@@ -432,7 +432,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t amount = 8;
 
       desc = fmt::format("Decrease Pan by : {:d}", amount);
-      addGenericEvent(beginOffset, curOffset - beginOffset, desc, "", CLR_PAN, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, desc, "", Type::Pan, ICON_CONTROL);
 
       // add MIDI events only if updated
       uint8_t newPan = static_cast<uint8_t>(std::max(static_cast<int8_t>(spcPan) - amount, 0));
@@ -451,7 +451,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t amount = 8;
 
       desc = fmt::format("Increase Pan by : {:d}", amount);
-      addGenericEvent(beginOffset, curOffset - beginOffset, desc, "", CLR_PAN, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, desc, "", Type::Pan, ICON_CONTROL);
 
       // add MIDI events only if updated
       uint8_t newPan = static_cast<uint8_t>(std::min(spcPan + amount, 0x7f));
@@ -472,7 +472,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t lfoRate = readByte(curOffset++);
 
       desc = fmt::format("Delay: {:d}  Depth: {:d}  Rate: {:d}", lfoDelay, lfoDepth, lfoRate);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO", desc, CLR_MODULATION, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO", desc, Type::Modulation, ICON_CONTROL);
       break;
     }
 
@@ -480,7 +480,7 @@ bool FalcomSnesTrack::readEvent() {
       bool lfoOn = readByte(curOffset++) != 0;
 
       desc = fmt::format("Pan LFO: {}", lfoOn ? "On" : "Off");
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO On/Off", desc, CLR_MODULATION, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO On/Off", desc, Type::Modulation, ICON_CONTROL);
       break;
     }
 
@@ -488,7 +488,7 @@ bool FalcomSnesTrack::readEvent() {
       int8_t newTuning = readByte(curOffset++);
 
       desc = fmt::format("Herz: {}{}Hz", newTuning >= 0 ? "+" : "-", newTuning);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc, CLR_TRANSPOSE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc, Type::Transpose, ICON_CONTROL);
 
       // TODO: more accurate fine tuning
       addFineTuningNoItem(newTuning / 128.0 * 64.0);
@@ -500,7 +500,7 @@ bool FalcomSnesTrack::readEvent() {
 
       desc = fmt::format("Loop Count {:d}", count);
       uint16_t repeatCountAddr = curOffset++;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc, CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc, Type::Loop, ICON_STARTREP);
 
       // save the repeat count
       parentSeq->repeatCountMap[repeatCountAddr] = count;
@@ -514,7 +514,7 @@ bool FalcomSnesTrack::readEvent() {
       int16_t repeatCountOffset = readShort(dest - 2);
       uint16_t repeatCountAddr = dest + repeatCountOffset;
       desc = fmt::format("Destination: ${:04X}  Loop Count Address: ${:04X}", dest, repeatCountAddr);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc, CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc, Type::Loop, ICON_ENDREP);
 
       if (!parentSeq->repeatCountMap.contains(repeatCountAddr)) {
         bContinue = false;
@@ -534,7 +534,7 @@ bool FalcomSnesTrack::readEvent() {
       uint16_t repeatCountAddr = curOffset + destOffset;
       uint16_t dest = repeatCountAddr + 1;
       desc = fmt::format("Destination: ${:04X}", dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc, CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc, Type::Loop, ICON_ENDREP);
 
       if (!parentSeq->repeatCountMap.contains(repeatCountAddr)) {
         bContinue = false;
@@ -556,7 +556,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t pitchEnvelopeRate = readByte(curOffset++);
 
       desc = fmt::format("Delay: {:d}  Depth: {:d}  Rate: {:d}", pitchEnvelopeDelay, pitchEnvelopeDepth, pitchEnvelopeRate);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope", desc, CLR_PITCHBEND, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope", desc, Type::PitchBend, ICON_CONTROL);
       break;
     }
 
@@ -564,7 +564,7 @@ bool FalcomSnesTrack::readEvent() {
       bool pitchEnvelopeOn = readByte(curOffset++) != 0;
 
       desc = fmt::format("Pitch Envelope: {}", pitchEnvelopeOn ? "On" : "Off");
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope On/Off", desc, CLR_PITCHBEND, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope On/Off", desc, Type::PitchBend, ICON_CONTROL);
       break;
     }
 
@@ -573,7 +573,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t adsr2 = readByte(curOffset++);
 	    spcADSR = adsr1 | (adsr2 << 8);
       desc = fmt::format("ADSR(1): ${:02X}  ADSR(2): ${:02X}", adsr1, adsr2);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -582,7 +582,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t newGAIN = readByte(curOffset++);
 
       desc = fmt::format("GAIN: ${:02X}", newGAIN);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN", desc, CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN", desc, Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -590,7 +590,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t newNCK = readByte(curOffset++) & 0x1f;
 
       desc = fmt::format("Noise Frequency (NCK): {:d}", newNCK);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Frequency", desc.c_str(), CLR_CHANGESTATE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Frequency", desc.c_str(), Type::ChangeState, ICON_CONTROL);
       break;
     }
 
@@ -598,7 +598,7 @@ bool FalcomSnesTrack::readEvent() {
       bool pitchModOn = (readByte(curOffset++) != 0);
 
       desc = fmt::format("Pitch Modulation: {}", pitchModOn ? "On" : "Off");
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc, CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc, Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -606,7 +606,7 @@ bool FalcomSnesTrack::readEvent() {
       bool echoOn = (readByte(curOffset++) != 0);
 
       desc = fmt::format("Echo Write: {}", echoOn ? "On" : "Off");
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc, CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc, Type::Reverb, ICON_CONTROL);
       addReverbNoItem(echoOn ? 40 : 0);
       break;
     }
@@ -617,7 +617,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t spcFIR = readByte(curOffset++);
 
       desc = fmt::format("Delay: {:d}  Feedback: {:d}  FIR: {:d}", spcEDL, spcEFB, spcFIR);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc, CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc, Type::Reverb, ICON_CONTROL);
 
       // enable echo for the channel
       addReverbNoItem(40);
@@ -628,7 +628,7 @@ bool FalcomSnesTrack::readEvent() {
       bool echoVolumeOn = readByte(curOffset++) != 0;
 
       desc = fmt::format("Echo Volume: {}", echoVolumeOn ? "On" : "Off");
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume On/Off", desc, CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume On/Off", desc, Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -637,7 +637,7 @@ bool FalcomSnesTrack::readEvent() {
       int8_t echoVolumeRight = readByte(curOffset++);
 
       desc = fmt::format("Echo Volume Left: {:d}  Echo Volume Right: {:d}", echoVolumeLeft, echoVolumeRight);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc, CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc, Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -646,7 +646,7 @@ bool FalcomSnesTrack::readEvent() {
       curOffset += 8; // FIR C0-C7
 
       desc = fmt::format("Preset: #{:d}", presetNo);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR Overwrite", desc, CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR Overwrite", desc, Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -665,7 +665,7 @@ bool FalcomSnesTrack::readEvent() {
 
         curOffset = dest;
         if (!isOffsetUsed(dest)) {
-          addGenericEvent(beginOffset, length, "Jump", desc, CLR_LOOPFOREVER);
+          addGenericEvent(beginOffset, length, "Jump", desc, Type::LoopForever);
         }
         else {
           bContinue = addLoopForever(beginOffset, length, "Jump");

--- a/src/main/formats/HOSA/HOSASeq.cpp
+++ b/src/main/formats/HOSA/HOSASeq.cpp
@@ -224,7 +224,7 @@ bool HOSATrack::readEvent(void) {
           //Reverb
         case (0x02):
           curOffset++;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", "", CLR_REVERB);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", "", Type::Reverb);
           break;
           //------------
           //Instrument
@@ -261,7 +261,7 @@ bool HOSATrack::readEvent(void) {
           //Dal Segno. (Loop)
         case (0x09):
           curOffset++;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Dal Segno.(Loop)", "", CLR_LOOP);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Dal Segno.(Loop)", "", Type::Loop);
           break;
           //------------
           //Unknown
@@ -281,7 +281,7 @@ bool HOSATrack::readEvent(void) {
       uint32_t beginOffset2 = curOffset;
       ReadDeltaTime(cCom_bit5, &iDeltaTimeCom);
       if (curOffset != beginOffset2) {
-        addGenericEvent(beginOffset2, curOffset - beginOffset2, "Delta time", "", CLR_CHANGESTATE);
+        addGenericEvent(beginOffset2, curOffset - beginOffset2, "Delta time", "", Type::ChangeState);
       };
 
       //----------------------------------

--- a/src/main/formats/HeartBeatPS1/HeartBeatPS1Seq.cpp
+++ b/src/main/formats/HeartBeatPS1/HeartBeatPS1Seq.cpp
@@ -180,7 +180,7 @@ bool HeartBeatPS1Seq::readEvent() {
       switch (controlNum)        //control number
       {
         case 1:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
@@ -188,28 +188,28 @@ bool HeartBeatPS1Seq::readEvent() {
 
         // identical to CC#11?
         case 2:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Breath Controller?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Breath Controller?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 4:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Foot Controller?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Foot Controller?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 5:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Time?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Time?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 6 :
-          addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry", "", CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry", "", Type::Misc);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
@@ -221,7 +221,7 @@ bool HeartBeatPS1Seq::readEvent() {
           break;
 
         case 9:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 9", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 9", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
@@ -238,147 +238,147 @@ bool HeartBeatPS1Seq::readEvent() {
           break;
 
         case 20:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 20", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 20", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 21:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 21", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 21", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 22:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 22", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 22", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 23:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 23", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 23", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 32:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Bank LSB?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Bank LSB?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 52:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 52", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 52", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 53:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 53", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 53", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 54:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 54", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 54", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 55:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 55", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 55", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 56:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 56", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 56", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 64:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Hold 1?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Hold 1?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 69:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Hold 2?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Hold 2?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 71:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Resonance?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Resonance?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 72:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Release Time?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Release Time?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 73:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Attack Time?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Attack Time?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 74:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Cut Off Frequency?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Cut Off Frequency?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 75:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Decay Time?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Decay Time?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 76:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Rate?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Rate?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 77:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Depth?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Depth?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 78:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Delay?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Delay?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 79:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 79", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control 79", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
@@ -389,7 +389,7 @@ bool HeartBeatPS1Seq::readEvent() {
           break;
 
         case 92:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
@@ -398,15 +398,15 @@ bool HeartBeatPS1Seq::readEvent() {
         case 98:
           switch (value) {
             case 20 :
-              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #20", "", CLR_MISC);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #20", "", Type::Misc);
               break;
 
             case 30 :
-              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #30", "", CLR_MISC);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #30", "", Type::Misc);
               break;
 
             default:
-              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1", "", CLR_MISC);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1", "", Type::Misc);
               break;
           }
 
@@ -419,15 +419,15 @@ bool HeartBeatPS1Seq::readEvent() {
         case 99 :
           switch (value) {
             case 20 :
-              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", CLR_LOOP);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", Type::Loop);
               break;
 
             case 30 :
-              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", CLR_LOOP);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", Type::Loop);
               break;
 
             default:
-              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 2", "", CLR_MISC);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 2", "", Type::Misc);
               break;
           }
 
@@ -437,28 +437,28 @@ bool HeartBeatPS1Seq::readEvent() {
           break;
 
         case 121:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Reset All Controllers", "", CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Reset All Controllers", "", Type::Misc);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 126:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "MONO?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "MONO?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         case 127:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Poly?", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Poly?", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         default:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control Event", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control Event", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesSeq.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesSeq.cpp
@@ -281,7 +281,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Note Length & Param",
                       desc,
-                      CLR_CHANGESTATE);
+                      Type::ChangeState);
       break;
     }
 
@@ -316,7 +316,7 @@ bool HeartBeatSnesTrack::readEvent() {
 
       desc = fmt::format("Duration: {:d}", dur);
       makePrevDurNoteEnd(getTime() + dur);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, CLR_TIE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, Type::Tie);
       addTime(spcNoteDuration);
       break;
     }
@@ -331,7 +331,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Slur On",
                       desc,
-                      CLR_PORTAMENTO,
+                      Type::Portamento,
                       ICON_CONTROL);
       slur = true;
       break;
@@ -342,7 +342,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Slur Off",
                       desc,
-                      CLR_PORTAMENTO,
+                      Type::Portamento,
                       ICON_CONTROL);
       slur = false;
       break;
@@ -397,7 +397,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Vibrato",
                       desc,
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -409,7 +409,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Vibrato Fade",
                       desc,
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -419,7 +419,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Vibrato Off",
                       desc,
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -467,7 +467,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Tremolo",
                       desc,
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -477,7 +477,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Tremolo Off",
                       desc,
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -505,7 +505,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Pitch Envelope (To)",
                       desc,
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -520,7 +520,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Pitch Envelope (From)",
                       desc,
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -530,7 +530,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Pitch Envelope Off",
                       desc,
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -549,7 +549,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Echo Volume",
                       desc,
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -560,7 +560,7 @@ bool HeartBeatSnesTrack::readEvent() {
       uint8_t spcFIR = readByte(curOffset++);
 
       desc = fmt::format("Delay: {:d}  Feedback: {:d}  FIR: {:d}", spcEDL, spcEFB, spcFIR);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc, CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc, Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -576,7 +576,7 @@ bool HeartBeatSnesTrack::readEvent() {
 
     case EVENT_ECHO_FIR: {
       curOffset += 8; // FIR C0-C7
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR", desc, CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR", desc, Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -590,7 +590,7 @@ bool HeartBeatSnesTrack::readEvent() {
       uint8_t sr = adsr2 & 0x1f;
 
       desc = fmt::format("AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}", ar, dr, sl, sr);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -602,7 +602,7 @@ bool HeartBeatSnesTrack::readEvent() {
       spcNoteVolume = HeartBeatSnesSeq::NOTE_VEL_TABLE[velIndex];
       desc += fmt::format("  Duration: {:d} ({:d})  Velocity: {:d} ({:d})",
           durIndex, spcNoteDurRate, velIndex, spcNoteVolume);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Note Param", desc, CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Note Param", desc, Type::ChangeState);
       break;
     }
 
@@ -615,7 +615,7 @@ bool HeartBeatSnesTrack::readEvent() {
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc, CLR_LOOPFOREVER);
+        addGenericEvent(beginOffset, length, "Jump", desc, Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -632,7 +632,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Pattern Play",
                       desc,
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
 
       subReturnOffset = curOffset - parentSeq->dwOffset;
@@ -642,7 +642,7 @@ bool HeartBeatSnesTrack::readEvent() {
     }
 
     case EVENT_RET: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern End", desc, CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern End", desc, Type::Loop, ICON_ENDREP);
       curOffset = parentSeq->dwOffset + subReturnOffset;
       break;
     }
@@ -652,7 +652,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Noise On",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -662,7 +662,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Noise Off",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -674,7 +674,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Noise Frequency",
                       desc,
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -735,7 +735,7 @@ bool HeartBeatSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "Loop Count",
                           desc,
-                          CLR_LOOP,
+                          Type::Loop,
                           ICON_STARTREP);
           break;
         }
@@ -749,7 +749,7 @@ bool HeartBeatSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "Loop Again",
                           desc,
-                          CLR_LOOP,
+                          Type::Loop,
                           ICON_ENDREP);
 
           if (loopCount != 0) {
@@ -768,7 +768,7 @@ bool HeartBeatSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "ADSR Attack Rate",
                           desc,
-                          CLR_ADSR,
+                          Type::Adsr,
                           ICON_CONTROL);
           break;
         }
@@ -780,7 +780,7 @@ bool HeartBeatSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "ADSR Decay Rate",
                           desc,
-                          CLR_ADSR,
+                          Type::Adsr,
                           ICON_CONTROL);
           break;
         }
@@ -792,7 +792,7 @@ bool HeartBeatSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "ADSR Sustain Level",
                           desc,
-                          CLR_ADSR,
+                          Type::Adsr,
                           ICON_CONTROL);
           break;
         }
@@ -804,7 +804,7 @@ bool HeartBeatSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "ADSR Release Rate",
                           desc,
-                          CLR_ADSR,
+                          Type::Adsr,
                           ICON_CONTROL);
           break;
         }
@@ -816,7 +816,7 @@ bool HeartBeatSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "ADSR Sustain Rate",
                           desc,
-                          CLR_ADSR,
+                          Type::Adsr,
                           ICON_CONTROL);
           break;
         }
@@ -826,7 +826,7 @@ bool HeartBeatSnesTrack::readEvent() {
           bool invertRight = readByte(curOffset++) != 0;
           desc = fmt::format("Invert Left: {}  Invert Right: {}",
                              invertLeft ? "On" : "Off", invertRight ? "On" : "Off");
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Surround", desc, CLR_PAN, ICON_CONTROL);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Surround", desc, Type::Pan, ICON_CONTROL);
           break;
         }
 

--- a/src/main/formats/HudsonSnes/HudsonSnesSeq.cpp
+++ b/src/main/formats/HudsonSnes/HudsonSnesSeq.cpp
@@ -592,13 +592,13 @@ bool HudsonSnesTrack::readEvent() {
     }
 
     case EVENT_NOP: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), Type::Misc, ICON_BINARY);
       break;
     }
 
     case EVENT_NOP1: {
       curOffset++;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), Type::Misc, ICON_BINARY);
       break;
     }
 
@@ -668,7 +668,7 @@ bool HudsonSnesTrack::readEvent() {
         if (prevNoteSlurred && key == prevNoteKey) {
           // tie
           makePrevDurNoteEnd(getTime() + dur);
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), Type::Tie, ICON_NOTE);
         }
         else {
           // note
@@ -713,7 +713,7 @@ bool HudsonSnesTrack::readEvent() {
       else {
         desc << "Length: " << "Full-Length - " << (int) (newQuantize - 8);
       }
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str().c_str(), CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str().c_str(), Type::DurationNote);
       break;
     }
 
@@ -762,7 +762,7 @@ bool HudsonSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Reverse Phase",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -784,7 +784,7 @@ bool HudsonSnesTrack::readEvent() {
     case EVENT_LOOP_START: {
       uint8_t count = readByte(curOffset);
       desc << "Loop Count: " << (int) count;
-      addGenericEvent(beginOffset, 2, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, 2, "Loop Start", desc.str().c_str(), Type::Loop, ICON_STARTREP);
 
       if (spcCallStackPtr + 3 > HUDSONSNES_CALLSTACK_SIZE) {
         // stack overflow
@@ -804,7 +804,7 @@ bool HudsonSnesTrack::readEvent() {
     }
 
     case EVENT_LOOP_END: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), Type::Loop, ICON_ENDREP);
 
       if (spcCallStackPtr < 3) {
         // access violation
@@ -829,7 +829,7 @@ bool HudsonSnesTrack::readEvent() {
     case EVENT_SUBROUTINE: {
       uint16_t dest = readShort(curOffset);
       desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, 3, "Pattern Play", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, 3, "Pattern Play", desc.str().c_str(), Type::Loop, ICON_STARTREP);
 
       if (spcCallStackPtr + 2 > HUDSONSNES_CALLSTACK_SIZE) {
         // stack overflow
@@ -855,7 +855,7 @@ bool HudsonSnesTrack::readEvent() {
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -879,7 +879,7 @@ bool HudsonSnesTrack::readEvent() {
                         curOffset - beginOffset,
                         "Vibrato",
                         desc.str().c_str(),
-                        CLR_MODULATION,
+                        Type::Modulation,
                         ICON_CONTROL);
       }
       else { // HUDSONSNES_V2
@@ -891,7 +891,7 @@ bool HudsonSnesTrack::readEvent() {
                         curOffset - beginOffset,
                         "Vibrato",
                         desc.str().c_str(),
-                        CLR_MODULATION,
+                        Type::Modulation,
                         ICON_CONTROL);
       }
       break;
@@ -904,7 +904,7 @@ bool HudsonSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Vibrato Delay",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -917,7 +917,7 @@ bool HudsonSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Echo Volume",
                       desc.str().c_str(),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -932,13 +932,13 @@ bool HudsonSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Echo Parameter",
                       desc.str().c_str(),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_ON: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.str().c_str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -964,7 +964,7 @@ bool HudsonSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Attack Pitch Envelope On",
                       desc.str().c_str(),
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -974,7 +974,7 @@ bool HudsonSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Attack Pitch Envelope Off",
                       desc.str().c_str(),
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -985,7 +985,7 @@ bool HudsonSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Infinite Loop Point",
                       desc.str().c_str(),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
       break;
     }
@@ -1001,7 +1001,7 @@ bool HudsonSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Infinite Loop Point (Ignore after the Second Time)",
                       desc.str().c_str(),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
       if (!loopPointOnceProcessed) {
         infiniteLoopPoint = curOffset;
@@ -1065,7 +1065,7 @@ bool HudsonSnesTrack::readEvent() {
                         curOffset - beginOffset,
                         "End Pattern",
                         desc.str().c_str(),
-                        CLR_LOOP,
+                        Type::Loop,
                         ICON_ENDREP);
 
         if (spcCallStackPtr < 2) {
@@ -1148,7 +1148,7 @@ bool HudsonSnesTrack::readEvent() {
         }
 
         case SUBEVENT_NOP: {
-          addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), Type::Misc, ICON_BINARY);
           break;
         }
 
@@ -1163,7 +1163,7 @@ bool HudsonSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "Echo Off",
                           desc.str().c_str(),
-                          CLR_REVERB,
+                          Type::Reverb,
                           ICON_CONTROL);
           break;
         }
@@ -1173,7 +1173,7 @@ bool HudsonSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "Percussion On",
                           desc.str().c_str(),
-                          CLR_CHANGESTATE,
+                          Type::ChangeState,
                           ICON_CONTROL);
           break;
         }
@@ -1183,7 +1183,7 @@ bool HudsonSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "Percussion Off",
                           desc.str().c_str(),
-                          CLR_CHANGESTATE,
+                          Type::ChangeState,
                           ICON_CONTROL);
           break;
         }
@@ -1195,14 +1195,14 @@ bool HudsonSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "Vibrato Type",
                           desc.str().c_str(),
-                          CLR_LFO,
+                          Type::Lfo,
                           ICON_CONTROL);
           break;
         }
 
         case SUBEVENT_NOTE_VEL_OFF: {
           parentSeq->DisableNoteVelocity = true;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Note Velocity Off", desc.str().c_str(), CLR_MISC, ICON_CONTROL);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Note Velocity Off", desc.str().c_str(), Type::Misc, ICON_CONTROL);
           break;
         }
 
@@ -1210,7 +1210,7 @@ bool HudsonSnesTrack::readEvent() {
           uint8_t reg = readByte(curOffset++);
           uint8_t val = readByte(curOffset++);
           desc << "Register: " << (int) reg << "  Value: " << (int) val;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "MOV (Immediate)", desc.str().c_str(), CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "MOV (Immediate)", desc.str().c_str(), Type::Misc);
 
           if (reg < HUDSONSNES_USERRAM_SIZE) {
             parentSeq->UserRAM[reg] = val;
@@ -1223,7 +1223,7 @@ bool HudsonSnesTrack::readEvent() {
           uint8_t regDst = readByte(curOffset++);
           uint8_t regSrc = readByte(curOffset++);
           desc << "Destination Register: " << (int) regDst << "  Source Register: " << (int) regSrc;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "MOV", desc.str().c_str(), CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "MOV", desc.str().c_str(), Type::Misc);
 
           if (regDst < HUDSONSNES_USERRAM_SIZE && regSrc < HUDSONSNES_USERRAM_SIZE) {
             uint8_t val = parentSeq->UserRAM[regSrc];
@@ -1237,7 +1237,7 @@ bool HudsonSnesTrack::readEvent() {
           uint8_t reg = readByte(curOffset++);
           uint8_t val = readByte(curOffset++);
           desc << "Register: " << (int) reg << "  Value: " << (int) val;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "CMP (Immediate)", desc.str().c_str(), CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "CMP (Immediate)", desc.str().c_str(), Type::Misc);
 
           if (reg < HUDSONSNES_USERRAM_SIZE) {
             parentSeq->UserCmpReg = parentSeq->UserRAM[reg] - val;
@@ -1250,7 +1250,7 @@ bool HudsonSnesTrack::readEvent() {
           uint8_t regDst = readByte(curOffset++);
           uint8_t regSrc = readByte(curOffset++);
           desc << "Destination Register: " << (int) regDst << "  Source Register: " << (int) regSrc;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "CMP", desc.str().c_str(), CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "CMP", desc.str().c_str(), Type::Misc);
 
           if (regDst < HUDSONSNES_USERRAM_SIZE && regSrc < HUDSONSNES_USERRAM_SIZE) {
             parentSeq->UserCmpReg = parentSeq->UserRAM[regDst] - parentSeq->UserRAM[regSrc];
@@ -1263,7 +1263,7 @@ bool HudsonSnesTrack::readEvent() {
           uint16_t dest = readShort(curOffset);
           curOffset += 2;
           desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "BNE", desc.str().c_str(), CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "BNE", desc.str().c_str(), Type::Misc);
 
           if (parentSeq->UserCmpReg != 0) {
             curOffset = dest;
@@ -1276,7 +1276,7 @@ bool HudsonSnesTrack::readEvent() {
           uint16_t dest = readShort(curOffset);
           curOffset += 2;
           desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "BEQ", desc.str().c_str(), CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "BEQ", desc.str().c_str(), Type::Misc);
 
           if (parentSeq->UserCmpReg != 0) {
             curOffset = dest;
@@ -1289,7 +1289,7 @@ bool HudsonSnesTrack::readEvent() {
           uint16_t dest = readShort(curOffset);
           curOffset += 2;
           desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "BCS", desc.str().c_str(), CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "BCS", desc.str().c_str(), Type::Misc);
 
           if (parentSeq->UserCarry) {
             curOffset = dest;
@@ -1302,7 +1302,7 @@ bool HudsonSnesTrack::readEvent() {
           uint16_t dest = readShort(curOffset);
           curOffset += 2;
           desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "BCC", desc.str().c_str(), CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "BCC", desc.str().c_str(), Type::Misc);
 
           if (!parentSeq->UserCarry) {
             curOffset = dest;
@@ -1315,7 +1315,7 @@ bool HudsonSnesTrack::readEvent() {
           uint16_t dest = readShort(curOffset);
           curOffset += 2;
           desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "BMI", desc.str().c_str(), CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "BMI", desc.str().c_str(), Type::Misc);
 
           if ((parentSeq->UserCmpReg & 0x80) != 0) {
             curOffset = dest;
@@ -1328,7 +1328,7 @@ bool HudsonSnesTrack::readEvent() {
           uint16_t dest = readShort(curOffset);
           curOffset += 2;
           desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "BPL", desc.str().c_str(), CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "BPL", desc.str().c_str(), Type::Misc);
 
           if ((parentSeq->UserCmpReg & 0x80) == 0) {
             curOffset = dest;
@@ -1344,7 +1344,7 @@ bool HudsonSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "ADSR Attack Rate",
                           desc.str().c_str(),
-                          CLR_ADSR,
+                          Type::Adsr,
                           ICON_CONTROL);
           break;
         }
@@ -1356,7 +1356,7 @@ bool HudsonSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "ADSR Decay Rate",
                           desc.str().c_str(),
-                          CLR_ADSR,
+                          Type::Adsr,
                           ICON_CONTROL);
           break;
         }
@@ -1368,7 +1368,7 @@ bool HudsonSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "ADSR Sustain Level",
                           desc.str().c_str(),
-                          CLR_ADSR,
+                          Type::Adsr,
                           ICON_CONTROL);
           break;
         }
@@ -1380,7 +1380,7 @@ bool HudsonSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "ADSR Sustain Rate",
                           desc.str().c_str(),
-                          CLR_ADSR,
+                          Type::Adsr,
                           ICON_CONTROL);
           break;
         }
@@ -1392,7 +1392,7 @@ bool HudsonSnesTrack::readEvent() {
                           curOffset - beginOffset,
                           "ADSR Release Rate",
                           desc.str().c_str(),
-                          CLR_ADSR,
+                          Type::Adsr,
                           ICON_CONTROL);
           break;
         }

--- a/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
@@ -199,7 +199,7 @@ bool ItikitiSnesTrack::readEvent() {
         addRest(start, curOffset - start, len);
       } else if (tie) {
         makePrevDurNoteEnd(getTime() + dur);
-        addGenericEvent(start, curOffset - start, "Tie", description.str(), CLR_TIE, ICON_NOTE);
+        addGenericEvent(start, curOffset - start, "Tie", description.str(), Type::Tie, ICON_NOTE);
         addTime(len);
       } else {
         const uint8_t key_index = command >> 3;
@@ -219,7 +219,7 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_MASTER_VOLUME: {
       const uint8_t vol = readByte(curOffset++);
       description << "Volume: " << vol;
-      addGenericEvent(start, curOffset - start, "Master Volume", description.str(), CLR_VOLUME,
+      addGenericEvent(start, curOffset - start, "Master Volume", description.str(), Type::Volume,
                       ICON_CONTROL);
       break;
     }
@@ -227,7 +227,7 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_ECHO_VOLUME: {
       const uint8_t vol = readByte(curOffset++);
       description << "Volume: " << vol;
-      addGenericEvent(start, curOffset - start, "Echo Volume", description.str(), CLR_REVERB,
+      addGenericEvent(start, curOffset - start, "Echo Volume", description.str(), Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -243,7 +243,7 @@ bool ItikitiSnesTrack::readEvent() {
       const uint8_t filter_index = readByte(curOffset++);
       description << "Feedback: " << feedback << "  FIR: " << filter_index;
       addGenericEvent(start, curOffset - start, "Echo Feedback & FIR", description.str(),
-                      CLR_REVERB, ICON_CONTROL);
+                      Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -265,7 +265,7 @@ bool ItikitiSnesTrack::readEvent() {
       const uint8_t nck = readByte(curOffset++) & 0x1f;
       description << "Noise Frequency (NCK): " << nck;
       addGenericEvent(start, curOffset - start, "Noise Frequency", description.str(),
-                      CLR_CHANGESTATE, ICON_CONTROL);
+                      Type::ChangeState, ICON_CONTROL);
       break;
     }
 
@@ -274,7 +274,7 @@ bool ItikitiSnesTrack::readEvent() {
       curOffset += 2;
       description << "Length Bits: 0x" << std::hex << std::setfill('0') << std::setw(4) << bits;
       addGenericEvent(start, curOffset - start, "Note Length Pattern", description.str(),
-                      CLR_DURNOTE);
+                      Type::DurationNote);
 
       size_t size_written = 0;
       for (unsigned int index = 0; index < 16 && size_written < m_note_length_table.size();
@@ -298,7 +298,7 @@ bool ItikitiSnesTrack::readEvent() {
       description << "Lengths: " << arg1 << ", " << arg2 << ", " << arg3 << ", " << arg4
                   << ", " << arg5 << ", " << arg6 << ", " << arg7;
       addGenericEvent(start, curOffset - start, "Custom Note Length Pattern", description.str(),
-                      CLR_DURNOTE);
+                      Type::DurationNote);
 
       m_note_length_table[0] = arg1;
       m_note_length_table[1] = arg2;
@@ -314,7 +314,7 @@ bool ItikitiSnesTrack::readEvent() {
       const uint8_t note_number = readByte(curOffset++);
       description << "Note Number: " << note_number;
       addGenericEvent(start, curOffset - start, "Note Number Base", description.str(),
-                      CLR_CHANGESTATE, ICON_CONTROL);
+                      Type::ChangeState, ICON_CONTROL);
       m_note_number_base = note_number;
       break;
     }
@@ -365,7 +365,7 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_ADSR_AR: {
       const uint8_t ar = readByte(curOffset++) & 15;
       description << "AR: " << ar;
-      addGenericEvent(start, curOffset - start, "ADSR Attack Rate", description.str(), CLR_ADSR,
+      addGenericEvent(start, curOffset - start, "ADSR Attack Rate", description.str(), Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -373,7 +373,7 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_ADSR_DR: {
       const uint8_t dr = readByte(curOffset++) & 7;
       description << "DR: " << dr;
-      addGenericEvent(start, curOffset - start, "ADSR Decay Rate", description.str(), CLR_ADSR,
+      addGenericEvent(start, curOffset - start, "ADSR Decay Rate", description.str(), Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -381,7 +381,7 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_ADSR_SL: {
       const uint8_t sl = readByte(curOffset++) & 7;
       description << "SL: " << sl;
-      addGenericEvent(start, curOffset - start, "ADSR Sustain Level", description.str(), CLR_ADSR,
+      addGenericEvent(start, curOffset - start, "ADSR Sustain Level", description.str(), Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -389,13 +389,13 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_ADSR_SR: {
       const uint8_t sr = readByte(curOffset++) & 15;
       description << "SR: " << sr;
-      addGenericEvent(start, curOffset - start, "ADSR Sustain Rate", description.str(), CLR_ADSR,
+      addGenericEvent(start, curOffset - start, "ADSR Sustain Rate", description.str(), Type::Adsr,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_DEFAULT: {
-      addGenericEvent(start, curOffset - start, "Default ADSR", description.str(), CLR_ADSR,
+      addGenericEvent(start, curOffset - start, "Default ADSR", description.str(), Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -418,14 +418,14 @@ bool ItikitiSnesTrack::readEvent() {
         const uint8_t rate = readByte(curOffset++);
         const uint8_t depth = readByte(curOffset++);
         description << "Delay: " << delay << "  Rate: " << rate << "  Depth: " << depth;
-        addGenericEvent(start, curOffset - start, "Vibrato", description.str(), CLR_MODULATION,
+        addGenericEvent(start, curOffset - start, "Vibrato", description.str(), Type::Modulation,
                         ICON_CONTROL);
         break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_VIBRATO_OFF: {
       // The command changes vibrato depth to 0.
-      addGenericEvent(start, curOffset - start, "Vibrato Off", description.str(), CLR_MODULATION,
+      addGenericEvent(start, curOffset - start, "Vibrato Off", description.str(), Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -436,13 +436,13 @@ bool ItikitiSnesTrack::readEvent() {
       const uint8_t rate = readByte(curOffset++);
       const uint8_t depth = readByte(curOffset++);
       description << "Delay: " << delay << "  Rate: " << rate << "  Depth: " << depth;
-      addGenericEvent(start, curOffset - start, "Tremolo", description.str(), CLR_MODULATION,
+      addGenericEvent(start, curOffset - start, "Tremolo", description.str(), Type::Modulation,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_TREMOLO_OFF: {
-      addGenericEvent(start, curOffset - start, "Tremolo Off", description.str(), CLR_MODULATION,
+      addGenericEvent(start, curOffset - start, "Tremolo Off", description.str(), Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -451,38 +451,38 @@ bool ItikitiSnesTrack::readEvent() {
       const uint8_t depth = readByte(curOffset++);
       const uint8_t rate = readByte(curOffset++);
       description << "Depth: " << depth << "  Rate: " << rate;
-      addGenericEvent(start, curOffset - start, "Pan LFO", description.str(), CLR_MODULATION,
+      addGenericEvent(start, curOffset - start, "Pan LFO", description.str(), Type::Modulation,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_PAN_LFO_OFF: {
-      addGenericEvent(start, curOffset - start, "Pan LFO Off", description.str(), CLR_MODULATION,
+      addGenericEvent(start, curOffset - start, "Pan LFO Off", description.str(), Type::Modulation,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_NOISE_ON: {
-      addGenericEvent(start, curOffset - start, "Noise On", description.str(), CLR_CHANGESTATE,
+      addGenericEvent(start, curOffset - start, "Noise On", description.str(), Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_NOISE_OFF: {
-      addGenericEvent(start, curOffset - start, "Noise Off", description.str(), CLR_CHANGESTATE,
+      addGenericEvent(start, curOffset - start, "Noise Off", description.str(), Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_PITCH_MOD_ON: {
       addGenericEvent(start, curOffset - start, "Pitch Modulation On", description.str(),
-                      CLR_CHANGESTATE, ICON_CONTROL);
+                      Type::ChangeState, ICON_CONTROL);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_PITCH_MOD_OFF: {
       addGenericEvent(start, curOffset - start, "Pitch Modulation Off", description.str(),
-                      CLR_CHANGESTATE, ICON_CONTROL);
+                      Type::ChangeState, ICON_CONTROL);
       break;
     }
 
@@ -513,11 +513,11 @@ bool ItikitiSnesTrack::readEvent() {
       if (value <= 0x7f) {
         description << "Range: " << value << " semitones";
         addGenericEvent(start, curOffset - start, "Note Randomization On", description.str(),
-                        CLR_CHANGESTATE, ICON_CONTROL);
+                        Type::ChangeState, ICON_CONTROL);
       } else if (value == 0x83) {
         // Detailed behavior has not yet been analyzed
         addGenericEvent(start, curOffset - start, "Change Volume Mode (Global)", description.str(),
-                        CLR_VOLUME, ICON_CONTROL);
+                        Type::Volume, ICON_CONTROL);
       } else {
         descr = logEvent(command, spdlog::level::debug, "Event", value);
         addUnknown(start, curOffset - start, "Unknown Event", descr);
@@ -527,7 +527,7 @@ bool ItikitiSnesTrack::readEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_NOTE_RANDOMIZATION_OFF: {
       addGenericEvent(start, curOffset - start, "Note Randomization Off", description.str(),
-                      CLR_CHANGESTATE, ICON_CONTROL);
+                      Type::ChangeState, ICON_CONTROL);
       break;
     }
 
@@ -535,7 +535,7 @@ bool ItikitiSnesTrack::readEvent() {
       const uint8_t length = readByte(curOffset++); // in ticks
       const int8_t semitones = static_cast<int8_t>(readByte(curOffset++));
       description << "Length: " << length << "  Key: " << semitones << " semitones";
-      addGenericEvent(start, curOffset - start, "Pitch Slide", description.str(), CLR_PITCHBEND,
+      addGenericEvent(start, curOffset - start, "Pitch Slide", description.str(), Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -547,7 +547,7 @@ bool ItikitiSnesTrack::readEvent() {
         description << "Infinite";
       else
         description << (count + 1);
-      addGenericEvent(start, curOffset - start, "Loop Start", description.str(), CLR_LOOP,
+      addGenericEvent(start, curOffset - start, "Loop Start", description.str(), Type::Loop,
                       ICON_STARTREP);
 
       if (m_loop_level + 1 >= kItikitiSnesSeqMaxLoopLevel) {
@@ -571,7 +571,7 @@ bool ItikitiSnesTrack::readEvent() {
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(start, length, "Jump", description.str(), CLR_LOOPFOREVER);
+        addGenericEvent(start, length, "Jump", description.str(), Type::LoopForever);
       } else {
         stop_parser = !addLoopForever(start, length, "Jump");
       }
@@ -584,7 +584,7 @@ bool ItikitiSnesTrack::readEvent() {
         stop_parser = !addLoopForever(start, curOffset - start);
         curOffset = m_loop_start_addresses[m_loop_level];
       } else {
-        addGenericEvent(start, curOffset - start, "Loop End", description.str(), CLR_LOOP,
+        addGenericEvent(start, curOffset - start, "Loop End", description.str(), Type::Loop,
                         ICON_ENDREP);
 
         m_loop_counts[m_loop_level]--;
@@ -607,7 +607,7 @@ bool ItikitiSnesTrack::readEvent() {
       description << "Count: " << target_count << "  Destination: $" << std::hex << std::setfill('0')
                   << std::setw(4) << std::uppercase << dest;
       addGenericEvent(start, curOffset - start, "Loop Break / Jump to Volta", description.str(),
-                      CLR_LOOP, ICON_ENDREP);
+                      Type::Loop, ICON_ENDREP);
       
       if (++m_alt_loop_count == target_count) {
         curOffset = dest;

--- a/src/main/formats/KonamiGX/KonamiGXSeq.cpp
+++ b/src/main/formats/KonamiGX/KonamiGXSeq.cpp
@@ -266,13 +266,13 @@ bool KonamiGXTrack::readEvent(void) {
 
       case 0xFD:
         curOffset += 4;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", CLR_LOOP);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", Type::Loop);
         break;
 
       case 0xFE:
         bInJump = true;
         jump_return_offset = curOffset + 4;
-        addGenericEvent(beginOffset, jump_return_offset - beginOffset, "Jump", "", CLR_LOOP);
+        addGenericEvent(beginOffset, jump_return_offset - beginOffset, "Jump", "", Type::Loop);
         curOffset = getWordBE(curOffset);
         //if (curOffset > 0x100000)
         //	return 0;

--- a/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
@@ -129,7 +129,7 @@ bool KonamiPS1Track::readEvent() {
     std::stringstream description;
     description << "Duration: " << delta;
     addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time",
-      description.str(), CLR_REST, ICON_REST);
+      description.str(), Type::Rest, ICON_REST);
 
     skipDeltaTime = true;
     return true;
@@ -174,7 +174,7 @@ bool KonamiPS1Track::readEvent() {
       case 6:
         description << "Parameter: " << paramByte;
         addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry",
-          description.str(), CLR_MISC);
+          description.str(), Type::Misc);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
           pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
@@ -195,7 +195,7 @@ bool KonamiPS1Track::readEvent() {
       case 15:
         description << "Parameter: " << paramByte;
         addGenericEvent(beginOffset, curOffset - beginOffset, "Stereo Widening (?)",
-                        description.str(), CLR_PAN, ICON_CONTROL);
+                        description.str(), Type::Pan, ICON_CONTROL);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
           pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
@@ -209,7 +209,7 @@ bool KonamiPS1Track::readEvent() {
       case 70:
         description << "Parameter: " << paramByte;
         addGenericEvent(beginOffset, curOffset - beginOffset, "Set Channe", description.str(),
-                        CLR_PAN, ICON_CONTROL);
+                        Type::Pan, ICON_CONTROL);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
           pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
@@ -270,7 +270,7 @@ bool KonamiPS1Track::readEvent() {
       case 99:
         description << "Parameter: " << paramByte;
         addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN (LSB)", description.str(),
-                        CLR_MISC);
+                        Type::Misc);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
           pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
@@ -278,13 +278,13 @@ bool KonamiPS1Track::readEvent() {
 
       case 100:
         if (paramByte == 20) {
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", CLR_LOOP);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", Type::Loop);
         } else if (paramByte == 30) {
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", CLR_LOOP);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", Type::Loop);
         } else {
           description << "Parameter: " << paramByte;
           addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN (LSB)", description.str(),
-                          CLR_MISC);
+                          Type::Misc);
         }
         if (readMode == READMODE_CONVERT_TO_MIDI) {
           pMidiTrack->addControllerEvent(channel, command, paramByte);
@@ -294,7 +294,7 @@ bool KonamiPS1Track::readEvent() {
       case 118:
         description << "Parameter: " << paramByte;
         addGenericEvent(beginOffset, curOffset - beginOffset, "Seq Beat", description.str(),
-                        CLR_MISC);
+                        Type::Misc);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
           pMidiTrack->addControllerEvent(channel, command, paramByte);
         }

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -450,7 +450,7 @@ bool KonamiSnesTrack::readEvent(void) {
         // TODO: Note volume can be changed during a tied note
         // See the end of Konami Logo sequence for example
         makePrevDurNoteEnd(getTime() + dur);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), Type::Tie, ICON_NOTE);
       }
       else {
         addNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur);
@@ -463,7 +463,7 @@ bool KonamiSnesTrack::readEvent(void) {
     }
 
     case EVENT_PERCUSSION_ON: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion On", desc.str().c_str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion On", desc.str().c_str(), Type::ChangeState);
       if (!percussion) {
         addProgramChange(beginOffset, curOffset - beginOffset, 127 << 7, true);
         percussion = true;
@@ -472,7 +472,7 @@ bool KonamiSnesTrack::readEvent(void) {
     }
 
     case EVENT_PERCUSSION_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion Off", desc.str().c_str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion Off", desc.str().c_str(), Type::ChangeState);
       if (percussion) {
         addProgramChange(beginOffset, curOffset - beginOffset, instrument, true);
         percussion = false;
@@ -486,7 +486,7 @@ bool KonamiSnesTrack::readEvent(void) {
 
       desc << "GAIN: " << (int) newGAINAmount << " ($" << std::hex << std::setfill('0') << std::setw(2)
           << std::uppercase << (int) newGAIN << ")";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN", desc.str().c_str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -529,12 +529,12 @@ bool KonamiSnesTrack::readEvent(void) {
         }
 
         makePrevDurNoteEnd(getTime() + dur);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), Type::Tie, ICON_NOTE);
         addTime(noteLength);
         prevNoteSlurred = (noteDurationRate == parentSeq->NOTE_DUR_RATE_MAX);
       }
       else {
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), Type::Tie, ICON_NOTE);
         addTime(noteLength);
       }
       break;
@@ -584,7 +584,7 @@ bool KonamiSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Per-Instrument Pan Off",
                         desc.str().c_str(),
-                        CLR_PAN,
+                        Type::Pan,
                         ICON_CONTROL);
       }
       else if (instrumentPanOn) {
@@ -592,7 +592,7 @@ bool KonamiSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Per-Instrument Pan On",
                         desc.str().c_str(),
-                        CLR_PAN,
+                        Type::Pan,
                         ICON_CONTROL);
       }
       else {
@@ -643,7 +643,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Vibrato",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -658,13 +658,13 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Random Pitch",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
 
     case EVENT_LOOP_START: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), Type::Loop, ICON_STARTREP);
       loopReturnAddr = curOffset;
       break;
     }
@@ -680,7 +680,7 @@ bool KonamiSnesTrack::readEvent(void) {
         bContinue = addLoopForever(beginOffset, curOffset - beginOffset, "Loop End");
       }
       else {
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), Type::Loop, ICON_STARTREP);
       }
 
       bool loopAgain;
@@ -713,7 +713,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Loop Start #2",
                       desc.str().c_str(),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
       loopReturnAddr2 = curOffset;
       break;
@@ -734,7 +734,7 @@ bool KonamiSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Loop End #2",
                         desc.str().c_str(),
-                        CLR_LOOP,
+                        Type::Loop,
                         ICON_STARTREP);
       }
 
@@ -776,7 +776,7 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t newTempo = readByte(curOffset++);
       uint8_t fadeSpeed = readByte(curOffset++);
       desc << "BPM: " << parentSeq->getTempoInBPM(newTempo) << "  Fade Length: " << (int) fadeSpeed;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tempo Fade", desc.str().c_str(), CLR_TEMPO, ICON_TEMPO);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tempo Fade", desc.str().c_str(), Type::Tempo, ICON_TEMPO);
       break;
     }
 
@@ -789,14 +789,14 @@ bool KonamiSnesTrack::readEvent(void) {
     case EVENT_ADSR1: {
       uint8_t newADSR1 = readByte(curOffset++);
       desc << "ADSR(1): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) newADSR1;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(1)", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(1)", desc.str().c_str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
     case EVENT_ADSR2: {
       uint8_t newADSR2 = readByte(curOffset++);
       desc << "ADSR(2): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) newADSR2;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(2)", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(2)", desc.str().c_str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -815,7 +815,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Volume Fade",
                       desc.str().c_str(),
-                      CLR_VOLUME,
+                      Type::Volume,
                       ICON_CONTROL);
       break;
     }
@@ -827,7 +827,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Portamento",
                       desc.str().c_str(),
-                      CLR_PORTAMENTO,
+                      Type::Portamento,
                       ICON_CONTROL);
       break;
     }
@@ -842,7 +842,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Envelope",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -859,7 +859,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Envelope",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -880,7 +880,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Slide",
                       desc.str().c_str(),
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -902,7 +902,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Slide",
                       desc.str().c_str(),
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -922,7 +922,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Slide",
                       desc.str().c_str(),
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -935,7 +935,7 @@ bool KonamiSnesTrack::readEvent(void) {
       desc << "EON: " << (int) echoChannels << "  EVOL(L): " << (int) echoVolumeL << "  EVOL(R): "
           << (int) echoVolumeR;
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str().c_str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -950,7 +950,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Echo Param",
                       desc.str().c_str(),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -960,7 +960,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Loop With Volta Start",
                       desc.str().c_str(),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
 
       voltaLoopStart = curOffset;
@@ -974,7 +974,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Loop With Volta End",
                       desc.str().c_str(),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
 
       if (voltaEndMeansPlayFromStart) {
@@ -1001,7 +1001,7 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t newPan = readByte(curOffset++);
       uint8_t fadeSpeed = readByte(curOffset++);
       desc << "Pan: " << (int) newPan << "  Fade Length: " << (int) fadeSpeed;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc.str().c_str(), Type::Pan, ICON_CONTROL);
       break;
     }
 
@@ -1012,7 +1012,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Vibrato Fade",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -1025,7 +1025,7 @@ bool KonamiSnesTrack::readEvent(void) {
 
       desc << "ADSR(1): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) newADSR1
           << "  ADSR(2): $" << (int) newADSR2 << "  GAIN: $" << (int) newGAIN;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(2)", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(2)", desc.str().c_str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -1038,12 +1038,12 @@ bool KonamiSnesTrack::readEvent(void) {
       assert(dest >= dwOffset);
 
       if (curOffset < 0x10000 && readByte(curOffset) == 0xff) {
-        addGenericEvent(curOffset, 1, "End of Track", "", CLR_TRACKEND, ICON_TRACKEND);
+        addGenericEvent(curOffset, 1, "End of Track", "", Type::TrackEnd, ICON_TRACKEND);
       }
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -1060,7 +1060,7 @@ bool KonamiSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pattern Play",
                       desc.str().c_str(),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
 
       assert(dest >= dwOffset);
@@ -1077,7 +1077,7 @@ bool KonamiSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "End Pattern",
                         desc.str().c_str(),
-                        CLR_TRACKEND,
+                        Type::TrackEnd,
                         ICON_ENDREP);
 
         inSubroutine = false;

--- a/src/main/formats/MoriSnes/MoriSnesSeq.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesSeq.cpp
@@ -229,7 +229,7 @@ bool MoriSnesTrack::readEvent() {
       }
     }
 
-    addGenericEvent(beginOffset, curOffset - beginOffset, "Note Param", desc.str().c_str(), CLR_DURNOTE);
+    addGenericEvent(beginOffset, curOffset - beginOffset, "Note Param", desc.str().c_str(), Type::DurationNote);
     beginOffset = curOffset;
     desc.str("");
 
@@ -330,7 +330,7 @@ bool MoriSnesTrack::readEvent() {
       auto prevTiedNoteIter = std::find(tiedNoteKeys.begin(), tiedNoteKeys.end(), key);
       if (prevTiedNoteIter != tiedNoteKeys.end()) {
         makePrevDurNoteEnd(getTime() + dur);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), Type::Tie, ICON_NOTE);
 
         if (!tied) {
           // finish tied note
@@ -371,7 +371,7 @@ bool MoriSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Program Change",
                       desc.str().c_str(),
-                      CLR_PROGCHANGE,
+                      Type::ProgramChange,
                       ICON_PROGCHANGE);
       addProgramChangeNoItem(instrNum, false);
       break;
@@ -389,7 +389,7 @@ bool MoriSnesTrack::readEvent() {
         addPan(beginOffset, curOffset - beginOffset, midiPan);
       }
       else {
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Random Pan", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Random Pan", desc.str().c_str(), Type::Pan, ICON_CONTROL);
       }
       break;
     }
@@ -411,7 +411,7 @@ bool MoriSnesTrack::readEvent() {
     case EVENT_PRIORITY: {
       uint8_t newPriority = readByte(curOffset++);
       desc << "Priority: " << (int) newPriority;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Priority", desc.str().c_str(), CLR_PRIORITY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Priority", desc.str().c_str(), Type::Priority);
       break;
     }
 
@@ -425,13 +425,13 @@ bool MoriSnesTrack::readEvent() {
     }
 
     case EVENT_ECHO_ON: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.str().c_str(), Type::Reverb, ICON_CONTROL);
       addReverbNoItem(40);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), Type::Reverb, ICON_CONTROL);
       addReverbNoItem(0);
       break;
     }
@@ -447,7 +447,7 @@ bool MoriSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Echo Param",
                       desc.str().c_str(),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -461,7 +461,7 @@ bool MoriSnesTrack::readEvent() {
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -478,7 +478,7 @@ bool MoriSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Pattern Play",
                       desc.str().c_str(),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
 
       if (spcCallStackPtr + 2 > MORISNES_CALLSTACK_SIZE) {
@@ -500,7 +500,7 @@ bool MoriSnesTrack::readEvent() {
     }
 
     case EVENT_RET: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "End Pattern", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "End Pattern", desc.str().c_str(), Type::Loop, ICON_ENDREP);
 
       if (spcCallStackPtr < 2) {
         // access violation
@@ -516,7 +516,7 @@ bool MoriSnesTrack::readEvent() {
     case EVENT_LOOP_START: {
       uint8_t count = readByte(curOffset++);
       desc << "Loop Count: " << (int) count;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), Type::Loop, ICON_STARTREP);
 
       if (spcCallStackPtr + 3 > MORISNES_CALLSTACK_SIZE) {
         // stack overflow
@@ -533,7 +533,7 @@ bool MoriSnesTrack::readEvent() {
     }
 
     case EVENT_LOOP_END: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), Type::Loop, ICON_ENDREP);
 
       if (spcCallStackPtr < 3) {
         // access violation
@@ -564,7 +564,7 @@ bool MoriSnesTrack::readEvent() {
     case EVENT_NOTE_NUMBER: {
       int8_t newNoteNumber = readByte(curOffset++);
       spcNoteNumberBase = newNoteNumber;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Note Number Base", desc.str().c_str(), CLR_NOTEON);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Note Number Base", desc.str().c_str(), Type::NoteOn);
       break;
     }
 
@@ -584,7 +584,7 @@ bool MoriSnesTrack::readEvent() {
       // do not stop tied note here
       // example: Gokinjo Bouken Tai - Battle (28:0000, Sax at 3rd channel)
       desc << "Duration: " << spcDeltaTime;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Wait", desc.str().c_str(), CLR_REST, ICON_REST);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Wait", desc.str().c_str(), Type::Rest, ICON_REST);
       addTime(spcDeltaTime);
       break;
     }
@@ -620,12 +620,12 @@ bool MoriSnesTrack::readEvent() {
     }
 
     case EVENT_KEY_ON: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Key On", desc.str().c_str(), CLR_NOTEON, ICON_NOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Key On", desc.str().c_str(), Type::NoteOn, ICON_NOTE);
       break;
     }
 
     case EVENT_KEY_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Key Off", desc.str().c_str(), CLR_NOTEOFF, ICON_NOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Key Off", desc.str().c_str(), Type::NoteOff, ICON_NOTE);
       break;
     }
 
@@ -648,7 +648,7 @@ bool MoriSnesTrack::readEvent() {
     case EVENT_TIMEBASE: {
       bool fast = ((readByte(curOffset++) & 1) != 0);
       desc << "Timebase: " << (fast ? SEQ_PPQN : SEQ_PPQN / 2);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Timebase", desc.str().c_str(), CLR_TEMPO, ICON_TEMPO);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Timebase", desc.str().c_str(), Type::Tempo, ICON_TEMPO);
 
       if (parentSeq->fastTempo != fast) {
         addTempoBPMNoItem(parentSeq->getTempoInBPM(parentSeq->spcTempo, fast));

--- a/src/main/formats/NDS/NDSSeq.cpp
+++ b/src/main/formats/NDS/NDSSeq.cpp
@@ -132,7 +132,7 @@ bool NDSTrack::readEvent(void) {
         // Add an End Track if it exists afterward, for completeness sake
         if (readMode == READMODE_ADD_TO_UI && !isOffsetUsed(curOffset)) {
           if (readByte(curOffset) == 0xFF) {
-            addGenericEvent(curOffset, 1, "End of Track", "", CLR_TRACKEND, ICON_TRACKEND);
+            addGenericEvent(curOffset, 1, "End of Track", "", Type::TrackEnd, ICON_TRACKEND);
           }
         }
 
@@ -144,7 +144,7 @@ bool NDSTrack::readEvent(void) {
           bContinue = false;
         }
         else {
-          addGenericEvent(beginOffset, 4, "Jump", "", CLR_LOOPFOREVER);
+          addGenericEvent(beginOffset, 4, "Jump", "", Type::LoopForever);
         }
 
         curOffset = jumpAddr;
@@ -154,7 +154,7 @@ bool NDSTrack::readEvent(void) {
       case 0x95:
         hasLoopReturnOffset = true;
         loopReturnOffset = curOffset + 3;
-        addGenericEvent(beginOffset, curOffset + 3 - beginOffset, "Call", "", CLR_LOOP);
+        addGenericEvent(beginOffset, curOffset + 3 - beginOffset, "Call", "", Type::Loop);
         curOffset = readByte(curOffset) + (readByte(curOffset + 1) << 8)
             + (readByte(curOffset + 2) << 16) + parentSeq->dwOffset + 0x1C;
         break;
@@ -261,7 +261,7 @@ bool NDSTrack::readEvent(void) {
       // [loveemu] (ex: Children of Mana: SEQ_BGM000)
       case 0xC6:
         curOffset++;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Priority", "", CLR_CHANGESTATE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Priority", "", Type::ChangeState);
         break;
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_ARR1_)
@@ -398,7 +398,7 @@ bool NDSTrack::readEvent(void) {
           bContinue = false;
         }
 
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Return", "", CLR_LOOP);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Return", "", Type::Loop);
         curOffset = loopReturnOffset;
         return bContinue;
 	  }

--- a/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
@@ -174,7 +174,7 @@ bool NamcoSnesSeq::readEvent() {
     case EVENT_DELTA_TIME: {
       spcDeltaTime = readByte(curOffset++);
       desc << "Duration: " << spcDeltaTime;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", desc.str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", desc.str(), Type::ChangeState);
       break;
     }
 
@@ -188,7 +188,7 @@ bool NamcoSnesSeq::readEvent() {
         }
       }
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Open Tracks", desc.str(), CLR_MISC, ICON_TRACK);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Open Tracks", desc.str(), Type::Misc, ICON_TRACK);
       break;
     }
 
@@ -200,7 +200,7 @@ bool NamcoSnesSeq::readEvent() {
                       curOffset - beginOffset,
                       "Pattern Play",
                       desc.str().c_str(),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
 
       subReturnAddress = curOffset;
@@ -220,7 +220,7 @@ bool NamcoSnesSeq::readEvent() {
                         curOffset - beginOffset,
                         "Pattern End",
                         desc.str().c_str(),
-                        CLR_LOOP,
+                        Type::Loop,
                         ICON_ENDREP);
         curOffset = subReturnAddress;
         subReturnAddress = 0;
@@ -231,7 +231,7 @@ bool NamcoSnesSeq::readEvent() {
     case EVENT_DELTA_MULTIPLIER: {
       spcDeltaTimeScale = readByte(curOffset++);
       desc << "Delta Time Scale: " << spcDeltaTimeScale;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time Multiplier", desc.str(), CLR_MISC, ICON_TEMPO);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time Multiplier", desc.str(), Type::Misc, ICON_TEMPO);
       break;
     }
 
@@ -247,7 +247,7 @@ bool NamcoSnesSeq::readEvent() {
       curOffset += 2;
       desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again", desc.str().c_str(), Type::Loop, ICON_ENDREP);
 
       loopCount++;
       if (loopCount == count) {
@@ -268,7 +268,7 @@ bool NamcoSnesSeq::readEvent() {
       curOffset += 2;
       desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), Type::Loop, ICON_ENDREP);
 
       loopCount++;
       if (loopCount == count) {
@@ -290,7 +290,7 @@ bool NamcoSnesSeq::readEvent() {
                       curOffset - beginOffset,
                       "Loop Again (Alt)",
                       desc.str().c_str(),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_ENDREP);
 
       loopCountAlt++;
@@ -312,7 +312,7 @@ bool NamcoSnesSeq::readEvent() {
       curOffset += 2;
       desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), Type::Loop, ICON_ENDREP);
 
       loopCountAlt++;
       if (loopCountAlt == count) {
@@ -332,12 +332,12 @@ bool NamcoSnesSeq::readEvent() {
 
       // scan end event
       if (curOffset + 1 <= 0x10000 && readByte(curOffset) == 0x03 && (subReturnAddress & 0xff00) == 0) {
-        addGenericEvent(curOffset, 1, "End of Track", "", CLR_TRACKEND, ICON_TRACKEND);
+        addGenericEvent(curOffset, 1, "End of Track", "", Type::TrackEnd, ICON_TRACKEND);
       }
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+        addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -417,7 +417,7 @@ bool NamcoSnesSeq::readEvent() {
         }
       }
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Note", desc.str(), CLR_DURNOTE, ICON_NOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Note", desc.str(), Type::DurationNote, ICON_NOTE);
       addTime(dur);
       break;
     }
@@ -425,7 +425,7 @@ bool NamcoSnesSeq::readEvent() {
     case EVENT_ECHO_DELAY: {
       uint8_t echoDelay = readByte(curOffset++);
       desc << "Echo Delay: " << echoDelay;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Delay", desc.str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Delay", desc.str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -447,14 +447,14 @@ bool NamcoSnesSeq::readEvent() {
     case EVENT_ECHO: {
       bool echoOn = (readByte(curOffset++) != 0);
       desc << "Echo Write: " << (echoOn ? "On" : "Off");
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
     case EVENT_WAIT: {
       uint16_t dur = spcDeltaTime * spcDeltaTimeScale;
       desc << "Delta Time: " << spcDeltaTime;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Wait", desc.str(), CLR_TIE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Wait", desc.str(), Type::Tie);
       addTime(dur);
       break;
     }
@@ -462,14 +462,14 @@ bool NamcoSnesSeq::readEvent() {
     case EVENT_ECHO_FEEDBACK: {
       int8_t echoFeedback = readByte(curOffset++);
       desc << "Echo Feedback: " << echoFeedback;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Feedback", desc.str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Feedback", desc.str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_FIR: {
       uint8_t echoFilter = readByte(curOffset++);
       desc << "Echo FIR: " << echoFilter;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR", desc.str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR", desc.str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -477,14 +477,14 @@ bool NamcoSnesSeq::readEvent() {
       int8_t echoVolumeLeft = readByte(curOffset++);
       int8_t echoVolumeRight = readByte(curOffset++);
       desc << "Echo Volume Left: " << echoVolumeLeft << "  Echo Volume Right: " << echoVolumeRight;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc.str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc.str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_ADDRESS: {
       uint16_t echoAddress = readByte(curOffset++) << 8;
       desc << "ESA: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) echoAddress;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Address", desc.str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Address", desc.str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -545,20 +545,20 @@ bool NamcoSnesSeq::readEvent() {
                           curOffset - beginOffset,
                           controlName,
                           desc.str(),
-                          CLR_PROGCHANGE,
+                          Type::ProgramChange,
                           ICON_PROGCHANGE);
           break;
 
         case CONTROL_VOLUME:
-          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc.str(), CLR_VOLUME, ICON_CONTROL);
+          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc.str(), Type::Volume, ICON_CONTROL);
           break;
 
         case CONTROL_PAN:
-          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc.str(), CLR_PAN, ICON_CONTROL);
+          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc.str(), Type::Pan, ICON_CONTROL);
           break;
 
         case CONTROL_ADSR:
-          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc.str(), CLR_ADSR, ICON_CONTROL);
+          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc.str(), Type::Adsr, ICON_CONTROL);
           break;
 
         default:

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -811,13 +811,13 @@ bool NinSnesTrack::readEvent(void) {
     }
 
     case EVENT_NOP: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), Type::Misc, ICON_BINARY);
       break;
     }
 
     case EVENT_NOP1: {
       curOffset++;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), Type::Misc, ICON_BINARY);
       break;
     }
 
@@ -882,7 +882,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Note Param",
                       desc.str().c_str(),
-                      CLR_DURNOTE,
+                      Type::DurationNote,
                       ICON_CONTROL);
       break;
     }
@@ -903,7 +903,7 @@ bool NinSnesTrack::readEvent(void) {
       duration = std::min(std::max(duration, (uint8_t) 1), (uint8_t) (shared->spcNoteDuration - 2));
       desc << "Duration: " << (int) duration;
       makePrevDurNoteEnd(getTime() + duration);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), Type::Tie);
       addTime(shared->spcNoteDuration);
       break;
     }
@@ -999,7 +999,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Vibrato",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -1009,7 +1009,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Vibrato Off",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -1070,7 +1070,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Tremolo",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -1080,7 +1080,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Tremolo Off",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -1113,16 +1113,16 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pattern Play",
                       desc.str().c_str(),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
 
       // Add the next "END" event to UI
       if (curOffset < 0x10000 && readByte(curOffset) == parentSeq->STATUS_END) {
         if (shared->loopCount == 0) {
-          addGenericEvent(curOffset, 1, "Section End", desc.str().c_str(), CLR_TRACKEND, ICON_ENDREP);
+          addGenericEvent(curOffset, 1, "Section End", desc.str().c_str(), Type::TrackEnd, ICON_ENDREP);
         }
         else {
-          addGenericEvent(curOffset, 1, "Pattern End", desc.str().c_str(), CLR_TRACKEND, ICON_ENDREP);
+          addGenericEvent(curOffset, 1, "Pattern End", desc.str().c_str(), Type::TrackEnd, ICON_ENDREP);
         }
       }
 
@@ -1137,7 +1137,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Vibrato Fade",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -1153,7 +1153,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Envelope (To)",
                       desc.str().c_str(),
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -1169,7 +1169,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Envelope (From)",
                       desc.str().c_str(),
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -1179,7 +1179,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Envelope Off",
                       desc.str().c_str(),
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -1195,7 +1195,7 @@ bool NinSnesTrack::readEvent(void) {
       // In Quintet games (at least in Terranigma), the fine tuning command overwrites the fractional part of instrument tuning.
       // In other words, we cannot calculate the tuning amount without reading the instrument table.
       uint8_t newTuning = readByte(curOffset++);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc.str().c_str(), CLR_PITCHBEND, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc.str().c_str(), Type::PitchBend, ICON_CONTROL);
       addFineTuningNoItem((newTuning / 256.0) * 61.8); // obviously not correct, but better than nothing?
       break;
     }
@@ -1218,12 +1218,12 @@ bool NinSnesTrack::readEvent(void) {
       }
 
       desc << "  Volume Left: " << (int) spcEVOL_L << "  Volume Right: " << (int) spcEVOL_R;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str().c_str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -1233,7 +1233,7 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t spcFIR = readByte(curOffset++);
 
       desc << "Delay: " << (int) spcEDL << "  Feedback: " << (int) spcEFB << "  FIR: " << (int) spcFIR;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc.str().c_str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -1248,7 +1248,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Echo Volume Fade",
                       desc.str().c_str(),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
@@ -1264,7 +1264,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Pitch Slide",
                       desc.str().c_str(),
-                      CLR_PITCHBEND,
+                      Type::PitchBend,
                       ICON_CONTROL);
       break;
     }
@@ -1278,7 +1278,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Percussion Base",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -1299,7 +1299,7 @@ bool NinSnesTrack::readEvent(void) {
       // KONAMI EVENTS START >>
 
     case EVENT_KONAMI_LOOP_START: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), Type::Loop, ICON_STARTREP);
       shared->konamiLoopStart = curOffset;
       shared->konamiLoopCount = 0;
       break;
@@ -1312,7 +1312,7 @@ bool NinSnesTrack::readEvent(void) {
 
       desc << "Times: " << (int) times << "  Volume Delta: " << (int) volumeDelta << "  Pitch Delta: "
           << (int) pitchDelta << "/16 semitones";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), Type::Loop, ICON_ENDREP);
 
       shared->konamiLoopCount++;
       if (shared->konamiLoopCount != times) {
@@ -1329,7 +1329,7 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t gain = readByte(curOffset++);
       desc << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << "ADSR(1): $" << adsr1
           << "  ADSR(2): $" << adsr2 << "  GAIN: $" << gain;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR/GAIN", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR/GAIN", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -1360,7 +1360,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Note Param",
                       desc.str().c_str(),
-                      CLR_DURNOTE,
+                      Type::DurationNote,
                       ICON_CONTROL);
       break;
     }
@@ -1397,7 +1397,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Note Param",
                       desc.str().c_str(),
-                      CLR_DURNOTE,
+                      Type::DurationNote,
                       ICON_CONTROL);
       break;
     }
@@ -1414,12 +1414,12 @@ bool NinSnesTrack::readEvent(void) {
 
     case EVENT_INTELLI_LEGATO_ON: {
       // TODO: cancel keyoff of note (i.e. full duration)
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato On", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato On", desc.str(), Type::Portamento, ICON_CONTROL);
       break;
     }
 
     case EVENT_INTELLI_LEGATO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato Off", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato Off", desc.str(), Type::Portamento, ICON_CONTROL);
       break;
     }
 
@@ -1428,7 +1428,7 @@ bool NinSnesTrack::readEvent(void) {
       uint16_t dest = curOffset + offset;
 
       desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump (Short)", desc.str().c_str(), CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump (Short)", desc.str().c_str(), Type::Misc);
 
       // condition for branch has not been researched yet
       curOffset = dest;
@@ -1440,7 +1440,7 @@ bool NinSnesTrack::readEvent(void) {
       uint16_t dest = curOffset + offset;
 
       desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Jump (Short)", desc.str().c_str(), CLR_MISC);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Jump (Short)", desc.str().c_str(), Type::Misc);
 
       curOffset = dest;
       break;
@@ -1451,7 +1451,7 @@ bool NinSnesTrack::readEvent(void) {
       if (param < 0xf0) {
         // wait for APU port #2
         desc << "Value: " << param;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Wait for APU Port #2", desc.str(), CLR_CHANGESTATE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Wait for APU Port #2", desc.str(), Type::ChangeState);
       }
       else {
         // set/clear bitflag in $ca
@@ -1466,7 +1466,7 @@ bool NinSnesTrack::readEvent(void) {
                             curOffset - beginOffset,
                             "Use Custom Percussion Table",
                             desc.str(),
-                            CLR_CHANGESTATE);
+                            Type::ChangeState);
             break;
 
           case 7:
@@ -1475,7 +1475,7 @@ bool NinSnesTrack::readEvent(void) {
                             curOffset - beginOffset,
                             "Use Custom Note Param",
                             desc.str(),
-                            CLR_CHANGESTATE);
+                            Type::ChangeState);
             break;
 
           default:
@@ -1488,7 +1488,7 @@ bool NinSnesTrack::readEvent(void) {
     case EVENT_INTELLI_WRITE_APU_PORT: {
       uint8_t value = readByte(curOffset++);
       desc << "Value: " << value;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Write APU Port", desc.str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Write APU Port", desc.str(), Type::ChangeState);
       break;
     }
 
@@ -1505,14 +1505,14 @@ bool NinSnesTrack::readEvent(void) {
         parentSeq->intelliVoiceParamTable = curOffset;
         curOffset += parentSeq->intelliVoiceParamTableSize * 4;
         desc << "Number of Items: " << parentSeq->intelliVoiceParamTableSize;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Voice Param Table", desc.str(), CLR_MISC);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Voice Param Table", desc.str(), Type::Misc);
       }
       else {
         if (parentSeq->version == NINSNES_INTELLI_FE3 || parentSeq->version == NINSNES_INTELLI_TA) {
           uint8_t instrNum = param & 0x3f;
           curOffset += 6;
           desc << "Instrument: " << instrNum;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Overwrite Instrument Region", desc.str(), CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Overwrite Instrument Region", desc.str(), Type::Misc);
         }
         else {
           addUnknown(beginOffset, curOffset - beginOffset);
@@ -1589,7 +1589,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "Load Voice Param",
                       desc.str(),
-                      CLR_PROGCHANGE,
+                      Type::ProgramChange,
                       ICON_PROGCHANGE);
       break;
     }
@@ -1599,7 +1599,7 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t adsr2 = readByte(curOffset++);
       desc << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << "ADSR(1): $" << adsr1
           << "  ADSR(2): $" << adsr2;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -1611,7 +1611,7 @@ bool NinSnesTrack::readEvent(void) {
       desc << "ADSR(1): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << adsr1
           << "  Sustain Rate: " << std::dec << sustain_rate << "  Sustain Level: " << sustain_level
           << "  (ADSR(2): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << adsr2 << ")";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -1624,7 +1624,7 @@ bool NinSnesTrack::readEvent(void) {
                       curOffset - beginOffset,
                       "GAIN Sustain Time/Rate",
                       desc.str(),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -1632,7 +1632,7 @@ bool NinSnesTrack::readEvent(void) {
     case EVENT_INTELLI_GAIN_SUSTAIN_TIME: {
       uint8_t sustainDurRate = readByte(curOffset++);
       desc << "Duration for Sustain: " << sustainDurRate << "/256";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN Sustain Time", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN Sustain Time", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -1641,7 +1641,7 @@ bool NinSnesTrack::readEvent(void) {
       // however, note that Fire Emblem 4 does not switch to GAIN mode until note off.
       uint8_t gain = readByte(curOffset++);
       desc << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << "  GAIN: $" << gain;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN (Release Rate)", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN (Release Rate)", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -1680,7 +1680,7 @@ bool NinSnesTrack::readEvent(void) {
                             curOffset - beginOffset,
                             "Use Custom Note Param",
                             desc.str(),
-                            CLR_CHANGESTATE);
+                            Type::ChangeState);
           }
           else if (param == 0x40) {
             desc << "Status: " << (bitValue ? "On" : "Off");
@@ -1688,15 +1688,15 @@ bool NinSnesTrack::readEvent(void) {
                             curOffset - beginOffset,
                             "Use Custom Percussion Table",
                             desc.str(),
-                            CLR_CHANGESTATE);
+                            Type::ChangeState);
           }
           else {
             desc << "Value: $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << param;
             if (type == 0x01) {
-              addGenericEvent(beginOffset, curOffset - beginOffset, "Set Flags On", desc.str(), CLR_CHANGESTATE);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "Set Flags On", desc.str(), Type::ChangeState);
             }
             else {
-              addGenericEvent(beginOffset, curOffset - beginOffset, "Set Flags Off", desc.str(), CLR_CHANGESTATE);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "Set Flags Off", desc.str(), Type::ChangeState);
             }
           }
 
@@ -1705,7 +1705,7 @@ bool NinSnesTrack::readEvent(void) {
 
         case 0x03:
           // TODO: cancel keyoff of note (i.e. full duration)
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Legato On", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Legato On", desc.str(), Type::Portamento, ICON_CONTROL);
           break;
 
         case 0x04:
@@ -1713,7 +1713,7 @@ bool NinSnesTrack::readEvent(void) {
                           curOffset - beginOffset,
                           "Legato Off",
                           desc.str(),
-                          CLR_PORTAMENTO,
+                          Type::Portamento,
                           ICON_CONTROL);
           break;
 
@@ -1766,10 +1766,10 @@ bool NinSnesTrack::readEvent(void) {
   // (because it often gets interrupted by the end of other track)
   if (curOffset + 1 <= 0x10000 && statusByte != parentSeq->STATUS_END && readByte(curOffset) == parentSeq->STATUS_END) {
     if (shared->loopCount == 0) {
-      addGenericEvent(curOffset, 1, "Section End", desc.str().c_str(), CLR_TRACKEND, ICON_TRACKEND);
+      addGenericEvent(curOffset, 1, "Section End", desc.str().c_str(), Type::TrackEnd, ICON_TRACKEND);
     }
     else {
-      addGenericEvent(curOffset, 1, "Pattern End", desc.str().c_str(), CLR_TRACKEND, ICON_ENDREP);
+      addGenericEvent(curOffset, 1, "Pattern End", desc.str().c_str(), Type::TrackEnd, ICON_ENDREP);
     }
   }
 

--- a/src/main/formats/PS1/PS1Seq.cpp
+++ b/src/main/formats/PS1/PS1Seq.cpp
@@ -155,13 +155,13 @@ bool PS1Seq::readEvent() {
       {
         //bank select
         case 0 :
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Bank Select", "", CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Bank Select", "", Type::Misc);
           addBankSelectNoItem(value);
           break;
 
         //data entry
         case 6 :
-          addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry", "", CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry", "", Type::Misc);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
@@ -196,15 +196,15 @@ bool PS1Seq::readEvent() {
         case 98 :
           switch (value) {
             case 20 :
-              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #20", "", CLR_MISC);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #20", "", Type::Misc);
               break;
 
             case 30 :
-              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #30", "", CLR_MISC);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1 #30", "", Type::Misc);
               break;
 
             default:
-              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1", "", CLR_MISC);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 1", "", Type::Misc);
               break;
           }
 
@@ -217,15 +217,15 @@ bool PS1Seq::readEvent() {
         case 99 :
           switch (value) {
             case 20 :
-              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", CLR_LOOP, ICON_STARTREP);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", Type::Loop, ICON_STARTREP);
               break;
 
             case 30 :
-              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", CLR_LOOP, ICON_ENDREP);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", Type::Loop, ICON_ENDREP);
               break;
 
             default:
-              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 2", "", CLR_MISC);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN 2", "", Type::Misc);
               break;
           }
 
@@ -236,7 +236,7 @@ bool PS1Seq::readEvent() {
 
         //(0x64) RPN 1 (LSB), no effect?
         case 100 :
-          addGenericEvent(beginOffset, curOffset - beginOffset, "RPN 1", "", CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "RPN 1", "", Type::Misc);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
@@ -244,7 +244,7 @@ bool PS1Seq::readEvent() {
 
         //(0x65) RPN 2 (MSB), no effect?
         case 101 :
-          addGenericEvent(beginOffset, curOffset - beginOffset, "RPN 2", "", CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "RPN 2", "", Type::Misc);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
@@ -252,14 +252,14 @@ bool PS1Seq::readEvent() {
 
         //reset all controllers
         case 121 :
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Reset All Controllers", "", CLR_MISC);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Reset All Controllers", "", Type::Misc);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }
           break;
 
         default:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Control Event", "", CLR_UNKNOWN);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Control Event", "", Type::Unknown);
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             pMidiTrack->addControllerEvent(channel, controlNum, value);
           }

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesSeq.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesSeq.cpp
@@ -233,7 +233,7 @@ bool PandoraBoxSnesTrack::readEvent() {
     }
 
     case EVENT_NOP: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str(), CLR_MISC, ICON_BINARY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str(), Type::Misc, ICON_BINARY);
       break;
     }
 
@@ -274,7 +274,7 @@ bool PandoraBoxSnesTrack::readEvent() {
         if (prevNoteSlurred && key == prevNoteKey) {
           // tie
           makePrevDurNoteEnd(getTime() + dur);
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str(), CLR_TIE, ICON_NOTE);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str(), Type::Tie, ICON_NOTE);
         }
         else {
           // note
@@ -291,14 +291,14 @@ bool PandoraBoxSnesTrack::readEvent() {
     case EVENT_OCTAVE: {
       octave = (statusByte - 0x40);
       desc << "Octave: " << octave;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Octave", desc.str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Octave", desc.str(), Type::ChangeState);
       break;
     }
 
     case EVENT_QUANTIZE: {
       spcNoteQuantize = (statusByte - 0x48);
       desc << "Length: " << spcNoteQuantize << "/8";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str(), CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str(), Type::DurationNote);
       break;
     }
 
@@ -328,7 +328,7 @@ bool PandoraBoxSnesTrack::readEvent() {
     case EVENT_TUNING: {
       int8_t newTuning = readByte(curOffset++);
       desc << "Hearz: " << (newTuning >= 0 ? "+" : "") << newTuning << " Hz";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc.str(), CLR_TRANSPOSE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc.str(), Type::Transpose, ICON_CONTROL);
       break;
     }
 
@@ -398,7 +398,7 @@ bool PandoraBoxSnesTrack::readEvent() {
           "  Arg4: " << arg4 <<
           "  Arg5: " << arg5;
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Param", desc.str(), CLR_MODULATION, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Param", desc.str(), Type::Modulation, ICON_CONTROL);
       break;
     }
 
@@ -409,7 +409,7 @@ bool PandoraBoxSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Vibrato On/Off",
                       desc.str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -427,7 +427,7 @@ bool PandoraBoxSnesTrack::readEvent() {
     case EVENT_LOOP_START: {
       uint8_t count = readByte(curOffset++);
       desc << "Times: " << (int) count;
-      addGenericEvent(beginOffset, 2, "Loop Start", desc.str(), CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, 2, "Loop Start", desc.str(), Type::Loop, ICON_STARTREP);
 
       if (spcCallStackPtr + 5 > PANDORABOXSNES_CALLSTACK_SIZE) {
         // stack overflow
@@ -460,7 +460,7 @@ bool PandoraBoxSnesTrack::readEvent() {
       }
       else {
         // regular loop
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str(), CLR_LOOP, ICON_ENDREP);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str(), Type::Loop, ICON_ENDREP);
 
         // decrease repeat count (0 becomes an infinite loop, as a result)
         spcCallStack[spcCallStackPtr - 1]--;
@@ -483,7 +483,7 @@ bool PandoraBoxSnesTrack::readEvent() {
     }
 
     case EVENT_LOOP_BREAK: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str(), Type::Loop, ICON_ENDREP);
 
       if (spcCallStackPtr < 5) {
         // access violation
@@ -504,7 +504,7 @@ bool PandoraBoxSnesTrack::readEvent() {
       uint8_t dspValue = readByte(curOffset++);
       desc << "Register: $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) dspReg
           << "  Value: $" << (int) dspValue;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Write to DSP", desc.str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Write to DSP", desc.str(), Type::ChangeState);
       break;
     }
 
@@ -527,7 +527,7 @@ bool PandoraBoxSnesTrack::readEvent() {
         desc << "  Noise Frequency (NCK): " << " (Keep Current)";
       }
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Param", desc.str(), CLR_CHANGESTATE, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Param", desc.str(), Type::ChangeState, ICON_CONTROL);
       break;
     }
 
@@ -550,7 +550,7 @@ bool PandoraBoxSnesTrack::readEvent() {
           "  SL: " << slRate << "/127" << " (" << sl << ")" <<
           "  Arg5: " << xxRate << "/127";
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 

--- a/src/main/formats/PrismSnes/PrismSnesSeq.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesSeq.cpp
@@ -322,7 +322,7 @@ bool PrismSnesTrack::readEvent() {
 
     case EVENT_NOP2: {
       curOffset += 2;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str(), CLR_MISC, ICON_BINARY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str(), Type::Misc, ICON_BINARY);
       break;
     }
 
@@ -350,7 +350,7 @@ bool PrismSnesTrack::readEvent() {
         makePrevDurNoteEnd(getTime() + dur);
         desc << "Abs Key: " << key << " (" << MidiEvent::getNoteName(key) << "  Velocity: " << NOTE_VELOCITY << "  Duration: "
             << dur;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Note (Tied)", desc.str(), CLR_DURNOTE, ICON_NOTE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Note (Tied)", desc.str(), Type::DurationNote, ICON_NOTE);
       }
       else {
         if (eventType == EVENT_NOISE_NOTE) {
@@ -391,7 +391,7 @@ bool PrismSnesTrack::readEvent() {
           "  Note Number (To): " << noteNumberTo << " ("
           << ((noteTo & 0x80) != 0 ? "Noise" : MidiEvent::getNoteName(noteNumberTo)) << ")" <<
           "  Length: " << len << "  Duration: " << dur;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc.str(), CLR_PITCHBEND, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc.str(), Type::PitchBend, ICON_CONTROL);
 
       addNoteByDurNoItem(noteNumberFrom, NOTE_VELOCITY, dur);
       addTime(len);
@@ -412,7 +412,7 @@ bool PrismSnesTrack::readEvent() {
       uint8_t dur = getDuration(curOffset, len, durDelta);
 
       desc << "Length: " << len << "  Duration: " << dur;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie with Duration", desc.str(), CLR_TIE, ICON_NOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie with Duration", desc.str(), Type::Tie, ICON_NOTE);
       makePrevDurNoteEnd(getTime() + dur);
       addTime(len);
       break;
@@ -420,7 +420,7 @@ bool PrismSnesTrack::readEvent() {
 
     case EVENT_TIE: {
       prevNoteSlurred = true;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str(), CLR_TIE, ICON_NOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str(), Type::Tie, ICON_NOTE);
       break;
     }
 
@@ -441,7 +441,7 @@ bool PrismSnesTrack::readEvent() {
       }
 
       desc << "Duration: " << len;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Rest", desc.str(), CLR_REST, ICON_REST);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Rest", desc.str(), Type::Rest, ICON_REST);
       addTime(len);
       break;
     }
@@ -456,7 +456,7 @@ bool PrismSnesTrack::readEvent() {
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
       desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump", desc.str(), CLR_LOOP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump", desc.str(), Type::Loop);
 
       if (parentSeq->conditionSwitch) {
         curOffset = dest;
@@ -466,7 +466,7 @@ bool PrismSnesTrack::readEvent() {
 
     case EVENT_CONDITION: {
       parentSeq->conditionSwitch = true;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Condition On", desc.str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Condition On", desc.str(), Type::ChangeState);
       break;
     }
 
@@ -475,25 +475,25 @@ bool PrismSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Restore Echo Param",
                       desc.str(),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       break;
     }
 
     case EVENT_SAVE_ECHO_PARAM: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Save Echo Param", desc.str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Save Echo Param", desc.str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
     case EVENT_SLUR_OFF: {
       slur = false;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Slur Off", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Slur Off", desc.str(), Type::Portamento, ICON_CONTROL);
       break;
     }
 
     case EVENT_SLUR_ON: {
       slur = true;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Slur On", desc.str(), CLR_PORTAMENTO, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Slur On", desc.str(), Type::Portamento, ICON_CONTROL);
       break;
     }
 
@@ -501,51 +501,51 @@ bool PrismSnesTrack::readEvent() {
       uint16_t envelopeAddress = readShort(curOffset);
       curOffset += 2;
       desc << "Envelope: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << envelopeAddress;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Volume Envelope", desc.str(), CLR_VOLUME, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Volume Envelope", desc.str(), Type::Volume, ICON_CONTROL);
       addVolumeEnvelope(envelopeAddress);
       break;
     }
 
     case EVENT_DEFAULT_PAN_TABLE_1: {
       panTable.assign(std::begin(PrismSnesSeq::PAN_TABLE_1), std::end(PrismSnesSeq::PAN_TABLE_1));
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Default Pan Table #1", desc.str(), CLR_PAN, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Default Pan Table #1", desc.str(), Type::Pan, ICON_CONTROL);
       break;
     }
 
     case EVENT_DEFAULT_PAN_TABLE_2: {
       panTable.assign(std::begin(PrismSnesSeq::PAN_TABLE_2), std::end(PrismSnesSeq::PAN_TABLE_2));
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Default Pan Table #2", desc.str(), CLR_PAN, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Default Pan Table #2", desc.str(), Type::Pan, ICON_CONTROL);
       break;
     }
 
     case EVENT_INC_APU_PORT_3: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Increment APU Port 3", desc.str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Increment APU Port 3", desc.str(), Type::ChangeState);
       break;
     }
 
     case EVENT_INC_APU_PORT_2: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Increment APU Port 2", desc.str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Increment APU Port 2", desc.str(), Type::ChangeState);
       break;
     }
 
     case EVENT_PLAY_SONG_3: {
       uint8_t songIndex = readByte(curOffset++);
       desc << "Song Index: " << songIndex;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Play Song (3)", desc.str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Play Song (3)", desc.str(), Type::ChangeState);
       break;
     }
 
     case EVENT_PLAY_SONG_2: {
       uint8_t songIndex = readByte(curOffset++);
       desc << "Song Index: " << songIndex;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Play Song (2)", desc.str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Play Song (2)", desc.str(), Type::ChangeState);
       break;
     }
 
     case EVENT_PLAY_SONG_1: {
       uint8_t songIndex = readByte(curOffset++);
       desc << "Song Index: " << songIndex;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Play Song (1)", desc.str(), CLR_CHANGESTATE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Play Song (1)", desc.str(), Type::ChangeState);
       break;
     }
 
@@ -561,7 +561,7 @@ bool PrismSnesTrack::readEvent() {
       uint16_t envelopeSpeed = readByte(curOffset++);
       desc << "Envelope: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << envelopeAddress
           << "  Speed: " << std::dec << std::setfill(' ') << std::setw(0) << envelopeSpeed;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Envelope", desc.str(), CLR_PAN, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Envelope", desc.str(), Type::Pan, ICON_CONTROL);
       addPanEnvelope(envelopeAddress);
       break;
     }
@@ -570,7 +570,7 @@ bool PrismSnesTrack::readEvent() {
       uint16_t panTableAddress = readShort(curOffset);
       curOffset += 2;
       desc << "Pan Table: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << panTableAddress;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Table", desc.str(), CLR_PAN, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Table", desc.str(), Type::Pan, ICON_CONTROL);
 
       // update pan table
       if (panTableAddress + 21 <= 0x10000) {
@@ -585,14 +585,14 @@ bool PrismSnesTrack::readEvent() {
 
     case EVENT_DEFAULT_LENGTH_OFF: {
       defaultLength = 0;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Default Length Off", desc.str(), CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Default Length Off", desc.str(), Type::DurationNote);
       break;
     }
 
     case EVENT_DEFAULT_LENGTH: {
       defaultLength = readByte(curOffset++);
       desc << "Duration: " << defaultLength;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Default Length", desc.str(), CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Default Length", desc.str(), Type::DurationNote);
       break;
     }
 
@@ -602,7 +602,7 @@ bool PrismSnesTrack::readEvent() {
       curOffset += 2;
       desc << "Loop Count: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Until", desc.str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Until", desc.str(), Type::Loop, ICON_ENDREP);
 
       bool doJump;
       if (loopCount == 0) {
@@ -632,7 +632,7 @@ bool PrismSnesTrack::readEvent() {
       curOffset += 2;
       desc << "Loop Count: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
           << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Until (Alt)", desc.str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Until (Alt)", desc.str(), Type::Loop, ICON_ENDREP);
 
       bool doJump;
       if (loopCountAlt == 0) {
@@ -657,7 +657,7 @@ bool PrismSnesTrack::readEvent() {
     }
 
     case EVENT_RET: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern End", desc.str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern End", desc.str(), Type::Loop, ICON_ENDREP);
 
       if (subReturnAddr != 0) {
         curOffset = subReturnAddr;
@@ -671,7 +671,7 @@ bool PrismSnesTrack::readEvent() {
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
       desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern Play", desc.str(), CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern Play", desc.str(), Type::Loop, ICON_STARTREP);
 
       subReturnAddr = curOffset;
       curOffset = dest;
@@ -686,12 +686,12 @@ bool PrismSnesTrack::readEvent() {
       uint32_t length = curOffset - beginOffset;
 
       if (curOffset < 0x10000 && readByte(curOffset) == 0xff) {
-        addGenericEvent(curOffset, 1, "End of Track", "", CLR_TRACKEND, ICON_TRACKEND);
+        addGenericEvent(curOffset, 1, "End of Track", "", Type::TrackEnd, ICON_TRACKEND);
       }
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc.str(), CLR_LOOPFOREVER);
+        addGenericEvent(beginOffset, length, "Jump", desc.str(), Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -720,12 +720,12 @@ bool PrismSnesTrack::readEvent() {
     case EVENT_VIBRATO_DELAY: {
       uint8_t lfoDelay = readByte(curOffset++);
       desc << "Delay: " << (int) lfoDelay;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Delay", desc.str(), CLR_MODULATION, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Delay", desc.str(), Type::Modulation, ICON_CONTROL);
       break;
     }
 
     case EVENT_VIBRATO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Off", desc.str(), CLR_MODULATION, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Off", desc.str(), Type::Modulation, ICON_CONTROL);
       break;
     }
 
@@ -734,7 +734,7 @@ bool PrismSnesTrack::readEvent() {
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
       desc << "Delay: " << (int) lfoDelay << "  Arg2: " << (int) arg2 << "  Arg3: " << (int) arg3;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc.str(), CLR_MODULATION, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc.str(), Type::Modulation, ICON_CONTROL);
       break;
     }
 
@@ -792,7 +792,7 @@ bool PrismSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "GAIN Envelope (Rest)",
                       desc.str(),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       addGAINEnvelope(envelopeAddress);
       break;
@@ -807,20 +807,20 @@ bool PrismSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "GAIN Envelope Decay Time",
                       desc.str(),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
 
     case EVENT_MANUAL_DURATION_OFF: {
       manualDuration = false;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Manual Duration Off", desc.str(), CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Manual Duration Off", desc.str(), Type::DurationNote);
       break;
     }
 
     case EVENT_MANUAL_DURATION_ON: {
       manualDuration = true;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Manual Duration On", desc.str(), CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Manual Duration On", desc.str(), Type::DurationNote);
       break;
     }
 
@@ -828,7 +828,7 @@ bool PrismSnesTrack::readEvent() {
       manualDuration = false;
       autoDurationThreshold = readByte(curOffset++);
       desc << "Duration: Full-Length - " << autoDurationThreshold;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Auto Duration Threshold", desc.str(), CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Auto Duration Threshold", desc.str(), Type::DurationNote);
       break;
     }
 
@@ -840,7 +840,7 @@ bool PrismSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "GAIN Envelope (Sustain)",
                       desc.str(),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       addGAINEnvelope(envelopeAddress);
       break;
@@ -854,7 +854,7 @@ bool PrismSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Echo Volume Envelope",
                       desc.str(),
-                      CLR_REVERB,
+                      Type::Reverb,
                       ICON_CONTROL);
       addEchoVolumeEnvelope(envelopeAddress);
       break;
@@ -866,7 +866,7 @@ bool PrismSnesTrack::readEvent() {
       int8_t echoVolumeMono = readByte(curOffset++);
       desc << "Left Volume: " << echoVolumeLeft << "  Right Volume: " << echoVolumeRight << "  Mono Volume: "
           << echoVolumeMono;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc.str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc.str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -887,7 +887,7 @@ bool PrismSnesTrack::readEvent() {
       int8_t echoVolumeMono = readByte(curOffset++);
       desc << "Feedback: " << echoFeedback << "  Left Volume: " << echoVolumeLeft << "  Right Volume: "
           << echoVolumeRight << "  Mono Volume: " << echoVolumeMono;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc.str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc.str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
@@ -903,7 +903,7 @@ bool PrismSnesTrack::readEvent() {
         uint8_t instrNum = readByte(curOffset++);
         desc << "Instrument: " << instrNum;
       }
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), CLR_ADSR, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), Type::Adsr, ICON_CONTROL);
       break;
     }
 
@@ -915,7 +915,7 @@ bool PrismSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "GAIN Envelope (Decay)",
                       desc.str(),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       addGAINEnvelope(envelopeAddress);
       break;

--- a/src/main/formats/RareSnes/RareSnesSeq.cpp
+++ b/src/main/formats/RareSnes/RareSnesSeq.cpp
@@ -476,7 +476,7 @@ bool RareSnesTrack::readEvent(void) {
 
         curOffset = dest;
         if (!isOffsetUsed(dest) || rptNestLevel != 0) // nest level check is required for Stickerbrush Symphony
-          addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+          addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), Type::LoopForever);
         else
           bContinue = addLoopForever(beginOffset, length, "Jump");
         break;
@@ -493,7 +493,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         (times == 1 ? "Pattern Play" : "Pattern Repeat"),
                         desc.str().c_str(),
-                        CLR_LOOP,
+                        Type::Loop,
                         ICON_STARTREP);
 
         if (rptNestLevel == RARESNES_RPTNESTMAX) {
@@ -519,7 +519,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Pattern Play",
                         desc.str().c_str(),
-                        CLR_LOOP,
+                        Type::Loop,
                         ICON_STARTREP);
 
         if (rptNestLevel == RARESNES_RPTNESTMAX) {
@@ -541,7 +541,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "End Pattern",
                         desc.str().c_str(),
-                        CLR_TRACKEND,
+                        Type::TrackEnd,
                         ICON_ENDREP);
 
         if (rptNestLevel == 0) {
@@ -577,7 +577,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Default Duration On",
                         desc.str().c_str(),
-                        CLR_DURNOTE,
+                        Type::DurationNote,
                         ICON_NOTE);
         break;
       }
@@ -588,7 +588,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Default Duration Off",
                         desc.str().c_str(),
-                        CLR_DURNOTE,
+                        Type::DurationNote,
                         ICON_NOTE);
         break;
 
@@ -598,7 +598,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Pitch Slide Up",
                         desc.str().c_str(),
-                        CLR_PITCHBEND,
+                        Type::PitchBend,
                         ICON_CONTROL);
         break;
       }
@@ -609,7 +609,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Pitch Slide Down",
                         desc.str().c_str(),
-                        CLR_PITCHBEND,
+                        Type::PitchBend,
                         ICON_CONTROL);
         break;
       }
@@ -619,7 +619,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Pitch Slide Off",
                         desc.str().c_str(),
-                        CLR_PITCHBEND,
+                        Type::PitchBend,
                         ICON_CONTROL);
         break;
 
@@ -648,7 +648,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Vibrato (Short)",
                         desc.str().c_str(),
-                        CLR_MODULATION,
+                        Type::Modulation,
                         ICON_CONTROL);
         break;
       }
@@ -658,7 +658,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Vibrato Off",
                         desc.str().c_str(),
-                        CLR_MODULATION,
+                        Type::Modulation,
                         ICON_CONTROL);
         break;
 
@@ -668,7 +668,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Vibrato",
                         desc.str().c_str(),
-                        CLR_MODULATION,
+                        Type::Modulation,
                         ICON_CONTROL);
         break;
       }
@@ -678,7 +678,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Tremolo Off",
                         desc.str().c_str(),
-                        CLR_MODULATION,
+                        Type::Modulation,
                         ICON_CONTROL);
         break;
 
@@ -688,7 +688,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Tremolo",
                         desc.str().c_str(),
-                        CLR_MODULATION,
+                        Type::Modulation,
                         ICON_CONTROL);
         break;
       }
@@ -699,7 +699,7 @@ bool RareSnesTrack::readEvent(void) {
         spcADSR = newADSR;
 
         desc << "ADSR: " << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) newADSR;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str().c_str(), CLR_ADSR, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str().c_str(), Type::Adsr, ICON_CONTROL);
         break;
       }
 
@@ -707,7 +707,7 @@ bool RareSnesTrack::readEvent(void) {
         // TODO: At least it's not Master Volume in Donkey Kong Country 2
         uint8_t newVol = readByte(curOffset++);
         desc << "Volume: " << newVol;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Master Volume?", desc.str(), CLR_VOLUME, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Master Volume?", desc.str(), Type::Volume, ICON_CONTROL);
         break;
       }
 
@@ -728,7 +728,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Tuning",
                         desc.str().c_str(),
-                        CLR_PITCHBEND,
+                        Type::PitchBend,
                         ICON_CONTROL);
         break;
       }
@@ -741,7 +741,7 @@ bool RareSnesTrack::readEvent(void) {
 
         // add event without MIDI event
         desc << "Transpose: " << newTransp;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Transpose", desc.str(), CLR_TRANSPOSE, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Transpose", desc.str(), Type::Transpose, ICON_CONTROL);
 
         cKeyCorrection = SEQ_KEYOFS;
         break;
@@ -758,7 +758,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Transpose (Relative)",
                         desc.str(),
-                        CLR_TRANSPOSE,
+                        Type::Transpose,
                         ICON_CONTROL);
 
         cKeyCorrection += deltaTransp;
@@ -777,7 +777,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Echo Param",
                         desc.str().c_str(),
-                        CLR_REVERB,
+                        Type::Reverb,
                         ICON_CONTROL);
         break;
       }
@@ -806,7 +806,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Echo FIR",
                         desc.str().c_str(),
-                        CLR_REVERB,
+                        Type::Reverb,
                         ICON_CONTROL);
         break;
       }
@@ -818,7 +818,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Noise Frequency",
                         desc.str().c_str(),
-                        CLR_CHANGESTATE,
+                        Type::ChangeState,
                         ICON_CONTROL);
         break;
       }
@@ -828,7 +828,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Noise On",
                         desc.str().c_str(),
-                        CLR_CHANGESTATE,
+                        Type::ChangeState,
                         ICON_CONTROL);
         break;
 
@@ -837,7 +837,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Noise Off",
                         desc.str().c_str(),
-                        CLR_CHANGESTATE,
+                        Type::ChangeState,
                         ICON_CONTROL);
         break;
 
@@ -848,7 +848,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Set Alt Note 1",
                         desc.str().c_str(),
-                        CLR_CHANGESTATE,
+                        Type::ChangeState,
                         ICON_NOTE);
         break;
 
@@ -859,7 +859,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Set Alt Note 2",
                         desc.str().c_str(),
-                        CLR_CHANGESTATE,
+                        Type::ChangeState,
                         ICON_NOTE);
         break;
 
@@ -869,7 +869,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Pitch Slide Down (Short)",
                         desc.str().c_str(),
-                        CLR_PITCHBEND,
+                        Type::PitchBend,
                         ICON_CONTROL);
         break;
       }
@@ -880,7 +880,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Pitch Slide Up (Short)",
                         desc.str().c_str(),
-                        CLR_PITCHBEND,
+                        Type::PitchBend,
                         ICON_CONTROL);
         break;
       }
@@ -891,7 +891,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Long Duration On",
                         desc.str().c_str(),
-                        CLR_DURNOTE,
+                        Type::DurationNote,
                         ICON_NOTE);
         break;
 
@@ -901,7 +901,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Long Duration Off",
                         desc.str().c_str(),
-                        CLR_DURNOTE,
+                        Type::DurationNote,
                         ICON_NOTE);
         break;
 
@@ -928,7 +928,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Set Vol/ADSR Preset 1",
                         desc.str(),
-                        CLR_VOLUME,
+                        Type::Volume,
                         ICON_CONTROL);
         break;
       }
@@ -956,7 +956,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Set Vol/ADSR Preset 2",
                         desc.str(),
-                        CLR_VOLUME,
+                        Type::Volume,
                         ICON_CONTROL);
         break;
       }
@@ -984,7 +984,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Set Vol/ADSR Preset 3",
                         desc.str(),
-                        CLR_VOLUME,
+                        Type::Volume,
                         ICON_CONTROL);
         break;
       }
@@ -1012,7 +1012,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Set Vol/ADSR Preset 4",
                         desc.str(),
-                        CLR_VOLUME,
+                        Type::Volume,
                         ICON_CONTROL);
         break;
       }
@@ -1040,7 +1040,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Set Vol/ADSR Preset 5",
                         desc.str(),
-                        CLR_VOLUME,
+                        Type::Volume,
                         ICON_CONTROL);
         break;
       }
@@ -1093,7 +1093,7 @@ bool RareSnesTrack::readEvent(void) {
 
       case EVENT_RESETADSR:
         spcADSR = 0x8FE0;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Reset ADSR", "ADSR: 8FE0", CLR_ADSR, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Reset ADSR", "ADSR: 8FE0", Type::Adsr, ICON_CONTROL);
         break;
 
       case EVENT_RESETADSRSOFT:
@@ -1102,7 +1102,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Reset ADSR (Soft)",
                         "ADSR: 8EE0",
-                        CLR_ADSR,
+                        Type::Adsr,
                         ICON_CONTROL);
         break;
 
@@ -1174,7 +1174,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Echo Delay",
                         desc.str().c_str(),
-                        CLR_REVERB,
+                        Type::Reverb,
                         ICON_CONTROL);
         break;
       }
@@ -1198,7 +1198,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Set Volume Preset",
                         desc.str(),
-                        CLR_VOLUME,
+                        Type::Volume,
                         ICON_CONTROL);
         break;
       }
@@ -1220,7 +1220,7 @@ bool RareSnesTrack::readEvent(void) {
                         curOffset - beginOffset,
                         "Pitch Slide/Vibrato/Tremolo Off",
                         desc.str(),
-                        CLR_CHANGESTATE,
+                        Type::ChangeState,
                         ICON_CONTROL);
         break;
 
@@ -1257,7 +1257,7 @@ void RareSnesTrack::addVolLR(uint32_t offset,
 
   std::ostringstream desc;
   desc << "Left Volume: " << spcVolL << "  Right Volume: " << spcVolR;
-  addGenericEvent(offset, length, sEventName, desc.str(), CLR_VOLUME, ICON_CONTROL);
+  addGenericEvent(offset, length, sEventName, desc.str(), Type::Volume, ICON_CONTROL);
 
   // add MIDI events only if updated
   if (newMidiVol != vol) {

--- a/src/main/formats/SegSat/SegSatSeq.cpp
+++ b/src/main/formats/SegSat/SegSatSeq.cpp
@@ -139,7 +139,7 @@ bool SegSatSeq::readEvent() {
           curOffset += 2;
           remainingEventsInLoop = readByte(curOffset++);
           loopEndPos = curOffset;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", CLR_LOOP);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop", "", Type::Loop);
           curOffset = loopOffset;
           bInLoop = true;
           break;
@@ -149,7 +149,7 @@ bool SegSatSeq::readEvent() {
           if (foreverLoopStart == -1) {
             foreverLoopStart = curOffset;
             addGenericEvent(beginOffset, curOffset - beginOffset,
-              "Forever Loop Start Point", "", CLR_LOOP, ICON_STARTREP);
+              "Forever Loop Start Point", "", Type::Loop, ICON_STARTREP);
           } else {
             if (!addLoopForever(beginOffset, curOffset - beginOffset))
               return false;
@@ -161,23 +161,23 @@ bool SegSatSeq::readEvent() {
           addEndOfTrack(beginOffset, curOffset - beginOffset);
           return false;
         case 0x87:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Add 256 Duration Ticks", "", CLR_TIE);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Add 256 Duration Ticks", "", Type::Tie);
           durationAccumulator += 256;
           break;
         case 0x88:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Add 512 Duration Ticks", "", CLR_TIE);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Add 512 Duration Ticks", "", Type::Tie);
           durationAccumulator += 512;
           break;
         case 0x89:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Add 2048 Duration Ticks", "", CLR_TIE);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Add 2048 Duration Ticks", "", Type::Tie);
           durationAccumulator += 2048;
           break;
         case 0x8A:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Add 4096 Duration Ticks", "", CLR_TIE);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Add 4096 Duration Ticks", "", Type::Tie);
           durationAccumulator += 4096;
           break;
         case 0x8B:
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Add 8192 Duration Ticks", "", CLR_TIE);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Add 8192 Duration Ticks", "", Type::Tie);
           durationAccumulator += 8192;
           break;
         case 0x8C:

--- a/src/main/formats/SonyPS2/SonyPS2Seq.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Seq.cpp
@@ -121,7 +121,7 @@ bool SonyPS2Seq::readEvent(void) {
 
         case 6 :
           //AddGenericEvent(beginOffset, curOffset-beginOffset, "NRPN Data Entry", NULL, BG_CLR_PINK);
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop start number", "", CLR_LOOP);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop start number", "", Type::Loop);
           break;
 
         //volume
@@ -141,18 +141,18 @@ bool SonyPS2Seq::readEvent(void) {
 
         //0 == endless loop
         case 38 :
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop count", "", CLR_LOOP);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Loop count", "", Type::Loop);
           break;
 
         //(0x63) nrpn msb
         case 99 :
           switch (value) {
             case 0 :
-              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", CLR_LOOP);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", "", Type::Loop);
               break;
 
             case 1 :
-              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", CLR_LOOP);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", Type::Loop);
               break;
           }
           break;
@@ -197,7 +197,7 @@ bool SonyPS2Seq::readEvent(void) {
     }
 
     default:
-      addGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", CLR_UNRECOGNIZED);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", Type::Unrecognized);
       return false;
   }
   return true;

--- a/src/main/formats/SquarePS2/SquarePS2Seq.cpp
+++ b/src/main/formats/SquarePS2/SquarePS2Seq.cpp
@@ -90,7 +90,7 @@ bool BGMTrack::readEvent(void) {
       //rest_time += current_delta_time;
       //if (nScanMode == MODE_SCAN)
       //	AddBGMEvent("Loop Begin", ICON_STARTREP, aBGMTracks[cur_track]->pTreeItem, offsetAtDelta, j-offsetAtDelta, BG_CLR_CYAN);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Begin", "", CLR_LOOP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Begin", "", Type::Loop);
       break;
 
     // Loop end
@@ -99,7 +99,7 @@ bool BGMTrack::readEvent(void) {
 //		loop_counter++;
       //if (loop_counter < num_loops)
       //	j = loop_start;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", CLR_LOOP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", Type::Loop);
       break;
 
     //end of track?
@@ -250,7 +250,7 @@ bool BGMTrack::readEvent(void) {
       break;
 
     default :
-      addGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", CLR_UNRECOGNIZED);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "UNKNOWN", "", Type::Unrecognized);
       break;
 
   }

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
@@ -312,7 +312,7 @@ bool SuzukiSnesTrack::readEvent() {
       }
       else if (noteIndex == 13) {
         makePrevDurNoteEnd(getTime() + dur);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), CLR_TIE, ICON_NOTE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), Type::Tie, ICON_NOTE);
         addTime(dur);
       }
       else {
@@ -339,7 +339,7 @@ bool SuzukiSnesTrack::readEvent() {
     }
 
     case EVENT_NOP: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), CLR_MISC, ICON_BINARY);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), Type::Misc, ICON_BINARY);
       break;
     }
 
@@ -350,7 +350,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Noise Frequency",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -360,7 +360,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Noise On",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -370,7 +370,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Noise Off",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -380,7 +380,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Pitch Modulation On",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -390,7 +390,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Pitch Modulation Off",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -474,7 +474,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Timer 1 Frequency",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_TEMPO);
       break;
     }
@@ -486,7 +486,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Timer 1 Frequency (Relative)",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_TEMPO);
       break;
     }
@@ -496,7 +496,7 @@ bool SuzukiSnesTrack::readEvent() {
       int realLoopCount = (count == 0) ? 256 : count;
 
       desc << "Loop Count: " << realLoopCount;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), CLR_LOOP, ICON_STARTREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), Type::Loop, ICON_STARTREP);
 
       if (loopLevel >= SUZUKISNES_LOOP_LEVEL_MAX) {
         // stack overflow
@@ -511,7 +511,7 @@ bool SuzukiSnesTrack::readEvent() {
     }
 
     case EVENT_LOOP_END: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), Type::Loop, ICON_ENDREP);
 
       if (loopLevel == 0) {
         // stack overflow
@@ -534,7 +534,7 @@ bool SuzukiSnesTrack::readEvent() {
     }
 
     case EVENT_LOOP_BREAK: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), CLR_LOOP, ICON_ENDREP);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), Type::Loop, ICON_ENDREP);
 
       if (loopLevel == 0) {
         // stack overflow
@@ -556,7 +556,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Infinite Loop Point",
                       desc.str().c_str(),
-                      CLR_LOOP,
+                      Type::Loop,
                       ICON_STARTREP);
       break;
     }
@@ -566,7 +566,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Default ADSR",
                       desc.str().c_str(),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -578,7 +578,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "ADSR Attack Rate",
                       desc.str().c_str(),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -590,7 +590,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "ADSR Decay Rate",
                       desc.str().c_str(),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -602,7 +602,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "ADSR Sustain Level",
                       desc.str().c_str(),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -614,7 +614,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "ADSR Sustain Rate",
                       desc.str().c_str(),
-                      CLR_ADSR,
+                      Type::Adsr,
                       ICON_CONTROL);
       break;
     }
@@ -623,7 +623,7 @@ bool SuzukiSnesTrack::readEvent() {
       // TODO: save duration rate and apply to note length
       uint8_t newDurRate = readByte(curOffset++);
       desc << "Duration Rate: " << (int) newDurRate;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str().c_str(), CLR_DURNOTE);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.str().c_str(), Type::DurationNote);
       break;
     }
 
@@ -640,7 +640,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Noise Frequency (Relative)",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -667,7 +667,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Volume Fade",
                       desc.str().c_str(),
-                      CLR_VOLUME,
+                      Type::Volume,
                       ICON_CONTROL);
       break;
     }
@@ -680,7 +680,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Portamento",
                       desc.str().c_str(),
-                      CLR_PORTAMENTO,
+                      Type::Portamento,
                       ICON_CONTROL);
       break;
     }
@@ -690,7 +690,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Portamento On/Off",
                       desc.str().c_str(),
-                      CLR_PORTAMENTO,
+                      Type::Portamento,
                       ICON_CONTROL);
       break;
     }
@@ -712,7 +712,7 @@ bool SuzukiSnesTrack::readEvent() {
       desc << "Fade Length: " << (int) fadeLength << "  Pan: " << (int) (pan >> 1);
 
       // TODO: correct midi pan value, apply volume scale, do pan slide
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc.str().c_str(), CLR_PAN, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc.str().c_str(), Type::Pan, ICON_CONTROL);
       break;
     }
 
@@ -724,7 +724,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Pan LFO",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -734,7 +734,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Pan LFO Restart",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -744,7 +744,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Pan LFO Off",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -770,7 +770,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Percussion On",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -780,7 +780,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Percussion Off",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -793,7 +793,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Vibrato",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -807,7 +807,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Vibrato",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -817,7 +817,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Vibrato Off",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -830,7 +830,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Tremolo",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -844,7 +844,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Tremolo",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -854,7 +854,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Tremolo Off",
                       desc.str().c_str(),
-                      CLR_MODULATION,
+                      Type::Modulation,
                       ICON_CONTROL);
       break;
     }
@@ -864,7 +864,7 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Slur On",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
@@ -874,18 +874,18 @@ bool SuzukiSnesTrack::readEvent() {
                       curOffset - beginOffset,
                       "Slur Off",
                       desc.str().c_str(),
-                      CLR_CHANGESTATE,
+                      Type::ChangeState,
                       ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_ON: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.str().c_str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), CLR_REVERB, ICON_CONTROL);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), Type::Reverb, ICON_CONTROL);
       break;
     }
 

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
@@ -194,7 +194,7 @@ bool TamSoftPS1Track::readEvent() {
   if (statusByte >= 0x00 && statusByte <= 0x7f) {
     // if status_byte == 0, it actually sets 0xffffffff to delta-time o_O
     desc << "Delta Time: " << statusByte;
-    addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", desc.str(), CLR_REST);
+    addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", desc.str(), Type::Rest);
     addTime(statusByte);
   }
   else if (statusByte >= 0x80 && statusByte <= 0xdf) {
@@ -230,7 +230,7 @@ bool TamSoftPS1Track::readEvent() {
         uint8_t midiPan = convertVolumeBalanceToStdMidiPan(volumeBalanceLeft / 256.0, volumeBalanceRight / 256.0, &volumeScale);
 
         desc << "Left Volume: " << volumeBalanceLeft << "  Right Volume: " << volumeBalanceRight;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Volume Balance", desc.str(), CLR_PAN, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Volume Balance", desc.str(), Type::Pan, ICON_CONTROL);
         addPanNoItem(midiPan);
         break;
       }
@@ -283,7 +283,7 @@ bool TamSoftPS1Track::readEvent() {
       case 0xE6: {
         uint8_t mode = readByte(curOffset++);
         desc << "Reverb Mode: " << mode;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Mode", desc.str(), CLR_REVERB, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Mode", desc.str(), Type::Reverb, ICON_CONTROL);
         break;
       }
 
@@ -291,7 +291,7 @@ bool TamSoftPS1Track::readEvent() {
         uint8_t depth = readByte(curOffset++);
         desc << "Reverb Depth: " << depth;
         parentSeq->reverbDepth = depth << 8;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", desc.str(), CLR_REVERB, ICON_CONTROL);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", desc.str(), Type::Reverb, ICON_CONTROL);
         break;
       }
 
@@ -316,7 +316,7 @@ bool TamSoftPS1Track::readEvent() {
 
       case 0xF0: {
         finalizeAllNotes();
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Note Off", desc.str(), CLR_NOTEOFF, ICON_NOTE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Note Off", desc.str(), Type::NoteOff, ICON_NOTE);
         break;
       }
 
@@ -337,7 +337,7 @@ bool TamSoftPS1Track::readEvent() {
 
         curOffset = dest;
         if (!isOffsetUsed(dest)) {
-          addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), CLR_LOOPFOREVER);
+          addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), Type::LoopForever);
         }
         else {
           bContinue = addLoopForever(beginOffset, length, "Jump");

--- a/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
@@ -119,7 +119,7 @@ bool TriAcePS1Track::readEvent(void) {
   else
     switch (status_byte) {
       case 0x80 :
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Score Pattern End", "", CLR_TRACKEND);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Score Pattern End", "", Type::TrackEnd);
         return false;
 
       //unknown
@@ -207,13 +207,13 @@ bool TriAcePS1Track::readEvent(void) {
 
       //Dal Segno: start point
       case 0x8D :
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Dal Segno: start point", "", CLR_UNKNOWN);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Dal Segno: start point", "", Type::Unknown);
         break;
 
       //Dal Segno: end point
       case 0x8E :
         curOffset++;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Dal Segno: end point", "", CLR_UNKNOWN);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Dal Segno: end point", "", Type::Unknown);
         break;
 
       //rest
@@ -298,7 +298,7 @@ bool TriAcePS1Track::readEvent(void) {
       case 0x9E :
         impliedNoteDur = readByte(curOffset++);
         impliedVelocity = readByte(curOffset++);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Imply Note Params", "", CLR_CHANGESTATE);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Imply Note Params", "", Type::ChangeState);
         break;
 
       default :

--- a/src/ui/qt/util/Helpers.cpp
+++ b/src/ui/qt/util/Helpers.cpp
@@ -155,77 +155,77 @@ const QIcon &iconForItemType(VGMItem::Icon type) {
   return i_gen;
 }
 
-QColor colorForEventColor(VGMItem::EventColor eventColor) {
-  switch (eventColor) {
-    case VGMItem::CLR_UNKNOWN:
+QColor colorForItemType(VGMItem::Type type) {
+  switch (type) {
+    case VGMItem::Type::Unknown:
       return EventColors::CLR_BG_DARK;
-    case VGMItem::CLR_UNRECOGNIZED:
+    case VGMItem::Type::Unrecognized:
       return EventColors::CLR_RED;
-    case VGMItem::CLR_HEADER:
+    case VGMItem::Type::Header:
       return EventColors::CLR_GRAY;
-    case VGMItem::CLR_MISC:
+    case VGMItem::Type::Misc:
       return EventColors::CLR_DARK_GRAY;
-    case VGMItem::CLR_MARKER:
+    case VGMItem::Type::Marker:
       return EventColors::CLR_DARK_GRAY;
-    case VGMItem::CLR_TIMESIG:
+    case VGMItem::Type::TimeSignature:
       return EventColors::CLR_ORANGE;
-    case VGMItem::CLR_TEMPO:
+    case VGMItem::Type::Tempo:
       return EventColors::CLR_GREEN;
-    case VGMItem::CLR_PROGCHANGE:
+    case VGMItem::Type::ProgramChange:
       return EventColors::CLR_PERIWINKLE;
-    case VGMItem::CLR_BANKSELECT:
+    case VGMItem::Type::BankSelect:
       return EventColors::CLR_PERIWINKLE;
-    case VGMItem::CLR_TRANSPOSE:
+    case VGMItem::Type::Transpose:
       return EventColors::CLR_DARK_GREEN;
-    case VGMItem::CLR_PRIORITY:
+    case VGMItem::Type::Priority:
       return EventColors::CLR_DARK_GREEN;
-    case VGMItem::CLR_VOLUME:
+    case VGMItem::Type::Volume:
       return EventColors::CLR_MAGENTA;
-    case VGMItem::CLR_EXPRESSION:
+    case VGMItem::Type::Expression:
       return EventColors::CLR_MAGENTA;
-    case VGMItem::CLR_PAN:
+    case VGMItem::Type::Pan:
       return EventColors::CLR_ORANGE;
-    case VGMItem::CLR_NOTEON:
-    case VGMItem::CLR_DURNOTE:
+    case VGMItem::Type::NoteOn:
+    case VGMItem::Type::DurationNote:
       return EventColors::CLR_BLUE;
-    case VGMItem::CLR_NOTEOFF:
+    case VGMItem::Type::NoteOff:
       return EventColors::CLR_LIGHT_BLUE;
-    case VGMItem::CLR_TIE:
+    case VGMItem::Type::Tie:
       return EventColors::CLR_LIGHT_BLUE;
-    case VGMItem::CLR_REST:
+    case VGMItem::Type::Rest:
       return EventColors::CLR_LIGHT_BLUE;
-    case VGMItem::CLR_PITCHBEND:
+    case VGMItem::Type::PitchBend:
       return EventColors::CLR_GREEN;
-    case VGMItem::CLR_PITCHBENDRANGE:
+    case VGMItem::Type::PitchBendRange:
       return EventColors::CLR_DARK_GREEN;
-    case VGMItem::CLR_MODULATION:
+    case VGMItem::Type::Modulation:
       return EventColors::CLR_LIGHT_GREEN;
-    case VGMItem::CLR_PORTAMENTO:
+    case VGMItem::Type::Portamento:
       return EventColors::CLR_LIGHT_GREEN;
-    case VGMItem::CLR_PORTAMENTOTIME:
+    case VGMItem::Type::PortamentoTime:
       return EventColors::CLR_LIGHT_GREEN;
-    case VGMItem::CLR_CHANGESTATE:
+    case VGMItem::Type::ChangeState:
       return EventColors::CLR_GRAY;
-    case VGMItem::CLR_ADSR:
+    case VGMItem::Type::Adsr:
       return EventColors::CLR_GRAY;
-    case VGMItem::CLR_LFO:
+    case VGMItem::Type::Lfo:
       return EventColors::CLR_GRAY;
-    case VGMItem::CLR_REVERB:
+    case VGMItem::Type::Reverb:
       return EventColors::CLR_GRAY;
-    case VGMItem::CLR_SUSTAIN:
+    case VGMItem::Type::Sustain:
       return EventColors::CLR_YELLOW;
-    case VGMItem::CLR_LOOP:
+    case VGMItem::Type::Loop:
       return EventColors::CLR_LIGHT_RED;
-    case VGMItem::CLR_LOOPFOREVER:
+    case VGMItem::Type::LoopForever:
       return EventColors::CLR_LIGHT_RED;
-    case VGMItem::CLR_TRACKEND:
+    case VGMItem::Type::TrackEnd:
       return EventColors::CLR_RED;
   }
   return EventColors::CLR_RED;
 }
 
-QColor textColorForEventColor(VGMItem::EventColor eventColor) {
-    if (eventColor == VGMItem::CLR_UNKNOWN) {
+QColor textColorForItemType(VGMItem::Type type) {
+    if (type == VGMItem::Type::Unknown) {
       return EventColors::CLR_GRAY;
     }
     return EventColors::CLR_BG_DARK;

--- a/src/ui/qt/util/Helpers.h
+++ b/src/ui/qt/util/Helpers.h
@@ -13,8 +13,8 @@
 const QIcon &iconForFile(VGMFileVariant file);
 const QIcon &iconForItemType(VGMItem::Icon type);
 
-QColor colorForEventColor(VGMItem::EventColor eventColor);
-QColor textColorForEventColor(VGMItem::EventColor eventColor);
+QColor colorForItemType(VGMItem::Type type);
+QColor textColorForItemType(VGMItem::Type type);
 
 QString getFullDescriptionForTooltip(VGMItem* item);
 

--- a/src/ui/qt/workarea/HexView.cpp
+++ b/src/ui/qt/workarea/HexView.cpp
@@ -462,8 +462,8 @@ bool HexView::handleSelectedItemPaintEvent(QObject* obj, QPaintEvent* event) {
     auto itemData = std::vector<uint8_t>(selectedItem->unLength);
     vgmfile->readBytes(selectedItem->dwOffset, selectedItem->unLength, itemData.data());
 
-    QColor bgColor = colorForEventColor(selectedItem->color);
-    QColor textColor = textColorForEventColor(selectedItem->color);
+    QColor bgColor = colorForItemType(selectedItem->type);
+    QColor textColor = textColorForItemType(selectedItem->type);
 
     pixmapPainter.setFont(this->font());
     pixmapPainter.translate(SELECTION_PADDING, SELECTION_PADDING);
@@ -653,8 +653,8 @@ void HexView::printData(QPainter& painter, int startAddress, int endAddress) con
         translateAndPrintAscii(painter, data + dataOffset, col, emptyAddressBytes, windowColor, defaultTextColor);
         emptyAddressBytes = 0;
       }
-      QColor bgColor = colorForEventColor(item->color);
-      QColor textColor = textColorForEventColor(item->color);
+      QColor bgColor = colorForItemType(item->type);
+      QColor textColor = textColorForItemType(item->type);
       int col = startCol + offset;
 
       // In case the event spans multiple lines, account for how far into the event we are at this line


### PR DESCRIPTION
This renames EventColor to Type and makes it changes it to an `enum class`.

Additionally, this removes the unused VGMItem::ItemType and the getter methods which used it.

This shouldn't have changed any logic.

After the merge, I will add the commit to .git-blame-ignore-revs.

## Motivation and Context
This is the first part of a larger refactor. The goal is for the VGMItem::Type enum to be the sole determiner of a VGMItem's icon and color. In the next PR, I will remove the VGMItem::Icon enum and expand VGMItem::Type.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
