### PR TITLE
KonamiArcade: support reverse samples and program changes > 127

### DIFF
--- a/src/main/components/instr/VGMSamp.h
+++ b/src/main/components/instr/VGMSamp.h
@@ -37,6 +37,8 @@ public:
   inline void setLoopLength(uint32_t theLoopLength) { loop.loopLength = theLoopLength; }
   inline void setLoopStartMeasure(LoopMeasure measure) { loop.loopStartMeasure = measure; }
   inline void setLoopLengthMeasure(LoopMeasure measure) { loop.loopLengthMeasure = measure; }
+  inline bool reverse() { return m_reverse; }
+  inline void setReverse(bool reverse) { m_reverse = reverse; }
 
   bool onSaveAsWav();
   bool saveAsWav(const std::string &filepath);
@@ -61,6 +63,9 @@ public:
   long pan{0};
 
   VGMSampColl *parSampColl;
+
+private:
+  bool m_reverse = false;
 };
 
 

--- a/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
@@ -37,7 +37,8 @@ void KonamiArcadeInstrSet::addSampleInfoChildren(VGMItem* sampInfoItem, u32 off)
   sampInfoItem->addChild(off, 3, "Loop Offset");
   sampInfoItem->addChild(off + 3, 3, "Sample Offset");
   std::string sampleTypeStr;
-  switch (readByte(off + 6)) {
+  u8 flagsByte = readByte(off + 6);
+  switch (flagsByte & 0xc) {
     case static_cast<int>(konami_mw_sample_info::sample_type::PCM_8):
       sampleTypeStr = "PCM 8";
       break;
@@ -47,6 +48,9 @@ void KonamiArcadeInstrSet::addSampleInfoChildren(VGMItem* sampInfoItem, u32 off)
     case static_cast<int>(konami_mw_sample_info::sample_type::ADPCM):
       sampleTypeStr = "ADPCM";
       break;
+  }
+  if (flagsByte & 0x20) {
+    sampleTypeStr += " (Reverse)";
   }
   sampInfoItem->addChild(off + 6, 1, fmt::format("Sample Type: {}", sampleTypeStr));
   sampInfoItem->addChild(off + 7, 1, fmt::format("Loops: {}", readByte(off + 7) > 0 ? "True" : "False"));
@@ -64,8 +68,10 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
                                       "Instrument Sample Infos");
   int sampNum = 0;
   for (u32 off = instrSampleTableOffset; off < sfxSampleTableOffset; off += sizeof(konami_mw_sample_info)) {
-    std::string name = fmt::format("Instrument {}", sampNum);
-    VGMInstr* instr = new VGMInstr(this, off, sizeof(konami_mw_sample_info), 0, sampNum, name);
+    int bank = sampNum > 127 ? 1 : 0;
+    int instrNum = sampNum > 127 ? sampNum - 128 : sampNum;
+    std::string name = fmt::format("Instrument {} Bank {}", instrNum, bank);
+    VGMInstr* instr = new VGMInstr(this, off, sizeof(konami_mw_sample_info), bank, instrNum, name);
     VGMRgn* rgn = new VGMRgn(instr, off, sizeof(konami_mw_sample_info));
     rgn->sampNum = sampNum;
     rgn->release_time = instrReleaseTime;
@@ -99,7 +105,7 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
     this,
     m_drumTableOffset,
     sizeof(m_drums),
-    1,
+    2,
     0,
     "Drum Kit"
   );
@@ -155,13 +161,14 @@ bool KonamiArcadeSampColl::parseHeader() {
   return true;
 }
 
