### PR TITLE
rewrite of PSXSPU::decompVAGBlk(). fixes potential clipping

### DIFF
--- a/src/main/formats/common/PSXSPU.h
+++ b/src/main/formats/common/PSXSPU.h
@@ -355,7 +355,7 @@ class PSXSamp : public VGMSamp {
   static uint32_t getSampleLength(const RawFile *file, uint32_t offset, uint32_t endOffset, bool &loop);
 
  private:
-  static void decompVAGBlk(s16 *pSmp, const VAGBlk* pVBlk, f32 *prev1, f32 *prev2);
+  static void decompVAGBlk(s16 *pSmp, const VAGBlk* pVBlk, s32 prev[2]);
 
  public:
   bool bSetLoopOnConversion{false};


### PR DESCRIPTION
This rewrites the PSX ADPCM sample decompression algorithm with a lot of help from ChatGPT o3. I found that the previous version was potentially clipping samples (ex: FFIX - Crossing Those Hills sample 18, heard obviously in sample and faintly at end of song). This clipping is inconsistent and depends on the compiler used. 

It looks like the `decompVAGBlk()` function was doing some bit manipulation / casting that caused implementation-defined behavior. Also, probably most critically, it wasn't clamping the value to the signed 16 bit range.

This new implementation is int instead of float based and should be more reliable and faster. I dug into the logic and compared against another [int based implementation](https://github.com/vgmstream/vgmstream/blob/1ef807b594be26c57c4d004bec23f5b296d49992/src/coding/psx_decoder.c#L162). I also asked ChatGPT to compare it against several others implementations. I am confident the logic is sound.

## How Has This Been Tested?
Clipping is gone in the problem sample. Tested other conversions with no issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
