### PR TITLE
Remove stringstream usage from formats

### DIFF
--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -223,10 +223,10 @@ static std::string logEvent(uint8_t statusByte, spdlog::level::level_enum level 
 
 template<typename... Args>
 static std::string describeUnknownEvent(uint8_t statusByte, Args... args) {
-  return logEvent(statusByte, spdlog::level::off, "Event", args...);
+  return logEvent(statusByte, spdlog::level::off, "Unknown Event", args...);
 }
 
 template<typename... Args>
 static std::string describeUnknownSubevent(uint8_t statusByte, Args... args) {
-  return logEvent(statusByte, spdlog::level::off, "Subevent", args...);
+  return logEvent(statusByte, spdlog::level::off, "Unknown Subevent", args...);
 }

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -225,3 +225,8 @@ template<typename... Args>
 static std::string describeUnknownEvent(uint8_t statusByte, Args... args) {
   return logEvent(statusByte, spdlog::level::off, "Event", args...);
 }
+
+template<typename... Args>
+static std::string describeUnknownSubevent(uint8_t statusByte, Args... args) {
+  return logEvent(statusByte, spdlog::level::off, "Subevent", args...);
+}

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -89,8 +89,7 @@ bool AkaoSnesSeq::parseHeader() {
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t addrTrackStart = getShortAddress(curOffset);
     if (addrTrackStart != addrSequenceEnd) {
-      header->addChild(curOffset, 2,
-                       fmt::format("Track Pointer {}", trackIndex + 1));
+      header->addChild(curOffset, 2, fmt::format("Track Pointer {}", trackIndex + 1));
     }
     else {
       header->addChild(curOffset, 2, "NULL");

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -6,6 +6,7 @@
 #include "AkaoSnesSeq.h"
 #include "AkaoSnesInstr.h"
 #include "ScaleConversion.h"
+#include <spdlog/fmt/fmt.h>
 
 DECLARE_FORMAT(AkaoSnes);
 
@@ -88,9 +89,8 @@ bool AkaoSnesSeq::parseHeader() {
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t addrTrackStart = getShortAddress(curOffset);
     if (addrTrackStart != addrSequenceEnd) {
-      std::stringstream trackName;
-      trackName << "Track Pointer " << (trackIndex + 1);
-      header->addChild(curOffset, 2, trackName.str().c_str());
+      header->addChild(curOffset, 2,
+                       fmt::format("Track Pointer {}", trackIndex + 1));
     }
     else {
       header->addChild(curOffset, 2, "NULL");
@@ -1177,7 +1177,7 @@ bool AkaoSnesTrack::readEvent(void) {
     case EVENT_ONETIME_DURATION: {
       uint8_t dur = readByte(curOffset++);
       onetimeDuration = dur;
-      desc = fmt::format("Duration: {}", dur);
+      desc = fmt::format("Duration: {:d}", dur);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Duration (One-Time)",
         desc, Type::DurationChange);
       break;
@@ -1186,7 +1186,7 @@ bool AkaoSnesTrack::readEvent(void) {
     case EVENT_JUMP_TO_SFX_LO: {
       // TODO: EVENT_JUMP_TO_SFX_LO
       uint8_t sfxIndex = readByte(curOffset++);
-      desc = fmt::format("SFX: {}", sfxIndex);
+      desc = fmt::format("SFX: {:d}", sfxIndex);
       addUnknown(beginOffset, curOffset - beginOffset, "Jump to SFX (LOWORD)", desc);
       bContinue = false;
       break;
@@ -1195,7 +1195,7 @@ bool AkaoSnesTrack::readEvent(void) {
     case EVENT_JUMP_TO_SFX_HI: {
       // TODO: EVENT_JUMP_TO_SFX_HI
       uint8_t sfxIndex = readByte(curOffset++);
-      desc = fmt::format("SFX: {}", sfxIndex);
+      desc = fmt::format("SFX: {:d}", sfxIndex);
       addUnknown(beginOffset, curOffset - beginOffset, "Jump to SFX (HIWORD)", desc);
       bContinue = false;
       break;
@@ -1204,7 +1204,7 @@ bool AkaoSnesTrack::readEvent(void) {
     case EVENT_PLAY_SFX: {
       // TODO: EVENT_PLAY_SFX
       uint8_t arg1 = readByte(curOffset++);
-      desc = fmt::format("Arg1: {}", arg1);
+      desc = fmt::format("Arg1: {:d}", arg1);
       addUnknown(beginOffset, curOffset - beginOffset, "Play SFX", desc);
       break;
     }
@@ -1430,7 +1430,7 @@ bool AkaoSnesTrack::readEvent(void) {
       uint8_t arg1 = readByte(curOffset++) & 15;
       uint16_t dest = getShortAddress(curOffset);
       curOffset += 2;
-      desc = fmt::format("Arg1: {}  Destination: ${:04X}", arg1, dest);
+      desc = fmt::format("Arg1: {:d}  Destination: ${:04X}", arg1, dest);
       addUnknown(beginOffset, curOffset - beginOffset, "CPU-Controlled Jump", desc);
       break;
     }

--- a/src/main/formats/ChunSnes/ChunSnesSeq.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesSeq.cpp
@@ -430,9 +430,8 @@ bool ChunSnesTrack::readEvent() {
       uint8_t dr = (adsr1 & 0x70) >> 4;
       uint8_t sl = (adsr2 & 0xe0) >> 5;
       uint8_t sr = adsr2 & 0x1f;
-      desc = fmt::format(
-          "AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}  SR (Release): {:d}",
-          ar, dr, sl, sr, release_sr);
+      desc = fmt::format("AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}  SR (Release): {:d}",
+                         ar, dr, sl, sr, release_sr);
       addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR & Release Rate", desc, Type::Adsr);
       break;
     }

--- a/src/main/formats/ChunSnes/ChunSnesSeq.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesSeq.cpp
@@ -5,6 +5,7 @@
  */
 #include "ChunSnesSeq.h"
 #include "ScaleConversion.h"
+#include <spdlog/fmt/fmt.h>
 
 DECLARE_FORMAT(ChunSnes);
 
@@ -75,9 +76,8 @@ bool ChunSnesSeq::parseHeader() {
       addrTrackStart = dwOffset + ofsTrackStart;
     }
 
-    std::stringstream trackName;
-    trackName << "Track Pointer " << (trackIndex + 1);
-    header->addChild(curOffset, 2, trackName.str());
+    auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
+    header->addChild(curOffset, 2, trackName);
 
     ChunSnesTrack *track = new ChunSnesTrack(this, addrTrackStart);
     track->index = static_cast<uint8_t>(aTracks.size());
@@ -430,8 +430,9 @@ bool ChunSnesTrack::readEvent() {
       uint8_t dr = (adsr1 & 0x70) >> 4;
       uint8_t sl = (adsr2 & 0xe0) >> 5;
       uint8_t sr = adsr2 & 0x1f;
-      desc = fmt::format("AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}  SR (Release): {:d}",
-                          ar, dr, sl, sr, release_sr);
+      desc = fmt::format(
+          "AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}  SR (Release): {:d}",
+          ar, dr, sl, sr, release_sr);
       addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR & Release Rate", desc, Type::Adsr);
       break;
     }
@@ -440,9 +441,7 @@ bool ChunSnesTrack::readEvent() {
       uint8_t param = readByte(curOffset++);
       bool invertLeft = (param & 1) != 0;
       bool invertRight = (param & 2) != 0;
-      desc = fmt::format("Invert Left: {}  Invert Right: {}",
-                                invertLeft ? "On" : "Off",
-                                invertRight ? "On" : "Off");
+      desc = fmt::format("Invert Left: {}  Invert Right: {}", invertLeft ? "On" : "Off", invertRight ? "On" : "Off");
       addGenericEvent(beginOffset, curOffset - beginOffset, "Surround", desc, Type::Pan);
       break;
     }
@@ -724,10 +723,7 @@ bool ChunSnesTrack::readEvent() {
     case EVENT_PITCH_SLIDE: {
       int8_t semitones = readByte(curOffset++);
       uint8_t length = readByte(curOffset++);
-      desc = fmt::format("Key: {}{} semitones  Length: {:d}",
-                          semitones > 0 ? "+" : "",
-                      semitones,
-                      length);
+      desc = fmt::format("Key: {}{} semitones  Length: {:d}", semitones > 0 ? "+" : "", semitones, length);
 
       addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc, Type::PitchBendSlide);
       break;

--- a/src/main/formats/CompileSnes/CompileSnesSeq.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesSeq.cpp
@@ -5,6 +5,7 @@
  */
 #include "CompileSnesSeq.h"
 #include "ScaleConversion.h"
+#include <spdlog/fmt/fmt.h>
 
 DECLARE_FORMAT(CompileSnes);
 
@@ -56,10 +57,9 @@ bool CompileSnesSeq::parseHeader() {
 
   uint32_t curOffset = dwOffset + 1;
   for (uint8_t trackIndex = 0; trackIndex < nNumTracks; trackIndex++) {
-    std::stringstream trackName;
-    trackName << "Track " << (trackIndex + 1);
+    auto trackName = fmt::format("Track {}", trackIndex + 1);
 
-    VGMHeader *trackHeader = header->addHeader(curOffset, 14, trackName.str().c_str());
+    VGMHeader *trackHeader = header->addHeader(curOffset, 14, trackName.c_str());
     trackHeader->addChild(curOffset, 1, "Channel");
     trackHeader->addChild(curOffset + 1, 1, "Flags");
     trackHeader->addChild(curOffset + 2, 1, "Volume");

--- a/src/main/formats/CompileSnes/CompileSnesSeq.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesSeq.cpp
@@ -59,7 +59,7 @@ bool CompileSnesSeq::parseHeader() {
   for (uint8_t trackIndex = 0; trackIndex < nNumTracks; trackIndex++) {
     auto trackName = fmt::format("Track {}", trackIndex + 1);
 
-    VGMHeader *trackHeader = header->addHeader(curOffset, 14, trackName.c_str());
+    VGMHeader *trackHeader = header->addHeader(curOffset, 14, trackName);
     trackHeader->addChild(curOffset, 1, "Channel");
     trackHeader->addChild(curOffset + 1, 1, "Flags");
     trackHeader->addChild(curOffset + 2, 1, "Volume");

--- a/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
@@ -590,7 +590,7 @@ bool FalcomSnesTrack::readEvent() {
       uint8_t newNCK = readByte(curOffset++) & 0x1f;
 
       desc = fmt::format("Noise Frequency (NCK): {:d}", newNCK);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Frequency", desc.c_str(), Type::Noise);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Frequency", desc, Type::Noise);
       break;
     }
 

--- a/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
@@ -1,5 +1,6 @@
 #include "FalcomSnesSeq.h"
 #include "ScaleConversion.h"
+#include <spdlog/fmt/fmt.h>
 
 DECLARE_FORMAT(FalcomSnes);
 
@@ -68,9 +69,8 @@ bool FalcomSnesSeq::parseHeader() {
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t ofsTrackStart = readShort(curOffset);
     if (ofsTrackStart != 0) {
-      std::stringstream trackName;
-      trackName << "Track Pointer " << (trackIndex + 1);
-      header->addChild(curOffset, 2, trackName.str());
+      auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
+      header->addChild(curOffset, 2, trackName);
     }
     else {
       header->addChild(curOffset, 2, "NULL");

--- a/src/main/formats/GraphResSnes/GraphResSnesSeq.cpp
+++ b/src/main/formats/GraphResSnes/GraphResSnesSeq.cpp
@@ -5,6 +5,7 @@
  */
 #include "GraphResSnesSeq.h"
 #include "ScaleConversion.h"
+#include <spdlog/fmt/fmt.h>
 
 using namespace std;
 
@@ -49,8 +50,7 @@ bool GraphResSnesSeq::parseHeader() {
 
   uint32_t curOffset = dwOffset;
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
-    std::stringstream trackName;
-    trackName << "Track Pointer " << (trackIndex + 1);
+    auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
 
     bool trackUsed = (readByte(curOffset) != 0);
     if (trackUsed) {
@@ -59,7 +59,7 @@ bool GraphResSnesSeq::parseHeader() {
     else {
       header->addChild(curOffset, 1, "Disable Track");
     }
-    header->addChild(curOffset + 1, 2, trackName.str());
+    header->addChild(curOffset + 1, 2, trackName);
     curOffset += 3;
   }
 

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesSeq.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesSeq.cpp
@@ -76,7 +76,7 @@ bool HeartBeatSnesSeq::parseHeader() {
     }
 
     auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
-    header->addChild(curOffset, 2, trackName.c_str());
+    header->addChild(curOffset, 2, trackName);
 
     curOffset += 2;
   }

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesSeq.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesSeq.cpp
@@ -5,6 +5,7 @@
  */
 #include "HeartBeatSnesSeq.h"
 #include "ScaleConversion.h"
+#include <spdlog/fmt/fmt.h>
 
 using namespace std;
 
@@ -74,9 +75,8 @@ bool HeartBeatSnesSeq::parseHeader() {
       break;
     }
 
-    std::stringstream trackName;
-    trackName << "Track Pointer " << (trackIndex + 1);
-    header->addChild(curOffset, 2, trackName.str().c_str());
+    auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
+    header->addChild(curOffset, 2, trackName.c_str());
 
     curOffset += 2;
   }

--- a/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
@@ -217,14 +217,14 @@ bool ItikitiSnesTrack::readEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_MASTER_VOLUME: {
       const uint8_t vol = readByte(curOffset++);
-      desc = fmt::format("Volume: {}", vol);
+      desc = fmt::format("Volume: {:d}", vol);
       addGenericEvent(start, curOffset - start, "Master Volume", desc, Type::MasterVolume);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ECHO_VOLUME: {
       const uint8_t vol = readByte(curOffset++);
-      desc = fmt::format("Volume: {}", vol);
+      desc = fmt::format("Volume: {:d}", vol);
       addGenericEvent(start, curOffset - start, "Echo Volume", desc, Type::Reverb);
       break;
     }
@@ -238,9 +238,8 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_ECHO_FEEDBACK_FIR: {
       const int8_t feedback = static_cast<int8_t>(readByte(curOffset++));
       const uint8_t filter_index = readByte(curOffset++);
-      desc = fmt::format("Feedback: {}  FIR: {}", feedback, filter_index);
-      addGenericEvent(start, curOffset - start, "Echo Feedback & FIR", desc,
-                      Type::Reverb);
+      desc = fmt::format("Feedback: {:d}  FIR: {:d}", feedback, filter_index);
+      addGenericEvent(start, curOffset - start, "Echo Feedback & FIR", desc, Type::Reverb);
       break;
     }
 
@@ -260,9 +259,8 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_NOISE_FREQ: {
       // Driver bug: This command sets the noise frequency for the next track from the current.
       const uint8_t nck = readByte(curOffset++) & 0x1f;
-      desc = fmt::format("Noise Frequency (NCK): {}", nck);
-      addGenericEvent(start, curOffset - start, "Noise Frequency", desc,
-                      Type::Noise);
+      desc = fmt::format("Noise Frequency (NCK): {:d}", nck);
+      addGenericEvent(start, curOffset - start, "Noise Frequency", desc, Type::Noise);
       break;
     }
 
@@ -270,8 +268,7 @@ bool ItikitiSnesTrack::readEvent() {
       const uint16_t bits = readShort(curOffset);
       curOffset += 2;
       desc = fmt::format("Length Bits: 0x{:04X}", bits);
-      addGenericEvent(start, curOffset - start, "Note Length Pattern", desc,
-                      Type::DurationNote);
+      addGenericEvent(start, curOffset - start, "Note Length Pattern", desc, Type::DurationNote);
 
       size_t size_written = 0;
       for (unsigned int index = 0; index < 16 && size_written < m_note_length_table.size();
@@ -292,7 +289,7 @@ bool ItikitiSnesTrack::readEvent() {
       const uint8_t arg5 = readByte(curOffset++);
       const uint8_t arg6 = readByte(curOffset++);
       const uint8_t arg7 = readByte(curOffset++);
-      desc = fmt::format("Lengths: {}, {}, {}, {}, {}, {}, {}",
+      desc = fmt::format("Lengths: {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}",
                                arg1, arg2, arg3, arg4, arg5, arg6, arg7);
       addGenericEvent(start, curOffset - start, "Custom Note Length Pattern", desc,
                       Type::DurationNote);
@@ -309,9 +306,8 @@ bool ItikitiSnesTrack::readEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_NOTE_NUMBER_BASE: {
       const uint8_t note_number = readByte(curOffset++);
-      desc = fmt::format("Note Number: {}", note_number);
-      addGenericEvent(start, curOffset - start, "Note Number Base", desc,
-                      Type::ChangeState);
+      desc = fmt::format("Note Number: {:d}", note_number);
+      addGenericEvent(start, curOffset - start, "Note Number Base", desc, Type::ChangeState);
       m_note_number_base = note_number;
       break;
     }
@@ -361,28 +357,28 @@ bool ItikitiSnesTrack::readEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_AR: {
       const uint8_t ar = readByte(curOffset++) & 15;
-      desc = fmt::format("AR: {}", ar);
+      desc = fmt::format("AR: {:d}", ar);
       addGenericEvent(start, curOffset - start, "ADSR Attack Rate", desc, Type::Adsr);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_DR: {
       const uint8_t dr = readByte(curOffset++) & 7;
-      desc = fmt::format("DR: {}", dr);
+      desc = fmt::format("DR: {:d}", dr);
       addGenericEvent(start, curOffset - start, "ADSR Decay Rate", desc, Type::Adsr);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_SL: {
       const uint8_t sl = readByte(curOffset++) & 7;
-      desc = fmt::format("SL: {}", sl);
+      desc = fmt::format("SL: {:d}", sl);
       addGenericEvent(start, curOffset - start, "ADSR Sustain Level", desc, Type::Adsr);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_SR: {
       const uint8_t sr = readByte(curOffset++) & 15;
-      desc = fmt::format("SR: {}", sr);
+      desc = fmt::format("SR: {:d}", sr);
       addGenericEvent(start, curOffset - start, "ADSR Sustain Rate", desc, Type::Adsr);
       break;
     }
@@ -409,7 +405,7 @@ bool ItikitiSnesTrack::readEvent() {
         const uint8_t delay = readByte(curOffset++);
         const uint8_t rate = readByte(curOffset++);
         const uint8_t depth = readByte(curOffset++);
-        desc = fmt::format("Delay: {}  Rate: {}  Depth: {}", delay, rate, depth);
+        desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}", delay, rate, depth);
         addGenericEvent(start, curOffset - start, "Vibrato", desc, Type::Vibrato);
         break;
     }
@@ -425,7 +421,7 @@ bool ItikitiSnesTrack::readEvent() {
       const uint8_t delay = readByte(curOffset++);
       const uint8_t rate = readByte(curOffset++);
       const uint8_t depth = readByte(curOffset++);
-      desc = fmt::format("Delay: {}  Rate: {}  Depth: {}", delay, rate, depth);
+      desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}", delay, rate, depth);
       addGenericEvent(start, curOffset - start, "Tremolo", desc, Type::Tremelo);
       break;
     }
@@ -438,7 +434,7 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_PAN_LFO_ON: {
       const uint8_t depth = readByte(curOffset++);
       const uint8_t rate = readByte(curOffset++);
-      desc = fmt::format("Depth: {}  Rate: {}", depth, rate);
+      desc = fmt::format("Depth: {:d}  Rate: {:d}", depth, rate);
       addGenericEvent(start, curOffset - start, "Pan LFO", desc, Type::PanLfo);
       break;
     }
@@ -495,7 +491,7 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_SPECIAL: {
       const uint8_t value = readByte(curOffset++);
       if (value <= 0x7f) {
-        desc = fmt::format("Range: {} semitones", value);
+        desc = fmt::format("Range: {:d} semitones", value);
         addGenericEvent(start, curOffset - start, "Note Randomization On", desc,
                         Type::ChangeState);
       } else if (value == 0x83) {
@@ -518,7 +514,7 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_PITCH_SLIDE: {
       const uint8_t length = readByte(curOffset++); // in ticks
       const int8_t semitones = static_cast<int8_t>(readByte(curOffset++));
-      desc = fmt::format("Length: {}  Key: {} semitones", length, semitones);
+      desc = fmt::format("Length: {:d}  Key: {:d} semitones", length, semitones);
       addGenericEvent(start, curOffset - start, "Pitch Slide", desc, Type::PitchBendSlide);
       break;
     }
@@ -526,7 +522,7 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_LOOP_START: {
       const uint8_t count = readByte(curOffset++);
       desc = (count == 0) ? std::string("Repeat Count: Infinite")
-                                 : fmt::format("Repeat Count: {}", count + 1);
+                                 : fmt::format("Repeat Count: {:d}", count + 1);
       addGenericEvent(start, curOffset - start, "Loop Start", desc, Type::RepeatStart);
 
       if (m_loop_level + 1 >= kItikitiSnesSeqMaxLoopLevel) {
@@ -581,7 +577,7 @@ bool ItikitiSnesTrack::readEvent() {
       const uint16_t dest = readDecodedOffset(curOffset);
       curOffset += 2;
 
-      desc = fmt::format("Count: {}  Destination: ${:04X}", target_count, dest);
+      desc = fmt::format("Count: {:d}  Destination: ${:04X}", target_count, dest);
       addGenericEvent(start, curOffset - start, "Loop Break / Jump to Volta", desc,
                       Type::LoopBreak);
       

--- a/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
@@ -5,6 +5,7 @@
  */
 #include "ItikitiSnesSeq.h"
 #include "ScaleConversion.h"
+#include <spdlog/fmt/fmt.h>
 
 DECLARE_FORMAT(ItikitiSnes);
 
@@ -46,11 +47,10 @@ bool ItikitiSnesSeq::parseHeader() {
   m_base_offset = static_cast<uint16_t>(first_address) - first_offset;
 
   for (unsigned int track_index = 0; track_index < nNumTracks; track_index++) {
-    std::stringstream track_name;
-    track_name << "Track " << (track_index + 1);
+    std::string track_name = fmt::format("Track {}", track_index + 1);
 
     const uint32_t offset_to_pointer = dwOffset + 2 + (2 * track_index);
-    header->addChild(offset_to_pointer, 2, track_name.str());
+    header->addChild(offset_to_pointer, 2, track_name);
   }
 
   header->setGuessedLength();
@@ -150,26 +150,25 @@ bool ItikitiSnesTrack::readEvent() {
   const auto event_type = seq->getEventType(command);
 
   bool stop_parser = false;
-  std::stringstream description;
-  std::string descr;
+  std::string desc;
   switch (event_type) {
     case ItikitiSnesSeqEventType::EVENT_UNKNOWN0:
-      descr = logEvent(command, spdlog::level::debug);
-      addUnknown(start, curOffset - start, "Unknown Event", descr);
+      desc = logEvent(command, spdlog::level::debug);
+      addUnknown(start, curOffset - start, "Unknown Event", desc);
       break;
 
     case ItikitiSnesSeqEventType::EVENT_UNKNOWN1: {
       const auto arg1 = readByte(curOffset++);
-      descr = logEvent(command, spdlog::level::debug, "Event", arg1);
-      addUnknown(start, curOffset - start, "Unknown Event", descr);
+      desc = logEvent(command, spdlog::level::debug, "Event", arg1);
+      addUnknown(start, curOffset - start, "Unknown Event", desc);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_UNKNOWN2: {
       const auto arg1 = readByte(curOffset++);
       const auto arg2 = readByte(curOffset++);
-      descr = logEvent(command, spdlog::level::debug, "Event", arg1, arg2);
-      addUnknown(start, curOffset - start, "Unknown Event", descr);
+      desc = logEvent(command, spdlog::level::debug, "Event", arg1, arg2);
+      addUnknown(start, curOffset - start, "Unknown Event", desc);
       break;
     }
 
@@ -177,8 +176,8 @@ bool ItikitiSnesTrack::readEvent() {
       const auto arg1 = readByte(curOffset++);
       const auto arg2 = readByte(curOffset++);
       const auto arg3 = readByte(curOffset++);
-      descr = logEvent(command, spdlog::level::debug, "Event", arg1, arg2, arg3);
-      addUnknown(start, curOffset - start, "Unknown Event", descr);
+      desc = logEvent(command, spdlog::level::debug, "Event", arg1, arg2, arg3);
+      addUnknown(start, curOffset - start, "Unknown Event", desc);
       break;
     }
 
@@ -199,7 +198,7 @@ bool ItikitiSnesTrack::readEvent() {
         addRest(start, curOffset - start, len);
       } else if (tie) {
         makePrevDurNoteEnd(getTime() + dur);
-        addGenericEvent(start, curOffset - start, "Tie", description.str(), Type::Tie);
+        addGenericEvent(start, curOffset - start, "Tie", desc, Type::Tie);
         addTime(len);
       } else {
         const uint8_t key_index = command >> 3;
@@ -218,15 +217,15 @@ bool ItikitiSnesTrack::readEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_MASTER_VOLUME: {
       const uint8_t vol = readByte(curOffset++);
-      description << "Volume: " << vol;
-      addGenericEvent(start, curOffset - start, "Master Volume", description.str(), Type::MasterVolume);
+      desc = fmt::format("Volume: {}", vol);
+      addGenericEvent(start, curOffset - start, "Master Volume", desc, Type::MasterVolume);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ECHO_VOLUME: {
       const uint8_t vol = readByte(curOffset++);
-      description << "Volume: " << vol;
-      addGenericEvent(start, curOffset - start, "Echo Volume", description.str(), Type::Reverb);
+      desc = fmt::format("Volume: {}", vol);
+      addGenericEvent(start, curOffset - start, "Echo Volume", desc, Type::Reverb);
       break;
     }
 
@@ -239,8 +238,8 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_ECHO_FEEDBACK_FIR: {
       const int8_t feedback = static_cast<int8_t>(readByte(curOffset++));
       const uint8_t filter_index = readByte(curOffset++);
-      description << "Feedback: " << feedback << "  FIR: " << filter_index;
-      addGenericEvent(start, curOffset - start, "Echo Feedback & FIR", description.str(),
+      desc = fmt::format("Feedback: {}  FIR: {}", feedback, filter_index);
+      addGenericEvent(start, curOffset - start, "Echo Feedback & FIR", desc,
                       Type::Reverb);
       break;
     }
@@ -261,8 +260,8 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_NOISE_FREQ: {
       // Driver bug: This command sets the noise frequency for the next track from the current.
       const uint8_t nck = readByte(curOffset++) & 0x1f;
-      description << "Noise Frequency (NCK): " << nck;
-      addGenericEvent(start, curOffset - start, "Noise Frequency", description.str(),
+      desc = fmt::format("Noise Frequency (NCK): {}", nck);
+      addGenericEvent(start, curOffset - start, "Noise Frequency", desc,
                       Type::Noise);
       break;
     }
@@ -270,8 +269,8 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_SELECT_NOTE_LENGTH_PATTERN: {
       const uint16_t bits = readShort(curOffset);
       curOffset += 2;
-      description << "Length Bits: 0x" << std::hex << std::setfill('0') << std::setw(4) << bits;
-      addGenericEvent(start, curOffset - start, "Note Length Pattern", description.str(),
+      desc = fmt::format("Length Bits: 0x{:04X}", bits);
+      addGenericEvent(start, curOffset - start, "Note Length Pattern", desc,
                       Type::DurationNote);
 
       size_t size_written = 0;
@@ -293,9 +292,9 @@ bool ItikitiSnesTrack::readEvent() {
       const uint8_t arg5 = readByte(curOffset++);
       const uint8_t arg6 = readByte(curOffset++);
       const uint8_t arg7 = readByte(curOffset++);
-      description << "Lengths: " << arg1 << ", " << arg2 << ", " << arg3 << ", " << arg4
-                  << ", " << arg5 << ", " << arg6 << ", " << arg7;
-      addGenericEvent(start, curOffset - start, "Custom Note Length Pattern", description.str(),
+      desc = fmt::format("Lengths: {}, {}, {}, {}, {}, {}, {}",
+                               arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+      addGenericEvent(start, curOffset - start, "Custom Note Length Pattern", desc,
                       Type::DurationNote);
 
       m_note_length_table[0] = arg1;
@@ -310,8 +309,8 @@ bool ItikitiSnesTrack::readEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_NOTE_NUMBER_BASE: {
       const uint8_t note_number = readByte(curOffset++);
-      description << "Note Number: " << note_number;
-      addGenericEvent(start, curOffset - start, "Note Number Base", description.str(),
+      desc = fmt::format("Note Number: {}", note_number);
+      addGenericEvent(start, curOffset - start, "Note Number Base", desc,
                       Type::ChangeState);
       m_note_number_base = note_number;
       break;
@@ -362,34 +361,34 @@ bool ItikitiSnesTrack::readEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_AR: {
       const uint8_t ar = readByte(curOffset++) & 15;
-      description << "AR: " << ar;
-      addGenericEvent(start, curOffset - start, "ADSR Attack Rate", description.str(), Type::Adsr);
+      desc = fmt::format("AR: {}", ar);
+      addGenericEvent(start, curOffset - start, "ADSR Attack Rate", desc, Type::Adsr);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_DR: {
       const uint8_t dr = readByte(curOffset++) & 7;
-      description << "DR: " << dr;
-      addGenericEvent(start, curOffset - start, "ADSR Decay Rate", description.str(), Type::Adsr);
+      desc = fmt::format("DR: {}", dr);
+      addGenericEvent(start, curOffset - start, "ADSR Decay Rate", desc, Type::Adsr);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_SL: {
       const uint8_t sl = readByte(curOffset++) & 7;
-      description << "SL: " << sl;
-      addGenericEvent(start, curOffset - start, "ADSR Sustain Level", description.str(), Type::Adsr);
+      desc = fmt::format("SL: {}", sl);
+      addGenericEvent(start, curOffset - start, "ADSR Sustain Level", desc, Type::Adsr);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_SR: {
       const uint8_t sr = readByte(curOffset++) & 15;
-      description << "SR: " << sr;
-      addGenericEvent(start, curOffset - start, "ADSR Sustain Rate", description.str(), Type::Adsr);
+      desc = fmt::format("SR: {}", sr);
+      addGenericEvent(start, curOffset - start, "ADSR Sustain Rate", desc, Type::Adsr);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_ADSR_DEFAULT: {
-      addGenericEvent(start, curOffset - start, "Default ADSR", description.str(), Type::Adsr);
+      addGenericEvent(start, curOffset - start, "Default ADSR", desc, Type::Adsr);
       break;
     }
 
@@ -410,14 +409,14 @@ bool ItikitiSnesTrack::readEvent() {
         const uint8_t delay = readByte(curOffset++);
         const uint8_t rate = readByte(curOffset++);
         const uint8_t depth = readByte(curOffset++);
-        description << "Delay: " << delay << "  Rate: " << rate << "  Depth: " << depth;
-        addGenericEvent(start, curOffset - start, "Vibrato", description.str(), Type::Vibrato);
+        desc = fmt::format("Delay: {}  Rate: {}  Depth: {}", delay, rate, depth);
+        addGenericEvent(start, curOffset - start, "Vibrato", desc, Type::Vibrato);
         break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_VIBRATO_OFF: {
       // The command changes vibrato depth to 0.
-      addGenericEvent(start, curOffset - start, "Vibrato Off", description.str(), Type::Vibrato);
+      addGenericEvent(start, curOffset - start, "Vibrato Off", desc, Type::Vibrato);
       break;
     }
 
@@ -426,47 +425,47 @@ bool ItikitiSnesTrack::readEvent() {
       const uint8_t delay = readByte(curOffset++);
       const uint8_t rate = readByte(curOffset++);
       const uint8_t depth = readByte(curOffset++);
-      description << "Delay: " << delay << "  Rate: " << rate << "  Depth: " << depth;
-      addGenericEvent(start, curOffset - start, "Tremolo", description.str(), Type::Tremelo);
+      desc = fmt::format("Delay: {}  Rate: {}  Depth: {}", delay, rate, depth);
+      addGenericEvent(start, curOffset - start, "Tremolo", desc, Type::Tremelo);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_TREMOLO_OFF: {
-      addGenericEvent(start, curOffset - start, "Tremolo Off", description.str(), Type::Tremelo);
+      addGenericEvent(start, curOffset - start, "Tremolo Off", desc, Type::Tremelo);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_PAN_LFO_ON: {
       const uint8_t depth = readByte(curOffset++);
       const uint8_t rate = readByte(curOffset++);
-      description << "Depth: " << depth << "  Rate: " << rate;
-      addGenericEvent(start, curOffset - start, "Pan LFO", description.str(), Type::PanLfo);
+      desc = fmt::format("Depth: {}  Rate: {}", depth, rate);
+      addGenericEvent(start, curOffset - start, "Pan LFO", desc, Type::PanLfo);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_PAN_LFO_OFF: {
-      addGenericEvent(start, curOffset - start, "Pan LFO Off", description.str(), Type::PanLfo);
+      addGenericEvent(start, curOffset - start, "Pan LFO Off", desc, Type::PanLfo);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_NOISE_ON: {
-      addGenericEvent(start, curOffset - start, "Noise On", description.str(), Type::Noise);
+      addGenericEvent(start, curOffset - start, "Noise On", desc, Type::Noise);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_NOISE_OFF: {
-      addGenericEvent(start, curOffset - start, "Noise Off", description.str(), Type::Noise);
+      addGenericEvent(start, curOffset - start, "Noise Off", desc, Type::Noise);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_PITCH_MOD_ON: {
-      addGenericEvent(start, curOffset - start, "Pitch Modulation On", description.str(),
+      addGenericEvent(start, curOffset - start, "Pitch Modulation On", desc,
                       Type::Modulation);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_PITCH_MOD_OFF: {
-      addGenericEvent(start, curOffset - start, "Pitch Modulation Off", description.str(),
+      addGenericEvent(start, curOffset - start, "Pitch Modulation Off", desc,
                       Type::Modulation);
       break;
     }
@@ -496,22 +495,22 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_SPECIAL: {
       const uint8_t value = readByte(curOffset++);
       if (value <= 0x7f) {
-        description << "Range: " << value << " semitones";
-        addGenericEvent(start, curOffset - start, "Note Randomization On", description.str(),
+        desc = fmt::format("Range: {} semitones", value);
+        addGenericEvent(start, curOffset - start, "Note Randomization On", desc,
                         Type::ChangeState);
       } else if (value == 0x83) {
         // Detailed behavior has not yet been analyzed
-        addGenericEvent(start, curOffset - start, "Change Volume Mode (Global)", description.str(),
+        addGenericEvent(start, curOffset - start, "Change Volume Mode (Global)", desc,
                         Type::Volume);
       } else {
-        descr = logEvent(command, spdlog::level::debug, "Event", value);
-        addUnknown(start, curOffset - start, "Unknown Event", descr);
+        desc = logEvent(command, spdlog::level::debug, "Event", value);
+        addUnknown(start, curOffset - start, "Unknown Event", desc);
       }
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_NOTE_RANDOMIZATION_OFF: {
-      addGenericEvent(start, curOffset - start, "Note Randomization Off", description.str(),
+      addGenericEvent(start, curOffset - start, "Note Randomization Off", desc,
                       Type::ChangeState);
       break;
     }
@@ -519,19 +518,16 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_PITCH_SLIDE: {
       const uint8_t length = readByte(curOffset++); // in ticks
       const int8_t semitones = static_cast<int8_t>(readByte(curOffset++));
-      description << "Length: " << length << "  Key: " << semitones << " semitones";
-      addGenericEvent(start, curOffset - start, "Pitch Slide", description.str(), Type::PitchBendSlide);
+      desc = fmt::format("Length: {}  Key: {} semitones", length, semitones);
+      addGenericEvent(start, curOffset - start, "Pitch Slide", desc, Type::PitchBendSlide);
       break;
     }
 
     case ItikitiSnesSeqEventType::EVENT_LOOP_START: {
       const uint8_t count = readByte(curOffset++);
-      description << "Repeat Count: ";
-      if (count == 0)
-        description << "Infinite";
-      else
-        description << (count + 1);
-      addGenericEvent(start, curOffset - start, "Loop Start", description.str(), Type::RepeatStart);
+      desc = (count == 0) ? std::string("Repeat Count: Infinite")
+                                 : fmt::format("Repeat Count: {}", count + 1);
+      addGenericEvent(start, curOffset - start, "Loop Start", desc, Type::RepeatStart);
 
       if (m_loop_level + 1 >= kItikitiSnesSeqMaxLoopLevel) {
         L_WARN("Loop Start: too many nesting loops");
@@ -548,13 +544,12 @@ bool ItikitiSnesTrack::readEvent() {
     case ItikitiSnesSeqEventType::EVENT_GOTO: {
       const uint16_t dest = readDecodedOffset(curOffset);
       curOffset += 2;
-      description << "Destination: $" << std::hex << std::setfill('0') << std::setw(4)
-                  << std::uppercase << dest;
+      desc = fmt::format("Destination: ${:04X}", dest);
       const auto length = curOffset - start;
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(start, length, "Jump", description.str(), Type::LoopForever);
+        addGenericEvent(start, length, "Jump", desc, Type::LoopForever);
       } else {
         stop_parser = !addLoopForever(start, length, "Jump");
       }
@@ -567,7 +562,7 @@ bool ItikitiSnesTrack::readEvent() {
         stop_parser = !addLoopForever(start, curOffset - start);
         curOffset = m_loop_start_addresses[m_loop_level];
       } else {
-        addGenericEvent(start, curOffset - start, "Loop End", description.str(), Type::RepeatEnd);
+        addGenericEvent(start, curOffset - start, "Loop End", desc, Type::RepeatEnd);
 
         m_loop_counts[m_loop_level]--;
         if (m_loop_counts[m_loop_level] == 0) {
@@ -586,9 +581,8 @@ bool ItikitiSnesTrack::readEvent() {
       const uint16_t dest = readDecodedOffset(curOffset);
       curOffset += 2;
 
-      description << "Count: " << target_count << "  Destination: $" << std::hex << std::setfill('0')
-                  << std::setw(4) << std::uppercase << dest;
-      addGenericEvent(start, curOffset - start, "Loop Break / Jump to Volta", description.str(),
+      desc = fmt::format("Count: {}  Destination: ${:04X}", target_count, dest);
+      addGenericEvent(start, curOffset - start, "Loop Break / Jump to Volta", desc,
                       Type::LoopBreak);
       
       if (++m_alt_loop_count == target_count) {
@@ -599,8 +593,8 @@ bool ItikitiSnesTrack::readEvent() {
 
     case ItikitiSnesSeqEventType::EVENT_UNDEFINED:
     default:
-      descr = logEvent(command);
-      addUnknown(start, curOffset - start, "Unknown Event", descr);
+      desc = logEvent(command);
+      addUnknown(start, curOffset - start, "Unknown Event", desc);
       stop_parser = true;
       break;
   }

--- a/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
@@ -6,7 +6,6 @@
 
 #include "KonamiPS1Seq.h"
 
-#include <sstream>
 #include <spdlog/fmt/fmt.h>
 
 DECLARE_FORMAT(KonamiPS1);
@@ -126,10 +125,9 @@ bool KonamiPS1Track::readEvent() {
     uint32_t delta = readVarLen(curOffset);
     addTime(delta);
 
-    std::stringstream description;
-    description << "Duration: " << delta;
+    std::string description = fmt::format("Duration: {}", delta);
     addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time",
-      description.str(), Type::Rest);
+                    description, Type::Rest);
 
     skipDeltaTime = true;
     return true;
@@ -150,7 +148,7 @@ bool KonamiPS1Track::readEvent() {
     prevKey = noteNumber;
     prevVel = velocity;
   } else {
-    std::stringstream description;
+    std::string description;
 
     uint8_t paramByte;
     if (command == 0x4a) {
@@ -172,9 +170,9 @@ bool KonamiPS1Track::readEvent() {
         break;
 
       case 6:
-        description << "Parameter: " << paramByte;
+        description = fmt::format("Parameter: {}", paramByte);
         addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry",
-          description.str(), Type::Misc);
+                        description, Type::Misc);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
           pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
@@ -193,22 +191,21 @@ bool KonamiPS1Track::readEvent() {
         break;
 
       case 15:
-        description << "Parameter: " << paramByte;
+        description = fmt::format("Parameter: {}", paramByte);
         addGenericEvent(beginOffset, curOffset - beginOffset, "Stereo Widening (?)",
-                        description.str(), Type::Pan);
+                        description, Type::Pan);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
           pMidiTrack->addControllerEvent(channel, command, paramByte);
         }
         break;
 
       case 64:
-        description << "Parameter: " << paramByte;
         addSustainEvent(beginOffset, curOffset - beginOffset, paramByte);
         break;
 
       case 70:
-        description << "Parameter: " << paramByte;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Channel", description.str(),
+        description = fmt::format("Parameter: {}", paramByte);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Channel", description,
                         Type::Pan);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
           pMidiTrack->addControllerEvent(channel, command, paramByte);
@@ -268,8 +265,8 @@ bool KonamiPS1Track::readEvent() {
         break;
 
       case 99:
-        description << "Parameter: " << paramByte;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN (LSB)", description.str(),
+        description = fmt::format("Parameter: {}", paramByte);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN (LSB)", description,
                         Type::Misc);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
           pMidiTrack->addControllerEvent(channel, command, paramByte);
@@ -282,8 +279,8 @@ bool KonamiPS1Track::readEvent() {
         } else if (paramByte == 30) {
           addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", Type::Loop);
         } else {
-          description << "Parameter: " << paramByte;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN (LSB)", description.str(),
+          description = fmt::format("Parameter: {}", paramByte);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN (LSB)", description,
                           Type::Misc);
         }
         if (readMode == READMODE_CONVERT_TO_MIDI) {
@@ -292,8 +289,8 @@ bool KonamiPS1Track::readEvent() {
         break;
 
       case 118:
-        description << "Parameter: " << paramByte;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Seq Beat", description.str(),
+        description = fmt::format("Parameter: {}", paramByte);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Seq Beat", description,
                         Type::Misc);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
           pMidiTrack->addControllerEvent(channel, command, paramByte);

--- a/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
@@ -125,7 +125,7 @@ bool KonamiPS1Track::readEvent() {
     uint32_t delta = readVarLen(curOffset);
     addTime(delta);
 
-    std::string description = fmt::format("Duration: {}", delta);
+    std::string description = fmt::format("Duration: {:d}", delta);
     addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time",
                     description, Type::Rest);
 
@@ -170,7 +170,7 @@ bool KonamiPS1Track::readEvent() {
         break;
 
       case 6:
-        description = fmt::format("Parameter: {}", paramByte);
+        description = fmt::format("Parameter: {:d}", paramByte);
         addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN Data Entry",
                         description, Type::Misc);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
@@ -191,7 +191,7 @@ bool KonamiPS1Track::readEvent() {
         break;
 
       case 15:
-        description = fmt::format("Parameter: {}", paramByte);
+        description = fmt::format("Parameter: {:d}", paramByte);
         addGenericEvent(beginOffset, curOffset - beginOffset, "Stereo Widening (?)",
                         description, Type::Pan);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
@@ -204,7 +204,7 @@ bool KonamiPS1Track::readEvent() {
         break;
 
       case 70:
-        description = fmt::format("Parameter: {}", paramByte);
+        description = fmt::format("Parameter: {:d}", paramByte);
         addGenericEvent(beginOffset, curOffset - beginOffset, "Set Channel", description,
                         Type::Pan);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
@@ -265,7 +265,7 @@ bool KonamiPS1Track::readEvent() {
         break;
 
       case 99:
-        description = fmt::format("Parameter: {}", paramByte);
+        description = fmt::format("Parameter: {:d}", paramByte);
         addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN (LSB)", description,
                         Type::Misc);
         if (readMode == READMODE_CONVERT_TO_MIDI) {
@@ -279,7 +279,7 @@ bool KonamiPS1Track::readEvent() {
         } else if (paramByte == 30) {
           addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", "", Type::Loop);
         } else {
-          description = fmt::format("Parameter: {}", paramByte);
+          description = fmt::format("Parameter: {:d}", paramByte);
           addGenericEvent(beginOffset, curOffset - beginOffset, "NRPN (LSB)", description,
                           Type::Misc);
         }
@@ -289,7 +289,7 @@ bool KonamiPS1Track::readEvent() {
         break;
 
       case 118:
-        description = fmt::format("Parameter: {}", paramByte);
+        description = fmt::format("Parameter: {:d}", paramByte);
         addGenericEvent(beginOffset, curOffset - beginOffset, "Seq Beat", description,
                         Type::Misc);
         if (readMode == READMODE_CONVERT_TO_MIDI) {

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -1002,7 +1002,7 @@ bool KonamiSnesTrack::readEvent(void) {
   }
 
   //auto trace = fmt::format("{:08X}: {:02X} -> {:08X}", beginOffset, statusByte, curOffset);
-  //LogDebug(trace.c_str());
+  //LogDebug(trace);
 
   return bContinue;
 }

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -5,6 +5,7 @@
  */
 #include "KonamiSnesSeq.h"
 #include "ScaleConversion.h"
+#include "spdlog/fmt/fmt.h"
 
 DECLARE_FORMAT(KonamiSnes);
 
@@ -327,7 +328,7 @@ bool KonamiSnesTrack::readEvent(void) {
   uint8_t statusByte = readByte(curOffset++);
   bool bContinue = true;
 
-  std::stringstream desc;
+  std::string desc;
 
   KonamiSnesSeqEventType eventType = (KonamiSnesSeqEventType) 0;
   std::map<uint8_t, KonamiSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -337,27 +338,22 @@ bool KonamiSnesTrack::readEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      desc = fmt::format("Event: 0x{:02X}", statusByte);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}", statusByte, arg1);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -365,12 +361,10 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2
-          << "  Arg3: " << (int) arg3;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      desc = fmt::format(
+          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}",
+          statusByte, arg1, arg2, arg3);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -379,13 +373,10 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
       uint8_t arg4 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2
-          << "  Arg3: " << (int) arg3
-          << "  Arg4: " << (int) arg4;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      desc = fmt::format(
+          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
+          statusByte, arg1, arg2, arg3, arg4);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -395,14 +386,10 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t arg3 = readByte(curOffset++);
       uint8_t arg4 = readByte(curOffset++);
       uint8_t arg5 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2
-          << "  Arg3: " << (int) arg3
-          << "  Arg4: " << (int) arg4
-          << "  Arg5: " << (int) arg5;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      desc = fmt::format(
+          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}  Arg5: {:d}",
+          statusByte, arg1, arg2, arg3, arg4, arg5);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -450,7 +437,7 @@ bool KonamiSnesTrack::readEvent(void) {
         // TODO: Note volume can be changed during a tied note
         // See the end of Konami Logo sequence for example
         makePrevDurNoteEnd(getTime() + dur);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), Type::Tie);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, Type::Tie);
       }
       else {
         addNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur);
@@ -463,7 +450,7 @@ bool KonamiSnesTrack::readEvent(void) {
     }
 
     case EVENT_PERCUSSION_ON: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion On", desc.str().c_str(), Type::ChangeState);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion On", desc, Type::ChangeState);
       if (!percussion) {
         addProgramChange(beginOffset, curOffset - beginOffset, 127 << 7, true);
         percussion = true;
@@ -472,7 +459,7 @@ bool KonamiSnesTrack::readEvent(void) {
     }
 
     case EVENT_PERCUSSION_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion Off", desc.str().c_str(), Type::ChangeState);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion Off", desc, Type::ChangeState);
       if (percussion) {
         addProgramChange(beginOffset, curOffset - beginOffset, instrument, true);
         percussion = false;
@@ -484,9 +471,8 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t newGAINAmount = readByte(curOffset++);
       uint8_t newGAIN = convertGAINAmountToGAIN(newGAINAmount);
 
-      desc << "GAIN: " << (int) newGAINAmount << " ($" << std::hex << std::setfill('0') << std::setw(2)
-          << std::uppercase << (int) newGAIN << ")";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN", desc.str().c_str(), Type::Adsr);
+      desc = fmt::format("GAIN: {} (${:02X})", newGAINAmount, newGAIN);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN", desc, Type::Adsr);
       break;
     }
 
@@ -529,12 +515,12 @@ bool KonamiSnesTrack::readEvent(void) {
         }
 
         makePrevDurNoteEnd(getTime() + dur);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), Type::Tie);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, Type::Tie);
         addTime(noteLength);
         prevNoteSlurred = (noteDurationRate == parentSeq->NOTE_DUR_RATE_MAX);
       }
       else {
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), Type::Tie);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, Type::Tie);
         addTime(noteLength);
       }
       break;
@@ -583,14 +569,14 @@ bool KonamiSnesTrack::readEvent(void) {
         addGenericEvent(beginOffset,
                         curOffset - beginOffset,
                         "Per-Instrument Pan Off",
-                        desc.str().c_str(),
+                        desc,
                         Type::Pan);
       }
       else if (instrumentPanOn) {
         addGenericEvent(beginOffset,
                         curOffset - beginOffset,
                         "Per-Instrument Pan On",
-                        desc.str().c_str(),
+                        desc,
                         Type::Pan);
       }
       else {
@@ -635,12 +621,13 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t vibratoDelay = readByte(curOffset++);
       uint8_t vibratoRate = readByte(curOffset++);
       uint8_t vibratoDepth = readByte(curOffset++);
-      desc << "Delay: " << (int) vibratoDelay << "  Rate: " << (int) vibratoRate << "  Depth: "
-          << (int) vibratoDepth;
+      desc = fmt::format(
+          "Delay: {:d}  Rate: {:d}  Depth: {:d}",
+          vibratoDelay, vibratoRate, vibratoDepth);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Vibrato",
-                      desc.str().c_str(),
+                      desc,
                       Type::Vibrato);
       break;
     }
@@ -649,18 +636,18 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t envRate = readByte(curOffset++);
       uint16_t envPitchMask = readShort(curOffset);
       curOffset += 2;
-      desc << "Rate: " << (int) envRate << "  Pitch Mask: $" << std::hex << std::setfill('0') << std::setw(4)
-          << std::uppercase << (int) envPitchMask;
+      desc = fmt::format(
+          "Rate: {:d}  Pitch Mask: ${:04X}", envRate, envPitchMask);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Random Pitch",
-                      desc.str().c_str(),
+                      desc,
                       Type::Modulation);
       break;
     }
 
-    case EVENT_LOOP_START: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), Type::RepeatStart);
+      case EVENT_LOOP_START: {
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc, Type::RepeatStart);
       loopReturnAddr = curOffset;
       break;
     }
@@ -670,13 +657,14 @@ bool KonamiSnesTrack::readEvent(void) {
       int8_t volumeDelta = readByte(curOffset++);
       int8_t pitchDelta = readByte(curOffset++);
 
-      desc << "Times: " << (int) times << "  Volume Delta: " << (int) volumeDelta << "  Pitch Delta: "
-          << (int) pitchDelta;
+      desc = fmt::format(
+          "Times: {:d}  Volume Delta: {:d}  Pitch Delta: {:d}",
+          times, volumeDelta, pitchDelta);
       if (times == 0) {
         bContinue = addLoopForever(beginOffset, curOffset - beginOffset, "Loop End");
       }
       else {
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), Type::RepeatStart);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc, Type::RepeatStart);
       }
 
       bool loopAgain;
@@ -704,32 +692,33 @@ bool KonamiSnesTrack::readEvent(void) {
       break;
     }
 
-    case EVENT_LOOP_START_2: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Loop Start #2",
-                      desc.str().c_str(),
-                      Type::RepeatStart);
-      loopReturnAddr2 = curOffset;
-      break;
-    }
+      case EVENT_LOOP_START_2: {
+        addGenericEvent(beginOffset,
+                        curOffset - beginOffset,
+                        "Loop Start #2",
+                        desc,
+                        Type::RepeatStart);
+        loopReturnAddr2 = curOffset;
+        break;
+      }
 
     case EVENT_LOOP_END_2: {
       uint8_t times = readByte(curOffset++);
       int8_t volumeDelta = readByte(curOffset++);
       int8_t pitchDelta = readByte(curOffset++);
 
-      desc << "Times: " << (int) times << "  Volume Delta: " << (int) volumeDelta << "  Pitch Delta: "
-          << (int) pitchDelta;
+      desc = fmt::format(
+          "Times: {:d}  Volume Delta: {:d}  Pitch Delta: {:d}",
+          times, volumeDelta, pitchDelta);
       if (times == 0) {
         bContinue = addLoopForever(beginOffset, curOffset - beginOffset, "Loop End #2");
       }
       else {
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "Loop End #2",
-                        desc.str().c_str(),
-                        Type::RepeatStart);
+          addGenericEvent(beginOffset,
+                          curOffset - beginOffset,
+                          "Loop End #2",
+                          desc,
+                          Type::RepeatStart);
       }
 
       bool loopAgain;
@@ -769,8 +758,10 @@ bool KonamiSnesTrack::readEvent(void) {
     case EVENT_TEMPO_FADE: {
       uint8_t newTempo = readByte(curOffset++);
       uint8_t fadeSpeed = readByte(curOffset++);
-      desc << "BPM: " << parentSeq->getTempoInBPM(newTempo) << "  Fade Length: " << (int) fadeSpeed;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tempo Fade", desc.str().c_str(), Type::Tempo);
+      desc = fmt::format(
+          "BPM: {}  Fade Length: {}",
+          parentSeq->getTempoInBPM(newTempo), fadeSpeed);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tempo Fade", desc, Type::Tempo);
       break;
     }
 
@@ -782,15 +773,15 @@ bool KonamiSnesTrack::readEvent(void) {
 
     case EVENT_ADSR1: {
       uint8_t newADSR1 = readByte(curOffset++);
-      desc << "ADSR(1): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) newADSR1;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(1)", desc.str().c_str(), Type::Adsr);
+      desc = fmt::format("ADSR(1): ${:02X}", newADSR1);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(1)", desc, Type::Adsr);
       break;
     }
 
     case EVENT_ADSR2: {
       uint8_t newADSR2 = readByte(curOffset++);
-      desc << "ADSR(2): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) newADSR2;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(2)", desc.str().c_str(), Type::Adsr);
+      desc = fmt::format("ADSR(2): ${:02X}", newADSR2);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(2)", desc, Type::Adsr);
       break;
     }
 
@@ -804,22 +795,22 @@ bool KonamiSnesTrack::readEvent(void) {
     case EVENT_VOLUME_FADE: {
       uint8_t newVolume = readByte(curOffset++);
       uint8_t fadeSpeed = readByte(curOffset++);
-      desc << "Volume: " << (int) newVolume << "  Fade Length: " << (int) fadeSpeed;
+      desc = fmt::format("Volume: {:d}  Fade Length: {:d}", newVolume, fadeSpeed);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Volume Fade",
-                      desc.str().c_str(),
+                      desc,
                       Type::VolumeSlide);
       break;
     }
 
     case EVENT_PORTAMENTO: {
       uint8_t portamentoSpeed = readByte(curOffset++);
-      desc << "Portamento Speed: " << (int) portamentoSpeed;
+      desc = fmt::format("Portamento Speed: {:d}", portamentoSpeed);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Portamento",
-                      desc.str().c_str(),
+                      desc,
                       Type::Portamento);
       break;
     }
@@ -828,12 +819,13 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t pitchEnvDelay = readByte(curOffset++);
       uint8_t pitchEnvSpeed = readByte(curOffset++);
       uint8_t pitchEnvDepth = readByte(curOffset++);
-      desc << "Delay: " << (int) pitchEnvDelay << "  Speed: " << (int) pitchEnvSpeed << "  Depth: "
-          << (int) -pitchEnvDepth;
+      desc = fmt::format(
+          "Delay: {:d}  Speed: {:d}  Depth: {:d}",
+          pitchEnvDelay, pitchEnvSpeed, -pitchEnvDepth);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Envelope",
-                      desc.str().c_str(),
+                      desc,
                       Type::PitchEnvelope);
       break;
     }
@@ -844,12 +836,13 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t pitchEnvOffset = readByte(curOffset++);
       int16_t pitchDelta = readShort(curOffset);
       curOffset += 2;
-      desc << "Delay: " << (int) pitchEnvDelay << "  Length: " << (int) pitchEnvLength << "  Offset: "
-          << (int) -pitchEnvOffset << " semitones" << "  Delta: " << (pitchDelta / 256.0) << " semitones";
+      desc = fmt::format(
+          "Delay: {:d}  Length: {:d}  Offset: {:d} semitones  Delta: {:.1f} semitones",
+          pitchEnvDelay, pitchEnvLength, -pitchEnvOffset, pitchDelta / 256.0);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Envelope",
-                      desc.str().c_str(),
+                      desc,
                       Type::PitchEnvelope);
       break;
     }
@@ -865,11 +858,11 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
-      desc << "Arg1: " << (int) arg1 << "  Arg2: " << (int) arg2 << "  Arg3: " << (int) arg3;
+      desc = fmt::format("Arg1: {:d}  Arg2: {:d}  Arg3: {:d}", arg1, arg2, arg3);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Slide",
-                      desc.str().c_str(),
+                      desc,
                       Type::PitchBendSlide);
       break;
     }
@@ -878,19 +871,19 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
-      desc << "Arg1: " << (int) arg1 << "  Arg2: " << (int) arg2 << "  Arg3: " << (int) arg3;
+      desc = fmt::format("Arg1: {:d}  Arg2: {:d}  Arg3: {:d}", arg1, arg2, arg3);
 
       if (arg2 != 0) {
         uint8_t arg4 = readByte(curOffset++);
         uint8_t arg5 = readByte(curOffset++);
         uint8_t arg6 = readByte(curOffset++);
-        desc << "Arg4: " << (int) arg4 << "  Arg5: " << (int) arg5 << "  Arg6: " << (int) arg6;
+        fmt::format_to(std::back_inserter(desc), "  Arg4: {:d}  Arg5: {:d}  Arg6: {:d}", arg4, arg5, arg6);
       }
 
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Slide",
-                      desc.str().c_str(),
+                      desc,
                       Type::PitchBendSlide);
       break;
     }
@@ -904,12 +897,13 @@ bool KonamiSnesTrack::readEvent(void) {
 
       uint8_t pitchSlideNoteNumber = (pitchSlideNote & 0x7f) + transpose;
 
-      desc << "Delay: " << (int) pitchSlideDelay << "  Length: " << (int) pitchSlideLength << "  Final Note: "
-          << (int) pitchSlideNoteNumber << "  Delta: " << (pitchDelta / 256.0) << " semitones";
+      desc = fmt::format(
+          "Delay: {:d}  Length: {:d}  Final Note: {:d}  Delta: {:.1f} semitones",
+          pitchSlideDelay, pitchSlideLength, pitchSlideNoteNumber, pitchDelta / 256.0);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Slide",
-                      desc.str().c_str(),
+                      desc,
                       Type::PitchBendSlide);
       break;
     }
@@ -919,10 +913,11 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t echoVolumeL = readByte(curOffset++);
       uint8_t echoVolumeR = readByte(curOffset++);
 
-      desc << "EON: " << (int) echoChannels << "  EVOL(L): " << (int) echoVolumeL << "  EVOL(R): "
-          << (int) echoVolumeR;
+      desc = fmt::format(
+          "EON: {:d}  EVOL(L): {:d}  EVOL(R): {:d}",
+          echoChannels, echoVolumeL, echoVolumeR);
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str().c_str(), Type::Reverb);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc, Type::Reverb);
       break;
     }
 
@@ -931,12 +926,14 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t echoFeedback = readByte(curOffset++);
       uint8_t echoArg3 = readByte(curOffset++);
 
-      desc << "EDL: " << (int) echoDelay << "  EFB: " << (int) echoFeedback << "  Arg3: " << (int) echoArg3;
+      desc = fmt::format(
+          "EDL: {:d}  EFB: {:d}  Arg3: {:d}",
+          echoDelay, echoFeedback, echoArg3);
 
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Echo Param",
-                      desc.str().c_str(),
+                      desc,
                       Type::Reverb);
       break;
     }
@@ -945,7 +942,7 @@ bool KonamiSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Loop With Volta Start",
-                      desc.str().c_str(),
+                      desc,
                       Type::RepeatStart);
 
       voltaLoopStart = curOffset;
@@ -958,7 +955,7 @@ bool KonamiSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Loop With Volta End",
-                      desc.str().c_str(),
+                      desc,
                       Type::RepeatStart);
 
       if (voltaEndMeansPlayFromStart) {
@@ -984,18 +981,18 @@ bool KonamiSnesTrack::readEvent(void) {
     case EVENT_PAN_FADE: {
       uint8_t newPan = readByte(curOffset++);
       uint8_t fadeSpeed = readByte(curOffset++);
-      desc << "Pan: " << (int) newPan << "  Fade Length: " << (int) fadeSpeed;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc.str().c_str(), Type::PanSlide);
+      desc = fmt::format("Pan: {:d}  Fade Length: {:d}", newPan, fadeSpeed);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc, Type::PanSlide);
       break;
     }
 
     case EVENT_VIBRATO_FADE: {
       uint8_t fadeSpeed = readByte(curOffset++);
-      desc << "Fade Length: " << (int) fadeSpeed;
+      desc = fmt::format("Fade Length: {:d}", fadeSpeed);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Vibrato Fade",
-                      desc.str().c_str(),
+                      desc,
                       Type::Vibrato);
       break;
     }
@@ -1006,16 +1003,17 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t newGAINAmount = readByte(curOffset++);
       uint8_t newGAIN = convertGAINAmountToGAIN(newGAINAmount);
 
-      desc << "ADSR(1): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) newADSR1
-          << "  ADSR(2): $" << (int) newADSR2 << "  GAIN: $" << (int) newGAIN;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(2)", desc.str().c_str(), Type::Adsr);
+      desc = fmt::format(
+          "ADSR(1): ${:02X}  ADSR(2): ${:02X}  GAIN: ${:02X}",
+          newADSR1, newADSR2, newGAIN);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(2)", desc, Type::Adsr);
       break;
     }
 
     case EVENT_GOTO: {
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
-      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      desc = fmt::format("Destination: ${:04X}", dest);
       uint32_t length = curOffset - beginOffset;
 
       assert(dest >= dwOffset);
@@ -1026,7 +1024,7 @@ bool KonamiSnesTrack::readEvent(void) {
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), Type::LoopForever);
+        addGenericEvent(beginOffset, length, "Jump", desc, Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -1038,11 +1036,11 @@ bool KonamiSnesTrack::readEvent(void) {
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
 
-      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      desc = fmt::format("Destination: ${:04X}", dest);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pattern Play",
-                      desc.str().c_str(),
+                      desc,
                       Type::RepeatStart);
 
       assert(dest >= dwOffset);
@@ -1058,7 +1056,7 @@ bool KonamiSnesTrack::readEvent(void) {
         addGenericEvent(beginOffset,
                         curOffset - beginOffset,
                         "End Pattern",
-                        desc.str().c_str(),
+                        desc,
                         Type::RepeatEnd);
 
         inSubroutine = false;
@@ -1079,9 +1077,8 @@ bool KonamiSnesTrack::readEvent(void) {
     }
   }
 
-  //std::ostringstream ssTrace;
-  //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
-  //LogDebug(ssTrace.str().c_str());
+  //auto trace = fmt::format("{:08X}: {:02X} -> {:08X}", beginOffset, statusByte, curOffset);
+  //LogDebug(trace.c_str());
 
   return bContinue;
 }

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -566,18 +566,12 @@ bool KonamiSnesTrack::readEvent(void) {
       }
 
       if (instrumentPanOff) {
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "Per-Instrument Pan Off",
-                        desc,
-                        Type::Pan);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Per-Instrument Pan Off",
+                        desc, Type::Pan);
       }
       else if (instrumentPanOn) {
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "Per-Instrument Pan On",
-                        desc,
-                        Type::Pan);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Per-Instrument Pan On",
+                        desc, Type::Pan);
       }
       else {
         uint8_t volumeLeft;
@@ -621,14 +615,9 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t vibratoDelay = readByte(curOffset++);
       uint8_t vibratoRate = readByte(curOffset++);
       uint8_t vibratoDepth = readByte(curOffset++);
-      desc = fmt::format(
-          "Delay: {:d}  Rate: {:d}  Depth: {:d}",
-          vibratoDelay, vibratoRate, vibratoDepth);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Vibrato",
-                      desc,
-                      Type::Vibrato);
+      desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}",
+                         vibratoDelay, vibratoRate, vibratoDepth);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, Type::Vibrato);
       break;
     }
 
@@ -636,18 +625,13 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t envRate = readByte(curOffset++);
       uint16_t envPitchMask = readShort(curOffset);
       curOffset += 2;
-      desc = fmt::format(
-          "Rate: {:d}  Pitch Mask: ${:04X}", envRate, envPitchMask);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Random Pitch",
-                      desc,
-                      Type::Modulation);
+      desc = fmt::format("Rate: {:d}  Pitch Mask: ${:04X}", envRate, envPitchMask);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Random Pitch", desc, Type::Modulation);
       break;
     }
 
-      case EVENT_LOOP_START: {
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc, Type::RepeatStart);
+    case EVENT_LOOP_START: {
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc, Type::RepeatStart);
       loopReturnAddr = curOffset;
       break;
     }
@@ -657,9 +641,8 @@ bool KonamiSnesTrack::readEvent(void) {
       int8_t volumeDelta = readByte(curOffset++);
       int8_t pitchDelta = readByte(curOffset++);
 
-      desc = fmt::format(
-          "Times: {:d}  Volume Delta: {:d}  Pitch Delta: {:d}",
-          times, volumeDelta, pitchDelta);
+      desc = fmt::format("Times: {:d}  Volume Delta: {:d}  Pitch Delta: {:d}",
+                         times, volumeDelta, pitchDelta);
       if (times == 0) {
         bContinue = addLoopForever(beginOffset, curOffset - beginOffset, "Loop End");
       }
@@ -693,11 +676,7 @@ bool KonamiSnesTrack::readEvent(void) {
     }
 
       case EVENT_LOOP_START_2: {
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "Loop Start #2",
-                        desc,
-                        Type::RepeatStart);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start #2", desc, Type::RepeatStart);
         loopReturnAddr2 = curOffset;
         break;
       }
@@ -707,18 +686,13 @@ bool KonamiSnesTrack::readEvent(void) {
       int8_t volumeDelta = readByte(curOffset++);
       int8_t pitchDelta = readByte(curOffset++);
 
-      desc = fmt::format(
-          "Times: {:d}  Volume Delta: {:d}  Pitch Delta: {:d}",
-          times, volumeDelta, pitchDelta);
+      desc = fmt::format("Times: {:d}  Volume Delta: {:d}  Pitch Delta: {:d}",
+                         times, volumeDelta, pitchDelta);
       if (times == 0) {
         bContinue = addLoopForever(beginOffset, curOffset - beginOffset, "Loop End #2");
       }
       else {
-          addGenericEvent(beginOffset,
-                          curOffset - beginOffset,
-                          "Loop End #2",
-                          desc,
-                          Type::RepeatStart);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End #2", desc, Type::RepeatStart);
       }
 
       bool loopAgain;
@@ -758,9 +732,7 @@ bool KonamiSnesTrack::readEvent(void) {
     case EVENT_TEMPO_FADE: {
       uint8_t newTempo = readByte(curOffset++);
       uint8_t fadeSpeed = readByte(curOffset++);
-      desc = fmt::format(
-          "BPM: {}  Fade Length: {}",
-          parentSeq->getTempoInBPM(newTempo), fadeSpeed);
+      desc = fmt::format("BPM: {}  Fade Length: {}", parentSeq->getTempoInBPM(newTempo), fadeSpeed);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Tempo Fade", desc, Type::Tempo);
       break;
     }
@@ -796,22 +768,14 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t newVolume = readByte(curOffset++);
       uint8_t fadeSpeed = readByte(curOffset++);
       desc = fmt::format("Volume: {:d}  Fade Length: {:d}", newVolume, fadeSpeed);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Volume Fade",
-                      desc,
-                      Type::VolumeSlide);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Volume Fade", desc, Type::VolumeSlide);
       break;
     }
 
     case EVENT_PORTAMENTO: {
       uint8_t portamentoSpeed = readByte(curOffset++);
       desc = fmt::format("Portamento Speed: {:d}", portamentoSpeed);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Portamento",
-                      desc,
-                      Type::Portamento);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento", desc, Type::Portamento);
       break;
     }
 
@@ -819,13 +783,9 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t pitchEnvDelay = readByte(curOffset++);
       uint8_t pitchEnvSpeed = readByte(curOffset++);
       uint8_t pitchEnvDepth = readByte(curOffset++);
-      desc = fmt::format(
-          "Delay: {:d}  Speed: {:d}  Depth: {:d}",
-          pitchEnvDelay, pitchEnvSpeed, -pitchEnvDepth);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Pitch Envelope",
-                      desc,
+      desc = fmt::format("Delay: {:d}  Speed: {:d}  Depth: {:d}",
+                         pitchEnvDelay, pitchEnvSpeed, -pitchEnvDepth);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope", desc,
                       Type::PitchEnvelope);
       break;
     }
@@ -836,13 +796,9 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t pitchEnvOffset = readByte(curOffset++);
       int16_t pitchDelta = readShort(curOffset);
       curOffset += 2;
-      desc = fmt::format(
-          "Delay: {:d}  Length: {:d}  Offset: {:d} semitones  Delta: {:.1f} semitones",
-          pitchEnvDelay, pitchEnvLength, -pitchEnvOffset, pitchDelta / 256.0);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Pitch Envelope",
-                      desc,
+      desc = fmt::format("Delay: {:d}  Length: {:d}  Offset: {:d} semitones  Delta: {:.1f} semitones",
+                         pitchEnvDelay, pitchEnvLength, -pitchEnvOffset, pitchDelta / 256.0);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope", desc,
                       Type::PitchEnvelope);
       break;
     }
@@ -859,10 +815,7 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
       desc = fmt::format("Arg1: {:d}  Arg2: {:d}  Arg3: {:d}", arg1, arg2, arg3);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Pitch Slide",
-                      desc,
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc,
                       Type::PitchBendSlide);
       break;
     }
@@ -877,13 +830,11 @@ bool KonamiSnesTrack::readEvent(void) {
         uint8_t arg4 = readByte(curOffset++);
         uint8_t arg5 = readByte(curOffset++);
         uint8_t arg6 = readByte(curOffset++);
-        fmt::format_to(std::back_inserter(desc), "  Arg4: {:d}  Arg5: {:d}  Arg6: {:d}", arg4, arg5, arg6);
+        fmt::format_to(std::back_inserter(desc), "  Arg4: {:d}  Arg5: {:d}  Arg6: {:d}",
+                       arg4, arg5, arg6);
       }
 
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Pitch Slide",
-                      desc,
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc,
                       Type::PitchBendSlide);
       break;
     }
@@ -897,13 +848,9 @@ bool KonamiSnesTrack::readEvent(void) {
 
       uint8_t pitchSlideNoteNumber = (pitchSlideNote & 0x7f) + transpose;
 
-      desc = fmt::format(
-          "Delay: {:d}  Length: {:d}  Final Note: {:d}  Delta: {:.1f} semitones",
-          pitchSlideDelay, pitchSlideLength, pitchSlideNoteNumber, pitchDelta / 256.0);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Pitch Slide",
-                      desc,
+      desc = fmt::format("Delay: {:d}  Length: {:d}  Final Note: {:d}  Delta: {:.1f} semitones",
+                         pitchSlideDelay, pitchSlideLength, pitchSlideNoteNumber, pitchDelta / 256.0);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc,
                       Type::PitchBendSlide);
       break;
     }
@@ -913,9 +860,8 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t echoVolumeL = readByte(curOffset++);
       uint8_t echoVolumeR = readByte(curOffset++);
 
-      desc = fmt::format(
-          "EON: {:d}  EVOL(L): {:d}  EVOL(R): {:d}",
-          echoChannels, echoVolumeL, echoVolumeR);
+      desc = fmt::format("EON: {:d}  EVOL(L): {:d}  EVOL(R): {:d}",
+                         echoChannels, echoVolumeL, echoVolumeR);
 
       addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc, Type::Reverb);
       break;
@@ -926,24 +872,15 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t echoFeedback = readByte(curOffset++);
       uint8_t echoArg3 = readByte(curOffset++);
 
-      desc = fmt::format(
-          "EDL: {:d}  EFB: {:d}  Arg3: {:d}",
-          echoDelay, echoFeedback, echoArg3);
+      desc = fmt::format("EDL: {:d}  EFB: {:d}  Arg3: {:d}", echoDelay, echoFeedback, echoArg3);
 
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Echo Param",
-                      desc,
-                      Type::Reverb);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc, Type::Reverb);
       break;
     }
 
     case EVENT_LOOP_WITH_VOLTA_START: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Loop With Volta Start",
-                      desc,
-                      Type::RepeatStart);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop With Volta Start",
+                      desc, Type::RepeatStart);
 
       voltaLoopStart = curOffset;
       voltaEndMeansPlayFromStart = false;
@@ -952,11 +889,8 @@ bool KonamiSnesTrack::readEvent(void) {
     }
 
     case EVENT_LOOP_WITH_VOLTA_END: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Loop With Volta End",
-                      desc,
-                      Type::RepeatStart);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop With Volta End",
+                      desc, Type::RepeatStart);
 
       if (voltaEndMeansPlayFromStart) {
         // second time - end of first volta bracket: play from start
@@ -989,10 +923,7 @@ bool KonamiSnesTrack::readEvent(void) {
     case EVENT_VIBRATO_FADE: {
       uint8_t fadeSpeed = readByte(curOffset++);
       desc = fmt::format("Fade Length: {:d}", fadeSpeed);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Vibrato Fade",
-                      desc,
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Fade", desc,
                       Type::Vibrato);
       break;
     }
@@ -1003,9 +934,8 @@ bool KonamiSnesTrack::readEvent(void) {
       uint8_t newGAINAmount = readByte(curOffset++);
       uint8_t newGAIN = convertGAINAmountToGAIN(newGAINAmount);
 
-      desc = fmt::format(
-          "ADSR(1): ${:02X}  ADSR(2): ${:02X}  GAIN: ${:02X}",
-          newADSR1, newADSR2, newGAIN);
+      desc = fmt::format("ADSR(1): ${:02X}  ADSR(2): ${:02X}  GAIN: ${:02X}",
+                         newADSR1, newADSR2, newGAIN);
       addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR(2)", desc, Type::Adsr);
       break;
     }
@@ -1037,10 +967,7 @@ bool KonamiSnesTrack::readEvent(void) {
       curOffset += 2;
 
       desc = fmt::format("Destination: ${:04X}", dest);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Pattern Play",
-                      desc,
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern Play", desc,
                       Type::RepeatStart);
 
       assert(dest >= dwOffset);
@@ -1053,10 +980,7 @@ bool KonamiSnesTrack::readEvent(void) {
 
     case EVENT_END: {
       if (inSubroutine) {
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "End Pattern",
-                        desc,
+        addGenericEvent(beginOffset, curOffset - beginOffset, "End Pattern", desc,
                         Type::RepeatEnd);
 
         inSubroutine = false;

--- a/src/main/formats/MoriSnes/MoriSnesSeq.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesSeq.cpp
@@ -76,7 +76,7 @@ bool MoriSnesSeq::parseHeader() {
       TrackStartAddress[trackIndex] = curOffset + ofsTrackStart;
 
       auto trackName = fmt::format("Track {} Offset", trackIndex + 1);
-      header->addChild(beginOffset, curOffset - beginOffset, trackName.c_str());
+      header->addChild(beginOffset, curOffset - beginOffset, trackName);
     }
     else {
       header->addUnknownChild(beginOffset, curOffset - beginOffset);
@@ -249,13 +249,13 @@ bool MoriSnesTrack::readEvent() {
   switch (eventType) {
     case EVENT_UNKNOWN0:
       desc = fmt::format("Event: 0x{:02X}", statusByte);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = readByte(curOffset++);
       desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}", statusByte, arg1);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -263,7 +263,7 @@ bool MoriSnesTrack::readEvent() {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -273,7 +273,7 @@ bool MoriSnesTrack::readEvent() {
       uint8_t arg3 = readByte(curOffset++);
       desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}",
                          statusByte, arg1, arg2, arg3);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -284,7 +284,7 @@ bool MoriSnesTrack::readEvent() {
       uint8_t arg4 = readByte(curOffset++);
       desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
                          statusByte, arg1, arg2, arg3, arg4);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 

--- a/src/main/formats/MoriSnes/MoriSnesSeq.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesSeq.cpp
@@ -229,7 +229,7 @@ bool MoriSnesTrack::readEvent() {
       }
     }
 
-    addGenericEvent(beginOffset, curOffset - beginOffset, "Note Param", desc.c_str(), Type::DurationNote);
+    addGenericEvent(beginOffset, curOffset - beginOffset, "Note Param", desc, Type::DurationNote);
     beginOffset = curOffset;
     desc.clear();
 
@@ -271,9 +271,8 @@ bool MoriSnesTrack::readEvent() {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
-      desc = fmt::format(
-          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}",
-          statusByte, arg1, arg2, arg3);
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}",
+                         statusByte, arg1, arg2, arg3);
       addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
       break;
     }
