### PR TITLE
Remove the preamble about third-party licenses from `LICENSE`.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,3 @@
-VGMTrans is released under the zlib/libpng license. This distribution
-incorporates code from various projects, each governed by its respective
-license. Full license details can be found in the source distribution's
-licenses directory or within the binary application's About dialog under
-the License tab.
-
-The zlib/libpng License
-
 VGMTrans Copyright (c) 2002-2025 The VGMTrans Team
 
 This software is provided 'as-is', without any express or implied

--- a/README.md
+++ b/README.md
@@ -145,4 +145,7 @@ for contributing effectively.
 - [@brr890](https://twitter.com/brr890) and [@tssf](https://twitter.com/tssf): Contributed a lot of hints on PS1 AKAO format.
 
 ## License
-Licensed under the zlib/libpng License. See [`LICENSE`](LICENSE).
+Licensed under the zlib License. See [`LICENSE`](LICENSE).
+
+This project bundles some third‑party components, each under its own license. You can review every license in the 
+`licenses/` folder of the source tree or, in the compiled app, via **About → License**.


### PR DESCRIPTION
This moves the statement about third-party licenses out of the LICENSE file and into the README. This seems to be the norm, and hopefully will now cause github to detect that we are using the zlib license, as it does for [other projects](https://github.com/zlib-ng/zlib-ng).
