### PR TITLE
Update attest-build-provenance to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
             "bin/VGMTrans-${{ github.sha }}.dmg" \
             "bin"
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         if: ${{ github.event_name != 'pull_request' }}
         with:
           subject-name: VGMTrans-${{ github.sha }}-${{ env.GITHUB_REF_NAME }}-${{ matrix.target }}-${{ runner.os }}
@@ -145,7 +145,7 @@ jobs:
           cp ${{ github.workspace }}/LICENSE appdir/usr/share/licenses/VGMTrans/
           mv VGMTrans*.AppImage VGMTrans.AppImage
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         if: ${{ github.event_name != 'pull_request' }}
         with:
           subject-name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-x86_64-${{ runner.os }}
@@ -191,7 +191,7 @@ jobs:
          run: 7z a "VGMTrans-${{ github.sha }}.zip" -r ".\build\win-${{ matrix.target }}\bin\*"
 
        - name: Generate artifact attestation
-         uses: actions/attest-build-provenance@v1
+         uses: actions/attest-build-provenance@v2
          if: ${{ github.event_name != 'pull_request' }}
          with:
            subject-name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-${{ matrix.target }}-${{ runner.os }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update attest-build-provenance action to v2 to make attesting multiple artifacts more efficient and streamlined by creating a single attestation referencing all specified subjects instead of generating separate attestations for each artifact.

## Motivation and Context
My change will make attesting multiple build platforms more efficient by referencing all subjects in a single attestation.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually triggered workflow after pushing my changes and monitored workflow run on actions.
<!--- Include details of your testing environment, and the tests you ran to -->
Windows 11, I used GitHub actions to test changes since I only changed the yaml file.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
