### PR TITLE
Refactor some format files to use fmt

### DIFF
--- a/src/main/formats/GraphResSnes/GraphResSnesSeq.cpp
+++ b/src/main/formats/GraphResSnes/GraphResSnesSeq.cpp
@@ -5,6 +5,7 @@
  */
 #include "GraphResSnesSeq.h"
 #include "ScaleConversion.h"
+#include "spdlog/fmt/fmt.h"
 
 using namespace std;
 
@@ -49,8 +50,7 @@ bool GraphResSnesSeq::parseHeader() {
 
   uint32_t curOffset = dwOffset;
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
-    std::stringstream trackName;
-    trackName << "Track Pointer " << (trackIndex + 1);
+    auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
 
     bool trackUsed = (readByte(curOffset) != 0);
     if (trackUsed) {
@@ -59,7 +59,7 @@ bool GraphResSnesSeq::parseHeader() {
     else {
       header->addChild(curOffset, 1, "Disable Track");
     }
-    header->addChild(curOffset + 1, 2, trackName.str());
+    header->addChild(curOffset + 1, 2, trackName);
     curOffset += 3;
   }
 

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -1,6 +1,7 @@
 #include "NinSnesSeq.h"
 #include "SeqEvent.h"
 #include "ScaleConversion.h"
+#include "spdlog/fmt/fmt.h"
 
 DECLARE_FORMAT(NinSnes);
 
@@ -655,9 +656,8 @@ bool NinSnesSection::parseTrackPointers() {
         }
       }
 
-      std::stringstream trackName;
-      trackName << "Track " << (trackIndex + 1);
-      track = new NinSnesTrack(this, startAddress, 0, trackName.str());
+      auto trackName = fmt::format("Track {}", trackIndex + 1);
+      track = new NinSnesTrack(this, startAddress, 0, trackName);
 
       numActiveTracks++;
     }

--- a/src/main/formats/SquarePS2/SquarePS2Seq.cpp
+++ b/src/main/formats/SquarePS2/SquarePS2Seq.cpp
@@ -1,4 +1,5 @@
 #include "SquarePS2Seq.h"
+#include "spdlog/fmt/fmt.h"
 
 DECLARE_FORMAT(SquarePS2);
 
@@ -30,11 +31,10 @@ bool BGMSeq::parseHeader() {
   setPPQN(readShort(dwOffset + 0xE));
   unLength = readWord(dwOffset + 0x10);
 
-  ostringstream theName;
-  theName << "BGM " << seqID;
+  std::string name = fmt::format("BGM {}", seqID);
   if (seqID != assocWDID)
-    theName << "using WD " << assocWDID;
-  setName(theName.str());
+    name += fmt::format("using WD {}", assocWDID);
+  setName(name);
   return true;
 }
 


### PR DESCRIPTION
Testing ChatGPT Codex to automate the removal of stringstream usage.

This PR should be more comprehensive, so closing.