### PR TITLE
Volume logic refactoring

### DIFF
--- a/src/main/components/seq/SeqEvent.cpp
+++ b/src/main/components/seq/SeqEvent.cpp
@@ -87,6 +87,9 @@ SetOctaveSeqEvent::SetOctaveSeqEvent(SeqTrack *pTrack,
 VolSeqEvent::VolSeqEvent(SeqTrack *pTrack, uint8_t volume, uint32_t offset, uint32_t length, const std::string &name)
     : SeqEvent(pTrack, offset, length, name, Type::Volume), vol(volume) { }
 
+VolSeqEvent::VolSeqEvent(SeqTrack *pTrack, double volume, uint32_t offset, uint32_t length, const std::string &name)
+    : SeqEvent(pTrack, offset, length, name, Type::Volume), percentVol(volume) { }
+
 // ***********
 // Volume14BitSeqEvent
 // ***********
@@ -133,12 +136,11 @@ MastVolSlideSeqEvent::MastVolSlideSeqEvent(SeqTrack *pTrack,
 // ExpressionSeqEvent
 // ******************
 
-ExpressionSeqEvent::ExpressionSeqEvent(SeqTrack *pTrack,
-                                       uint8_t theLevel,
-                                       uint32_t offset,
-                                       uint32_t length,
-                                       const std::string &name)
+ExpressionSeqEvent::ExpressionSeqEvent(SeqTrack *pTrack, u8 theLevel, u32 offset, u32 length, const std::string &name)
     : SeqEvent(pTrack, offset, length, name, Type::Expression), level(theLevel) { }
+
+ExpressionSeqEvent::ExpressionSeqEvent(SeqTrack *pTrack, double level, u32 offset, u32 length, const std::string &name)
+    : SeqEvent(pTrack, offset, length, name, Type::Expression), percentLevel(level) { }
 
 // ***********************
 // ExpressionSlideSeqEvent

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -144,7 +144,7 @@ class VolSeqEvent : public SeqEvent {
 
   std::string description() override {
     if (percentVol > 0) {
-      return fmt::format("{} - volume: {:f}", name(), percentVol);
+      return fmt::format("{} - volume: {:.1f}", name(), percentVol);
     }
     return fmt::format("{} - volume: {:d}", name(), vol);
   };
@@ -232,7 +232,7 @@ class ExpressionSeqEvent : public SeqEvent {
 
   std::string description() override {
     if (percentLevel > 0) {
-      return fmt::format("{} - expression: {:f}", name(), percentLevel);
+      return fmt::format("{} - expression: {:.1f}", name(), percentLevel);
     }
     return fmt::format("{} - expression: {:d}", name(), level);
   };

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -139,12 +139,18 @@ class VolSeqEvent : public SeqEvent {
  public:
   VolSeqEvent(SeqTrack *pTrack, uint8_t volume, uint32_t offset = 0, uint32_t length = 0,
               const std::string &name = "");
+  VolSeqEvent(SeqTrack *pTrack, double volume, uint32_t offset = 0, uint32_t length = 0,
+              const std::string &name = "");
 
   std::string description() override {
+    if (percentVol > 0) {
+      return fmt::format("{} - volume: {:f}", name(), percentVol);
+    }
     return fmt::format("{} - volume: {:d}", name(), vol);
   };
 
-  uint8_t vol;
+  uint8_t vol = -1;
+  double percentVol = -1;
 };
 
 //  *******************
@@ -221,15 +227,19 @@ class MastVolSlideSeqEvent : public SeqEvent {
 
 class ExpressionSeqEvent : public SeqEvent {
  public:
-  ExpressionSeqEvent(SeqTrack *pTrack, uint8_t level, uint32_t offset = 0, uint32_t length = 0,
-                     const std::string &name = "");
+  ExpressionSeqEvent(SeqTrack *pTrack, u8 level, u32 offset = 0, u32 length = 0, const std::string &name = "");
+  ExpressionSeqEvent(SeqTrack *pTrack, double level, u32 offset = 0, u32 length = 0, const std::string &name = "");
 
   std::string description() override {
-    return fmt::format("{} - expression: {}", name(), static_cast<int>(level));
+    if (percentLevel > 0) {
+      return fmt::format("{} - expression: {:f}", name(), percentLevel);
+    }
+    return fmt::format("{} - expression: {:d}", name(), level);
   };
 
  public:
-  uint8_t level;
+  u8 level = -1;
+  double percentLevel = -1;
 };
 
 //  ***********************

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -668,7 +668,7 @@ double SeqTrack::applyLevelCorrection(double level, LevelController controller) 
   return level;
 }
 
-void SeqTrack::addLevelPercentNoItem(double level, LevelController controller, Resolution res, int absTime) {
+void SeqTrack::addLevelNoItem(double level, LevelController controller, Resolution res, int absTime) {
   u16 origLevel = static_cast<u16>(level * (res == Resolution::FourteenBit ? 16383.0 : 127.0));
   switch (controller) {
     case LevelController::Volume:
@@ -764,7 +764,7 @@ void SeqTrack::addVol(u32 offset, u32 length, double volPercent, Resolution res,
 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new VolSeqEvent(this, volPercent, offset, length, sEventName));
-  addLevelPercentNoItem(volPercent, LevelController::Volume, res, -1);
+  addLevelNoItem(volPercent, LevelController::Volume, res, -1);
 }
 
 void SeqTrack::addVol(uint32_t offset, uint32_t length, uint8_t newVol, const std::string &sEventName) {
@@ -776,7 +776,7 @@ void SeqTrack::addVol(uint32_t offset, uint32_t length, uint8_t newVol, const st
 }
 
 void SeqTrack::addVolNoItem(uint8_t newVol) {
-  addLevelPercentNoItem(newVol / 127.0, LevelController::Volume, Resolution::SevenBit);
+  addLevelNoItem(newVol / 127.0, LevelController::Volume, Resolution::SevenBit);
 }
 
 void SeqTrack::addVolSlide(uint32_t offset,
@@ -805,7 +805,7 @@ void SeqTrack::insertVol(uint32_t offset,
 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new VolSeqEvent(this, newVol, offset, length, sEventName));
-  addLevelPercentNoItem(newVol / 127.0, LevelController::Volume, Resolution::SevenBit);
+  addLevelNoItem(newVol / 127.0, LevelController::Volume, Resolution::SevenBit);
 }
 
 void SeqTrack::addExpression(u32 offset, u32 length, double levelPercent, Resolution res, const std::string &sEventName) {
@@ -813,7 +813,7 @@ void SeqTrack::addExpression(u32 offset, u32 length, double levelPercent, Resolu
 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new ExpressionSeqEvent(this, levelPercent, offset, length, sEventName));
-  addLevelPercentNoItem(levelPercent, LevelController::Expression, res, -1);
+  addLevelNoItem(levelPercent, LevelController::Expression, res, -1);
 }
 
 
@@ -826,7 +826,7 @@ void SeqTrack::addExpression(uint32_t offset, uint32_t length, uint8_t level, co
 }
 
 void SeqTrack::addExpressionNoItem(uint8_t level) {
-  addLevelPercentNoItem(level / 127.0, LevelController::Expression, Resolution::SevenBit);
+  addLevelNoItem(level / 127.0, LevelController::Expression, Resolution::SevenBit);
   expression = level;
 }
 
@@ -860,7 +860,7 @@ void SeqTrack::insertExpression(uint32_t offset,
 }
 
 void SeqTrack::insertExpressionNoItem(uint8_t level, uint32_t absTime) {
-  addLevelPercentNoItem(level / 127.0, LevelController::Expression, Resolution::SevenBit, absTime);
+  addLevelNoItem(level / 127.0, LevelController::Expression, Resolution::SevenBit, absTime);
 }
 
 void SeqTrack::addMasterVol(uint32_t offset, uint32_t length, uint8_t newVol, const std::string &sEventName) {
@@ -872,7 +872,7 @@ void SeqTrack::addMasterVol(uint32_t offset, uint32_t length, uint8_t newVol, co
 }
 
 void SeqTrack::addMasterVolNoItem(uint8_t newVol) {
-  addLevelPercentNoItem(newVol / 127.0, LevelController::MasterVolume, Resolution::SevenBit);
+  addLevelNoItem(newVol / 127.0, LevelController::MasterVolume, Resolution::SevenBit);
 }
 
 void SeqTrack::addMastVolSlide(uint32_t offset,

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -207,8 +207,8 @@ uint32_t SeqTrack::readVarLen(uint32_t &offset) const {
 }
 
 void SeqTrack::addControllerSlide(uint32_t dur,
-                                  uint8_t &prevVal,
-                                  uint8_t targVal,
+                                  u16 &prevVal,
+                                  u16 targVal,
                                   uint8_t(*scalerFunc)(uint8_t),
                                   void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t)) const {
   if (readMode != READMODE_CONVERT_TO_MIDI)
@@ -654,6 +654,119 @@ void SeqTrack::limitPrevDurNoteEnd(uint32_t absTime) const {
   }
 }
 
+
+double SeqTrack::applyLevelCorrection(double level, LevelController controller) const {
+  if (controller != LevelController::MasterVolume) {
+    PanVolumeCorrectionMode relevantCorrectionMode = controller == LevelController::Volume ?
+      PanVolumeCorrectionMode::kAdjustVolumeController :
+      PanVolumeCorrectionMode::kAdjustExpressionController;
+    if (parentSeq->panVolumeCorrectionMode == relevantCorrectionMode)
+      level *= panVolumeCorrectionRate;
+  }
+  if (parentSeq->usesLinearAmplitudeScale())
+    level = sqrt(level);
+  return level;
+}
+
+void SeqTrack::addLevelPercentNoItem(double level, LevelController controller, Resolution res, int absTime) {
+  u16 origLevel = static_cast<u16>(level * (res == Resolution::FourteenBit ? 16383.0 : 127.0));
+  switch (controller) {
+    case LevelController::Volume:
+      vol = origLevel;
+      break;
+    case LevelController::Expression:
+      expression = origLevel;
+      break;
+    case LevelController::MasterVolume:
+      mastVol = origLevel;
+      break;
+  }
+
+  level = applyLevelCorrection(level, LevelController::Volume);
+  switch (res) {
+    case Resolution::SevenBit: {
+      u8 midiLevel = static_cast<uint8_t>(std::min(level * 127.0, 127.0));
+      switch (controller) {
+        case LevelController::Volume:
+          if (readMode == READMODE_CONVERT_TO_MIDI) {
+            if (absTime < 0) {
+              pMidiTrack->addVol(channel, midiLevel);
+            } else {
+              pMidiTrack->insertVol(channel, midiLevel, absTime);
+            }
+          }
+          break;
+        case LevelController::Expression:
+          if (readMode == READMODE_CONVERT_TO_MIDI) {
+            if (absTime < 0) {
+              pMidiTrack->addExpression(channel, midiLevel);
+            } else {
+              pMidiTrack->insertExpression(channel, midiLevel, absTime);
+            }
+          }
+          break;
+        case LevelController::MasterVolume:
+          if (readMode == READMODE_CONVERT_TO_MIDI) {
+            if (absTime < 0) {
+              pMidiTrack->addMasterVol(channel, midiLevel);
+            } else {
+              pMidiTrack->insertMasterVol(channel, midiLevel, 0, absTime);
+            }
+          }
+          break;
+      }
+      break;
+    }
+    case Resolution::FourteenBit: {
+      u16 midiLevel = static_cast<uint16_t>(std::min(level * 16383.0, 16383.0));
+      u8 levelHi = static_cast<uint8_t>((midiLevel >> 7) & 0x7F);
+      u8 levelLo = static_cast<uint8_t>(midiLevel & 0x7F);
+      switch (controller) {
+        case LevelController::Volume:
+          if (readMode == READMODE_CONVERT_TO_MIDI) {
+            if (absTime < 0) {
+              pMidiTrack->addVolumeFine(channel, levelLo);
+              pMidiTrack->addVol(channel, levelHi);
+            } else {
+              pMidiTrack->insertVolumeFine(channel, levelLo, absTime);
+              pMidiTrack->insertVol(channel, levelHi, absTime);
+            }
+          }
+          break;
+        case LevelController::Expression:
+          if (readMode == READMODE_CONVERT_TO_MIDI) {
+            if (absTime < 0) {
+              pMidiTrack->addExpressionFine(channel, levelLo);
+              pMidiTrack->addExpression(channel, levelHi);
+            } else {
+              pMidiTrack->insertExpressionFine(channel, levelLo, absTime);
+              pMidiTrack->insertVol(channel, levelHi, absTime);
+            }
+          }
+          break;
+        case LevelController::MasterVolume:
+          if (readMode == READMODE_CONVERT_TO_MIDI) {
+            if (absTime < 0) {
+              pMidiTrack->addMasterVol(channel, levelHi, levelLo);
+            } else {
+              pMidiTrack->insertMasterVol(channel, levelHi, levelLo, absTime);
+            }
+          }
+          break;
+      }
+      break;
+    }
+  }
+}
+
+void SeqTrack::addVol(u32 offset, u32 length, double volPercent, Resolution res, const std::string &sEventName) {
+  onEvent(offset, length);
+
+  if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
+    addEvent(new VolSeqEvent(this, volPercent, offset, length, sEventName));
+  addLevelPercentNoItem(volPercent, LevelController::Volume, res, -1);
+}
+
 void SeqTrack::addVol(uint32_t offset, uint32_t length, uint8_t newVol, const std::string &sEventName) {
   onEvent(offset, length);
 
@@ -663,32 +776,7 @@ void SeqTrack::addVol(uint32_t offset, uint32_t length, uint8_t newVol, const st
 }
 
 void SeqTrack::addVolNoItem(uint8_t newVol) {
-  if (readMode == READMODE_CONVERT_TO_MIDI) {
-    const u8 finalVol = calculateLevel(newVol, LevelController::Volume);
-    pMidiTrack->addVol(channel, finalVol);
-  }
-  vol = newVol;
-}
-
-void SeqTrack::addVolume14Bit(uint32_t offset, uint32_t length, uint16_t volume, const std::string &sEventName) {
-  onEvent(offset, length);
-
-  if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
-    addEvent(new Volume14BitSeqEvent(this, volume, offset, length, sEventName));
-  addVolume14BitNoItem(volume);
-}
-
-// Add a 14 bit volume event by writing to controllers 39 and 7. Note that we assume the parameter
-// is in the range of 0 -> 127^2, but we normalize the value to the full 14 bit range: 0 -> (1 << 14) - 1
-void SeqTrack::addVolume14BitNoItem(uint16_t volume) {
-  if (readMode == READMODE_CONVERT_TO_MIDI) {
-    const u16 finalVol = calculateLevel14bit(volume, LevelController::Volume);
-    uint8_t volume_hi = static_cast<uint8_t>((finalVol >> 7) & 0x7F);
-    uint8_t volume_lo = static_cast<uint8_t>(finalVol & 0x7F);
-    pMidiTrack->addVolumeFine(channel, volume_lo);
-    pMidiTrack->addVol(channel, volume_hi);
-  }
-  vol = static_cast<uint8_t>((volume >> 7) & 0x7F);
+  addLevelPercentNoItem(newVol / 127.0, LevelController::Volume, Resolution::SevenBit);
 }
 
 void SeqTrack::addVolSlide(uint32_t offset,
@@ -715,13 +803,19 @@ void SeqTrack::insertVol(uint32_t offset,
                          const std::string &sEventName) {
   onEvent(offset, length);
 
-  const u8 finalVol = calculateLevel(newVol, LevelController::Volume);
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new VolSeqEvent(this, newVol, offset, length, sEventName));
-  else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->insertVol(channel, finalVol, absTime);
-  vol = newVol;
+  addLevelPercentNoItem(newVol / 127.0, LevelController::Volume, Resolution::SevenBit);
 }
+
+void SeqTrack::addExpression(u32 offset, u32 length, double levelPercent, Resolution res, const std::string &sEventName) {
+  onEvent(offset, length);
+
+  if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
+    addEvent(new ExpressionSeqEvent(this, levelPercent, offset, length, sEventName));
+  addLevelPercentNoItem(levelPercent, LevelController::Expression, res, -1);
+}
+
 
 void SeqTrack::addExpression(uint32_t offset, uint32_t length, uint8_t level, const std::string &sEventName) {
   onEvent(offset, length);
@@ -731,32 +825,8 @@ void SeqTrack::addExpression(uint32_t offset, uint32_t length, uint8_t level, co
   addExpressionNoItem(level);
 }
 
-double SeqTrack::calculateLevelPercent(u8 level, LevelController controller) {
-  double newVolPercent = level / 127.0;
-  PanVolumeCorrectionMode relevantCorrectionMode = controller == LevelController::Volume ?
-    PanVolumeCorrectionMode::kAdjustVolumeController : PanVolumeCorrectionMode::kAdjustExpressionController;
-  if (parentSeq->panVolumeCorrectionMode == relevantCorrectionMode)
-    newVolPercent *= panVolumeCorrectionRate;
-  if (parentSeq->usesLinearAmplitudeScale())
-    newVolPercent = sqrt(newVolPercent);
-  return newVolPercent;
-}
-
-u8 SeqTrack::calculateLevel(u8 level, LevelController controller) {
-  double levelPercent = calculateLevelPercent(level, controller);
-  return static_cast<uint8_t>(std::min(levelPercent * 127, 127.0));
-}
-
-u16 SeqTrack::calculateLevel14bit(u8 level, LevelController controller) {
-  double levelPercent = calculateLevelPercent(level, controller);
-  return static_cast<uint16_t>(std::min(levelPercent * 16383.0, 16383.0));
-}
-
 void SeqTrack::addExpressionNoItem(uint8_t level) {
-  if (readMode == READMODE_CONVERT_TO_MIDI) {
-    u8 finalExpression = calculateLevel(level, LevelController::Expression);
-    pMidiTrack->addExpression(channel, finalExpression);
-  }
+  addLevelPercentNoItem(level / 127.0, LevelController::Expression, Resolution::SevenBit);
   expression = level;
 }
 
@@ -784,20 +854,13 @@ void SeqTrack::insertExpression(uint32_t offset,
                                 const std::string &sEventName) {
   onEvent(offset, length);
 
-  const u8 finalExpression = calculateLevel(level,  LevelController::Expression);
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true))
     addEvent(new ExpressionSeqEvent(this, level, offset, length, sEventName));
-  else if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->insertExpression(channel, finalExpression, absTime);
-  expression = level;
+  insertExpressionNoItem(level, absTime);
 }
 
-void SeqTrack::insertExpressionNoItem(uint8_t level,
-                                      uint32_t absTime) {
-  u8 finalExpression = calculateLevel(level, LevelController::Expression);
-  if (readMode == READMODE_CONVERT_TO_MIDI)
-    pMidiTrack->insertExpression(channel, finalExpression, absTime);
-  expression = level;
+void SeqTrack::insertExpressionNoItem(uint8_t level, uint32_t absTime) {
+  addLevelPercentNoItem(level / 127.0, LevelController::Expression, Resolution::SevenBit, absTime);
 }
 
 void SeqTrack::addMasterVol(uint32_t offset, uint32_t length, uint8_t newVol, const std::string &sEventName) {
@@ -809,14 +872,7 @@ void SeqTrack::addMasterVol(uint32_t offset, uint32_t length, uint8_t newVol, co
 }
 
 void SeqTrack::addMasterVolNoItem(uint8_t newVol) {
-  if (readMode == READMODE_CONVERT_TO_MIDI) {
-    uint8_t finalVol = newVol;
-    if (parentSeq->usesLinearAmplitudeScale())
-      finalVol = convert7bitPercentVolValToStdMidiVal(newVol);
-
-    pMidiTrack->addMasterVol(channel, finalVol);
-  }
-  mastVol = newVol;
+  addLevelPercentNoItem(newVol / 127.0, LevelController::MasterVolume, Resolution::SevenBit);
 }
 
 void SeqTrack::addMastVolSlide(uint32_t offset,

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -62,14 +62,12 @@ class SeqTrack : public VGMItem {
  protected:
   virtual void onEvent(uint32_t offset, uint32_t length);
   virtual void addEvent(SeqEvent *pSeqEvent);
-  void addLevelNoItem(double level, LevelController controller, Resolution res, int absTime = -1);
 
  private:
   void addControllerSlide(u32 dur, u16 &prevVal, u16 targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t)) const;
   double applyLevelCorrection(double level, LevelController controller) const;
-  double calculateLevelPercent(u16 level, LevelController controller, Resolution inputRes =  Resolution::SevenBit) const;
-  u8 calculateLevel(u8 level, LevelController controller);
-  u16 calculateLevel14bit(u16 level, LevelController controller);
+  void addLevelNoItem(double level, LevelController controller, Resolution res, int absTime = -1);
+
  public:
   void addGenericEvent(uint32_t offset, uint32_t length, const std::string &sEventName, const std::string &sEventDesc, Type type);
   void addSetOctave(uint32_t offset, uint32_t length, uint8_t newOctave, const std::string &sEventName = "Set Octave");

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -22,6 +22,12 @@ enum ReadMode : uint8_t;
 enum class LevelController : uint8_t {
   Volume,
   Expression,
+  MasterVolume,
+};
+
+enum class Resolution : uint8_t {
+  SevenBit,
+  FourteenBit,
 };
 
 class SeqTrack : public VGMItem {
@@ -56,11 +62,14 @@ class SeqTrack : public VGMItem {
  protected:
   virtual void onEvent(uint32_t offset, uint32_t length);
   virtual void addEvent(SeqEvent *pSeqEvent);
+  void addLevelPercentNoItem(double level, LevelController controller, Resolution res, int absTime = -1);
+
  private:
-  void addControllerSlide(uint32_t dur, uint8_t &prevVal, uint8_t targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t)) const;
-  double calculateLevelPercent(u8 level, LevelController controller);
+  void addControllerSlide(u32 dur, u16 &prevVal, u16 targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t)) const;
+  double applyLevelCorrection(double level, LevelController controller) const;
+  double calculateLevelPercent(u16 level, LevelController controller, Resolution inputRes =  Resolution::SevenBit) const;
   u8 calculateLevel(u8 level, LevelController controller);
-  u16 calculateLevel14bit(u8 level, LevelController controller);
+  u16 calculateLevel14bit(u16 level, LevelController controller);
  public:
   void addGenericEvent(uint32_t offset, uint32_t length, const std::string &sEventName, const std::string &sEventDesc, Type type);
   void addSetOctave(uint32_t offset, uint32_t length, uint8_t newOctave, const std::string &sEventName = "Set Octave");
@@ -98,11 +107,11 @@ class SeqTrack : public VGMItem {
   void limitPrevDurNoteEnd(uint32_t absTime) const;
   void addVol(uint32_t offset, uint32_t length, uint8_t vol, const std::string &sEventName = "Volume");
   void addVolNoItem(uint8_t vol);
-  void addVolume14Bit(uint32_t offset, uint32_t length, uint16_t volume, const std::string &sEventName = "Volume");
-  void addVolume14BitNoItem(uint16_t volume);
+  void addVol(u32 offset, u32 length, double volPercent, Resolution res, const std::string &sEventName = "Volume");
   void addVolSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targVol, const std::string &sEventName = "Volume Slide");
   void insertVol(uint32_t offset, uint32_t length, uint8_t vol, uint32_t absTime, const std::string &sEventName = "Volume");
   void addExpression(uint32_t offset, uint32_t length, uint8_t level, const std::string &sEventName = "Expression");
+  void addExpression(u32 offset, u32 length, double levelPercent, Resolution res, const std::string &sEventName = "Expression");
   void addExpressionNoItem(uint8_t level);
   void addExpressionSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targExpr, const std::string &sEventName = "Expression Slide");
   void insertExpression(uint32_t offset, uint32_t length, uint8_t level, uint32_t absTime, const std::string &sEventName = "Expression");
@@ -201,11 +210,11 @@ class SeqTrack : public VGMItem {
   uint8_t prevKey;
   uint8_t prevVel;
   uint8_t octave;
-  uint8_t vol;
-  uint8_t expression;
-  uint8_t mastVol;
+  u16 vol;
+  u16 expression;
+  u16 mastVol;
   double panVolumeCorrectionRate; // as percentage of original volume (default: 1.0)
-  uint8_t prevPan;
+  u16 prevPan;
   uint8_t prevReverb;
   int8_t transpose;
   double fineTuningCents;

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -62,7 +62,7 @@ class SeqTrack : public VGMItem {
  protected:
   virtual void onEvent(uint32_t offset, uint32_t length);
   virtual void addEvent(SeqEvent *pSeqEvent);
-  void addLevelPercentNoItem(double level, LevelController controller, Resolution res, int absTime = -1);
+  void addLevelNoItem(double level, LevelController controller, Resolution res, int absTime = -1);
 
  private:
   void addControllerSlide(u32 dur, u16 &prevVal, u16 targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t)) const;

--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -298,15 +298,23 @@ void MidiTrack::addVolumeFine(uint8_t channel, uint8_t volume_lsb) {
   aEvents.push_back(new VolumeFineEvent(this, channel, getDelta(), volume_lsb));
 }
 
+void MidiTrack::insertVolumeFine(uint8_t channel, uint8_t volume_lsb, uint32_t absTime) {
+  aEvents.push_back(new VolumeFineEvent(this, channel, absTime, volume_lsb));
+}
+
 //TODO: Master Volume sysex events are meant to be global to device, not per channel.
 // For per channel master volume, we should add a system for normalizing controller vol events.
-void MidiTrack::addMasterVol(uint8_t channel, uint8_t mastVol) {
-  MidiEvent *newEvent = new MasterVolEvent(this, channel, getDelta(), mastVol);
+void MidiTrack::addMasterVol(uint8_t channel, u8 volMsb, u8 volLsb) {
+  MidiEvent *newEvent = new MasterVolEvent(this, channel, getDelta(), volMsb, volLsb);
   aEvents.push_back(newEvent);
 }
 
-void MidiTrack::insertMasterVol(uint8_t channel, uint8_t mastVol, uint32_t absTime) {
-  MidiEvent *newEvent = new MasterVolEvent(this, channel, absTime, mastVol);
+void MidiTrack::insertMasterVol(uint8_t channel, u8 volMsb, uint32_t absTime) {
+  insertMasterVol(channel, volMsb, 0, absTime);
+}
+
+void MidiTrack::insertMasterVol(uint8_t channel, u8 volMsb, u8 volLsb, uint32_t absTime) {
+  MidiEvent *newEvent = new MasterVolEvent(this, channel, absTime, volMsb, volLsb);
   aEvents.push_back(newEvent);
 }
 
@@ -316,6 +324,14 @@ void MidiTrack::addExpression(uint8_t channel, uint8_t expression) {
 
 void MidiTrack::insertExpression(uint8_t channel, uint8_t expression, uint32_t absTime) {
   aEvents.push_back(new ExpressionEvent(this, channel, absTime, expression));
+}
+
+void MidiTrack::addExpressionFine(uint8_t channel, uint8_t expression_lsb) {
+  aEvents.push_back(new ExpressionFineEvent(this, channel, getDelta(), expression_lsb));
+}
+
+void MidiTrack::insertExpressionFine(uint8_t channel, uint8_t expression_lsb, uint32_t absTime) {
+  aEvents.push_back(new ExpressionFineEvent(this, channel, absTime, expression_lsb));
 }
 
 void MidiTrack::addSustain(uint8_t channel, uint8_t depth) {

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -96,12 +96,16 @@ class MidiTrack {
   void addVol(uint8_t channel, uint8_t vol/*, int8_t priority = PRIORITY_MIDDLE*/);
   void insertVol(uint8_t channel, uint8_t vol, uint32_t absTime/*, int8_t priority = PRIORITY_MIDDLE*/);
   void addVolumeFine(uint8_t channel, uint8_t volume_lsb);
-  void addMasterVol(uint8_t channel, uint8_t mastVol/*, int8_t priority = PRIORITY_HIGHER*/);
-  void insertMasterVol(uint8_t channel, uint8_t mastVol, uint32_t absTime/*, int8_t priority = PRIORITY_HIGHER*/);
+  void insertVolumeFine(uint8_t channel, uint8_t volume_lsb, uint32_t absTime);
+  void addMasterVol(uint8_t channel, u8 volMsb, u8 volLsb = 0);
+  void insertMasterVol(uint8_t channel, u8 volMsb, uint32_t absTime);
+  void insertMasterVol(uint8_t channel, u8 volMsb, u8 volLsb, uint32_t absTime);
   void addPan(uint8_t channel, uint8_t pan);
   void insertPan(uint8_t channel, uint8_t pan, uint32_t absTime);
   void addExpression(uint8_t channel, uint8_t expression);
+  void addExpressionFine(uint8_t channel, uint8_t expression_lsb);
   void insertExpression(uint8_t channel, uint8_t expression, uint32_t absTime);
+  void insertExpressionFine(uint8_t channel, uint8_t expression_lsb, uint32_t absTime);
   void addReverb(uint8_t channel, uint8_t reverb);
   void insertReverb(uint8_t channel, uint8_t reverb, uint32_t absTime);
   void addModulation(uint8_t channel, uint8_t depth);
@@ -345,6 +349,14 @@ class ExpressionEvent
   MidiEventType eventType() override { return MIDIEVENT_EXPRESSION; }
 };
 
+class ExpressionFineEvent
+    : public ControllerEvent {
+public:
+  ExpressionFineEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t expression_lsb)
+      : ControllerEvent(prntTrk, channel, absoluteTime, 43, expression_lsb, PRIORITY_MIDDLE) { }
+  MidiEventType eventType() override { return MIDIEVENT_EXPRESSION; }
+};
+
 class SustainEvent
     : public ControllerEvent {
  public:
@@ -451,8 +463,8 @@ public:
 class MasterVolEvent
     : public SysexEvent {
 public:
-  MasterVolEvent(MidiTrack *prntTrk, uint8_t /* channel */, uint32_t absoluteTime, uint8_t msb)
-      : SysexEvent(prntTrk, absoluteTime, {0x07, 0x7F, 0x7F, 0x04, 0x01, 0, msb }, PRIORITY_HIGHER) { }
+  MasterVolEvent(MidiTrack *prntTrk, uint8_t /* channel */, uint32_t absoluteTime, u8 msb, u8 lsb)
+      : SysexEvent(prntTrk, absoluteTime, {0x07, 0x7F, 0x7F, 0x04, 0x01, lsb, msb }, PRIORITY_HIGHER) { }
   MidiEventType eventType() override { return MIDIEVENT_MASTERVOL; }
 };
 

--- a/src/main/formats/CPS/CPS2Seq.cpp
+++ b/src/main/formats/CPS/CPS2Seq.cpp
@@ -25,6 +25,7 @@ CPS2Seq::CPS2Seq(RawFile *file, uint32_t offset, CPS2FormatVer fmtVersion, std::
   setUsesMonophonicTracks();
   setAlwaysWriteInitialVol(127);
   setAlwaysWriteInitialMonoMode(true);
+  setUseLinearAmplitudeScale(true);
 }
 
 CPS2Seq::~CPS2Seq() {

--- a/src/main/formats/CPS/CPS2TrackV1.cpp
+++ b/src/main/formats/CPS/CPS2TrackV1.cpp
@@ -210,11 +210,12 @@ bool CPS2TrackV1::readEvent() {
         addGenericEvent(beginOffset, curOffset - beginOffset, "Set Duration", "", Type::ChangeState);
         break;
 
-      case 0x07 :
-        vol = readByte(curOffset++);
-        vol = convertPercentAmpToStdMidiVal(vol_table[vol] / static_cast<double>(0x1FFF));
-        this->addVol(beginOffset, curOffset - beginOffset, vol);
+      case 0x07 : {
+        u8 volIndex = readByte(curOffset++);
+        double volPercent = vol_table[volIndex] / static_cast<double>(0x1FFF);
+        addVol(beginOffset, curOffset - beginOffset, volPercent, Resolution::FourteenBit);
         break;
+      }
 
       case 0x08 : {
         uint8_t progNum = readByte(curOffset++);

--- a/src/main/formats/CPS/CPS2TrackV2.cpp
+++ b/src/main/formats/CPS/CPS2TrackV2.cpp
@@ -57,10 +57,10 @@ bool CPS2TrackV2::readEvent() {
   // Note opcodes are [0x80 - 0xBF]
   if (status_byte < 0xC0) {
     uint8_t velocity = status_byte & 0x3F;
-    uint8_t midiVel = convertPercentAmpToStdMidiVal(static_cast<double>(velocity) / static_cast<double>(0x3F));
+    velocity = (static_cast<double>(velocity) / static_cast<double>(0x3F)) * 127.0;
     uint8_t note = readByte(curOffset++) & 0x7F;
     uint32_t duration = readVarLength();
-    addNoteByDur(beginOffset, curOffset - beginOffset, note, midiVel, duration);
+    addNoteByDur(beginOffset, curOffset - beginOffset, note, velocity, duration);
     return true;
   }
 
@@ -122,9 +122,8 @@ bool CPS2TrackV2::readEvent() {
 
     case C6_TRACK_MASTER_VOLUME: {
       m_master_volume = readByte(curOffset++);
-      double volume_percent = m_master_volume * m_secondary_volume / (127.0 * 127.0);
-      uint16_t final_volume = convertPercentAmpToStd14BitMidiVal(volume_percent);
-      addVolume14Bit(beginOffset, curOffset - beginOffset, final_volume, "Track Master Volume");
+      double volPercent = (m_master_volume * m_secondary_volume) / (127.0 * 127.0);
+      addVol(beginOffset, curOffset - beginOffset, volPercent, Resolution::FourteenBit, "Track Master Volume");
       break;
     }
 
@@ -136,9 +135,8 @@ bool CPS2TrackV2::readEvent() {
 
     case EVENT_C8: {
       m_secondary_volume = readByte(curOffset++);
-      double volume_percent = m_master_volume * m_secondary_volume / (127.0 * 127.0);
-      uint16_t final_volume = convertPercentAmpToStd14BitMidiVal(volume_percent);
-      addVolume14Bit(beginOffset, curOffset - beginOffset, final_volume);
+      double volPercent = (m_master_volume * m_secondary_volume) / (127.0 * 127.0);
+      addVol(beginOffset, curOffset - beginOffset, volPercent, Resolution::FourteenBit);
       break;
     }
 

--- a/src/main/util/ScaleConversion.cpp
+++ b/src/main/util/ScaleConversion.cpp
@@ -124,9 +124,9 @@ uint8_t convertPercentAmpToStdMidiVal(double percent) {
 }
 
 // Takes a percentage amplitude value - one using a -20*log10(percent) scale for db attenuation
-// and converts it to a standard 14 bit midi value that uses -40*log10(x/(127*127)) for db attenuation
+// and converts it to a standard 14 bit midi value that uses -40*log10(x/16383) for db attenuation
 uint16_t convertPercentAmpToStd14BitMidiVal(double percent) {
-  return std::round((127.0 * 127.0) * sqrt(percent));
+  return std::round(16383.0 * sqrt(percent));
 }
 
 // db attenuation is expressed as a positive value. So, a reduction of 3.2db is expressed as 3.2, not -3.2.


### PR DESCRIPTION
I noticed that my last PR broke volume in CPS2TrackV2 due to the amplitude scale conversion being applied twice. In the course of fixing this, I've tried to remove repetitive code in SeqTrack which handles volume conversion (for Volume, Expression, and Master Volume events).

I also realized that it's silly that we have no methods for adding volume events that take percent values. Right now, we receive a 7-bit integer value which we then convert to a percent, then (usually) convert the scale, then convert back to 7-bit MIDI values. We should have the option to pass volume as a percent in the first step, so I've added overloaded `addVol()` and `addExpression()`. In time, I'd like to do the same for the `insert` and `NoItem` variant methods, and also note velocity. It's more intuitive except in cases where a driver uses a 7-bit value natively. Relatedly, in a future update, I'd like to make the linear amplitude scale option true by default, since it's the norm, not the exception.

I've centralized the logic for adding volume events into a new method `addLevelNoItem()`. This method takes a percent volume value, the controller to add events for (volume, expression, master volume), and the resolution (7-bit or 14-bit). It can also handle event insertion with an optional absTime param.

### Changes

SeqEvent:
  - update VolSeqEvent and ExpressionSeqEvent to alternatively accept a percent level value, add related constructors

SeqTrack:
  - add applyLevelCorrection() which takes a percent level value and applies pan correction and/or linear amplitude scale correction
  - addLevelNoItem() which handles adding or inserting volume, expression and master volume events of 7 or 14 bit resolution, add/insert Vol/Level/MastVol events to utilize it
  - add alternative addVol and addExpression methods which take percent level values rather than 7 bit ints
  - add insertExpressionNoItem()
  - update vol, expression, and mastVol to be u16 to allow for 14 bit values

ScaleConversion:
  - update convertPercentAmpToStd14BitMidiVal() to use the a full 14bit range as input instead of 127*127

MidiFile:
   - add ExpressionFineEvent class
   - addinsertVolumeFine(), addExpressionFine(), insertExpressionFine()
   - add MasterVolEvent constructor which takes an lsb value, and pass lsb into Sysex data.
   - update addMasterVol and insertMasterVol to accept an lsb byte

CPS2Seq:
  - update to use linear amplitude scale

## How Has This Been Tested?
I've tested that volume slides are still working as intended. I've tested by ear for breakage of various formats.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
