### PR TITLE
improve handling of PSX ADPCM encoding edge cases

### DIFF
--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -138,15 +138,16 @@ bool PSXSampColl::parseSampleInfo() {
 
       // Handle the case of an end frame using the format 00 07 77 77 77 77 77 etc
       while (i + 16 <= nEndOffset) {
-        u8 filterShiftByte = readByte(i);
         u8 flagByte = readByte(i + 1);
-        if (filterShiftByte == 0 && flagByte == 7) {
+        if (flagByte == 7) {
           extraGunkLength += 16;
           i += 16;
         } else {
           break;
         }
       }
+      // If endLoopOffset wasn't set, default it to the end of the sample
+      endLoopOffset = endLoopOffset >= beginOffset ? endLoopOffset : i;
       PSXSamp *samp = new PSXSamp(this,
                                   beginOffset,
                                   i - beginOffset,


### PR DESCRIPTION
This makes the following changes in PSXSPU:
- improve check for extraneous sample blocks by ignoring filter shift byte and only checking for flagByte == 7
- fix incorrect data length used for samples where the end flag is never set

For certain games (Crash 2/3):
- The first issue causes sample collections to incorrectly split, as the end offset of samples is incorrectly determined.
- The latter issue causes a crash during SF2 conversion due to an unsigned integer underflow of the sample data length value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
