### PR TITLE
KonamiArcade: add Portamento and Pitch Slide Mode

### DIFF
--- a/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
@@ -12,6 +12,12 @@
 
 #include <spdlog/fmt/fmt.h>
 
+// The driver doesn't define an envelope at the instrument level. Instead, it sets release time
+// via sequence events, which are currently unhandled. Adding artificial release times generally
+// makes things sound better.
+const double instrReleaseTime = 0.5;
+const double drumReleaseTime = 0.7;
+
 // ********************
 // KonamiArcadeInstrSet
 // ********************
@@ -62,6 +68,7 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
     VGMInstr* instr = new VGMInstr(this, off, sizeof(konami_mw_sample_info), 0, sampNum, name);
     VGMRgn* rgn = new VGMRgn(instr, off, sizeof(konami_mw_sample_info));
     rgn->sampNum = sampNum;
+    rgn->release_time = instrReleaseTime;
     instr->addRgn(rgn);
 
     auto instrSampInfoItem = instrSampInfos->addChild(off, sizeof(konami_mw_sample_info),
@@ -108,7 +115,8 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
     rgn->keyHigh = i + 24;
     int unityKey = (i + 24) + (0x2A - d.unity_key);
     rgn->sampNum = sampNum;
-    rgn->unityKey = unityKey; //i + 24;
+    rgn->unityKey = unityKey;
+    rgn->release_time = drumReleaseTime;
 
     rgn->addChild(off, 1, "Sample Number");
     rgn->addChild(off + 1, 1, "Unity Key");

--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
@@ -393,7 +393,7 @@ bool KonamiArcadeTrack::readEvent() {
       uint8_t dur = readByte(curOffset++);
       uint32_t newdur = (delta * dur) / 0x64;
       addTime(newdur);
-      this->makePrevDurNoteEnd();
+      makePrevDurNoteEnd();
       addTime(delta - newdur);
       auto desc = fmt::format("total delta: {:d} ticks  additional duration: {:d} ticks", delta, newdur);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Hold", desc, Type::Tie);
@@ -611,13 +611,14 @@ bool KonamiArcadeTrack::readEvent() {
         break;
       }
 
-      // insertPortamentoNoItem(true, m_prevNoteAbsTime);
-      makePrevDurNoteEnd(m_prevNoteAbsTime + delay + 1);  // add one to ensure the notes overlap to trigger portamento effect
+      makeTrulyPrevDurNoteEnd(m_prevNoteAbsTime + delay + 1);  // add one to ensure the notes overlap to trigger portamento effect
       insertPortamentoTime14BitNoItem(duration * m_timePerTickMicroseconds, m_prevNoteAbsTime + delay);
       insertPortamentoControlNoItem(m_prevFinalKey, m_prevNoteAbsTime + delay);
       u32 newNoteDur = m_prevNoteDur - delay;
       insertNoteByDurNoItem(targetNote, prevVel, newNoteDur, m_prevNoteAbsTime + delay);
-      // insertPortamentoNoItem(false, m_prevNoteAbsTime + m_prevNoteDur);
+      if (m_portamentoEnabled) {
+        insertPortamentoTime14BitNoItem(m_portamentoTime * m_timePerTickMicroseconds, m_prevNoteAbsTime + m_prevNoteDur);
+      }
       break;
     }
 

--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.h
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.h
@@ -42,6 +42,8 @@ public:
   bool readEvent() override;
 
 private:
+  void makeTrulyPrevDurNoteEnd(uint32_t absTime) const;
+
   u8 calculateMidiPanForK054539(u8 pan);
   void enablePercussion(bool& flag);
   void disablePercussion(bool& flag);
@@ -52,7 +54,14 @@ private:
   bool m_percussionFlag2;
   u32 m_prevNoteAbsTime;
   u32 m_prevNoteDur;
+  u32 m_prevNoteDelta;
+  u8 m_prevFinalKey;
   double m_timePerTickMicroseconds;
+  bool m_portamentoEnabled;
+  u8 m_portamentoTime;
+  u8 m_slideModeDelay;
+  u8 m_slideModeDuration;
+  s8 m_slideModeDepth;
   s8 m_driverTranspose;
   u8 m_releaseRate;
   u8 m_curProg;


### PR DESCRIPTION
KonamiArcade:
* add Portamento event
* add Pitch Slide Mode event
* handle loop transpose param (used for glissandos)

KonamiArcadeInstr:
* add an artificial release time value for instruments and drumkits

Also I've added the method `KonamiArcadeTrack::makeTrulyPrevDurNoteEnd()`. I may add a separate PR adding a better named function in SeqTrack (and likely renaming `SeqTrack::makePrevDurNoteEnd()`) Unlike `SeqTrack::makePrevDurNoteEnd()`, which can modify multiple duration note events, `makeTrulyPrevDurNoteEnd()` will only affect the last duration note added.  The former was inadvertently modifying multiple note events in the portamento logic.

This sounds worlds better on the juce3 branch. BASS doesn't support 14 bit portamento time, and its portamento handling seems off in general.
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