-u32 KonamiArcadeSampColl::determineSampleSize(u32 startOffset, konami_mw_sample_info::sample_type type) {
+u32 KonamiArcadeSampColl::determineSampleSize(u32 startOffset,
+  konami_mw_sample_info::sample_type sampleType, bool reverse) {
   // Each sample type uses a slightly different sentinel value.
   // In practice, we find that each sample ends with multiple sample values. The smallest pattern
   // being ADPCM with 4 0x88 bytes in a row.
   u16 endMarker;
   int inc = 1;
-  switch (type) {
+  switch (sampleType) {
     case konami_mw_sample_info::sample_type::PCM_8:
       endMarker = 0x8080;
       break;
@@ -173,14 +180,22 @@ u32 KonamiArcadeSampColl::determineSampleSize(u32 startOffset, konami_mw_sample_
       endMarker = 0x8888;
       break;
     default:
-      L_ERROR("K054539 sample info has invalid type: {:d}. Expected 0, 4, or 8.", static_cast<int>(type));
+      L_ERROR("K054539 sample info has invalid type: {:d}. Expected 0, 4, or 8.  Sample offset: {:X}", static_cast<int>(type), startOffset);
       endMarker = 0x8080;
       break;
   }
 
-  for (u32 off = startOffset; off < unLength + 2; off += inc) {
-    if (readShort(off) == endMarker) {
-      return off - startOffset;
+  if (reverse) {
+    for (u32 off = startOffset-2; off >= dwOffset + 2; off -= inc) {
+      if (readShort(off) == endMarker) {
+        return startOffset - off;
+      }
+    }
+  } else {
+    for (u32 off = startOffset; off < unLength + 2; off += inc) {
+      if (readShort(off) == endMarker) {
+        return off - startOffset;
+      }
     }
   }
   return unLength - startOffset;
@@ -193,20 +208,20 @@ bool KonamiArcadeSampColl::parseSampleInfo() {
     u32 sampleOffset = sampInfo.start_msb << 16 | sampInfo.start_mid << 8 | sampInfo.start_lsb;
     u32 sampleLoopOffset = sampInfo.loop_msb << 16 | sampInfo.loop_mid << 8 | sampInfo.loop_lsb;
     u32 relativeLoopOffset = sampleLoopOffset - sampleOffset;
-    u32 sampleSize = determineSampleSize(sampleOffset, sampInfo.type);
+    u32 sampleSize = determineSampleSize(sampleOffset, sampInfo.type(), sampInfo.reverse());
+    if (sampInfo.reverse()) {
+      sampleOffset = sampleOffset - sampleSize;
+    }
 
     auto name = fmt::format("Sample {:d}", sampNum++);
-    if (sampInfo.type == konami_mw_sample_info::sample_type::ADPCM) {
-      auto sample = new K054539AdpcmSamp(this, sampleOffset, sampleSize, 24000, name);
+    VGMSamp* sample;
+    if (sampInfo.type() == konami_mw_sample_info::sample_type::ADPCM) {
+      sample = new K054539AdpcmSamp(this, sampleOffset, sampleSize, 24000, name);
       sample->setWaveType(WT_PCM16);
-      sample->setLoopStatus(sampInfo.loops == 1);
-      sample->setLoopOffset(relativeLoopOffset);
-      sample->unityKey = 0x3C + 6;
-      sample->volume = volTable[sampInfo.attenuation];
       samples.push_back(sample);
     } else {
-      u16 bps = sampInfo.type == konami_mw_sample_info::sample_type::PCM_8 ? 8 : 16;
-      VGMSamp *sample = addSamp(sampleOffset,
+      u16 bps = sampInfo.type() == konami_mw_sample_info::sample_type::PCM_8 ? 8 : 16;
+      sample = addSamp(sampleOffset,
                            sampleSize,
                            sampleOffset,
                            sampleSize,
@@ -215,11 +230,12 @@ bool KonamiArcadeSampColl::parseSampleInfo() {
                            24000,
                            name);
       sample->setWaveType(bps == 8 ? WT_PCM8 : WT_PCM16);
-      sample->setLoopStatus(sampInfo.loops == 1);
-      sample->setLoopOffset(relativeLoopOffset);
-      sample->unityKey = 0x3C + 6;
-      sample->volume = volTable[sampInfo.attenuation];
     }
+    sample->setLoopStatus(sampInfo.loops == 1);
+    sample->setLoopOffset(relativeLoopOffset);
+    sample->unityKey = 0x3C + 6;
+    sample->volume = volTable[sampInfo.attenuation];
+    sample->setReverse(sampInfo.reverse());
   }
   return true;
 }

--- a/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
@@ -191,11 +191,11 @@ u32 KonamiArcadeSampColl::determineSampleSize(u32 startOffset,
         return startOffset - off;
       }
     }
-  } else {
-    for (u32 off = startOffset; off < unLength + 2; off += inc) {
-      if (readShort(off) == endMarker) {
-        return off - startOffset;
-      }
+    return startOffset;
+  }
+  for (u32 off = startOffset; off < unLength + 2; off += inc) {
+    if (readShort(off) == endMarker) {
+      return off - startOffset;
     }
   }
   return unLength - startOffset;

--- a/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
@@ -207,10 +207,11 @@ bool KonamiArcadeSampColl::parseSampleInfo() {
   for (auto sampInfo : sampInfos) {
     u32 sampleOffset = sampInfo.start_msb << 16 | sampInfo.start_mid << 8 | sampInfo.start_lsb;
     u32 sampleLoopOffset = sampInfo.loop_msb << 16 | sampInfo.loop_mid << 8 | sampInfo.loop_lsb;
-    u32 relativeLoopOffset = sampleLoopOffset - sampleOffset;
+    s32 relativeLoopOffset = sampleLoopOffset - sampleOffset;
     u32 sampleSize = determineSampleSize(sampleOffset, sampInfo.type(), sampInfo.reverse());
     if (sampInfo.reverse()) {
       sampleOffset = sampleOffset - sampleSize;
+      relativeLoopOffset = -relativeLoopOffset;
     }
 
     auto name = fmt::format("Sample {:d}", sampNum++);

--- a/src/main/formats/KonamiArcade/KonamiArcadeInstr.h
+++ b/src/main/formats/KonamiArcade/KonamiArcadeInstr.h
@@ -26,9 +26,22 @@ struct konami_mw_sample_info {
   u8 start_lsb;
   u8 start_mid;
   u8 start_msb;
-  sample_type type;
+  u8 flags;
   bool loops;
   u8 attenuation;
+
+private:
+  static constexpr u8 mask_sample_type = 0b0000'1100;  // bits 2-3
+  static constexpr u8 mask_reverse     = 0b0010'0000;  // bit 5
+
+public:
+  [[nodiscard]] constexpr sample_type type() const noexcept {
+    return static_cast<sample_type>(flags & mask_sample_type);
+  }
+
+  [[nodiscard]] constexpr bool reverse() const noexcept {
+    return (flags & mask_reverse) != 0;
+  }
 };
 
 // ********************
@@ -87,7 +100,7 @@ public:
   bool parseSampleInfo() override;
 
 private:
-  u32 determineSampleSize(u32 startOffset, konami_mw_sample_info::sample_type type);
+  u32 determineSampleSize(u32 startOffset, konami_mw_sample_info::sample_type type, bool reverse);
 
   std::vector<VGMItem*> samplePointers;
   KonamiArcadeInstrSet *instrset;

--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
@@ -479,12 +479,9 @@ bool KonamiArcadeTrack::readEvent() {
       break;
     }
 
-    // program change
+    // Program Change
     case 0xE2: {
       m_curProg = readByte(curOffset++);
-      if (m_curProg > 0x7F) {
-        printf("program # is greater than 0x7f\n");
-      }
       addProgramChange(beginOffset, curOffset - beginOffset, m_curProg, true);
       break;
     }
@@ -513,6 +510,7 @@ bool KonamiArcadeTrack::readEvent() {
       addUnknown(beginOffset, curOffset - beginOffset);
       break;
 
+    // Loop Start Marker
     case 0xE6:
       loopNum = 0;
       goto loopMarker;
@@ -525,6 +523,7 @@ bool KonamiArcadeTrack::readEvent() {
       break;
     }
 
+    // Loop
     case 0xE7:
       loopNum = 0;
       goto doLoop;
@@ -646,12 +645,12 @@ bool KonamiArcadeTrack::readEvent() {
       break;
     }
 
+    // Pitch Slide Mode
+    // When enabled, triggers a pitch slide similar to event F3 on every note on.
+    // Unlike F3, pitch is given as a relative value, and the slide goes FROM
+    // the new pitch to the pitch of the triggered note (F3 slides from note to target note)
+    // Pitch slide is disabled by setting the duration value to 0.
     case 0xF1: {
-      // Pitch Slide Mode
-      // When enabled, triggers a pitch slide similar to event F3 on every note on.
-      // Unlike F3, pitch is given as a relative value, and the slide goes FROM
-      // the new pitch to the pitch of the triggered note (F3 goes note pitch to slide pitch)
-      // Sequences disable this by calling the same event with 00 param values
       m_slideModeDelay = readByte(curOffset++);
       m_slideModeDelay = m_slideModeDelay == 0 ? 1 : m_slideModeDelay;
       m_slideModeDuration = readByte(curOffset++);
@@ -660,6 +659,7 @@ bool KonamiArcadeTrack::readEvent() {
       break;
     }
 
+    // Pitch Bend
     case 0xF2: {
       s8 pitchBend = readByte(curOffset++);
       // data byte of 0x40 == 1 semitone. Equivalent to 4096 in MIDI when range is default 2 semitones
@@ -667,7 +667,8 @@ bool KonamiArcadeTrack::readEvent() {
       break;
     }
 
-    case 0xF3: {      // Pitch Slide
+    // Pitch Slide
+    case 0xF3: {
       u8 delay = readByte(curOffset++);
       u8 duration = readByte(curOffset++);
       u8 targetNote = readByte(curOffset++);
@@ -704,12 +705,14 @@ bool KonamiArcadeTrack::readEvent() {
       break;
     }
 
+    // Subroutine Start
     case 0xF6:
       m_subroutineOffset = curOffset;
       m_needsSubroutineEnd = true;
       addGenericEvent(beginOffset, curOffset - beginOffset, "Subroutine Start", "", Type::Loop);
       break;
 
+    // Subroutine Return / Call Subroutine
     case 0xF7:
       if (m_needsSubroutineEnd) {
         m_needsSubroutineEnd = false;
@@ -744,7 +747,7 @@ bool KonamiArcadeTrack::readEvent() {
       break;
     }
 
-    //release rate
+    // Release Rate
     case 0xFA: {
       // lower value results in longer sustain
       m_releaseRate = readByte(curOffset++);
@@ -752,6 +755,7 @@ bool KonamiArcadeTrack::readEvent() {
       break;
     }
 
+    // Jump
     case 0xFD: {
       auto seq = static_cast<KonamiArcadeSeq*>(parentSeq);
       u32 dest;
@@ -777,6 +781,7 @@ bool KonamiArcadeTrack::readEvent() {
       return shouldContinue;
     }
 
+    // Call
     case 0xFE: {
       m_inJump = true;
       u32 dest;
@@ -798,6 +803,8 @@ bool KonamiArcadeTrack::readEvent() {
       curOffset = dest;
       break;
     }
+
+    // Return  / End of Track
     case 0xFF: {
       if (m_inJump) {
         addGenericEvent(beginOffset, 1, "Return", "", Type::Loop);

--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
@@ -141,7 +141,7 @@ u8 KonamiArcadeTrack::calculateMidiPanForK054539(u8 pan) {
 void KonamiArcadeTrack::enablePercussion(bool& flag) {
   flag = true;
   // Drums define their own pan, which is only used if the pan state value is 0
-  addBankSelectNoItem(1);
+  addBankSelectNoItem(2);
   addProgramChangeNoItem(0, false);
   applyTranspose();
 }
@@ -485,7 +485,7 @@ bool KonamiArcadeTrack::readEvent() {
       if (m_curProg > 0x7F) {
         printf("program # is greater than 0x7f\n");
       }
-      addProgramChange(beginOffset, curOffset - beginOffset, m_curProg);
+      addProgramChange(beginOffset, curOffset - beginOffset, m_curProg, true);
       break;
     }
 


### PR DESCRIPTION
Though it's sparsely used, Konami's K054539 sound chip supports a playback mode that reads samples in reverse. In both the hardware register and the sample info data, this mode is indicated by bit 5 of the byte that also determines sample type (8 bit PCM, 16 bit PCM, or ADPCM). So 0x20, 0x24, and 0x28 indicate reverse samples of those respective types.

An example of actual usage would be the Speak & Spell-esque synthesized voice 10 seconds into Mystic Warriors song 0.

In addition to updating the KonamiArcade sample info struct to provide this flag (via a reverse() method), I updated VGMSamp to support reverse samples. I also added reverse support for K054539AdpcmSamp, though I've yet to find an instance where it's used.

The second change I've made is supporting instrument sets with > 127 instruments (samples, really).  These are now split into banks 0 and 1, and the drum kit moved to bank 2. Program change events in the format use all 8 bits, so we just treat the 8th bit as the bank selection.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