@@ -283,9 +282,8 @@ bool MoriSnesTrack::readEvent() {
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
       uint8_t arg4 = readByte(curOffset++);
-      desc = fmt::format(
-          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
-          statusByte, arg1, arg2, arg3, arg4);
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
+                         statusByte, arg1, arg2, arg3, arg4);
       addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
       break;
     }
@@ -320,7 +318,7 @@ bool MoriSnesTrack::readEvent() {
       auto prevTiedNoteIter = std::find(tiedNoteKeys.begin(), tiedNoteKeys.end(), key);
       if (prevTiedNoteIter != tiedNoteKeys.end()) {
         makePrevDurNoteEnd(getTime() + dur);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.c_str(), Type::Tie);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, Type::Tie);
 
         if (!tied) {
           // finish tied note
@@ -360,7 +358,7 @@ bool MoriSnesTrack::readEvent() {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Program Change",
-                      desc.c_str(),
+                      desc,
                       Type::ProgramChange);
       addProgramChangeNoItem(instrNum, false);
       break;
@@ -378,7 +376,7 @@ bool MoriSnesTrack::readEvent() {
         addPan(beginOffset, curOffset - beginOffset, midiPan);
       }
       else {
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Random Pan", desc.c_str(), Type::Pan);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Random Pan", desc, Type::Pan);
       }
       break;
     }
