### PR TITLE
AkaoSeq: use fmt::format in place of stringstream

### DIFF
--- a/src/main/formats/Akao/AkaoSeq.h
+++ b/src/main/formats/Akao/AkaoSeq.h
@@ -234,6 +234,6 @@ class AkaoTrack final
   std::vector<uint32_t> conditional_jump_destinations;
 
  private:
-  void logUnknownEvent(const std::string& opcode_str, u32 beginOffset) const;
+  void logUnknownEvent(u32 beginOffset) const;
   [[nodiscard]] bool anyUnvisitedJumpDestinations();
 };

--- a/src/ui/qt/util/Helpers.cpp
+++ b/src/ui/qt/util/Helpers.cpp
@@ -395,7 +395,7 @@ QColor colorForItemType(VGMItem::Type type) {
     case VGMItem::Type::TrackEnd:          return EventColors::CLR_RED;
     case VGMItem::Type::Transpose:         return EventColors::CLR_DARK_GREEN;
     case VGMItem::Type::Tremelo:           return EventColors::CLR_MAGENTA;
-    case VGMItem::Type::Unknown:           return EventColors::CLR_MAGENTA;
+    case VGMItem::Type::Unknown:           return EventColors::CLR_BG_DARK;
     case VGMItem::Type::Unrecognized:      return EventColors::CLR_RED;
     case VGMItem::Type::UseDrumKit:        return EventColors::CLR_PERIWINKLE;
     case VGMItem::Type::Vibrato:           return EventColors::CLR_GREEN;


### PR DESCRIPTION
- AkaoSeq: use fmt::format in place of stringstream
- AkaoSeq: simplify logUnknownEvent()
- fix VGMItem::Type::Unknown event color

## How Has This Been Tested?
Tested that event strings are working as expected. Also verified logUnknownEvent output.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
