### PR TITLE
fix setting track length in readEvent() when bDetermineTrack is false

### DIFF
--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -266,7 +266,9 @@ void SeqTrack::addEvent(SeqEvent *pSeqEvent) {
   // care for a case where the new event is located before the start address
   // (example: Donkey Kong Country - Map, Track 7 of 8)
   if (dwOffset > pSeqEvent->dwOffset) {
-    unLength += (dwOffset - pSeqEvent->dwOffset);
+    if (bDetermineTrackLengthEventByEvent) {
+      unLength += (dwOffset - pSeqEvent->dwOffset);
+    }
     dwOffset = pSeqEvent->dwOffset;
   }
 


### PR DESCRIPTION
When a track adds an event that precedes the track's own offset, both the track's offset and the length of the track are updated. This breaks track length calculation when `bDetermineTrackLengthEventByEvent` is false (which in turn breaks conversion). In this case, no other event reads are updating track length, so the length ends up being the difference of the initial offset with the new earlier offset after all event reads are done. After this, the default means by which track length is set - setGuessedLength() - calculates but does not update track length because it is already a non-zero value.

It's not immediately clear to me why we have two different methods of setting track length to begin with. I would think that, unless set during construction, the track length should be set one of the two ways and we should get rid of `bDetermineTrackLengthEventByEvent`. Perhaps I'm missing something?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