@@ -400,7 +398,7 @@ bool MoriSnesTrack::readEvent() {
     case EVENT_PRIORITY: {
       uint8_t newPriority = readByte(curOffset++);
       desc = fmt::format("Priority: {:d}", newPriority);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Priority", desc.c_str(), Type::Priority);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Priority", desc, Type::Priority);
       break;
     }
 
@@ -414,13 +412,13 @@ bool MoriSnesTrack::readEvent() {
     }
 
     case EVENT_ECHO_ON: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.c_str(), Type::Reverb);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc, Type::Reverb);
       addReverbNoItem(40);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.c_str(), Type::Reverb);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc, Type::Reverb);
       addReverbNoItem(0);
       break;
     }
@@ -435,7 +433,7 @@ bool MoriSnesTrack::readEvent() {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Echo Param",
-                      desc.c_str(),
+                      desc,
                       Type::Reverb);
       break;
     }
@@ -449,7 +447,7 @@ bool MoriSnesTrack::readEvent() {
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc.c_str(), Type::LoopForever);
+        addGenericEvent(beginOffset, length, "Jump", desc, Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -465,7 +463,7 @@ bool MoriSnesTrack::readEvent() {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pattern Play",
-                      desc.c_str(),
+                      desc,
                       Type::RepeatStart);
 
       if (spcCallStackPtr + 2 > MORISNES_CALLSTACK_SIZE) {
@@ -487,7 +485,7 @@ bool MoriSnesTrack::readEvent() {
     }
 
     case EVENT_RET: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "End Pattern", desc.c_str(), Type::RepeatEnd);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "End Pattern", desc, Type::RepeatEnd);
 
       if (spcCallStackPtr < 2) {
         // access violation
@@ -503,7 +501,7 @@ bool MoriSnesTrack::readEvent() {
     case EVENT_LOOP_START: {
       uint8_t count = readByte(curOffset++);
       desc = fmt::format("Loop Count: {:d}", count);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.c_str(), Type::RepeatStart);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc, Type::RepeatStart);
 
       if (spcCallStackPtr + 3 > MORISNES_CALLSTACK_SIZE) {
         // stack overflow
@@ -520,7 +518,7 @@ bool MoriSnesTrack::readEvent() {
     }
 
     case EVENT_LOOP_END: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.c_str(), Type::RepeatEnd);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc, Type::RepeatEnd);
 
       if (spcCallStackPtr < 3) {
         // access violation
@@ -551,7 +549,7 @@ bool MoriSnesTrack::readEvent() {
     case EVENT_NOTE_NUMBER: {
       int8_t newNoteNumber = readByte(curOffset++);
       spcNoteNumberBase = newNoteNumber;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Note Number Base", desc.c_str(), Type::NoteOn);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Note Number Base", desc, Type::NoteOn);
       break;
     }
 
@@ -571,7 +569,7 @@ bool MoriSnesTrack::readEvent() {
       // do not stop tied note here
       // example: Gokinjo Bouken Tai - Battle (28:0000, Sax at 3rd channel)
       desc = fmt::format("Duration: {:d}", spcDeltaTime);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Wait", desc.c_str(), Type::Rest);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Wait", desc, Type::Rest);
       addTime(spcDeltaTime);
       break;
     }
