### PR TITLE
KonamiArcade update and CoarseTuningSeqEvent

### DIFF
--- a/src/main/components/seq/SeqEvent.cpp
+++ b/src/main/components/seq/SeqEvent.cpp
@@ -211,6 +211,14 @@ FineTuningSeqEvent::FineTuningSeqEvent(SeqTrack *pTrack, double cents,
                                        uint32_t offset, uint32_t length, const std::string &name)
     : SeqEvent(pTrack, offset, length, name, Type::Misc), m_cents(cents) { }
 
+// ********************
+// CoarseTuningSeqEvent
+// ********************
+
+CoarseTuningSeqEvent::CoarseTuningSeqEvent(SeqTrack *pTrack, double semitones,
+                                       uint32_t offset, uint32_t length, const std::string &name)
+    : SeqEvent(pTrack, offset, length, name, Type::Misc), m_semitones(semitones) { }
+
 // ****************************
 // ModulationDepthRangeSeqEvent
 // ****************************

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -352,6 +352,23 @@ private:
   double m_cents;
 };
 
+//  ********************
+//  CoarseTuningSeqEvent
+//  ********************
+
+class CoarseTuningSeqEvent : public SeqEvent {
+public:
+  CoarseTuningSeqEvent(SeqTrack *pTrack, double semitones, uint32_t offset = 0, uint32_t length = 0,
+                       const std::string &name = "");
+
+  std::string description() override {
+    return fmt::format("{} - coarse tuning: {}", name(), m_semitones);
+  };
+
+private:
+  double m_semitones;
+};
+
 //  ****************************
 //  ModulationDepthRangeSeqEvent
 //  ****************************

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -39,6 +39,8 @@ void SeqTrack::resetVars() {
   prevReverb = 40;
   channelGroup = 0;
   transpose = 0;
+  fineTuningCents = 0;
+  coarseTuningSemitones = 0;
   cDrumNote = -1;
   cKeyCorrection = 0;
   panVolumeCorrectionRate = 1.0;
@@ -984,13 +986,27 @@ void SeqTrack::addFineTuning(uint32_t offset, uint32_t length, double cents, con
 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new FineTuningSeqEvent(this, cents, offset, length, sEventName));
-  else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->addFineTuning(channel, cents);
+  addFineTuningNoItem(cents);
 }
 
