### PR TITLE
add CHDLoader and libchdr dependency as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/minizip-ng"]
 	path = lib/minizip-ng
 	url = https://github.com/zlib-ng/minizip-ng.git
+[submodule "lib/libchdr"]
+	path = lib/libchdr
+	url = https://github.com/rtissera/libchdr.git

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -13,11 +13,15 @@ if (USE_VENDORED_ZLIBNG)
   set(ZLIB_ENABLE_TESTS OFF)
   set(ZLIBNG_ENABLE_TESTS OFF)
   set(WITH_GTEST OFF)
+  set(ZLIB_COMPAT ON CACHE BOOL "Build zlib-ng with zlib-compatible API" FORCE)
   add_subdirectory("${PROJECT_SOURCE_DIR}/lib/zlib-ng" "${CMAKE_BINARY_DIR}/lib/zlib-ng" EXCLUDE_FROM_ALL)
 
-  set(ZLIBNG_FOUND TRUE)
-  set(ZLIBNG_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/lib/zlib-ng" "${CMAKE_BINARY_DIR}/lib/zlib-ng")
-  set(ZLIBNG_LIBRARY $<TARGET_FILE:zlibstatic>)
+#  set(ZLIBNG_FOUND TRUE)
+#  set(ZLIBNG_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/lib/zlib-ng" "${CMAKE_BINARY_DIR}/lib/zlib-ng")
+#  set(ZLIBNG_LIBRARY $<TARGET_FILE:zlibstatic>)
+
+  # ensure libchdr can find this build when searching for ZLIB
+  list(PREPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/lib/zlib-ng")
 endif()
 
 # Configure minizip-ng to use zlib and none of the other options

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -5,6 +5,7 @@
 # we added it in the root CMakeLists.txt file.
 
 option(USE_VENDORED_ZLIBNG "Use the vendored version of zlib-ng" ON)
+set(ZLIB_COMPAT ON CACHE BOOL "Compile zlib-ng with zlib compatible API" FORCE)
 
 if (USE_VENDORED_ZLIBNG)
   #include zlib-ng sans tests
@@ -15,9 +16,9 @@ if (USE_VENDORED_ZLIBNG)
   set(WITH_GTEST OFF)
   add_subdirectory("${PROJECT_SOURCE_DIR}/lib/zlib-ng" "${CMAKE_BINARY_DIR}/lib/zlib-ng" EXCLUDE_FROM_ALL)
 
-  set(ZLIBNG_FOUND TRUE)
-  set(ZLIBNG_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/lib/zlib-ng" "${CMAKE_BINARY_DIR}/lib/zlib-ng")
-  set(ZLIBNG_LIBRARY $<TARGET_FILE:zlibstatic>)
+  set(ZLIB_FOUND TRUE)
+  set(ZLIB_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/lib/zlib-ng" "${CMAKE_BINARY_DIR}/lib/zlib-ng")
+  set(ZLIB_LIBRARIES $<TARGET_FILE:zlibstatic>)
 endif()
 
 # Configure minizip-ng to use zlib and none of the other options

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -47,6 +47,10 @@ set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build libunarr as a shared library" FORCE)
 set(USE_SYSTEM_ZLIB OFF CACHE BOOL "Build with system zlib if possible" FORCE)
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/unarr" "${CMAKE_BINARY_DIR}/lib/unarr" EXCLUDE_FROM_ALL)
 
+set(WITH_SYSTEM_ZLIB ON CACHE BOOL "Use system zlib" FORCE)
+set(WITH_SYSTEM_ZSTD ON CACHE BOOL "Use system zstd" FORCE)
+add_subdirectory("${PROJECT_SOURCE_DIR}/lib/libchdr" "${CMAKE_BINARY_DIR}/lib/libchdr" EXCLUDE_FROM_ALL)
+
 file(GLOB_RECURSE MAIN_FILES "${PROJECT_SOURCE_DIR}/src/main/*.cpp"
      "${PROJECT_SOURCE_DIR}/src/main/*.h")
 
@@ -68,5 +72,5 @@ target_include_directories(vgmtranscore PUBLIC
         ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(
   vgmtranscore
-  PUBLIC spdlog::spdlog unarr zlibstatic minizip tinyxml mio
+  PUBLIC spdlog::spdlog unarr zlibstatic minizip tinyxml mio chdr-static
 )

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -47,7 +47,9 @@ set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build libunarr as a shared library" FORCE)
 set(USE_SYSTEM_ZLIB OFF CACHE BOOL "Build with system zlib if possible" FORCE)
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/unarr" "${CMAKE_BINARY_DIR}/lib/unarr" EXCLUDE_FROM_ALL)
 
+#set(WITH_SYSTEM_ZLIB ON CACHE BOOL "Use system zlib" FORCE)
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/libchdr" "${CMAKE_BINARY_DIR}/lib/libchdr" EXCLUDE_FROM_ALL)
+#include_directories(lib/libchdr/include)
 
 file(GLOB_RECURSE MAIN_FILES "${PROJECT_SOURCE_DIR}/src/main/*.cpp"
      "${PROJECT_SOURCE_DIR}/src/main/*.h")

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -50,9 +50,7 @@ set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build libunarr as a shared library" FORCE)
 set(USE_SYSTEM_ZLIB OFF CACHE BOOL "Build with system zlib if possible" FORCE)
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/unarr" "${CMAKE_BINARY_DIR}/lib/unarr" EXCLUDE_FROM_ALL)
 
-#set(WITH_SYSTEM_ZLIB ON CACHE BOOL "Use system zlib" FORCE)
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/libchdr" "${CMAKE_BINARY_DIR}/lib/libchdr" EXCLUDE_FROM_ALL)
-#include_directories(lib/libchdr/include)
 
 file(GLOB_RECURSE MAIN_FILES "${PROJECT_SOURCE_DIR}/src/main/*.cpp"
      "${PROJECT_SOURCE_DIR}/src/main/*.h")

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -13,15 +13,11 @@ if (USE_VENDORED_ZLIBNG)
   set(ZLIB_ENABLE_TESTS OFF)
   set(ZLIBNG_ENABLE_TESTS OFF)
   set(WITH_GTEST OFF)
-  set(ZLIB_COMPAT ON CACHE BOOL "Build zlib-ng with zlib-compatible API" FORCE)
   add_subdirectory("${PROJECT_SOURCE_DIR}/lib/zlib-ng" "${CMAKE_BINARY_DIR}/lib/zlib-ng" EXCLUDE_FROM_ALL)
 
-#  set(ZLIBNG_FOUND TRUE)
-#  set(ZLIBNG_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/lib/zlib-ng" "${CMAKE_BINARY_DIR}/lib/zlib-ng")
-#  set(ZLIBNG_LIBRARY $<TARGET_FILE:zlibstatic>)
-
-  # ensure libchdr can find this build when searching for ZLIB
-  list(PREPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/lib/zlib-ng")
+  set(ZLIBNG_FOUND TRUE)
+  set(ZLIBNG_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/lib/zlib-ng" "${CMAKE_BINARY_DIR}/lib/zlib-ng")
+  set(ZLIBNG_LIBRARY $<TARGET_FILE:zlibstatic>)
 endif()
 
 # Configure minizip-ng to use zlib and none of the other options
@@ -51,7 +47,6 @@ set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build libunarr as a shared library" FORCE)
 set(USE_SYSTEM_ZLIB OFF CACHE BOOL "Build with system zlib if possible" FORCE)
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/unarr" "${CMAKE_BINARY_DIR}/lib/unarr" EXCLUDE_FROM_ALL)
 
-set(WITH_SYSTEM_ZLIB ON CACHE BOOL "Use system zlib" FORCE)
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/libchdr" "${CMAKE_BINARY_DIR}/lib/libchdr" EXCLUDE_FROM_ALL)
 
 file(GLOB_RECURSE MAIN_FILES "${PROJECT_SOURCE_DIR}/src/main/*.cpp"

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -33,6 +33,8 @@ set(MZ_WZAES OFF)
 set(MZ_OPENSSL OFF)
 set(MZ_DECOMPRESS_ONLY ON)
 set(SKIP_INSTALL_ALL ON)
+set(MZ_FETCH_LIBS OFF CACHE BOOL "Disable minizip-ng third-party fetching" FORCE)
+set(MZ_FORCE_FETCH_LIBS OFF CACHE BOOL "Disable minizip-ng forced fetching" FORCE)
 
 # Add minizip-ng subdirectory
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/minizip-ng" "${CMAKE_BINARY_DIR}/lib/minizip-ng" EXCLUDE_FROM_ALL)

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -48,7 +48,6 @@ set(USE_SYSTEM_ZLIB OFF CACHE BOOL "Build with system zlib if possible" FORCE)
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/unarr" "${CMAKE_BINARY_DIR}/lib/unarr" EXCLUDE_FROM_ALL)
 
 set(WITH_SYSTEM_ZLIB ON CACHE BOOL "Use system zlib" FORCE)
-set(WITH_SYSTEM_ZSTD ON CACHE BOOL "Use system zstd" FORCE)
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/libchdr" "${CMAKE_BINARY_DIR}/lib/libchdr" EXCLUDE_FROM_ALL)
 
 file(GLOB_RECURSE MAIN_FILES "${PROJECT_SOURCE_DIR}/src/main/*.cpp"

--- a/src/main/components/PSFFile.cpp
+++ b/src/main/components/PSFFile.cpp
@@ -51,7 +51,7 @@ PSFFile::PSFFile(const RawFile &file) {
         auto exe_begin = file.begin() + 16 + reservedarea_size;
 
         if (m_exe_CRC !=
-            zng_crc32(zng_crc32(0L, nullptr, 0), reinterpret_cast<const Bytef *>(exe_begin), static_cast<uint32_t>(exe_size))) {
+            crc32(crc32(0L, nullptr, 0), reinterpret_cast<const Bytef *>(exe_begin), static_cast<uint32_t>(exe_size))) {
             throw std::runtime_error("CRC32 mismatch, data is corrupt");
         }
 

--- a/src/main/loaders/CHDLoader.cpp
+++ b/src/main/loaders/CHDLoader.cpp
@@ -1,0 +1,104 @@
+/*
+ * VGMTrans (c) 2002-2025
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#include "common.h"
+#include "CHDLoader.h"
+#include "FileLoader.h"
+#include "LoaderManager.h"
+#include "LogManager.h"
+
+extern "C" {
+#include <libchdr/chd.h>
+}
+
+namespace vgmtrans::loaders {
+LoaderRegistration<CHDLoader> _chd{"CHD"};
+}
+
+struct MemoryCoreFileCtx {
+  const RawFile *file;
+  size_t pos;
+};
+
+static uint64_t mem_fsize(core_file *fp) {
+  auto ctx = reinterpret_cast<MemoryCoreFileCtx *>(fp->argp);
+  return ctx->file->size();
+}
+
+static size_t mem_fread(void *ptr, size_t size, size_t nmemb, core_file *fp) {
+  auto ctx = reinterpret_cast<MemoryCoreFileCtx *>(fp->argp);
+  size_t len = size * nmemb;
+  if (ctx->pos + len > ctx->file->size()) {
+    len = ctx->file->size() - ctx->pos;
+  }
+  memcpy(ptr, ctx->file->data() + ctx->pos, len);
+  ctx->pos += len;
+  return size ? len / size : 0;
+}
+
+static int mem_fclose(core_file *) { return 0; }
+
+static int mem_fseek(core_file *fp, int64_t offset, int whence) {
+  auto ctx = reinterpret_cast<MemoryCoreFileCtx *>(fp->argp);
+  size_t newpos = 0;
+  switch (whence) {
+    case SEEK_SET:
+      newpos = static_cast<size_t>(offset);
+      break;
+    case SEEK_CUR:
+      newpos = ctx->pos + offset;
+      break;
+    case SEEK_END:
+      newpos = ctx->file->size() + offset;
+      break;
+    default:
+      return -1;
+  }
+  if (newpos > ctx->file->size()) return -1;
+  ctx->pos = newpos;
+  return 0;
+}
+
+void CHDLoader::apply(const RawFile *file) {
+  if (file->size() < 8) return;
+  if (!std::equal(file->begin(), file->begin() + 8, "MComprHD")) return;
+
+  MemoryCoreFileCtx ctx{file, 0};
+  core_file cfile{&ctx, mem_fsize, mem_fread, mem_fclose, mem_fseek};
+
+  chd_file *chd = nullptr;
+  chd_error err = chd_open_core_file(&cfile, CHD_OPEN_READ, nullptr, &chd);
+  if (err != CHDERR_NONE) {
+    L_ERROR("Failed to open CHD: {}", chd_error_string(err));
+    return;
+  }
+
+  const chd_header *hdr = chd_get_header(chd);
+  if (!hdr) {
+    chd_close(chd);
+    return;
+  }
+
+  std::vector<uint8_t> data(static_cast<size_t>(hdr->logicalbytes));
+  std::vector<uint8_t> hunkbuf(hdr->hunkbytes);
+  size_t offset = 0;
+  for (uint32_t h = 0; h < hdr->hunkcount; ++h) {
+    err = chd_read(chd, h, hunkbuf.data());
+    if (err != CHDERR_NONE) {
+      L_ERROR("CHD read error: {}", chd_error_string(err));
+      chd_close(chd);
+      return;
+    }
+    size_t to_copy = std::min<size_t>(hdr->hunkbytes, data.size() - offset);
+    memcpy(data.data() + offset, hunkbuf.data(), to_copy);
+    offset += to_copy;
+  }
+  chd_close(chd);
+
+  auto virtFile = new VirtFile(data.data(), static_cast<uint32_t>(data.size()),
+                               file->name(), file->path().string(), file->tag);
+  enqueue(virtFile);
+}

--- a/src/main/loaders/CHDLoader.h
+++ b/src/main/loaders/CHDLoader.h
@@ -1,0 +1,14 @@
+/*
+ * VGMTrans (c) 2002-2025
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+#pragma once
+
+#include "FileLoader.h"
+
+class CHDLoader : public FileLoader {
+ public:
+  ~CHDLoader() override = default;
+  void apply(const RawFile *) override;
+};

--- a/src/main/loaders/PSF2Loader.cpp
+++ b/src/main/loaders/PSF2Loader.cpp
@@ -34,7 +34,7 @@ static u32 get32lsb(const u8 *src) {
 int PSF2Loader::psf2_decompress_block(const RawFile *file, unsigned fileoffset,
                                       unsigned blocknumber, unsigned numblocks,
                                       unsigned char *decompressedblock, unsigned blocksize) {
-  size_t destlen;
+  unsigned long destlen;
   u8 *blocks = new u8[numblocks * 4];
 
   file->readBytes(fileoffset, numblocks * 4, blocks);

--- a/src/main/loaders/PSF2Loader.cpp
+++ b/src/main/loaders/PSF2Loader.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "PSF2Loader.h"
-#include <zlib-ng.h>
+#include <zlib.h>
 #include "LogManager.h"
 #include "components/PSFFile.h"
 
@@ -47,7 +47,7 @@ int PSF2Loader::psf2_decompress_block(const RawFile *file, unsigned fileoffset,
   file->readBytes(tempOffset, current_block, zblock);
 
   destlen = blocksize;
-  if (zng_uncompress(decompressedblock, &destlen, zblock, current_block) != Z_OK) {
+  if (uncompress(decompressedblock, &destlen, zblock, current_block) != Z_OK) {
     L_ERROR("Decompression failed");
     delete[] zblock;
     delete[] blocks;

--- a/src/main/util/decompression.h
+++ b/src/main/util/decompression.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #define ZLIB_CONST
-#include <zlib-ng.h>
+#include <zlib.h>
 #include <stdexcept>
 #include <array>
 
@@ -16,13 +16,13 @@ std::vector<char> zdecompress(T src) {
   std::vector<char> result;
 
   /* allocate inflate state */
-  zng_stream strm;
+  z_stream strm;
   strm.zalloc = Z_NULL;
   strm.zfree = Z_NULL;
   strm.opaque = Z_NULL;
   strm.avail_in = 0;
   strm.next_in = Z_NULL;
-  int ret = zng_inflateInit(&strm);
+  int ret = inflateInit(&strm);
   if (ret != Z_OK) {
     throw std::runtime_error("Failed to init decompression");
   }
@@ -36,7 +36,7 @@ std::vector<char> zdecompress(T src) {
   do {
     strm.avail_out = CHUNK;
     strm.next_out = reinterpret_cast<Bytef *>(out.data());
-    ret = zng_inflate(&strm, Z_NO_FLUSH);
+    ret = inflate(&strm, Z_NO_FLUSH);
 
     assert(ret != Z_STREAM_ERROR);
 
@@ -45,7 +45,7 @@ std::vector<char> zdecompress(T src) {
         [[fallthrough]];
       case Z_DATA_ERROR:
       case Z_MEM_ERROR:
-        (void)zng_inflateEnd(&strm);
+        (void)inflateEnd(&strm);
         throw std::runtime_error("Decompression failed");
     }
 
@@ -55,6 +55,6 @@ std::vector<char> zdecompress(T src) {
 
   assert(ret == Z_STREAM_END);
 
-  (void)zng_inflateEnd(&strm);
+  (void)inflateEnd(&strm);
   return result;
 }


### PR DESCRIPTION
This adds support for loading chd files, a compression format for cd-rom and hard drive images. It adds [libchdr](https://github.com/rtissera/libchdr) as a git submodule and dependency.

Note that I ran into some difficulties with libchdr's zlib dependency. Specifically, libchdr's CMake files were detecting our `zlibstatic` target and trying to use it, even though it was the non-zlib API compatible version of zlib-ng (and libchdr uses original zlib). To solve the error, I enabled the `ZLIB_COMPAT` option on zlib-ng and updated our usage of the API to the old zlib function names. The change was trivial and mainly involved removing prefixes from function and type names. Now libchdr can utilize our existing zlib-ng dependency.

## Motivation and Context
CHD is an increasingly popular cd-rom image format and also utilized by MAME.

## How Has This Been Tested?
CHD files are loading with contained files scanned successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