@@ -607,12 +605,12 @@ bool MoriSnesTrack::readEvent() {
     }
 
     case EVENT_KEY_ON: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Key On", desc.c_str(), Type::NoteOn);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Key On", desc, Type::NoteOn);
       break;
     }
 
     case EVENT_KEY_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Key Off", desc.c_str(), Type::NoteOff);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Key Off", desc, Type::NoteOff);
       break;
     }
 
@@ -635,7 +633,7 @@ bool MoriSnesTrack::readEvent() {
     case EVENT_TIMEBASE: {
       bool fast = ((readByte(curOffset++) & 1) != 0);
       desc = fmt::format("Timebase: {:d}", fast ? SEQ_PPQN : SEQ_PPQN / 2);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Timebase", desc.c_str(), Type::Tempo);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Timebase", desc, Type::Tempo);
 
       if (parentSeq->fastTempo != fast) {
         addTempoBPMNoItem(parentSeq->getTempoInBPM(parentSeq->spcTempo, fast));

--- a/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
@@ -177,7 +177,7 @@ bool NamcoSnesSeq::readEvent() {
       desc = "Tracks:";
       for (uint8_t trackIndex = 0; trackIndex < 8; trackIndex++) {
         if ((targetChannels & (0x80 >> trackIndex)) != 0) {
-          desc += fmt::format(" {}", trackIndex + 1);
+          desc += fmt::format(" {:d}", trackIndex + 1);
         }
       }
 
@@ -192,7 +192,7 @@ bool NamcoSnesSeq::readEvent() {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pattern Play",
-                      desc.c_str(),
+                      desc,
                       Type::RepeatStart);
 
       subReturnAddress = curOffset;
@@ -211,7 +211,7 @@ bool NamcoSnesSeq::readEvent() {
         addGenericEvent(beginOffset,
                         curOffset - beginOffset,
                         "Pattern End",
-                        desc.c_str(),
+                        desc,
                         Type::RepeatEnd);
         curOffset = subReturnAddress;
         subReturnAddress = 0;
@@ -237,7 +237,7 @@ bool NamcoSnesSeq::readEvent() {
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
       desc = fmt::format("Times: {:d}  Destination: ${:04X}", count, dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again", desc.c_str(), Type::RepeatEnd);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again", desc, Type::RepeatEnd);
 
       loopCount++;
       if (loopCount == count) {
@@ -257,7 +257,7 @@ bool NamcoSnesSeq::readEvent() {
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
       desc = fmt::format("Times: {:d}  Destination: ${:04X}", count, dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.c_str(), Type::RepeatEnd);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc, Type::RepeatEnd);
 
       loopCount++;
       if (loopCount == count) {
@@ -277,7 +277,7 @@ bool NamcoSnesSeq::readEvent() {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Loop Again (Alt)",
-                      desc.c_str(),
+                      desc,
                       Type::RepeatEnd);
 
       loopCountAlt++;
@@ -298,7 +298,7 @@ bool NamcoSnesSeq::readEvent() {
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
       desc = fmt::format("Times: {:d}  Destination: ${:04X}", count, dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.c_str(), Type::RepeatEnd);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc, Type::RepeatEnd);
 
       loopCountAlt++;
       if (loopCountAlt == count) {
@@ -323,7 +323,7 @@ bool NamcoSnesSeq::readEvent() {
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc.c_str(), Type::LoopForever);
+        addGenericEvent(beginOffset, length, "Jump", desc, Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -345,21 +345,21 @@ bool NamcoSnesSeq::readEvent() {
           if (keyByte >= NOTE_NUMBER_PERCUSSION_MIN) {
             key = keyByte - NOTE_NUMBER_PERCUSSION_MIN;
             noteType = NOTE_PERCUSSION;
-            desc += fmt::format(" [{}] Perc {}", trackIndex + 1, key);
+            desc += fmt::format(" [{:d}] Perc {}", trackIndex + 1, key);
           }
           else if (keyByte >= NOTE_NUMBER_NOISE_MIN) {
             key = keyByte & 0x1f;
             noteType = NOTE_NOISE;
-            desc += fmt::format(" [{}] Noise {}", trackIndex + 1, key);
+            desc += fmt::format(" [{:d}] Noise {}", trackIndex + 1, key);
           }
           else if (keyByte == NOTE_NUMBER_REST) {
             noteType = prevNoteType[trackIndex];
-            desc += fmt::format(" [{}] Rest", trackIndex + 1);
+            desc += fmt::format(" [{:d}] Rest", trackIndex + 1);
           }
           else {
             key = keyByte;
             noteType = NOTE_MELODY;
-            desc += fmt::format(" [{}] {} ({})", trackIndex + 1, key, MidiEvent::getNoteName(key + transpose));
+            desc += fmt::format(" [{:d}] {:d} ({})", trackIndex + 1, key, MidiEvent::getNoteName(key + transpose));
           }
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
@@ -421,7 +421,7 @@ bool NamcoSnesSeq::readEvent() {
       for (uint8_t trackIndex = 0; trackIndex < 8; trackIndex++) {
         if ((targetChannels & (0x80 >> trackIndex)) != 0) {
           uint8_t newValue = readByte(curOffset++);
-          desc += fmt::format(" [{}] {:d}", trackIndex + 1, newValue);
+          desc += fmt::format(" [{:d}] {:d}", trackIndex + 1, newValue);
         }
       }
 
@@ -489,7 +489,7 @@ bool NamcoSnesSeq::readEvent() {
       for (uint8_t trackIndex = 0; trackIndex < 8; trackIndex++) {
         if ((targetChannels & (0x80 >> trackIndex)) != 0) {
           uint8_t newValue = readByte(curOffset++);
-          desc += fmt::format(" [{}] {:d}", trackIndex + 1, newValue);
+          desc += fmt::format(" [{:d}] {:d}", trackIndex + 1, newValue);
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             channel = trackIndex;
@@ -526,11 +526,7 @@ bool NamcoSnesSeq::readEvent() {
 
       switch (controlType) {
         case CONTROL_PROGCHANGE:
-          addGenericEvent(beginOffset,
-                          curOffset - beginOffset,
-                          controlName,
-                          desc,
-                          Type::ProgramChange);
+          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc, Type::ProgramChange);
           break;
 
         case CONTROL_VOLUME:

--- a/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
@@ -1,5 +1,6 @@
 #include "NamcoSnesSeq.h"
 #include "ScaleConversion.h"
+#include <spdlog/fmt/fmt.h>
 
 DECLARE_FORMAT(NamcoSnes);
 
@@ -120,7 +121,7 @@ bool NamcoSnesSeq::readEvent() {
   uint8_t statusByte = readByte(curOffset++);
   bool bContinue = true;
 
-  std::stringstream desc;
+  std::string desc;
 
   NamcoSnesSeqEventType eventType = (NamcoSnesSeqEventType) 0;
   std::map<uint8_t, NamcoSnesSeqEventType>::iterator pEventType = EventMap.find(statusByte);
@@ -134,27 +135,22 @@ bool NamcoSnesSeq::readEvent() {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      desc = fmt::format("Event: 0x{:02X}", statusByte);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}", statusByte, arg1);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -162,44 +158,41 @@ bool NamcoSnesSeq::readEvent() {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2
-          << "  Arg3: " << (int) arg3;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}",
+                         statusByte, arg1, arg2, arg3);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
     case EVENT_DELTA_TIME: {
       spcDeltaTime = readByte(curOffset++);
-      desc << "Duration: " << spcDeltaTime;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", desc.str(), Type::ChangeState);
+      desc = fmt::format("Duration: {:d}", spcDeltaTime);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", desc, Type::ChangeState);
       break;
     }
 
     case EVENT_OPEN_TRACKS: {
       uint8_t targetChannels = readByte(curOffset++);
 
-      desc << "Tracks:";
+      desc = "Tracks:";
       for (uint8_t trackIndex = 0; trackIndex < 8; trackIndex++) {
         if ((targetChannels & (0x80 >> trackIndex)) != 0) {
-          desc << " " << (trackIndex + 1);
+          desc += fmt::format(" {}", trackIndex + 1);
         }
       }
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Open Tracks", desc.str(), Type::Misc);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Open Tracks", desc, Type::Misc);
       break;
     }
 
     case EVENT_CALL: {
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
-      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      desc = fmt::format("Destination: ${:04X}", dest);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pattern Play",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::RepeatStart);
 
       subReturnAddress = curOffset;
@@ -218,7 +211,7 @@ bool NamcoSnesSeq::readEvent() {
         addGenericEvent(beginOffset,
                         curOffset - beginOffset,
                         "Pattern End",
-                        desc.str().c_str(),
+                        desc.c_str(),
                         Type::RepeatEnd);
         curOffset = subReturnAddress;
         subReturnAddress = 0;
@@ -228,8 +221,8 @@ bool NamcoSnesSeq::readEvent() {
 
     case EVENT_DELTA_MULTIPLIER: {
       spcDeltaTimeScale = readByte(curOffset++);
-      desc << "Delta Time Scale: " << spcDeltaTimeScale;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time Multiplier", desc.str(), Type::Tempo);
+      desc = fmt::format("Delta Time Scale: {:d}", spcDeltaTimeScale);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time Multiplier", desc, Type::Tempo);
       break;
     }
 
@@ -243,9 +236,8 @@ bool NamcoSnesSeq::readEvent() {
       uint8_t count = readByte(curOffset++);
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
-      desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
-          << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again", desc.str().c_str(), Type::RepeatEnd);
+      desc = fmt::format("Times: {:d}  Destination: ${:04X}", count, dest);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Again", desc.c_str(), Type::RepeatEnd);
 
       loopCount++;
       if (loopCount == count) {
@@ -264,9 +256,8 @@ bool NamcoSnesSeq::readEvent() {
       uint8_t count = readByte(curOffset++);
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
-      desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
-          << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), Type::RepeatEnd);
+      desc = fmt::format("Times: {:d}  Destination: ${:04X}", count, dest);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.c_str(), Type::RepeatEnd);
 
       loopCount++;
       if (loopCount == count) {
@@ -282,12 +273,11 @@ bool NamcoSnesSeq::readEvent() {
       uint8_t count = readByte(curOffset++);
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
-      desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
-          << std::uppercase << (int) dest;
+      desc = fmt::format("Times: {:d}  Destination: ${:04X}", count, dest);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Loop Again (Alt)",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::RepeatEnd);
 
       loopCountAlt++;
@@ -307,9 +297,8 @@ bool NamcoSnesSeq::readEvent() {
       uint8_t count = readByte(curOffset++);
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
-      desc << "Times: " << count << "  Destination: $" << std::hex << std::setfill('0') << std::setw(4)
-          << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.str().c_str(), Type::RepeatEnd);
+      desc = fmt::format("Times: {:d}  Destination: ${:04X}", count, dest);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.c_str(), Type::RepeatEnd);
 
       loopCountAlt++;
       if (loopCountAlt == count) {
@@ -324,7 +313,7 @@ bool NamcoSnesSeq::readEvent() {
     case EVENT_GOTO: {
       uint16_t dest = readShort(curOffset);
       curOffset += 2;
-      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+      desc = fmt::format("Destination: ${:04X}", dest);
       uint32_t length = curOffset - beginOffset;
 
       // scan end event
@@ -334,7 +323,7 @@ bool NamcoSnesSeq::readEvent() {
 
       curOffset = dest;
       if (!isOffsetUsed(dest)) {
-        addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), Type::LoopForever);
+        addGenericEvent(beginOffset, length, "Jump", desc.c_str(), Type::LoopForever);
       }
       else {
         bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -346,7 +335,7 @@ bool NamcoSnesSeq::readEvent() {
       uint8_t targetChannels = readByte(curOffset++);
       uint16_t dur = spcDeltaTime * spcDeltaTimeScale;
 
-      desc << "Values:";
+      desc = "Values:";
       for (uint8_t trackIndex = 0; trackIndex < 8; trackIndex++) {
         if ((targetChannels & (0x80 >> trackIndex)) != 0) {
           uint8_t keyByte = readByte(curOffset++);
@@ -356,22 +345,21 @@ bool NamcoSnesSeq::readEvent() {
           if (keyByte >= NOTE_NUMBER_PERCUSSION_MIN) {
             key = keyByte - NOTE_NUMBER_PERCUSSION_MIN;
             noteType = NOTE_PERCUSSION;
-            desc << " [" << (trackIndex + 1) << "] " << "Perc " << key;
+            desc += fmt::format(" [{}] Perc {}", trackIndex + 1, key);
           }
           else if (keyByte >= NOTE_NUMBER_NOISE_MIN) {
             key = keyByte & 0x1f;
             noteType = NOTE_NOISE;
-            desc << " [" << (trackIndex + 1) << "] " << "Noise " << key;
+            desc += fmt::format(" [{}] Noise {}", trackIndex + 1, key);
           }
           else if (keyByte == NOTE_NUMBER_REST) {
             noteType = prevNoteType[trackIndex];
-            desc << " [" << (trackIndex + 1) << "] " << "Rest";
+            desc += fmt::format(" [{}] Rest", trackIndex + 1);
           }
           else {
             key = keyByte;
             noteType = NOTE_MELODY;
-            desc << " [" << (trackIndex + 1) << "] " << key << " (" << MidiEvent::getNoteName(key + transpose)
-                << ")";
+            desc += fmt::format(" [{}] {} ({})", trackIndex + 1, key, MidiEvent::getNoteName(key + transpose));
           }
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
@@ -414,74 +402,74 @@ bool NamcoSnesSeq::readEvent() {
         }
       }
 
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Note", desc.str(), Type::DurationNote);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Note", desc, Type::DurationNote);
       addTime(dur);
       break;
     }
 
     case EVENT_ECHO_DELAY: {
       uint8_t echoDelay = readByte(curOffset++);
-      desc << "Echo Delay: " << echoDelay;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Delay", desc.str(), Type::Reverb);
+      desc = fmt::format("Echo Delay: {:d}", echoDelay);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Delay", desc, Type::Reverb);
       break;
     }
 
     case EVENT_UNKNOWN_0B: {
       uint8_t targetChannels = readByte(curOffset++);
 
-      desc << "Values:";
+      desc = "Values:";
       for (uint8_t trackIndex = 0; trackIndex < 8; trackIndex++) {
         if ((targetChannels & (0x80 >> trackIndex)) != 0) {
           uint8_t newValue = readByte(curOffset++);
-          desc << " [" << (trackIndex + 1) << "] " << newValue;
+          desc += fmt::format(" [{}] {:d}", trackIndex + 1, newValue);
         }
       }
 
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
     case EVENT_ECHO: {
       bool echoOn = (readByte(curOffset++) != 0);
-      desc << "Echo Write: " << (echoOn ? "On" : "Off");
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str(), Type::Reverb);
+      desc = fmt::format("Echo Write: {}", echoOn ? "On" : "Off");
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc, Type::Reverb);
       break;
     }
 
     case EVENT_WAIT: {
       uint16_t dur = spcDeltaTime * spcDeltaTimeScale;
-      desc << "Delta Time: " << spcDeltaTime;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Wait", desc.str(), Type::Tie);
+      desc = fmt::format("Delta Time: {:d}", spcDeltaTime);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Wait", desc, Type::Tie);
       addTime(dur);
       break;
     }
 
     case EVENT_ECHO_FEEDBACK: {
       int8_t echoFeedback = readByte(curOffset++);
-      desc << "Echo Feedback: " << echoFeedback;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Feedback", desc.str(), Type::Reverb);
+      desc = fmt::format("Echo Feedback: {:d}", echoFeedback);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Feedback", desc, Type::Reverb);
       break;
     }
 
     case EVENT_ECHO_FIR: {
       uint8_t echoFilter = readByte(curOffset++);
-      desc << "Echo FIR: " << echoFilter;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR", desc.str(), Type::Reverb);
+      desc = fmt::format("Echo FIR: {:d}", echoFilter);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR", desc, Type::Reverb);
       break;
     }
 
     case EVENT_ECHO_VOLUME: {
       int8_t echoVolumeLeft = readByte(curOffset++);
       int8_t echoVolumeRight = readByte(curOffset++);
-      desc << "Echo Volume Left: " << echoVolumeLeft << "  Echo Volume Right: " << echoVolumeRight;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc.str(), Type::Reverb);
+      desc = fmt::format("Echo Volume Left: {:d}  Echo Volume Right: {:d}", echoVolumeLeft, echoVolumeRight);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc, Type::Reverb);
       break;
     }
 
     case EVENT_ECHO_ADDRESS: {
       uint16_t echoAddress = readByte(curOffset++) << 8;
-      desc << "ESA: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) echoAddress;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Address", desc.str(), Type::Reverb);
+      desc = fmt::format("ESA: ${:04X}", echoAddress);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Address", desc, Type::Reverb);
       break;
     }
 
@@ -497,11 +485,11 @@ bool NamcoSnesSeq::readEvent() {
         controlName = ControlChangeNames[controlType];
       }
 
-      desc << "Values:";
+      desc = "Values:";
       for (uint8_t trackIndex = 0; trackIndex < 8; trackIndex++) {
         if ((targetChannels & (0x80 >> trackIndex)) != 0) {
           uint8_t newValue = readByte(curOffset++);
-          desc << " [" << (trackIndex + 1) << "] " << newValue;
+          desc += fmt::format(" [{}] {:d}", trackIndex + 1, newValue);
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
             channel = trackIndex;
@@ -541,24 +529,24 @@ bool NamcoSnesSeq::readEvent() {
           addGenericEvent(beginOffset,
                           curOffset - beginOffset,
                           controlName,
-                          desc.str(),
+                          desc,
                           Type::ProgramChange);
           break;
 
         case CONTROL_VOLUME:
-          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc.str(), Type::Volume);
+          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc, Type::Volume);
           break;
 
         case CONTROL_PAN:
-          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc.str(), Type::Pan);
+          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc, Type::Pan);
           break;
 
         case CONTROL_ADSR:
-          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc.str(), Type::Adsr);
+          addGenericEvent(beginOffset, curOffset - beginOffset, controlName, desc, Type::Adsr);
           break;
 
         default:
-          addUnknown(beginOffset, curOffset - beginOffset, controlName, desc.str());
+          addUnknown(beginOffset, curOffset - beginOffset, controlName, desc);
           break;
       }
 

--- a/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
+++ b/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
@@ -1,4 +1,5 @@
 #include "NeverlandSnesSeq.h"
+#include <spdlog/fmt/fmt.h>
 
 DECLARE_FORMAT(NeverlandSnes);
 
@@ -70,17 +71,15 @@ bool NeverlandSnesSeq::parseHeader(void) {
     uint16_t trackSignPtr = dwOffset + 0x10 + trackIndex;
     uint8_t trackSign = readByte(trackSignPtr);
 
-    std::stringstream trackSignName;
-    trackSignName << "Track " << (trackIndex + 1) << " Entry";
-    header->addChild(trackSignPtr, 1, trackSignName.str());
+    auto trackSignName = fmt::format("Track {} Entry", trackIndex + 1);
+    header->addChild(trackSignPtr, 1, trackSignName);
 
     uint16_t sectionListOffsetPtr = dwOffset + 0x20 + (trackIndex * 2);
     if (trackSign != 0xff) {
       uint16_t sectionListAddress = getShortAddress(sectionListOffsetPtr);
 
-      std::stringstream playlistName;
-      playlistName << "Track " << (trackIndex + 1) << " Playlist Pointer";
-      header->addChild(sectionListOffsetPtr, 2, playlistName.str());
+      auto playlistName = fmt::format("Track {} Playlist Pointer", trackIndex + 1);
+      header->addChild(sectionListOffsetPtr, 2, playlistName);
 
       NeverlandSnesTrack *track = new NeverlandSnesTrack(this, sectionListAddress);
       aTracks.push_back(track);
@@ -140,7 +139,7 @@ bool NeverlandSnesTrack::readEvent(void) {
   uint8_t statusByte = readByte(curOffset++);
   bool bContinue = true;
 
-  std::stringstream desc;
+  std::string desc;
 
   NeverlandSnesSeqEventType eventType = (NeverlandSnesSeqEventType) 0;
   std::map<uint8_t, NeverlandSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -150,27 +149,22 @@ bool NeverlandSnesTrack::readEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      desc = fmt::format("Event: 0x{:02X}", statusByte);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}", statusByte, arg1);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -178,12 +172,8 @@ bool NeverlandSnesTrack::readEvent(void) {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2
-          << "  Arg3: " << (int) arg3;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}", statusByte, arg1, arg2, arg3);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -192,13 +182,10 @@ bool NeverlandSnesTrack::readEvent(void) {
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
       uint8_t arg4 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2
-          << "  Arg3: " << (int) arg3
-          << "  Arg4: " << (int) arg4;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      desc = fmt::format(
+          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
+          statusByte, arg1, arg2, arg3, arg4);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 

--- a/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
+++ b/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
@@ -71,14 +71,14 @@ bool NeverlandSnesSeq::parseHeader(void) {
     uint16_t trackSignPtr = dwOffset + 0x10 + trackIndex;
     uint8_t trackSign = readByte(trackSignPtr);
 
-    auto trackSignName = fmt::format("Track {} Entry", trackIndex + 1);
+    auto trackSignName = fmt::format("Track {:d} Entry", trackIndex + 1);
     header->addChild(trackSignPtr, 1, trackSignName);
 
     uint16_t sectionListOffsetPtr = dwOffset + 0x20 + (trackIndex * 2);
     if (trackSign != 0xff) {
       uint16_t sectionListAddress = getShortAddress(sectionListOffsetPtr);
 
-      auto playlistName = fmt::format("Track {} Playlist Pointer", trackIndex + 1);
+      auto playlistName = fmt::format("Track {:d} Playlist Pointer", trackIndex + 1);
       header->addChild(sectionListOffsetPtr, 2, playlistName);
 
       NeverlandSnesTrack *track = new NeverlandSnesTrack(this, sectionListAddress);
@@ -182,9 +182,8 @@ bool NeverlandSnesTrack::readEvent(void) {
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
       uint8_t arg4 = readByte(curOffset++);
-      desc = fmt::format(
-          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
-          statusByte, arg1, arg2, arg3, arg4);
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
+                         statusByte, arg1, arg2, arg3, arg4);
       addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -758,14 +758,14 @@ bool NinSnesTrack::readEvent(void) {
   switch (eventType) {
     case EVENT_UNKNOWN0: {
       desc = fmt::format("Event: 0x{:02X}", statusByte);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = readByte(curOffset++);
       desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}", statusByte, arg1);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -773,7 +773,7 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -784,7 +784,7 @@ bool NinSnesTrack::readEvent(void) {
       desc = fmt::format(
           "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}",
           statusByte, arg1, arg2, arg3);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -796,7 +796,7 @@ bool NinSnesTrack::readEvent(void) {
       desc = fmt::format(
           "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
           statusByte, arg1, arg2, arg3, arg4);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -801,13 +801,13 @@ bool NinSnesTrack::readEvent(void) {
     }
 
     case EVENT_NOP: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.c_str(), Type::Nop);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc, Type::Nop);
       break;
     }
 
     case EVENT_NOP1: {
       curOffset++;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.c_str(), Type::Nop);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc, Type::Nop);
       break;
     }
 
@@ -872,7 +872,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Note Param",
-                      desc.c_str(),
+                      desc,
                       Type::DurationChange);
       break;
     }
@@ -893,7 +893,7 @@ bool NinSnesTrack::readEvent(void) {
       duration = std::min(std::max(duration, (uint8_t) 1), (uint8_t) (shared->spcNoteDuration - 2));
       desc = fmt::format("Duration: {:d}", duration);
       makePrevDurNoteEnd(getTime() + duration);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.c_str(), Type::Tie);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, Type::Tie);
       addTime(shared->spcNoteDuration);
       break;
     }
@@ -989,7 +989,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Vibrato",
-                      desc.c_str(),
+                      desc,
                       Type::Vibrato);
       break;
     }
@@ -998,7 +998,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Vibrato Off",
-                      desc.c_str(),
+                      desc,
                       Type::Vibrato);
       break;
     }
@@ -1058,7 +1058,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Tremolo",
-                      desc.c_str(),
+                      desc,
                       Type::Tremelo);
       break;
     }
@@ -1067,7 +1067,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Tremolo Off",
-                      desc.c_str(),
+                      desc,
                       Type::Tremelo);
       break;
     }
@@ -1098,16 +1098,16 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pattern Play",
-                      desc.c_str(),
+                      desc,
                       Type::RepeatStart);
 
       // Add the next "END" event to UI
       if (curOffset < 0x10000 && readByte(curOffset) == parentSeq->STATUS_END) {
         if (shared->loopCount == 0) {
-          addGenericEvent(curOffset, 1, "Section End", desc.c_str(), Type::RepeatEnd);
+          addGenericEvent(curOffset, 1, "Section End", desc, Type::RepeatEnd);
         }
         else {
-          addGenericEvent(curOffset, 1, "Pattern End", desc.c_str(), Type::RepeatEnd);
+          addGenericEvent(curOffset, 1, "Pattern End", desc, Type::RepeatEnd);
         }
       }
 
@@ -1121,7 +1121,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Vibrato Fade",
-                      desc.c_str(),
+                      desc,
                       Type::Vibrato);
       break;
     }