-void SeqTrack::addFineTuningNoItem(double cents) const {
+void SeqTrack::addFineTuningNoItem(double cents) {
   if (readMode == READMODE_CONVERT_TO_MIDI)
     pMidiTrack->addFineTuning(channel, cents);
+  fineTuningCents = cents;
+}
+
+void SeqTrack::addCoarseTuning(uint32_t offset, uint32_t length, double semitones, const std::string &sEventName) {
+  onEvent(offset, length);
+
+  if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
+    addEvent(new CoarseTuningSeqEvent(this, semitones, offset, length, sEventName));
+  addCoarseTuningNoItem(semitones);
+}
+
+void SeqTrack::addCoarseTuningNoItem(double semitones) {
+  if (readMode == READMODE_CONVERT_TO_MIDI)
+    pMidiTrack->addCoarseTuning(channel, semitones);
+  coarseTuningSemitones = semitones;
 }
 
 void SeqTrack::addModulationDepthRange(uint32_t offset,

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -113,7 +113,9 @@ class SeqTrack : public VGMItem {
   void addPitchBendRange(uint32_t offset, uint32_t length, uint16_t cents, const std::string &sEventName = "Pitch Bend Range");
   void addPitchBendRangeNoItem(uint16_t cents) const;
   void addFineTuning(uint32_t offset, uint32_t length, double cents, const std::string &sEventName = "Fine Tuning");
-  void addFineTuningNoItem(double cents) const;
+  void addFineTuningNoItem(double cents);
+  void addCoarseTuning(uint32_t offset, uint32_t length, double semitones, const std::string &sEventName = "Coarse Tuning");
+  void addCoarseTuningNoItem(double semitones);
   void addModulationDepthRange(uint32_t offset, uint32_t length, double semitones, const std::string &sEventName = "Modulation Depth Range");
   void addModulationDepthRangeNoItem(double semitones) const;
   void addTranspose(uint32_t offset, uint32_t length, int8_t transpose, const std::string &sEventName = "Transpose");
@@ -192,6 +194,8 @@ class SeqTrack : public VGMItem {
   uint8_t prevPan;
   uint8_t prevReverb;
   int8_t transpose;
+  double fineTuningCents;
+  double coarseTuningSemitones;
   uint32_t curOffset;
   bool bInLoop;
   int8_t cDrumNote;            //-1 signals do not use drumNote, otherwise,

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -132,8 +132,9 @@ SynthFile* createSynthFile(
           }
         }
         // Otherwise, the sample number should be explicitly defined in the rgn.
-        else
+        else {
           realSampNum = rgn->sampNum;
+        }
 
         // Determine the sampCollNum (index into our finalSampColls vector)
         auto sampCollNum = finalSampColls.size();
@@ -149,6 +150,12 @@ SynthFile* createSynthFile(
         // get the real sampNum in the final DLS file.
         for (uint32_t k = 0; k < sampCollNum; k++)
           realSampNum += finalSampColls[k]->samples.size();
+
+        if (realSampNum >= finalSamps.size()) {
+          L_ERROR("Region has an explicit sample number that exceeds sample count. Sample Num: {:d} (Instrset "
+                  "{}, Instr {}, Region {})", realSampNum, inst, i, j);
+          realSampNum = 0;
+        }
 
         SynthRgn *newRgn = newInstr->addRgn();
         newRgn->setRanges(rgn->keyLow, rgn->keyHigh, rgn->velLow, rgn->velHigh);

--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
@@ -183,7 +183,7 @@ bool KonamiArcadeTrack::readEvent() {
     }
     u8 atten = 0x7f - vel;
 
-    u8 linearVel = volTable[atten] * 0x7F;
+    u8 linearVel = std::max(0.0, volTable[atten]) * 0x7F;
 
     // TODO: fix duration calculation. It uses dur as index to table at 0x1F0 in viostorm.
     // Something like this - need to verify the + 0.5 rounding thing

--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
@@ -501,18 +501,15 @@ bool KonamiArcadeTrack::readEvent() {
         m_needsSubroutineEnd = false;
         m_inSubRoutine = false;
         addGenericEvent(beginOffset, curOffset - beginOffset, "Subroutine Return", "", Type::Loop);
-        printf("Encountered subroutine return offset: %X\n", beginOffset);
       } else {
         if (m_inSubRoutine) {
           curOffset = m_subroutineReturnOffset;
           m_inSubRoutine = false;
-          printf("Returning from subroutine: %X. Jumping back to: %X\n", beginOffset, curOffset);
         } else {
           addGenericEvent(beginOffset, curOffset - beginOffset, "Call Subroutine", "", Type::Loop);
           m_inSubRoutine = true;
           m_subroutineReturnOffset = curOffset;
           curOffset = m_subroutineOffset;
-          printf("Calling subroutine: %X. Jumping to: %X\n", beginOffset, curOffset);
         }
       }
       break;

--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.h
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.h
@@ -38,9 +38,12 @@ public:
 
 private:
   u8 calculateMidiPanForK054539(u8 pan);
+  void enablePercussion(bool& flag);
+  void disablePercussion(bool& flag);
 
   bool m_inJump;
-  bool m_percussion;
+  bool m_percussionFlag1;
+  bool m_percussionFlag2;
   u8 m_releaseRate;
   u8 m_curProg;
   u32 m_loopMarker[2] = {};
@@ -51,5 +54,9 @@ private:
   u8 m_duration;
   u8 m_vol;
   u8 m_pan;
+  u32 m_subroutineOffset;
+  u32 m_subroutineReturnOffset;
+  bool m_needsSubroutineEnd = false;
+  bool m_inSubRoutine = false;
   u32 m_jumpReturnOffset;
 };

--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.h
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.h
@@ -40,10 +40,12 @@ private:
   u8 calculateMidiPanForK054539(u8 pan);
   void enablePercussion(bool& flag);
   void disablePercussion(bool& flag);
+  void applyTranspose();
 
   bool m_inJump;
   bool m_percussionFlag1;
   bool m_percussionFlag2;
+  s8 m_driverTranspose;
   u8 m_releaseRate;
   u8 m_curProg;
   u32 m_loopMarker[2] = {};


### PR DESCRIPTION
This improves conversion of the Mystic Warrior driver (KonamiArcade) and adds the CoarseTuningSeqEvent and related SeqTrack methods. Additionally, this adds state member variables to SeqTrack to track fine tuning (`fineTuningCents`) and coarse tuning (`coarseTuningSemitones`) values.

For the KonamiArcade driver, this specifically:
* adds events F6 and F7 which affect control flow. F6 sets a start marker, the next call to F7 sets an end marker, subsequent calls to F7 are like subroutine calls, jumping to the start marker and returning at the end marker
* adds event EB, which is an alternative means of setting percussion mode (don't know how it's unique from event 60)
* adds event EC - transpose. Because percussion mode uses a drum kit style instrument, I use coarse fine tuning instead of changing the actual note played in that mode. However, this workaround doesn't work with lib BASS, because lib BASS actually sends different notes when coarse fine tune is used (wtf). FluidSynth handles it fine, as it works on the juce3 branch.
* add proper parsing of some unknown events

Additionally:
* Add more proper UI elements for KonamiArcade instrument sets
* Handle an error in SF2Conversion where the sample number exceeds the count of actual samples (some KonamiArcade titles have bogus samp nums in their drum kits)

## Motivation and Context

https://github.com/user-attachments/assets/a890e0cc-95c1-412b-b24e-f3ba22b6dde9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
