### PR TITLE
fix incorrect icon paths

### DIFF
--- a/src/ui/qt/IconBar.cpp
+++ b/src/ui/qt/IconBar.cpp
@@ -23,8 +23,8 @@ IconBar::IconBar(QWidget *parent) : QWidget(parent) {
 }
 
 void IconBar::setupControls() {
-  s_playicon = QIcon(":/images/player_play.svg");
-  s_pauseicon = QIcon(":/images/player_pause.svg");
+  s_playicon = QIcon(":/icons/player_play.svg");
+  s_pauseicon = QIcon(":/icons/player_pause.svg");
 
   m_create = new QPushButton("Create collection manually");
   m_create->setAutoDefault(false);
@@ -46,7 +46,7 @@ void IconBar::setupControls() {
   layout()->addWidget(m_play);
 
   m_stop = new QPushButton();
-  m_stop->setIcon(QIcon(":/images/player_stop.svg"));
+  m_stop->setIcon(QIcon(":/icons/player_stop.svg"));
   m_stop->setDisabled(true);
   m_stop->setToolTip("Stop playback (Esc)");
   connect(m_stop, &QPushButton::pressed, this, &IconBar::stopPressed);

--- a/src/ui/qt/workarea/RawFileListView.cpp
+++ b/src/ui/qt/workarea/RawFileListView.cpp
@@ -17,7 +17,7 @@
 #include "VGMExport.h"
 
 static const QIcon& fileIcon() {
-  static QIcon fileIcon(":/images/file.svg");
+  static QIcon fileIcon(":/icons/file.svg");
   return fileIcon;
 }
 

--- a/src/ui/qt/workarea/VGMCollView.cpp
+++ b/src/ui/qt/workarea/VGMCollView.cpp
@@ -42,7 +42,7 @@ int VGMCollViewModel::rowCount(const QModelIndex &parent) const {
 QVariant VGMCollViewModel::data(const QModelIndex &index, int role) const {
   auto file = fileFromIndex(index);
   if (!file) {
-    return QIcon{":/images/file.svg"};
+    return QIcon{":/icons/file.svg"};
   }
 
   if (role == Qt::DisplayRole) {


### PR DESCRIPTION
Some path strings referencing the old `/images/` directory still exist, resulting in missing icons (like the play and stop buttons). This fixes that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