@@ -1137,7 +1137,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Envelope (To)",
-                      desc.c_str(),
+                      desc,
                       Type::PitchEnvelope);
       break;
     }
@@ -1153,7 +1153,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Envelope (From)",
-                      desc.c_str(),
+                      desc,
                       Type::PitchEnvelope);
       break;
     }
@@ -1162,7 +1162,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Envelope Off",
-                      desc.c_str(),
+                      desc,
                       Type::PitchEnvelope);
       break;
     }
@@ -1178,7 +1178,7 @@ bool NinSnesTrack::readEvent(void) {
       // In Quintet games (at least in Terranigma), the fine tuning command overwrites the fractional part of instrument tuning.
       // In other words, we cannot calculate the tuning amount without reading the instrument table.
       uint8_t newTuning = readByte(curOffset++);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc.c_str(), Type::FineTune);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc, Type::FineTune);
       addFineTuningNoItem((newTuning / 256.0) * 61.8); // obviously not correct, but better than nothing?
       break;
     }
@@ -1202,12 +1202,12 @@ bool NinSnesTrack::readEvent(void) {
       fmt::format_to(std::back_inserter(desc),
                      "  Volume Left: {:d}  Volume Right: {:d}",
                      spcEVOL_L, spcEVOL_R);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.c_str(), Type::Reverb);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc, Type::Reverb);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.c_str(), Type::Reverb);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc, Type::Reverb);
       break;
     }
 
@@ -1216,10 +1216,8 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t spcEFB = readByte(curOffset++);
       uint8_t spcFIR = readByte(curOffset++);
 
-      desc = fmt::format(
-          "Delay: {:d}  Feedback: {:d}  FIR: {:d}",
-          spcEDL, spcEFB, spcFIR);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc.c_str(), Type::Reverb);
+      desc = fmt::format("Delay: {:d}  Feedback: {:d}  FIR: {:d}", spcEDL, spcEFB, spcFIR);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc, Type::Reverb);
       break;
     }
 
@@ -1228,13 +1226,12 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t spcEVOL_L = readByte(curOffset++);
       uint8_t spcEVOL_R = readByte(curOffset++);
 
-      desc = fmt::format(
-          "Length: {:d}  Volume Left: {:d}  Volume Right: {:d}",
-          fadeLength, spcEVOL_L, spcEVOL_R);
+      desc = fmt::format("Length: {:d}  Volume Left: {:d}  Volume Right: {:d}",
+                         fadeLength, spcEVOL_L, spcEVOL_R);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Echo Volume Fade",
-                      desc.c_str(),
+                      desc,
                       Type::Reverb);
       break;
     }
@@ -1243,13 +1240,12 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t pitchSlideDelay = readByte(curOffset++);
       uint8_t pitchSlideLength = readByte(curOffset++);
       uint8_t pitchSlideTargetNote = readByte(curOffset++);
-      desc = fmt::format(
-          "Delay: {:d}  Length: {:d}  Note: {:d}",
-          pitchSlideDelay, pitchSlideLength, (int) (pitchSlideTargetNote - 0x80));
+      desc = fmt::format("Delay: {:d}  Length: {:d}  Note: {:d}",
+                         pitchSlideDelay, pitchSlideLength, (int) (pitchSlideTargetNote - 0x80));
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Slide",
-                      desc.c_str(),
+                      desc,
                       Type::PitchBendSlide);
       break;
     }
@@ -1259,10 +1255,7 @@ bool NinSnesTrack::readEvent(void) {
       parentSeq->spcPercussionBase = percussionBase;
 
       desc = fmt::format("Percussion Base: {:d}", percussionBase);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Percussion Base",
-                      desc.c_str(),
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion Base", desc,
                       Type::ChangeState);
       break;
     }
@@ -1283,7 +1276,7 @@ bool NinSnesTrack::readEvent(void) {
       // KONAMI EVENTS START >>
 
     case EVENT_KONAMI_LOOP_START: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.c_str(), Type::RepeatStart);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc, Type::RepeatStart);
       shared->konamiLoopStart = curOffset;
       shared->konamiLoopCount = 0;
       break;
@@ -1294,10 +1287,9 @@ bool NinSnesTrack::readEvent(void) {
       int8_t volumeDelta = readByte(curOffset++);
       int8_t pitchDelta = readByte(curOffset++);
 
-      desc = fmt::format(
-          "Times: {:d}  Volume Delta: {:d}  Pitch Delta: {:d}/16 semitones",
-          times, volumeDelta, pitchDelta);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.c_str(), Type::RepeatEnd);
+      desc = fmt::format("Times: {:d}  Volume Delta: {:d}  Pitch Delta: {:d}/16 semitones",
+                         times, volumeDelta, pitchDelta);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc, Type::RepeatEnd);
 
       shared->konamiLoopCount++;
       if (shared->konamiLoopCount != times) {
@@ -1346,10 +1338,7 @@ bool NinSnesTrack::readEvent(void) {
         }
       }
 
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Note Param",
-                      desc.c_str(),
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Note Param", desc,
                       Type::DurationChange);
       break;
     }
@@ -1375,23 +1364,18 @@ bool NinSnesTrack::readEvent(void) {
           shared->spcNoteDurRate = parentSeq->intelliDurVolTable[durIndex];
           fmt::format_to(std::back_inserter(desc),
                          "  Quantize: {} ({}/256)",
-                         durIndex,
-                         shared->spcNoteDurRate);
+                         durIndex, shared->spcNoteDurRate);
         }
         else { // 40..7f
           uint8_t velIndex = noteParam & 0x3f;
           shared->spcNoteVolume = parentSeq->intelliDurVolTable[velIndex];
           fmt::format_to(std::back_inserter(desc),
                          "  Velocity: {} ({}/256)",
-                         velIndex,
-                         shared->spcNoteVolume);
+                         velIndex, shared->spcNoteVolume);
         }
       }
 
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Note Param",
-                      desc.c_str(),
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Note Param", desc,
                       Type::DurationChange);
       break;
     }
@@ -1422,7 +1406,7 @@ bool NinSnesTrack::readEvent(void) {
       uint16_t dest = curOffset + offset;
 
       desc = fmt::format("Destination: ${:04X}", dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump (Short)", desc.c_str(), Type::Misc);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump (Short)", desc, Type::Misc);
 
       // condition for branch has not been researched yet
       curOffset = dest;
@@ -1434,7 +1418,7 @@ bool NinSnesTrack::readEvent(void) {
       uint16_t dest = curOffset + offset;
 
       desc = fmt::format("Destination: ${:04X}", dest);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Jump (Short)", desc.c_str(), Type::Misc);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Jump (Short)", desc, Type::Misc);
 
       curOffset = dest;
       break;
@@ -1444,7 +1428,7 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t param = readByte(curOffset++);
       if (param < 0xf0) {
         // wait for APU port #2
-        desc = fmt::format("Value: {}", param);
+        desc = fmt::format("Value: {:d}", param);
         addGenericEvent(beginOffset, curOffset - beginOffset, "Wait for APU Port #2", desc, Type::ChangeState);
       }
       else {
@@ -1456,20 +1440,14 @@ bool NinSnesTrack::readEvent(void) {
         switch (bit) {
           case 0:
             parentSeq->intelliUseCustomPercTable = bitValue;
-            addGenericEvent(beginOffset,
-                            curOffset - beginOffset,
-                            "Use Custom Percussion Table",
-                            desc,
-                            Type::ChangeState);
+            addGenericEvent(beginOffset, curOffset - beginOffset, "Use Custom Percussion Table",
+                            desc, Type::ChangeState);
             break;
 
           case 7:
             parentSeq->intelliUseCustomNoteParam = bitValue;
-            addGenericEvent(beginOffset,
-                            curOffset - beginOffset,
-                            "Use Custom Note Param",
-                            desc,
-                            Type::ChangeState);
+            addGenericEvent(beginOffset,curOffset - beginOffset, "Use Custom Note Param",
+                            desc, Type::ChangeState);
             break;
 
           default:
@@ -1481,7 +1459,7 @@ bool NinSnesTrack::readEvent(void) {
 
     case EVENT_INTELLI_WRITE_APU_PORT: {
       uint8_t value = readByte(curOffset++);
-      desc = fmt::format("Value: {}", value);
+      desc = fmt::format("Value: {:d}", value);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Write APU Port", desc, Type::ChangeState);
       break;
     }
@@ -1498,14 +1476,14 @@ bool NinSnesTrack::readEvent(void) {
         parentSeq->intelliVoiceParamTableSize = param;
         parentSeq->intelliVoiceParamTable = curOffset;
         curOffset += parentSeq->intelliVoiceParamTableSize * 4;
-        desc = fmt::format("Number of Items: {}", parentSeq->intelliVoiceParamTableSize);
+        desc = fmt::format("Number of Items: {:d}", parentSeq->intelliVoiceParamTableSize);
         addGenericEvent(beginOffset, curOffset - beginOffset, "Voice Param Table", desc, Type::Misc);
       }
       else {
         if (parentSeq->version == NINSNES_INTELLI_FE3 || parentSeq->version == NINSNES_INTELLI_TA) {
           uint8_t instrNum = param & 0x3f;
           curOffset += 6;
-          desc = fmt::format("Instrument: {}", instrNum);
+          desc = fmt::format("Instrument: {:d}", instrNum);
           addGenericEvent(beginOffset, curOffset - beginOffset, "Overwrite Instrument Region", desc, Type::Misc);
         }
         else {
@@ -1517,7 +1495,7 @@ bool NinSnesTrack::readEvent(void) {
 
     case EVENT_INTELLI_LOAD_VOICE_PARAM: {
       uint8_t paramIndex = readByte(curOffset++);
-      desc = fmt::format("Index: {}", paramIndex);
+      desc = fmt::format("Index: {:d}", paramIndex);
 
       if (paramIndex < parentSeq->intelliVoiceParamTableSize) {
         uint16_t addrVoiceParam = parentSeq->intelliVoiceParamTable + (paramIndex * 4);
@@ -1579,10 +1557,7 @@ bool NinSnesTrack::readEvent(void) {
         }
       }
 
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Load Voice Param",
-                      desc,
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Load Voice Param", desc,
                       Type::ProgramChange);
       break;
     }
@@ -1600,9 +1575,8 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t sustain_rate = readByte(curOffset++);
       uint8_t sustain_level = readByte(curOffset++);
 	  uint8_t adsr2 = (sustain_level << 5) | sustain_rate;
-      desc = fmt::format(
-          "ADSR(1): ${:02X}  Sustain Rate: {}  Sustain Level: {}  (ADSR(2): ${:02X})",
-          adsr1, sustain_rate, sustain_level, adsr2);
+      desc = fmt::format("ADSR(1): ${:02X}  Sustain Rate: {:d} Sustain Level: {}  (ADSR(2): ${:02X})",
+                         adsr1, sustain_rate, sustain_level, adsr2);
       addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, Type::Adsr);
       break;
     }
@@ -1610,20 +1584,16 @@ bool NinSnesTrack::readEvent(void) {
     case EVENT_INTELLI_GAIN_SUSTAIN_TIME_AND_RATE: {
       uint8_t sustainDurRate = readByte(curOffset++);
       uint8_t sustainGAIN = readByte(curOffset++);
-      desc = fmt::format(
-          "Duration for Sustain: {}/256  GAIN for Sustain: ${:02X}",
-          sustainDurRate, sustainGAIN);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "GAIN Sustain Time/Rate",
-                      desc,
-                      Type::Adsr);
+      desc = fmt::format("Duration for Sustain: {:d}/256  GAIN for Sustain: ${:02X}",
+                         sustainDurRate, sustainGAIN);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN Sustain Time/Rate",
+                      desc, Type::Adsr);
       break;
     }
 
     case EVENT_INTELLI_GAIN_SUSTAIN_TIME: {
       uint8_t sustainDurRate = readByte(curOffset++);
-      desc = fmt::format("Duration for Sustain: {}/256", sustainDurRate);
+      desc = fmt::format("Duration for Sustain: {:d}/256", sustainDurRate);
       addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN Sustain Time", desc, Type::Adsr);
       break;
     }
@@ -1668,19 +1638,13 @@ bool NinSnesTrack::readEvent(void) {
 
           if (param == 0x80) {
             desc = fmt::format("Status: {}", (bitValue ? "On" : "Off"));
-            addGenericEvent(beginOffset,
-                            curOffset - beginOffset,
-                            "Use Custom Note Param",
-                            desc,
-                            Type::ChangeState);
+            addGenericEvent(beginOffset, curOffset - beginOffset, "Use Custom Note Param",
+                            desc, Type::ChangeState);
           }
           else if (param == 0x40) {
             desc = fmt::format("Status: {}", (bitValue ? "On" : "Off"));
-            addGenericEvent(beginOffset,
-                            curOffset - beginOffset,
-                            "Use Custom Percussion Table",
-                            desc,
-                            Type::ChangeState);
+            addGenericEvent(beginOffset, curOffset - beginOffset, "Use Custom Percussion Table",
+                            desc, Type::ChangeState);
           }
           else {
             desc = fmt::format("Value: ${:02X}", param);
@@ -1701,10 +1665,7 @@ bool NinSnesTrack::readEvent(void) {
           break;
 
         case 0x04:
-          addGenericEvent(beginOffset,
-                          curOffset - beginOffset,
-                          "Legato Off",
-                          desc,
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Legato Off", desc,
                           Type::Portamento);
           break;
 
@@ -1757,10 +1718,10 @@ bool NinSnesTrack::readEvent(void) {
   // (because it often gets interrupted by the end of other track)
   if (curOffset + 1 <= 0x10000 && statusByte != parentSeq->STATUS_END && readByte(curOffset) == parentSeq->STATUS_END) {
     if (shared->loopCount == 0) {
-      addGenericEvent(curOffset, 1, "Section End", desc.c_str(), Type::TrackEnd);
+      addGenericEvent(curOffset, 1, "Section End", desc, Type::TrackEnd);
     }
     else {
-      addGenericEvent(curOffset, 1, "Pattern End", desc.c_str(), Type::RepeatEnd);
+      addGenericEvent(curOffset, 1, "Pattern End", desc, Type::RepeatEnd);
     }
   }
 

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -1,6 +1,7 @@
 #include "NinSnesSeq.h"
 #include "SeqEvent.h"
 #include "ScaleConversion.h"
+#include "spdlog/fmt/fmt.h"
 
 DECLARE_FORMAT(NinSnes);
 
@@ -655,9 +656,8 @@ bool NinSnesSection::parseTrackPointers() {
         }
       }
 
-      std::stringstream trackName;
-      trackName << "Track " << (trackIndex + 1);
-      track = new NinSnesTrack(this, startAddress, 0, trackName.str());
+      auto trackName = fmt::format("Track {}", trackIndex + 1);
+      track = new NinSnesTrack(this, startAddress, 0, trackName);
 
       numActiveTracks++;
     }
@@ -747,7 +747,7 @@ bool NinSnesTrack::readEvent(void) {
   uint8_t statusByte = readByte(curOffset++);
   bool bContinue = true;
 
-  std::stringstream desc;
+  std::string desc;
 
   NinSnesSeqEventType eventType = (NinSnesSeqEventType) 0;
   std::map<uint8_t, NinSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -757,28 +757,23 @@ bool NinSnesTrack::readEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0: {
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      desc = fmt::format("Event: 0x{:02X}", statusByte);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
       break;
     }
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}", statusByte, arg1);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
       break;
     }
 
@@ -786,12 +781,10 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2
-          << "  Arg3: " << (int) arg3;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      desc = fmt::format(
+          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}",
+          statusByte, arg1, arg2, arg3);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
       break;
     }
 
@@ -800,24 +793,21 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
       uint8_t arg4 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2
-          << "  Arg3: " << (int) arg3
-          << "  Arg4: " << (int) arg4;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str().c_str());
+      desc = fmt::format(
+          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
+          statusByte, arg1, arg2, arg3, arg4);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
       break;
     }
 
     case EVENT_NOP: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), Type::Nop);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.c_str(), Type::Nop);
       break;
     }
 
     case EVENT_NOP1: {
       curOffset++;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.str().c_str(), Type::Nop);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.c_str(), Type::Nop);
       break;
     }
 
