### PR TITLE
VGMSeq: fix: alwaysWriteInitialReverb() was returning initial expression

### DIFF
--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -69,7 +69,7 @@ class VGMSeq : public VGMFile {
     m_initial_expression = level;
   }
 
-  [[nodiscard]] bool alwaysWriteInitialReverb() const { return m_always_write_initial_expression; }
+  [[nodiscard]] bool alwaysWriteInitialReverb() const { return m_always_write_initial_reverb; }
   void setAlwaysWriteInitialReverb(uint8_t level = 127) {
     m_always_write_initial_reverb = true;
     m_initial_reverb_level = level;


### PR DESCRIPTION
One liner bug fix.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