@@ -862,7 +852,7 @@ bool NinSnesTrack::readEvent(void) {
       OnEventNoteParam:
       // param #0: duration
       shared->spcNoteDuration = statusByte;
-      desc << "Duration: " << (int) shared->spcNoteDuration;
+      desc = fmt::format("Duration: {:d}", shared->spcNoteDuration);
 
       // param #1: quantize and velocity (optional)
       if (curOffset + 1 < 0x10000 && readByte(curOffset) <= 0x7f) {
@@ -874,14 +864,15 @@ bool NinSnesTrack::readEvent(void) {
         shared->spcNoteDurRate = parentSeq->durRateTable[durIndex];
         shared->spcNoteVolume = parentSeq->volumeTable[velIndex];
 
-        desc << "  Quantize: " << (int) durIndex << " (" << (int) shared->spcNoteDurRate << "/256)"
-            << "  Velocity: " << (int) velIndex << " (" << (int) shared->spcNoteVolume << "/256)";
+        fmt::format_to(std::back_inserter(desc),
+                       "  Quantize: {:d} ({:d}/256)  Velocity: {:d} ({:d}/256)",
+                       durIndex, shared->spcNoteDurRate, velIndex, shared->spcNoteVolume);
       }
 
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Note Param",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::DurationChange);
       break;
     }
@@ -900,9 +891,9 @@ bool NinSnesTrack::readEvent(void) {
     case EVENT_TIE: {
       uint8_t duration = (shared->spcNoteDuration * shared->spcNoteDurRate) >> 8;
       duration = std::min(std::max(duration, (uint8_t) 1), (uint8_t) (shared->spcNoteDuration - 2));
-      desc << "Duration: " << (int) duration;
+      desc = fmt::format("Duration: {:d}", duration);
       makePrevDurNoteEnd(getTime() + duration);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.str().c_str(), Type::Tie);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.c_str(), Type::Tie);
       addTime(shared->spcNoteDuration);
       break;
     }
@@ -992,12 +983,13 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t vibratoRate = readByte(curOffset++);
       uint8_t vibratoDepth = readByte(curOffset++);
 
-      desc << "Delay: " << (int) vibratoDelay << "  Rate: " << (int) vibratoRate << "  Depth: "
-          << (int) vibratoDepth;
+      desc = fmt::format(
+          "Delay: {:d}  Rate: {:d}  Depth: {:d}",
+          vibratoDelay, vibratoRate, vibratoDepth);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Vibrato",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::Vibrato);
       break;
     }
@@ -1006,7 +998,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Vibrato Off",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::Vibrato);
       break;
     }
@@ -1021,7 +1013,7 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t fadeLength = readByte(curOffset++);
       uint8_t newVol = readByte(curOffset++);
 
-      desc << "Length: " << (int) fadeLength << "  Volume: " << (int) newVol;
+      desc = fmt::format("Length: {:d}  Volume: {:d}", fadeLength, newVol);
       addMastVolSlide(beginOffset, curOffset - beginOffset, fadeLength, newVol / 2);
       break;
     }
@@ -1060,13 +1052,13 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t tremoloDelay = readByte(curOffset++);
       uint8_t tremoloRate = readByte(curOffset++);
       uint8_t tremoloDepth = readByte(curOffset++);
-
-      desc << "Delay: " << (int) tremoloDelay << "  Rate: " << (int) tremoloRate << "  Depth: "
-          << (int) tremoloDepth;
+      desc = fmt::format(
+          "Delay: {:d}  Rate: {:d}  Depth: {:d}",
+          tremoloDelay, tremoloRate, tremoloDepth);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Tremolo",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::Tremelo);
       break;
     }
@@ -1075,7 +1067,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Tremolo Off",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::Tremelo);
       break;
     }
@@ -1102,21 +1094,20 @@ bool NinSnesTrack::readEvent(void) {
       shared->loopStartAddress = dest;
       shared->loopCount = times;
 
-      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest
-          << std::dec << std::setfill(' ') << std::setw(0) << "  Times: " << (int) times;
+      desc = fmt::format("Destination: ${:04X}  Times: {:d}", dest, times);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pattern Play",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::RepeatStart);
 
       // Add the next "END" event to UI
       if (curOffset < 0x10000 && readByte(curOffset) == parentSeq->STATUS_END) {
         if (shared->loopCount == 0) {
-          addGenericEvent(curOffset, 1, "Section End", desc.str().c_str(), Type::RepeatEnd);
+          addGenericEvent(curOffset, 1, "Section End", desc.c_str(), Type::RepeatEnd);
         }
         else {
-          addGenericEvent(curOffset, 1, "Pattern End", desc.str().c_str(), Type::RepeatEnd);
+          addGenericEvent(curOffset, 1, "Pattern End", desc.c_str(), Type::RepeatEnd);
         }
       }
 
@@ -1126,11 +1117,11 @@ bool NinSnesTrack::readEvent(void) {
 
     case EVENT_VIBRATO_FADE: {
       uint8_t fadeLength = readByte(curOffset++);
-      desc << "Length: " << (int) fadeLength;
+      desc = fmt::format("Length: {:d}", fadeLength);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Vibrato Fade",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::Vibrato);
       break;
     }
@@ -1140,12 +1131,13 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t pitchEnvLength = readByte(curOffset++);
       int8_t pitchEnvSemitones = (int8_t) readByte(curOffset++);
 
-      desc << "Delay: " << (int) pitchEnvDelay << "  Length: " << (int) pitchEnvLength << "  Semitones: "
-          << (int) pitchEnvSemitones;
+      desc = fmt::format(
+          "Delay: {:d}  Length: {:d}  Semitones: {:d}",
+          pitchEnvDelay, pitchEnvLength, pitchEnvSemitones);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Envelope (To)",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::PitchEnvelope);
       break;
     }
@@ -1155,12 +1147,13 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t pitchEnvLength = readByte(curOffset++);
       int8_t pitchEnvSemitones = (int8_t) readByte(curOffset++);
 
-      desc << "Delay: " << (int) pitchEnvDelay << "  Length: " << (int) pitchEnvLength << "  Semitones: "
-          << (int) pitchEnvSemitones;
+      desc = fmt::format(
+          "Delay: {:d}  Length: {:d}  Semitones: {:d}",
+          pitchEnvDelay, pitchEnvLength, pitchEnvSemitones);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Envelope (From)",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::PitchEnvelope);
       break;
     }
@@ -1169,7 +1162,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Envelope Off",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::PitchEnvelope);
       break;
     }
@@ -1185,7 +1178,7 @@ bool NinSnesTrack::readEvent(void) {
       // In Quintet games (at least in Terranigma), the fine tuning command overwrites the fractional part of instrument tuning.
       // In other words, we cannot calculate the tuning amount without reading the instrument table.
       uint8_t newTuning = readByte(curOffset++);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc.str().c_str(), Type::FineTune);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc.c_str(), Type::FineTune);
       addFineTuningNoItem((newTuning / 256.0) * 61.8); // obviously not correct, but better than nothing?
       break;
     }
@@ -1195,25 +1188,26 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t spcEVOL_L = readByte(curOffset++);
       uint8_t spcEVOL_R = readByte(curOffset++);
 
-      desc << "Channels: ";
+      desc = "Channels: ";
       for (int channelNo = MAX_TRACKS - 1; channelNo >= 0; channelNo--) {
         if ((spcEON & (1 << channelNo)) != 0) {
-          desc << (int) channelNo;
+          fmt::format_to(std::back_inserter(desc), "{}", channelNo);
           parentSeq->aTracks[channelNo]->addReverbNoItem(40);
-        }
-        else {
-          desc << "-";
+        } else {
+          desc.push_back('-');
           parentSeq->aTracks[channelNo]->addReverbNoItem(0);
         }
       }
 
-      desc << "  Volume Left: " << (int) spcEVOL_L << "  Volume Right: " << (int) spcEVOL_R;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.str().c_str(), Type::Reverb);
+      fmt::format_to(std::back_inserter(desc),
+                     "  Volume Left: {:d}  Volume Right: {:d}",
+                     spcEVOL_L, spcEVOL_R);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo", desc.c_str(), Type::Reverb);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.str().c_str(), Type::Reverb);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.c_str(), Type::Reverb);
       break;
     }
 
@@ -1222,8 +1216,10 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t spcEFB = readByte(curOffset++);
       uint8_t spcFIR = readByte(curOffset++);
 
-      desc << "Delay: " << (int) spcEDL << "  Feedback: " << (int) spcEFB << "  FIR: " << (int) spcFIR;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc.str().c_str(), Type::Reverb);
+      desc = fmt::format(
+          "Delay: {:d}  Feedback: {:d}  FIR: {:d}",
+          spcEDL, spcEFB, spcFIR);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc.c_str(), Type::Reverb);
       break;
     }
 
@@ -1232,12 +1228,13 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t spcEVOL_L = readByte(curOffset++);
       uint8_t spcEVOL_R = readByte(curOffset++);
 
-      desc << "Length: " << (int) fadeLength << "  Volume Left: " << (int) spcEVOL_L << "  Volume Right: "
-          << (int) spcEVOL_R;
+      desc = fmt::format(
+          "Length: {:d}  Volume Left: {:d}  Volume Right: {:d}",
+          fadeLength, spcEVOL_L, spcEVOL_R);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Echo Volume Fade",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::Reverb);
       break;
     }
@@ -1246,13 +1243,13 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t pitchSlideDelay = readByte(curOffset++);
       uint8_t pitchSlideLength = readByte(curOffset++);
       uint8_t pitchSlideTargetNote = readByte(curOffset++);
-
-      desc << "Delay: " << (int) pitchSlideDelay << "  Length: " << (int) pitchSlideLength << "  Note: "
-          << (int) (pitchSlideTargetNote - 0x80);
+      desc = fmt::format(
+          "Delay: {:d}  Length: {:d}  Note: {:d}",
+          pitchSlideDelay, pitchSlideLength, (int) (pitchSlideTargetNote - 0x80));
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Slide",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::PitchBendSlide);
       break;
     }
@@ -1261,11 +1258,11 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t percussionBase = readByte(curOffset++);
       parentSeq->spcPercussionBase = percussionBase;
 
-      desc << "Percussion Base: " << (int) percussionBase;
+      desc = fmt::format("Percussion Base: {:d}", percussionBase);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Percussion Base",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::ChangeState);
       break;
     }
@@ -1286,7 +1283,7 @@ bool NinSnesTrack::readEvent(void) {
       // KONAMI EVENTS START >>
 
     case EVENT_KONAMI_LOOP_START: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.str().c_str(), Type::RepeatStart);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.c_str(), Type::RepeatStart);
       shared->konamiLoopStart = curOffset;
       shared->konamiLoopCount = 0;
       break;
@@ -1297,9 +1294,10 @@ bool NinSnesTrack::readEvent(void) {
       int8_t volumeDelta = readByte(curOffset++);
       int8_t pitchDelta = readByte(curOffset++);
 
-      desc << "Times: " << (int) times << "  Volume Delta: " << (int) volumeDelta << "  Pitch Delta: "
-          << (int) pitchDelta << "/16 semitones";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.str().c_str(), Type::RepeatEnd);
+      desc = fmt::format(
+          "Times: {:d}  Volume Delta: {:d}  Pitch Delta: {:d}/16 semitones",
+          times, volumeDelta, pitchDelta);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.c_str(), Type::RepeatEnd);
 
       shared->konamiLoopCount++;
       if (shared->konamiLoopCount != times) {
@@ -1314,9 +1312,10 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t adsr1 = readByte(curOffset++);
       uint8_t adsr2 = readByte(curOffset++);
       uint8_t gain = readByte(curOffset++);
-      desc << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << "ADSR(1): $" << adsr1
-          << "  ADSR(2): $" << adsr2 << "  GAIN: $" << gain;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR/GAIN", desc.str(), Type::Adsr);
+      desc = fmt::format(
+          "ADSR(1): ${:02X}  ADSR(2): ${:02X}  GAIN: ${:02X}",
+          adsr1, adsr2, gain);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR/GAIN", desc, Type::Adsr);
       break;
     }
 
@@ -1327,26 +1326,30 @@ bool NinSnesTrack::readEvent(void) {
     case EVENT_LEMMINGS_NOTE_PARAM: {
       // param #0: duration
       shared->spcNoteDuration = statusByte;
-      desc << "Duration: " << (int) shared->spcNoteDuration;
+      desc = fmt::format("Duration: {:d}", shared->spcNoteDuration);
 
       // param #1: quantize (optional)
       if (curOffset + 1 < 0x10000 && readByte(curOffset) <= 0x7f) {
         uint8_t durByte = readByte(curOffset++);
         shared->spcNoteDurRate = (durByte << 1) + (durByte >> 1) + (durByte & 1); // approx percent?
-        desc << "  Quantize: " << durByte << " (" << shared->spcNoteDurRate << "/256)";
+        fmt::format_to(std::back_inserter(desc),
+                       "  Quantize: {} ({}/256)",
+                       durByte, shared->spcNoteDurRate);
 
         // param #2: velocity (optional)
         if (curOffset + 1 < 0x10000 && readByte(curOffset) <= 0x7f) {
           uint8_t velByte = readByte(curOffset++);
           shared->spcNoteVolume = velByte << 1;
-          desc << "  Velocity: " << velByte << " (" << shared->spcNoteVolume << "/256)";
+          fmt::format_to(std::back_inserter(desc),
+                         "  Velocity: {} ({}/256)",
+                         velByte, shared->spcNoteVolume);
         }
       }
 
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Note Param",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::DurationChange);
       break;
     }
@@ -1362,7 +1365,7 @@ bool NinSnesTrack::readEvent(void) {
 
       // param #0: duration
       shared->spcNoteDuration = statusByte;
-      desc << "Duration: " << (int) shared->spcNoteDuration;
+      desc = fmt::format("Duration: {:d}", shared->spcNoteDuration);
 
       // param #1,2...: quantize/velocity (optional)
       while (curOffset + 1 < 0x10000 && readByte(curOffset) <= 0x7f) {
@@ -1370,19 +1373,25 @@ bool NinSnesTrack::readEvent(void) {
         if (noteParam < 0x40) { // 00..3f
           uint8_t durIndex = noteParam & 0x3f;
           shared->spcNoteDurRate = parentSeq->intelliDurVolTable[durIndex];
-          desc << "  Quantize: " << durIndex << " (" << shared->spcNoteDurRate << "/256)";
+          fmt::format_to(std::back_inserter(desc),
+                         "  Quantize: {} ({}/256)",
+                         durIndex,
+                         shared->spcNoteDurRate);
         }
         else { // 40..7f
           uint8_t velIndex = noteParam & 0x3f;
           shared->spcNoteVolume = parentSeq->intelliDurVolTable[velIndex];
-          desc << "  Velocity: " << velIndex << " (" << shared->spcNoteVolume << "/256)";
+          fmt::format_to(std::back_inserter(desc),
+                         "  Velocity: {} ({}/256)",
+                         velIndex,
+                         shared->spcNoteVolume);
         }
       }
 
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Note Param",
-                      desc.str().c_str(),
+                      desc.c_str(),
                       Type::DurationChange);
       break;
     }
@@ -1399,12 +1408,12 @@ bool NinSnesTrack::readEvent(void) {
 
     case EVENT_INTELLI_LEGATO_ON: {
       // TODO: cancel keyoff of note (i.e. full duration)
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato On", desc.str(), Type::Portamento);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato On", desc, Type::Portamento);
       break;
     }
 
     case EVENT_INTELLI_LEGATO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato Off", desc.str(), Type::Portamento);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Legato Off", desc, Type::Portamento);
       break;
     }
 
@@ -1412,8 +1421,8 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t offset = readByte(curOffset++);
       uint16_t dest = curOffset + offset;
 
-      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump (Short)", desc.str().c_str(), Type::Misc);
+      desc = fmt::format("Destination: ${:04X}", dest);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Conditional Jump (Short)", desc.c_str(), Type::Misc);
 
       // condition for branch has not been researched yet
       curOffset = dest;
@@ -1424,8 +1433,8 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t offset = readByte(curOffset++);
       uint16_t dest = curOffset + offset;
 
-      desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Jump (Short)", desc.str().c_str(), Type::Misc);
+      desc = fmt::format("Destination: ${:04X}", dest);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Jump (Short)", desc.c_str(), Type::Misc);
 
       curOffset = dest;
       break;
@@ -1435,22 +1444,22 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t param = readByte(curOffset++);
       if (param < 0xf0) {
         // wait for APU port #2
-        desc << "Value: " << param;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Wait for APU Port #2", desc.str(), Type::ChangeState);
+        desc = fmt::format("Value: {}", param);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Wait for APU Port #2", desc, Type::ChangeState);
       }
       else {
         // set/clear bitflag in $ca
         uint8_t bit = param & 7;
         bool bitValue = (param & 8) == 0;
 
-        desc << "Status: " << (bitValue ? "On" : "Off");
+        desc = fmt::format("Status: {}", (bitValue ? "On" : "Off"));
         switch (bit) {
           case 0:
             parentSeq->intelliUseCustomPercTable = bitValue;
             addGenericEvent(beginOffset,
                             curOffset - beginOffset,
                             "Use Custom Percussion Table",
-                            desc.str(),
+                            desc,
                             Type::ChangeState);
             break;
 
@@ -1459,12 +1468,12 @@ bool NinSnesTrack::readEvent(void) {
             addGenericEvent(beginOffset,
                             curOffset - beginOffset,
                             "Use Custom Note Param",
-                            desc.str(),
+                            desc,
                             Type::ChangeState);
             break;
 
           default:
-            addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+            addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
         }
       }
       break;
@@ -1472,8 +1481,8 @@ bool NinSnesTrack::readEvent(void) {
 
     case EVENT_INTELLI_WRITE_APU_PORT: {
       uint8_t value = readByte(curOffset++);
-      desc << "Value: " << value;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Write APU Port", desc.str(), Type::ChangeState);
+      desc = fmt::format("Value: {}", value);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Write APU Port", desc, Type::ChangeState);
       break;
     }
 
@@ -1489,15 +1498,15 @@ bool NinSnesTrack::readEvent(void) {
         parentSeq->intelliVoiceParamTableSize = param;
         parentSeq->intelliVoiceParamTable = curOffset;
         curOffset += parentSeq->intelliVoiceParamTableSize * 4;
-        desc << "Number of Items: " << parentSeq->intelliVoiceParamTableSize;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Voice Param Table", desc.str(), Type::Misc);
+        desc = fmt::format("Number of Items: {}", parentSeq->intelliVoiceParamTableSize);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Voice Param Table", desc, Type::Misc);
       }
       else {
         if (parentSeq->version == NINSNES_INTELLI_FE3 || parentSeq->version == NINSNES_INTELLI_TA) {
           uint8_t instrNum = param & 0x3f;
           curOffset += 6;
-          desc << "Instrument: " << instrNum;
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Overwrite Instrument Region", desc.str(), Type::Misc);
+          desc = fmt::format("Instrument: {}", instrNum);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Overwrite Instrument Region", desc, Type::Misc);
         }
         else {
           addUnknown(beginOffset, curOffset - beginOffset);
@@ -1508,7 +1517,7 @@ bool NinSnesTrack::readEvent(void) {
 
     case EVENT_INTELLI_LOAD_VOICE_PARAM: {
       uint8_t paramIndex = readByte(curOffset++);
-      desc << "Index: " << paramIndex;
+      desc = fmt::format("Index: {}", paramIndex);
 
       if (paramIndex < parentSeq->intelliVoiceParamTableSize) {
         uint16_t addrVoiceParam = parentSeq->intelliVoiceParamTable + (paramIndex * 4);
@@ -1573,7 +1582,7 @@ bool NinSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Load Voice Param",
-                      desc.str(),
+                      desc,
                       Type::ProgramChange);
       break;
     }
@@ -1581,9 +1590,8 @@ bool NinSnesTrack::readEvent(void) {
     case EVENT_INTELLI_ADSR: {
       uint8_t adsr1 = readByte(curOffset++);
       uint8_t adsr2 = readByte(curOffset++);
-      desc << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << "ADSR(1): $" << adsr1
-          << "  ADSR(2): $" << adsr2;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), Type::Adsr);
+      desc = fmt::format("ADSR(1): ${:02X}  ADSR(2): ${:02X}", adsr1, adsr2);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, Type::Adsr);
       break;
     }
 
@@ -1592,30 +1600,31 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t sustain_rate = readByte(curOffset++);
       uint8_t sustain_level = readByte(curOffset++);
 	  uint8_t adsr2 = (sustain_level << 5) | sustain_rate;
-      desc << "ADSR(1): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << adsr1
-          << "  Sustain Rate: " << std::dec << sustain_rate << "  Sustain Level: " << sustain_level
-          << "  (ADSR(2): $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << adsr2 << ")";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc.str(), Type::Adsr);
+      desc = fmt::format(
+          "ADSR(1): ${:02X}  Sustain Rate: {}  Sustain Level: {}  (ADSR(2): ${:02X})",
+          adsr1, sustain_rate, sustain_level, adsr2);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, Type::Adsr);
       break;
     }
 
     case EVENT_INTELLI_GAIN_SUSTAIN_TIME_AND_RATE: {
       uint8_t sustainDurRate = readByte(curOffset++);
       uint8_t sustainGAIN = readByte(curOffset++);
-      desc << "Duration for Sustain: " << sustainDurRate << "/256" << std::hex << std::setfill('0') << std::setw(2)
-          << std::uppercase << "  GAIN for Sustain: $" << sustainGAIN;
+      desc = fmt::format(
+          "Duration for Sustain: {}/256  GAIN for Sustain: ${:02X}",
+          sustainDurRate, sustainGAIN);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "GAIN Sustain Time/Rate",
-                      desc.str(),
+                      desc,
                       Type::Adsr);
       break;
     }
 
     case EVENT_INTELLI_GAIN_SUSTAIN_TIME: {
       uint8_t sustainDurRate = readByte(curOffset++);
-      desc << "Duration for Sustain: " << sustainDurRate << "/256";
-      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN Sustain Time", desc.str(), Type::Adsr);
+      desc = fmt::format("Duration for Sustain: {}/256", sustainDurRate);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN Sustain Time", desc, Type::Adsr);
       break;
     }
 
@@ -1623,8 +1632,8 @@ bool NinSnesTrack::readEvent(void) {
       // This event will update GAIN immediately,
       // however, note that Fire Emblem 4 does not switch to GAIN mode until note off.
       uint8_t gain = readByte(curOffset++);
-      desc << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << "  GAIN: $" << gain;
-      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN (Release Rate)", desc.str(), Type::Adsr);
+      desc = fmt::format("  GAIN: ${:02X}", gain);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN (Release Rate)", desc, Type::Adsr);
       break;
     }
 
@@ -1658,28 +1667,28 @@ bool NinSnesTrack::readEvent(void) {
           }
 
           if (param == 0x80) {
-            desc << "Status: " << (bitValue ? "On" : "Off");
+            desc = fmt::format("Status: {}", (bitValue ? "On" : "Off"));
             addGenericEvent(beginOffset,
                             curOffset - beginOffset,
                             "Use Custom Note Param",
-                            desc.str(),
+                            desc,
                             Type::ChangeState);
           }
           else if (param == 0x40) {
-            desc << "Status: " << (bitValue ? "On" : "Off");
+            desc = fmt::format("Status: {}", (bitValue ? "On" : "Off"));
             addGenericEvent(beginOffset,
                             curOffset - beginOffset,
                             "Use Custom Percussion Table",
-                            desc.str(),
+                            desc,
                             Type::ChangeState);
           }
           else {
-            desc << "Value: $" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << param;
+            desc = fmt::format("Value: ${:02X}", param);
             if (type == 0x01) {
-              addGenericEvent(beginOffset, curOffset - beginOffset, "Set Flags On", desc.str(), Type::ChangeState);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "Set Flags On", desc, Type::ChangeState);
             }
             else {
-              addGenericEvent(beginOffset, curOffset - beginOffset, "Set Flags Off", desc.str(), Type::ChangeState);
+              addGenericEvent(beginOffset, curOffset - beginOffset, "Set Flags Off", desc, Type::ChangeState);
             }
           }
 
@@ -1688,14 +1697,14 @@ bool NinSnesTrack::readEvent(void) {
 
         case 0x03:
           // TODO: cancel keyoff of note (i.e. full duration)
-          addGenericEvent(beginOffset, curOffset - beginOffset, "Legato On", desc.str(), Type::Portamento);
+          addGenericEvent(beginOffset, curOffset - beginOffset, "Legato On", desc, Type::Portamento);
           break;
 
         case 0x04:
           addGenericEvent(beginOffset,
                           curOffset - beginOffset,
                           "Legato Off",
-                          desc.str(),
+                          desc,
                           Type::Portamento);
           break;
 
@@ -1748,10 +1757,10 @@ bool NinSnesTrack::readEvent(void) {
   // (because it often gets interrupted by the end of other track)
   if (curOffset + 1 <= 0x10000 && statusByte != parentSeq->STATUS_END && readByte(curOffset) == parentSeq->STATUS_END) {
     if (shared->loopCount == 0) {
-      addGenericEvent(curOffset, 1, "Section End", desc.str().c_str(), Type::TrackEnd);
+      addGenericEvent(curOffset, 1, "Section End", desc.c_str(), Type::TrackEnd);
     }
     else {
-      addGenericEvent(curOffset, 1, "Pattern End", desc.str().c_str(), Type::RepeatEnd);
+      addGenericEvent(curOffset, 1, "Pattern End", desc.c_str(), Type::RepeatEnd);
     }
   }
 

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesSeq.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesSeq.cpp
@@ -59,7 +59,7 @@ bool PandoraBoxSnesSeq::parseHeader() {
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t ofsTrackStart = readShort(curOffset);
     if (ofsTrackStart != 0xffff) {
-      auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
+      auto trackName = fmt::format("Track Pointer {:d}", trackIndex + 1);
       header->addChild(curOffset, 2, trackName);
     }
     else {
@@ -313,7 +313,7 @@ bool PandoraBoxSnesTrack::readEvent() {
 
     case EVENT_TUNING: {
       int8_t newTuning = readByte(curOffset++);
-      desc = fmt::format("{}{} Hz", (newTuning >= 0 ? "+" : ""), static_cast<int>(newTuning));
+      desc = fmt::format("{}{:d} Hz", (newTuning >= 0 ? "+" : ""), newTuning);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Fine Tuning", desc, Type::FineTune);
       break;
     }
@@ -489,8 +489,7 @@ bool PandoraBoxSnesTrack::readEvent() {
       uint8_t param = readByte(curOffset++);
 
       uint8_t newTarget = param & 3;
-      std::string targetDesc =
-          fmt::format("Channel Type: {}{}", newTarget, newTarget ? "" : " (Keep Current)");
+      std::string targetDesc = fmt::format("Channel Type: {:d}{}", newTarget, newTarget ? "" : " (Keep Current)");
 
       if ((param & 0x80) == 0) {
         uint8_t newNCK = (param >> 2) & 15;
@@ -516,8 +515,7 @@ bool PandoraBoxSnesTrack::readEvent() {
       uint8_t sr = (srRate * 0x1f) / 127;
       spcADSR = ((0x80 | (dr << 4) | ar) << 8) | ((sl << 5) | sr);
 
-      desc = fmt::format(
-          "AR: {:d}/127 ({:d})  DR: {:d}/127 ({:d})  SR: {:d}/127 ({:d})  SL: {:d}/127 ({:d})  Arg5: {:d}/127",
+      desc = fmt::format("AR: {:d}/127 ({:d})  DR: {:d}/127 ({:d})  SR: {:d}/127 ({:d})  SL: {:d}/127 ({:d})  Arg5: {:d}/127",
           arRate, ar, drRate, dr, srRate, sr, slRate, sl, xxRate);
 
       addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, Type::Adsr);

--- a/src/main/formats/PrismSnes/PrismSnesSeq.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesSeq.cpp
@@ -765,11 +765,7 @@ bool PrismSnesTrack::readEvent() {
       uint16_t envelopeAddress = readShort(curOffset);
       curOffset += 2;
       desc = fmt::format("Envelope: ${:04X}", envelopeAddress);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "GAIN Envelope (Rest)",
-                      desc,
-                      Type::Adsr);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN Envelope (Rest)", desc, Type::Adsr);
       addGAINEnvelope(envelopeAddress);
       break;
     }
@@ -778,11 +774,7 @@ bool PrismSnesTrack::readEvent() {
       uint8_t dur = readByte(curOffset++);
       uint8_t gain = readByte(curOffset++);
       desc = fmt::format("Duration: Full-Length - {:d}  GAIN: ${:02X}", dur, gain);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "GAIN Envelope Decay Time",
-                      desc,
-                      Type::Adsr);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN Envelope Decay Time", desc, Type::Adsr);
       break;
     }
 
@@ -810,11 +802,7 @@ bool PrismSnesTrack::readEvent() {
       uint16_t envelopeAddress = readShort(curOffset);
       curOffset += 2;
       desc = fmt::format("Envelope: ${:04X}", envelopeAddress);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "GAIN Envelope (Sustain)",
-                      desc,
-                      Type::Adsr);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN Envelope (Sustain)", desc, Type::Adsr);
       addGAINEnvelope(envelopeAddress);
       break;
     }
@@ -823,11 +811,7 @@ bool PrismSnesTrack::readEvent() {
       uint16_t envelopeAddress = readShort(curOffset);
       curOffset += 2;
       desc = fmt::format("Envelope: ${:04X}", envelopeAddress);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Echo Volume Envelope",
-                      desc,
-                      Type::Reverb);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume Envelope", desc, Type::Reverb);
       addEchoVolumeEnvelope(envelopeAddress);
       break;
     }
@@ -836,9 +820,8 @@ bool PrismSnesTrack::readEvent() {
       int8_t echoVolumeLeft = readByte(curOffset++);
       int8_t echoVolumeRight = readByte(curOffset++);
       int8_t echoVolumeMono = readByte(curOffset++);
-      desc = fmt::format(
-          "Left Volume: {:d}  Right Volume: {:d}  Mono Volume: {:d}",
-          echoVolumeLeft, echoVolumeRight, echoVolumeMono);
+      desc = fmt::format("Left Volume: {:d}  Right Volume: {:d}  Mono Volume: {:d}",
+                         echoVolumeLeft, echoVolumeRight, echoVolumeMono);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Volume", desc, Type::Reverb);
       break;
     }
@@ -858,9 +841,8 @@ bool PrismSnesTrack::readEvent() {
       int8_t echoVolumeLeft = readByte(curOffset++);
       int8_t echoVolumeRight = readByte(curOffset++);
       int8_t echoVolumeMono = readByte(curOffset++);
-      desc = fmt::format(
-          "Feedback: {:d}  Left Volume: {:d}  Right Volume: {:d}  Mono Volume: {:d}",
-          echoFeedback, echoVolumeLeft, echoVolumeRight, echoVolumeMono);
+      desc = fmt::format("Feedback: {:d}  Left Volume: {:d}  Right Volume: {:d}  Mono Volume: {:d}",
+                         echoFeedback, echoVolumeLeft, echoVolumeRight, echoVolumeMono);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc, Type::Reverb);
       break;
     }
@@ -883,11 +865,7 @@ bool PrismSnesTrack::readEvent() {
       uint16_t envelopeAddress = readShort(curOffset);
       curOffset += 2;
       desc = fmt::format("Envelope: ${:04X}", envelopeAddress);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "GAIN Envelope (Decay)",
-                      desc,
-                      Type::Adsr);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN Envelope (Decay)", desc, Type::Adsr);
       addGAINEnvelope(envelopeAddress);
       break;
     }

--- a/src/main/formats/RareSnes/RareSnesSeq.cpp
+++ b/src/main/formats/RareSnes/RareSnesSeq.cpp
@@ -635,8 +635,7 @@ bool RareSnesTrack::readEvent(void) {
         spcADSR = newADSR;
 
         auto desc = fmt::format("ADSR: {:04X}", newADSR);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc,
-                        Type::Adsr);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, Type::Adsr);
         break;
       }
 
@@ -662,8 +661,7 @@ bool RareSnesTrack::readEvent(void) {
         spcTuning = newTuning;
         auto desc = fmt::format("Tuning: {:d} ({:d} cents)", newTuning,
                                 int(getTuningInSemitones(newTuning) * 100 + 0.5));
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tuning", desc,
-                        Type::FineTune);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tuning", desc, Type::FineTune);
         break;
       }
 
@@ -674,8 +672,7 @@ bool RareSnesTrack::readEvent(void) {
         //AddTranspose(beginOffset, curOffset-beginOffset, 0, "Transpose (Abs)");
 
         auto desc = fmt::format("Transpose: {:d}", newTransp);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Transpose", desc,
-                        Type::Transpose);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Transpose", desc, Type::Transpose);
 
         cKeyCorrection = SEQ_KEYOFS;
         break;
@@ -701,10 +698,9 @@ bool RareSnesTrack::readEvent(void) {
         parentSeq->midiReverb = min(abs((int) newVolL) + abs((int) newVolR), 255) / 2;
         // TODO: update MIDI reverb value for each tracks?
 
-        auto desc = fmt::format("Feedback: {:d}  Volume: {:d}, {:d}", newFeedback,
-                                 newVolL, newVolR);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc,
-                        Type::Reverb);
+        auto desc = fmt::format("Feedback: {:d}  Volume: {:d}, {:d}",
+                                      newFeedback, newVolL, newVolR);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Param", desc, Type::Reverb);
         break;
       }
 
@@ -726,8 +722,7 @@ bool RareSnesTrack::readEvent(void) {
           desc += fmt::format(" {:02X}", newFIR[iFIRIndex]);
         }
 
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR", desc,
-                        Type::Reverb);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Echo FIR", desc, Type::Reverb);
         break;
       }
 
@@ -753,29 +748,27 @@ bool RareSnesTrack::readEvent(void) {
         altNoteByte1 = readByte(curOffset++);
         desc = fmt::format("Note: {:02X}", altNoteByte1);
         addGenericEvent(beginOffset, curOffset - beginOffset, "Set Alt Note 1",
-                        desc.c_str(), Type::ChangeState);
+                        desc, Type::ChangeState);
         break;
 
       case EVENT_SETALTNOTE2:
         altNoteByte2 = readByte(curOffset++);
         desc = fmt::format("Note: {:02X}", altNoteByte2);
         addGenericEvent(beginOffset, curOffset - beginOffset, "Set Alt Note 2",
-                        desc.c_str(), Type::ChangeState);
+                        desc, Type::ChangeState);
         break;
 
       case EVENT_PITCHSLIDEDOWNSHORT: {
         curOffset += 4;
         addGenericEvent(beginOffset, curOffset - beginOffset,
-                        "Pitch Slide Down (Short)", "",
-                        Type::PitchBendSlide);
+                        "Pitch Slide Down (Short)", "", Type::PitchBendSlide);
         break;
       }
 
       case EVENT_PITCHSLIDEUPSHORT: {
         curOffset += 4;
         addGenericEvent(beginOffset, curOffset - beginOffset,
-                        "Pitch Slide Up (Short)", "",
-                        Type::PitchBendSlide);
+                        "Pitch Slide Up (Short)", "", Type::PitchBendSlide);
         break;
       }
 
@@ -808,9 +801,8 @@ bool RareSnesTrack::readEvent(void) {
 
         // add event without MIDI events
         calculateVolPanFromVolLR(spcVolL, spcVolR, newMidiVol, newMidiPan);
-        desc = fmt::format(
-            "Left Volume: {:d}  Right Volume: {:d}  AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}",
-            newVolL, newVolR, ar, dr, sl, sr);
+        desc = fmt::format("Left Volume: {:d}  Right Volume: {:d}  AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}",
+                           newVolL, newVolR, ar, dr, sl, sr);
         addGenericEvent(beginOffset, curOffset - beginOffset,
                         "Set Vol/ADSR Preset 1", desc, Type::Volume);
         break;
@@ -833,9 +825,8 @@ bool RareSnesTrack::readEvent(void) {
 
         // add event without MIDI events
         calculateVolPanFromVolLR(spcVolL, spcVolR, newMidiVol, newMidiPan);
-        desc = fmt::format(
-            "Left Volume: {:d}  Right Volume: {:d}  AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}",
-            newVolL, newVolR, ar, dr, sl, sr);
+        desc = fmt::format("Left Volume: {:d}  Right Volume: {:d}  AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}",
+                           newVolL, newVolR, ar, dr, sl, sr);
         addGenericEvent(beginOffset, curOffset - beginOffset,
                         "Set Vol/ADSR Preset 2", desc, Type::Volume);
         break;
@@ -858,9 +849,8 @@ bool RareSnesTrack::readEvent(void) {
 
         // add event without MIDI events
         calculateVolPanFromVolLR(spcVolL, spcVolR, newMidiVol, newMidiPan);
-        desc = fmt::format(
-            "Left Volume: {:d}  Right Volume: {:d}  AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}",
-            newVolL, newVolR, ar, dr, sl, sr);
+        desc = fmt::format("Left Volume: {:d}  Right Volume: {:d}  AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}",
+                           newVolL, newVolR, ar, dr, sl, sr);
         addGenericEvent(beginOffset, curOffset - beginOffset,
                         "Set Vol/ADSR Preset 3", desc, Type::Volume);
         break;
@@ -883,11 +873,9 @@ bool RareSnesTrack::readEvent(void) {
 
         // add event without MIDI events
         calculateVolPanFromVolLR(spcVolL, spcVolR, newMidiVol, newMidiPan);
-        desc = fmt::format(
-            "Left Volume: {:d}  Right Volume: {:d}  AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}",
-            newVolL, newVolR, ar, dr, sl, sr);
-        addGenericEvent(beginOffset, curOffset - beginOffset,
-                        "Set Vol/ADSR Preset 4", desc, Type::Volume);
+        desc = fmt::format("Left Volume: {:d}  Right Volume: {:d}  AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}",
+                           newVolL, newVolR, ar, dr, sl, sr);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Vol/ADSR Preset 4", desc, Type::Volume);
         break;
       }
 
@@ -908,11 +896,9 @@ bool RareSnesTrack::readEvent(void) {
 
         // add event without MIDI events
         calculateVolPanFromVolLR(spcVolL, spcVolR, newMidiVol, newMidiPan);
-        desc = fmt::format(
-            "Left Volume: {:d}  Right Volume: {:d}  AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}",
-            newVolL, newVolR, ar, dr, sl, sr);
-        addGenericEvent(beginOffset, curOffset - beginOffset,
-                        "Set Vol/ADSR Preset 5", desc, Type::Volume);
+        desc = fmt::format("Left Volume: {:d}  Right Volume: {:d}  AR: {:d}  DR: {:d}  SL: {:d}  SR: {:d}",
+                           newVolL, newVolR, ar, dr, sl, sr);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Set Vol/ADSR Preset 5", desc, Type::Volume);
         break;
       }
 
@@ -988,7 +974,8 @@ bool RareSnesTrack::readEvent(void) {
 
         // instrument
         spcInstr = newProg;
-        addProgramChange(beginOffset, curOffset - beginOffset, newProg, true, "Program Change, Transpose, Tuning");
+        addProgramChange(beginOffset, curOffset - beginOffset, newProg, true,
+                         "Program Change, Transpose, Tuning");
 
         // transpose
         spcTranspose = spcTransposeAbs = newTransp;
@@ -1043,8 +1030,7 @@ bool RareSnesTrack::readEvent(void) {
       case EVENT_ECHODELAY: {
         uint8_t newEDL = readByte(curOffset++);
         auto desc = fmt::format("Delay: {:d}", newEDL);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Delay", desc,
-                        Type::Reverb);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Delay", desc, Type::Reverb);
         break;
       }
 
@@ -1082,8 +1068,7 @@ bool RareSnesTrack::readEvent(void) {
         break;
 
       case EVENT_LFOOFF:
-        addGenericEvent(beginOffset, curOffset - beginOffset,
-                        "Pitch Slide/Vibrato/Tremolo Off", "",
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide/Vibrato/Tremolo Off", "",
                         Type::ChangeState);
         break;
 

--- a/src/main/formats/SoftCreatSnes/SoftCreatSnesSeq.cpp
+++ b/src/main/formats/SoftCreatSnes/SoftCreatSnesSeq.cpp
@@ -48,7 +48,7 @@ bool SoftCreatSnesSeq::parseHeader(void) {
       return false;
     }
 
-    auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
+    auto trackName = fmt::format("Track Pointer {:d}", trackIndex + 1);
     header->addChild(addrTrackLowPtr, 1, trackName + " (LSB)");
     header->addChild(addrTrackHighPtr, 1, trackName + " (MSB)");
 
@@ -108,24 +108,26 @@ bool SoftCreatSnesTrack::readEvent(void) {
     eventType = pEventType->second;
   }
 
+  std::string desc;
+
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event",
-                 fmt::format("Event: 0x{:02X}", statusByte));
+      desc = fmt::format("Event: 0x{:02X}", statusByte);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = readByte(curOffset++);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event",
-                 fmt::format("Event: 0x{:02X}  Arg1: {:d}", statusByte, arg1));
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}", statusByte, arg1);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event",
-                 fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2));
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -133,8 +135,9 @@ bool SoftCreatSnesTrack::readEvent(void) {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event",
-                 fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}", statusByte, arg1, arg2, arg3));
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}",
+                         statusByte, arg1, arg2, arg3);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -143,10 +146,9 @@ bool SoftCreatSnesTrack::readEvent(void) {
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
       uint8_t arg4 = readByte(curOffset++);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event",
-                 fmt::format(
-                     "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
-                     statusByte, arg1, arg2, arg3, arg4));
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
+                         statusByte, arg1, arg2, arg3, arg4);
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 

--- a/src/main/formats/SoftCreatSnes/SoftCreatSnesSeq.cpp
+++ b/src/main/formats/SoftCreatSnes/SoftCreatSnesSeq.cpp
@@ -1,4 +1,5 @@
 #include "SoftCreatSnesSeq.h"
+#include <spdlog/fmt/fmt.h>
 
 DECLARE_FORMAT(SoftCreatSnes);
 
@@ -47,10 +48,9 @@ bool SoftCreatSnesSeq::parseHeader(void) {
       return false;
     }
 
-    std::stringstream trackName;
-    trackName << "Track Pointer " << (trackIndex + 1);
-    header->addChild(addrTrackLowPtr, 1, trackName.str() + " (LSB)");
-    header->addChild(addrTrackHighPtr, 1, trackName.str() + " (MSB)");
+    auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
+    header->addChild(addrTrackLowPtr, 1, trackName + " (LSB)");
+    header->addChild(addrTrackHighPtr, 1, trackName + " (MSB)");
 
     uint16_t addrTrackStart = readByte(addrTrackLowPtr) | (readByte(addrTrackHighPtr) << 8);
     if (addrTrackStart != 0xffff) {
@@ -101,7 +101,6 @@ bool SoftCreatSnesTrack::readEvent(void) {
   uint8_t statusByte = readByte(curOffset++);
   bool bContinue = true;
 
-  std::stringstream desc;
 
   SoftCreatSnesSeqEventType eventType = (SoftCreatSnesSeqEventType) 0;
   std::map<uint8_t, SoftCreatSnesSeqEventType>::iterator pEventType = parentSeq->EventMap.find(statusByte);
@@ -111,27 +110,22 @@ bool SoftCreatSnesTrack::readEvent(void) {
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event",
+                 fmt::format("Event: 0x{:02X}", statusByte));
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event",
+                 fmt::format("Event: 0x{:02X}  Arg1: {:d}", statusByte, arg1));
       break;
     }
 
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event",
+                 fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2));
       break;
     }
 
@@ -139,12 +133,8 @@ bool SoftCreatSnesTrack::readEvent(void) {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2
-          << "  Arg3: " << (int) arg3;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event",
+                 fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}", statusByte, arg1, arg2, arg3));
       break;
     }
 
@@ -153,13 +143,10 @@ bool SoftCreatSnesTrack::readEvent(void) {
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
       uint8_t arg4 = readByte(curOffset++);
-      desc << "Event: 0x" << std::hex << std::setfill('0') << std::setw(2) << std::uppercase << (int) statusByte
-          << std::dec << std::setfill(' ') << std::setw(0)
-          << "  Arg1: " << (int) arg1
-          << "  Arg2: " << (int) arg2
-          << "  Arg3: " << (int) arg3
-          << "  Arg4: " << (int) arg4;
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event",
+                 fmt::format(
+                     "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
+                     statusByte, arg1, arg2, arg3, arg4));
       break;
     }
 

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
@@ -69,7 +69,7 @@ bool SuzukiSnesSeq::parseHeader() {
     uint16_t addrTrackStart = readShort(curOffset);
 
     if (addrTrackStart != 0) {
-      auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
+      auto trackName = fmt::format("Track Pointer {:d}", trackIndex + 1);
       header->addChild(curOffset, 2, trackName.c_str());
 
       aTracks.push_back(new SuzukiSnesTrack(this, addrTrackStart));
@@ -249,8 +249,7 @@ bool SuzukiSnesTrack::readEvent() {
     case EVENT_UNKNOWN2: {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
-      desc = fmt::format(
-          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2);
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2);
       addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
       break;
     }
@@ -259,9 +258,8 @@ bool SuzukiSnesTrack::readEvent() {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
-      desc = fmt::format(
-          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}",
-          statusByte, arg1, arg2, arg3);
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}",
+                         statusByte, arg1, arg2, arg3);
       addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
       break;
     }
@@ -271,9 +269,8 @@ bool SuzukiSnesTrack::readEvent() {
       uint8_t arg2 = readByte(curOffset++);
       uint8_t arg3 = readByte(curOffset++);
       uint8_t arg4 = readByte(curOffset++);
-      desc = fmt::format(
-          "Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
-          statusByte, arg1, arg2, arg3, arg4);
+      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
+                         statusByte, arg1, arg2, arg3, arg4);
       addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
       break;
     }
@@ -303,7 +300,7 @@ bool SuzukiSnesTrack::readEvent() {
       }
       else if (noteIndex == 13) {
         makePrevDurNoteEnd(getTime() + dur);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc.c_str(), Type::Tie);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie", desc, Type::Tie);
         addTime(dur);
       }
       else {
@@ -330,53 +327,35 @@ bool SuzukiSnesTrack::readEvent() {
     }
 
     case EVENT_NOP: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc.c_str(), Type::Nop);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "NOP", desc, Type::Nop);
       break;
     }
 
     case EVENT_NOISE_FREQ: {
       uint8_t newNCK = readByte(curOffset++) & 0x1f;
       desc = fmt::format("Noise Frequency (NCK): {:d}", newNCK);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Noise Frequency",
-                      desc.c_str(),
-                      Type::Noise);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Frequency", desc, Type::Noise);
       break;
     }
 
     case EVENT_NOISE_ON: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Noise On",
-                      desc.c_str(),
-                      Type::Noise);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise On", desc, Type::Noise);
       break;
     }
 
     case EVENT_NOISE_OFF: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Noise Off",
-                      desc.c_str(),
-                      Type::Noise);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Off", desc, Type::Noise);
       break;
     }
 
     case EVENT_PITCH_MOD_ON: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Pitch Modulation On",
-                      desc.c_str(),
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Modulation On", desc,
                       Type::ChangeState);
       break;
     }
 
     case EVENT_PITCH_MOD_OFF: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Pitch Modulation Off",
-                      desc.c_str(),
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Modulation Off", desc,
                       Type::ChangeState);
       break;
     }
@@ -456,22 +435,16 @@ bool SuzukiSnesTrack::readEvent() {
     case EVENT_TIMER1_FREQ: {
       uint8_t newFreq = readByte(curOffset++);
       desc = fmt::format("Frequency: {}ms", 0.125 * newFreq);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Timer 1 Frequency",
-                      desc.c_str(),
-                      Type::Tempo);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Timer 1 Frequency",
+                      desc, Type::Tempo);
       break;
     }
 
     case EVENT_TIMER1_FREQ_REL: {
       int8_t delta = readByte(curOffset++);
       desc = fmt::format("Frequency Delta: {}ms", 0.125 * delta);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Timer 1 Frequency (Relative)",
-                      desc.c_str(),
-                      Type::ChangeState);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Timer 1 Frequency (Relative)",
+                      desc, Type::ChangeState);
       break;
     }
 
@@ -480,7 +453,7 @@ bool SuzukiSnesTrack::readEvent() {
       int realLoopCount = (count == 0) ? 256 : count;
 
       desc = fmt::format("Loop Count: {:d}", realLoopCount);
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc.c_str(), Type::RepeatStart);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Start", desc, Type::RepeatStart);
 
       if (loopLevel >= SUZUKISNES_LOOP_LEVEL_MAX) {
         // stack overflow
@@ -495,7 +468,7 @@ bool SuzukiSnesTrack::readEvent() {
     }
 
     case EVENT_LOOP_END: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc.c_str(), Type::RepeatEnd);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop End", desc, Type::RepeatEnd);
 
       if (loopLevel == 0) {
         // stack overflow
@@ -518,7 +491,7 @@ bool SuzukiSnesTrack::readEvent() {
     }
 
     case EVENT_LOOP_BREAK: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc.c_str(), Type::RepeatEnd);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Loop Break", desc, Type::RepeatEnd);
 
       if (loopLevel == 0) {
         // stack overflow
@@ -536,64 +509,41 @@ bool SuzukiSnesTrack::readEvent() {
 
     case EVENT_LOOP_POINT: {
       infiniteLoopPoint = curOffset;
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Infinite Loop Point",
-                      desc.c_str(),
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Infinite Loop Point", desc,
                       Type::RepeatStart);
       break;
     }
 
     case EVENT_ADSR_DEFAULT: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Default ADSR",
-                      desc.c_str(),
-                      Type::Adsr);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Default ADSR", desc, Type::Adsr);
       break;
     }
 
       case EVENT_ADSR_AR: {
         uint8_t newAR = readByte(curOffset++) & 15;
         desc = fmt::format("AR: {:d}", newAR);
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "ADSR Attack Rate",
-                        desc.c_str(),
-                        Type::Adsr);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Attack Rate", desc, Type::Adsr);
         break;
       }
 
       case EVENT_ADSR_DR: {
         uint8_t newDR = readByte(curOffset++) & 7;
         desc = fmt::format("DR: {:d}", newDR);
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "ADSR Decay Rate",
-                        desc.c_str(),
-                        Type::Adsr);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Decay Rate", desc, Type::Adsr);
         break;
       }
 
       case EVENT_ADSR_SL: {
         uint8_t newSL = readByte(curOffset++) & 7;
         desc = fmt::format("SL: {:d}", newSL);
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "ADSR Sustain Level",
-                        desc.c_str(),
-                        Type::Adsr);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Sustain Level", desc, Type::Adsr);
         break;
       }
 
       case EVENT_ADSR_SR: {
         uint8_t newSR = readByte(curOffset++) & 15;
         desc = fmt::format("SR: {:d}", newSR);
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "ADSR Sustain Rate",
-                        desc.c_str(),
-                        Type::Adsr);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR Sustain Rate", desc, Type::Adsr);
         break;
       }
 
@@ -601,7 +551,7 @@ bool SuzukiSnesTrack::readEvent() {
         // TODO: save duration rate and apply to note length
         uint8_t newDurRate = readByte(curOffset++);
         desc = fmt::format("Duration Rate: {:d}", newDurRate);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc.c_str(), Type::DurationNote);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Duration Rate", desc, Type::DurationNote);
         break;
       }
 
@@ -614,10 +564,7 @@ bool SuzukiSnesTrack::readEvent() {
     case EVENT_NOISE_FREQ_REL: {
       int8_t delta = readByte(curOffset++);
       desc = fmt::format("Noise Frequency (NCK) Delta: {:d}", delta);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Noise Frequency (Relative)",
-                      desc.c_str(),
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise Frequency (Relative)", desc,
                       Type::Noise);
       break;
     }
@@ -640,11 +587,7 @@ bool SuzukiSnesTrack::readEvent() {
         uint8_t fadeLength = readByte(curOffset++);
         uint8_t vol = readByte(curOffset++);
         desc = fmt::format("Fade Length: {:d}  Volume: {:d}", fadeLength, vol);
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "Volume Fade",
-                        desc.c_str(),
-                        Type::VolumeSlide);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Volume Fade", desc, Type::VolumeSlide);
         break;
       }
 
@@ -652,20 +595,12 @@ bool SuzukiSnesTrack::readEvent() {
         uint8_t arg1 = readByte(curOffset++);
         uint8_t arg2 = readByte(curOffset++);
         desc = fmt::format("Arg1: {:d}  Arg2: {:d}", arg1, arg2);
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "Portamento",
-                        desc.c_str(),
-                        Type::Portamento);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento", desc, Type::Portamento);
         break;
       }
 
     case EVENT_PORTAMENTO_TOGGLE: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Portamento On/Off",
-                      desc.c_str(),
-                      Type::Portamento);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento On/Off", desc, Type::Portamento);
       break;
     }
 
@@ -686,7 +621,7 @@ bool SuzukiSnesTrack::readEvent() {
         desc = fmt::format("Fade Length: {:d}  Pan: {:d}", fadeLength, pan >> 1);
 
         // TODO: correct midi pan value, apply volume scale, do pan slide
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc.c_str(), Type::PanSlide);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Pan Fade", desc, Type::PanSlide);
         break;
       }
 
@@ -694,29 +629,17 @@ bool SuzukiSnesTrack::readEvent() {
         uint8_t lfoDepth = readByte(curOffset++);
         uint8_t lfoRate = readByte(curOffset++);
         desc = fmt::format("Depth: {:d}  Rate: {:d}", lfoDepth, lfoRate);
-        addGenericEvent(beginOffset,
-                        curOffset - beginOffset,
-                        "Pan LFO",
-                        desc.c_str(),
-                        Type::PanLfo);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO", desc, Type::PanLfo);
         break;
     }
 
     case EVENT_PAN_LFO_RESTART: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Pan LFO Restart",
-                      desc.c_str(),
-                      Type::PanLfo);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Restart", desc, Type::PanLfo);
       break;
     }
 
     case EVENT_PAN_LFO_OFF: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Pan LFO Off",
-                      desc.c_str(),
-                      Type::PanLfo);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Pan LFO Off", desc, Type::PanLfo);
       break;
     }
 
@@ -737,20 +660,12 @@ bool SuzukiSnesTrack::readEvent() {
     }
 
     case EVENT_PERC_ON: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Percussion On",
-                      desc.c_str(),
-                      Type::UseDrumKit);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion On", desc, Type::UseDrumKit);
       break;
     }
 
     case EVENT_PERC_OFF: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Percussion Off",
-                      desc.c_str(),
-                      Type::UseDrumKit);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion Off", desc, Type::UseDrumKit);
       break;
     }
 
@@ -758,11 +673,7 @@ bool SuzukiSnesTrack::readEvent() {
       uint8_t lfoDepth = readByte(curOffset++);
       uint8_t lfoRate = readByte(curOffset++);
       desc = fmt::format("Depth: {:d}  Rate: {:d}", lfoDepth, lfoRate);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Vibrato",
-                      desc.c_str(),
-                      Type::Vibrato);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, Type::Vibrato);
       break;
     }
 
@@ -771,20 +682,12 @@ bool SuzukiSnesTrack::readEvent() {
       uint8_t lfoRate = readByte(curOffset++);
       uint8_t lfoDelay = readByte(curOffset++);
       desc = fmt::format("Depth: {:d}  Rate: {:d}  Delay: {:d}", lfoDepth, lfoRate, lfoDelay);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Vibrato",
-                      desc.c_str(),
-                      Type::Vibrato);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, Type::Vibrato);
       break;
     }
 
     case EVENT_VIBRATO_OFF: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Vibrato Off",
-                      desc.c_str(),
-                      Type::Vibrato);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Off", desc, Type::Vibrato);
       break;
     }
 
@@ -792,11 +695,7 @@ bool SuzukiSnesTrack::readEvent() {
       uint8_t lfoDepth = readByte(curOffset++);
       uint8_t lfoRate = readByte(curOffset++);
       desc = fmt::format("Depth: {:d}  Rate: {:d}", lfoDepth, lfoRate);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Tremolo",
-                      desc.c_str(),
-                      Type::Tremelo);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo", desc, Type::Tremelo);
       break;
     }
 
@@ -805,48 +704,32 @@ bool SuzukiSnesTrack::readEvent() {
       uint8_t lfoRate = readByte(curOffset++);
       uint8_t lfoDelay = readByte(curOffset++);
       desc = fmt::format("Depth: {:d}  Rate: {:d}  Delay: {:d}", lfoDepth, lfoRate, lfoDelay);
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Tremolo",
-                      desc.c_str(),
-                      Type::Tremelo);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo", desc, Type::Tremelo);
       break;
     }
 
     case EVENT_TREMOLO_OFF: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Tremolo Off",
-                      desc.c_str(),
-                      Type::Tremelo);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Off", desc, Type::Tremelo);
       break;
     }
 
     case EVENT_SLUR_ON: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Slur On",
-                      desc.c_str(),
-                      Type::Portamento);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Slur On", desc, Type::Portamento);
       break;
     }
 
     case EVENT_SLUR_OFF: {
-      addGenericEvent(beginOffset,
-                      curOffset - beginOffset,
-                      "Slur Off",
-                      desc.c_str(),
-                      Type::Portamento);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Slur Off", desc, Type::Portamento);
       break;
     }
 
     case EVENT_ECHO_ON: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc.c_str(), Type::Reverb);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo On", desc, Type::Reverb);
       break;
     }
 
     case EVENT_ECHO_OFF: {
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc.c_str(), Type::Reverb);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Echo Off", desc, Type::Reverb);
       break;
     }
 

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
@@ -70,7 +70,7 @@ bool SuzukiSnesSeq::parseHeader() {
 
     if (addrTrackStart != 0) {
       auto trackName = fmt::format("Track Pointer {:d}", trackIndex + 1);
-      header->addChild(curOffset, 2, trackName.c_str());
+      header->addChild(curOffset, 2, trackName);
 
       aTracks.push_back(new SuzukiSnesTrack(this, addrTrackStart));
     }
@@ -236,13 +236,13 @@ bool SuzukiSnesTrack::readEvent() {
   switch (eventType) {
     case EVENT_UNKNOWN0:
       desc = fmt::format("Event: 0x{:02X}", statusByte);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
 
     case EVENT_UNKNOWN1: {
       uint8_t arg1 = readByte(curOffset++);
       desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}", statusByte, arg1);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -250,7 +250,7 @@ bool SuzukiSnesTrack::readEvent() {
       uint8_t arg1 = readByte(curOffset++);
       uint8_t arg2 = readByte(curOffset++);
       desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -260,7 +260,7 @@ bool SuzukiSnesTrack::readEvent() {
       uint8_t arg3 = readByte(curOffset++);
       desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}",
                          statusByte, arg1, arg2, arg3);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -271,7 +271,7 @@ bool SuzukiSnesTrack::readEvent() {
       uint8_t arg4 = readByte(curOffset++);
       desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
                          statusByte, arg1, arg2, arg3, arg4);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       break;
     }
 
@@ -364,7 +364,7 @@ bool SuzukiSnesTrack::readEvent() {
       // TODO: EVENT_JUMP_TO_SFX_LO
       uint8_t sfxIndex = readByte(curOffset++);
       desc = fmt::format("SFX: {:d}", sfxIndex);
-      addUnknown(beginOffset, curOffset - beginOffset, "Jump to SFX (LOWORD)", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Jump to SFX (LOWORD)", desc);
       bContinue = false;
       break;
     }
@@ -373,7 +373,7 @@ bool SuzukiSnesTrack::readEvent() {
       // TODO: EVENT_JUMP_TO_SFX_HI
       uint8_t sfxIndex = readByte(curOffset++);
       desc = fmt::format("SFX: {:d}", sfxIndex);
-      addUnknown(beginOffset, curOffset - beginOffset, "Jump to SFX (HIWORD)", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Jump to SFX (HIWORD)", desc);
       bContinue = false;
       break;
     }
@@ -382,7 +382,7 @@ bool SuzukiSnesTrack::readEvent() {
       // TODO: EVENT_CALL_SFX_LO
       uint8_t sfxIndex = readByte(curOffset++);
       desc = fmt::format("SFX: {:d}", sfxIndex);
-      addUnknown(beginOffset, curOffset - beginOffset, "Call SFX (LOWORD)", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Call SFX (LOWORD)", desc);
       bContinue = false;
       break;
     }
@@ -391,7 +391,7 @@ bool SuzukiSnesTrack::readEvent() {
       // TODO: EVENT_CALL_SFX_HI
       uint8_t sfxIndex = readByte(curOffset++);
       desc = fmt::format("SFX: {:d}", sfxIndex);
-      addUnknown(beginOffset, curOffset - beginOffset, "Call SFX (HIWORD)", desc.c_str());
+      addUnknown(beginOffset, curOffset - beginOffset, "Call SFX (HIWORD)", desc);
       bContinue = false;
       break;
     }

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
@@ -191,13 +191,13 @@ bool TamSoftPS1Track::readEvent() {
 
   if (statusByte >= 0x00 && statusByte <= 0x7f) {
     // if status_byte == 0, it actually sets 0xffffffff to delta-time o_O
-    desc = fmt::format("Delta Time: {}", statusByte);
+    desc = fmt::format("Delta Time: {:d}", statusByte);
     addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", desc, Type::Rest);
     addTime(statusByte);
   }
   else if (statusByte >= 0x80 && statusByte <= 0xdf) {
     uint8_t key = statusByte & 0x7f;
-    desc = fmt::format("Key: {}", key);
+    desc = fmt::format("Key: {:d}", key);
 
     if (lastNoteKey >= 0) {
       finalizeAllNotes();
@@ -227,7 +227,7 @@ bool TamSoftPS1Track::readEvent() {
         double volumeScale;
         uint8_t midiPan = convertVolumeBalanceToStdMidiPan(volumeBalanceLeft / 256.0, volumeBalanceRight / 256.0, &volumeScale);
 
-        desc = fmt::format("Left Volume: {}  Right Volume: {}", volumeBalanceLeft, volumeBalanceRight);
+        desc = fmt::format("Left Volume: {:d}  Right Volume: {:d}", volumeBalanceLeft, volumeBalanceRight);
         addGenericEvent(beginOffset, curOffset - beginOffset, "Volume Balance", desc, Type::Pan);
         addPanNoItem(midiPan);
         break;
@@ -250,7 +250,7 @@ bool TamSoftPS1Track::readEvent() {
         // pitch bend
         uint16_t pitchRegValue = readShort(curOffset);
         curOffset += 2;
-        desc = fmt::format("Pitch: {}", pitchRegValue);
+        desc = fmt::format("Pitch: {:d}", pitchRegValue);
 
         double cents = 0;
         if (lastNoteKey >= 0) {
@@ -266,7 +266,7 @@ bool TamSoftPS1Track::readEvent() {
         // pitch bend that updates volume/ADSR registers too?
         uint16_t pitchRegValue = readShort(curOffset);
         curOffset += 2;
-        desc = fmt::format("Pitch: {}", pitchRegValue);
+        desc = fmt::format("Pitch: {:d}", pitchRegValue);
 
         double cents = 0;
         if (lastNoteKey >= 0) {
@@ -280,14 +280,14 @@ bool TamSoftPS1Track::readEvent() {
 
       case 0xE6: {
         uint8_t mode = readByte(curOffset++);
-        desc = fmt::format("Reverb Mode: {}", mode);
+        desc = fmt::format("Reverb Mode: {:d}", mode);
         addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Mode", desc, Type::Reverb);
         break;
       }
 
       case 0xE7: {
         uint8_t depth = readByte(curOffset++);
-        desc = fmt::format("Reverb Depth: {}", depth);
+        desc = fmt::format("Reverb Depth: {:d}", depth);
         parentSeq->reverbDepth = depth << 8;
         addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", desc, Type::Reverb);
         break;
@@ -335,7 +335,7 @@ bool TamSoftPS1Track::readEvent() {
 
         curOffset = dest;
         if (!isOffsetUsed(dest)) {
-          addGenericEvent(beginOffset, length, "Jump", desc.c_str(), Type::LoopForever);
+          addGenericEvent(beginOffset, length, "Jump", desc, Type::LoopForever);
         }
         else {
           bContinue = addLoopForever(beginOffset, length, "Jump");

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
@@ -7,7 +7,6 @@
 #include <iomanip>
 
 #include <spdlog/fmt/fmt.h>
-#include <sstream>
 #include "ScaleConversion.h"
 #include "TamSoftPS1Seq.h"
 
@@ -120,9 +119,8 @@ bool TamSoftPS1Seq::parseHeader() {
       for (uint8_t trackIndex = 0; trackIndex < maxTracks; trackIndex++) {
         uint32_t dwTrackHeaderOffset = dwHeaderOffset + 4 * trackIndex;
 
-        std::stringstream trackHeaderName;
-        trackHeaderName << "Track " << (trackIndex + 1);
-        VGMHeader *trackHeader = seqHeader->addHeader(dwTrackHeaderOffset, 4, trackHeaderName.str());
+        auto trackHeaderName = fmt::format("Track {}", trackIndex + 1);
+        VGMHeader *trackHeader = seqHeader->addHeader(dwTrackHeaderOffset, 4, trackHeaderName);
 
         uint8_t live = readByte(dwTrackHeaderOffset);
         uint32_t dwRelTrackOffset = readShort(dwTrackHeaderOffset + 2);
@@ -189,17 +187,17 @@ bool TamSoftPS1Track::readEvent() {
   uint8_t statusByte = readByte(curOffset++);
   bool bContinue = true;
 
-  std::stringstream desc;
+  std::string desc;
 
   if (statusByte >= 0x00 && statusByte <= 0x7f) {
     // if status_byte == 0, it actually sets 0xffffffff to delta-time o_O
-    desc << "Delta Time: " << statusByte;
-    addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", desc.str(), Type::Rest);
+    desc = fmt::format("Delta Time: {}", statusByte);
+    addGenericEvent(beginOffset, curOffset - beginOffset, "Delta Time", desc, Type::Rest);
     addTime(statusByte);
   }
   else if (statusByte >= 0x80 && statusByte <= 0xdf) {
     uint8_t key = statusByte & 0x7f;
-    desc << "Key: " << key;
+    desc = fmt::format("Key: {}", key);
 
     if (lastNoteKey >= 0) {
       finalizeAllNotes();
@@ -229,8 +227,8 @@ bool TamSoftPS1Track::readEvent() {
         double volumeScale;
         uint8_t midiPan = convertVolumeBalanceToStdMidiPan(volumeBalanceLeft / 256.0, volumeBalanceRight / 256.0, &volumeScale);
 
-        desc << "Left Volume: " << volumeBalanceLeft << "  Right Volume: " << volumeBalanceRight;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Volume Balance", desc.str(), Type::Pan);
+        desc = fmt::format("Left Volume: {}  Right Volume: {}", volumeBalanceLeft, volumeBalanceRight);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Volume Balance", desc, Type::Pan);
         addPanNoItem(midiPan);
         break;
       }
@@ -244,7 +242,7 @@ bool TamSoftPS1Track::readEvent() {
       case 0xE3: {
         uint16_t a1 = readShort(curOffset);
         curOffset += 2;
-        addUnknown(beginOffset, curOffset - beginOffset, "NOP", desc.str());
+        addUnknown(beginOffset, curOffset - beginOffset, "NOP", desc);
         break;
       }
 
@@ -252,15 +250,15 @@ bool TamSoftPS1Track::readEvent() {
         // pitch bend
         uint16_t pitchRegValue = readShort(curOffset);
         curOffset += 2;
-        desc << "Pitch: " << pitchRegValue;
+        desc = fmt::format("Pitch: {}", pitchRegValue);
 
         double cents = 0;
         if (lastNoteKey >= 0) {
           cents = pitchScaleToCents((double)pitchRegValue / lastNotePitch);
-          desc << " (" << cents << " cents)";
+          desc += fmt::format(" ({} cents)", cents);
         }
 
-        addUnknown(beginOffset, curOffset - beginOffset, "Pitch Bend", desc.str());
+        addUnknown(beginOffset, curOffset - beginOffset, "Pitch Bend", desc);
         break;
       }
 
@@ -268,30 +266,30 @@ bool TamSoftPS1Track::readEvent() {
         // pitch bend that updates volume/ADSR registers too?
         uint16_t pitchRegValue = readShort(curOffset);
         curOffset += 2;
-        desc << "Pitch: " << pitchRegValue;
+        desc = fmt::format("Pitch: {}", pitchRegValue);
 
         double cents = 0;
         if (lastNoteKey >= 0) {
           cents = pitchScaleToCents((double)pitchRegValue / lastNotePitch);
-          desc << " (" << cents << " cents)";
+          desc += fmt::format(" ({} cents)", cents);
         }
 
-        addUnknown(beginOffset, curOffset - beginOffset, "Note By Pitch?", desc.str());
+        addUnknown(beginOffset, curOffset - beginOffset, "Note By Pitch?", desc);
         break;
       }
 
       case 0xE6: {
         uint8_t mode = readByte(curOffset++);
-        desc << "Reverb Mode: " << mode;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Mode", desc.str(), Type::Reverb);
+        desc = fmt::format("Reverb Mode: {}", mode);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Mode", desc, Type::Reverb);
         break;
       }
 
       case 0xE7: {
         uint8_t depth = readByte(curOffset++);
-        desc << "Reverb Depth: " << depth;
+        desc = fmt::format("Reverb Depth: {}", depth);
         parentSeq->reverbDepth = depth << 8;
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", desc.str(), Type::Reverb);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Reverb Depth", desc, Type::Reverb);
         break;
       }
 
@@ -316,14 +314,14 @@ bool TamSoftPS1Track::readEvent() {
 
       case 0xF0: {
         finalizeAllNotes();
-        addGenericEvent(beginOffset, curOffset - beginOffset, "Note Off", desc.str(), Type::NoteOff);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Note Off", desc, Type::NoteOff);
         break;
       }
 
       case 0xF1: {
         uint16_t a1 = readByte(curOffset++);
-        desc << "Arg1: " << a1;
-        addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event F1", desc.str());
+        desc = fmt::format("Arg1: {:d}", a1);
+        addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event F1", desc);
         break;
       }
 
@@ -332,12 +330,12 @@ bool TamSoftPS1Track::readEvent() {
         curOffset += 2;
 
         uint32_t dest = curOffset + relOffset;
-        desc << "Destination: $" << std::hex << std::setfill('0') << std::setw(4) << std::uppercase << (int) dest;
+        desc = fmt::format("Destination: ${:04X}", dest);
         uint32_t length = curOffset - beginOffset;
 
         curOffset = dest;
         if (!isOffsetUsed(dest)) {
-          addGenericEvent(beginOffset, length, "Jump", desc.str().c_str(), Type::LoopForever);
+          addGenericEvent(beginOffset, length, "Jump", desc.c_str(), Type::LoopForever);
         }
         else {
           bContinue = addLoopForever(beginOffset, length, "Jump");
@@ -346,7 +344,7 @@ bool TamSoftPS1Track::readEvent() {
       }
 
       case 0xF9: {
-        addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event F9", desc.str());
+        addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event F9", desc);
         break;
       }
 


### PR DESCRIPTION
Replace stringstream usages in format files with std::string and fmt::format().

This PR was initially created as a test of OpenAI's new Codex service. After many prompts, I have coaxed Codex into performing an extensive refactor. I have now reviewed the changes and made additional commits to improve some of the interpolation (forcing unsigned chars to int format) and code formatting. I expect this PR fixes many instances of event descriptions which print parameters as ASCII characters instead of integers.

I have done basic testing, but nothing extensive given the scope of the refactor.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
