### PR TITLE
Volume fixes, decay rate improvement

### DIFF
--- a/src/main/components/instr/VGMRgn.cpp
+++ b/src/main/components/instr/VGMRgn.cpp
@@ -1,8 +1,9 @@
 /*
-* VGMTrans (c) 2002-2024
+ * VGMTrans (c) 2002-2024
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
  */
+#include "ScaleConversion.h"
 #include "VGMRgn.h"
 #include "VGMInstrSet.h"
 
@@ -22,7 +23,6 @@ VGMRgn::VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length, std::string na
       sampNum(0),
       sampOffset(-1),
       sampCollPtr(nullptr),
-      volume(-1),
       pan(0.5),
       attack_time(0),
       attack_transform(no_transform),
@@ -47,7 +47,6 @@ VGMRgn::VGMRgn(VGMInstr *instr, uint32_t offset, uint32_t length, uint8_t theKey
       sampNum(theSampNum),
       sampOffset(-1),
       sampCollPtr(nullptr),
-      volume(-1),
       pan(0.5),
       attack_time(0),
       attack_transform(no_transform),
@@ -119,12 +118,21 @@ void VGMRgn::addPan(uint8_t p, uint32_t offset, uint32_t length, const std::stri
 }
 
 void VGMRgn::setVolume(double vol) {
-  volume = vol;
+  m_attenDb = convertPercentAmplitudeToAttenDB(vol);
+}
+
+void VGMRgn::setAttenuation(double attenDb) {
+  m_attenDb = attenDb;
 }
 
 void VGMRgn::addVolume(double vol, uint32_t offset, uint32_t length) {
-  volume = vol;
+  setVolume(vol);
   addChild(new VGMRgnItem(this, VGMRgnItem::RIT_VOL, offset, length, "Volume"));
+}
+
+void VGMRgn::addAttenuation(double attenDb, uint32_t offset, uint32_t length) {
+  setAttenuation(attenDb);
+  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_VOL, offset, length, "Attenuation"));
 }
 
 void VGMRgn::addUnityKey(uint8_t uk, uint32_t offset, uint32_t length) {

--- a/src/main/components/instr/VGMRgn.h
+++ b/src/main/components/instr/VGMRgn.h
@@ -33,11 +33,13 @@ class VGMRgn : public VGMItem {
   void setFineTune(int16_t relativePitchCents) { fineTune = relativePitchCents; }
   void setPan(uint8_t pan);
   void addPan(uint8_t pan, uint32_t offset, uint32_t length = 1, const std::string& name = "Pan");
-  //void setAttenuation(long attenuation);
-  //void addAttenuation(long atten, uint32_t offset, uint32_t length = 1);
   void setVolume(double volume);
+  void setAttenuation(double decibels);
+  double attenDb() { return m_attenDb; }
   void addVolume(double volume, uint32_t offset, uint32_t length = 1);
+  void addAttenuation(double decibels, uint32_t offset, uint32_t length = 1);
   void addUnityKey(uint8_t unityKey, uint32_t offset, uint32_t length = 1);
+  void addCoarseTune(int16_t relativeSemitones, uint32_t offset, uint32_t length = 1);
   void addFineTune(int16_t relativePitchCents, uint32_t offset, uint32_t length = 1);
   void addKeyLow(uint8_t keyLow, uint32_t offset, uint32_t length = 1);
   void addKeyHigh(uint8_t keyHigh, uint32_t offset, uint32_t length = 1);
@@ -76,8 +78,6 @@ class VGMRgn : public VGMItem {
   //int sampCollNum;	//optional value. for formats that use multiple sampColls and reference samples base 0 for each sampColl (NDS, for instance)
   VGMSampColl *sampCollPtr;
 
-  //long attenuation;
-  double volume;    // as percentage of full volume.  This will be converted to to an attenuation when we convert to a SynthFile
   double pan;        //percentage.  0 = full left. 0.5 = center.  1 = full right
   double attack_time;            //in seconds
   uint16_t attack_transform;
@@ -87,6 +87,9 @@ class VGMRgn : public VGMItem {
   double sustain_time;        //in seconds (we don't support positive rate here, as is possible on psx)
   uint16_t release_transform;
   double release_time;        //in seconds
+
+private:
+  double m_attenDb {0};   // attenuation in decibels;
 };
 
 

--- a/src/main/components/instr/VGMRgn.h
+++ b/src/main/components/instr/VGMRgn.h
@@ -78,15 +78,15 @@ class VGMRgn : public VGMItem {
   //int sampCollNum;	//optional value. for formats that use multiple sampColls and reference samples base 0 for each sampColl (NDS, for instance)
   VGMSampColl *sampCollPtr;
 
-  double pan;        //percentage.  0 = full left. 0.5 = center.  1 = full right
-  double attack_time;            //in seconds
+  double pan;                 // percentage.  0 = full left. 0.5 = center.  1 = full right
+  double attack_time;         // in seconds
   uint16_t attack_transform;
-  double hold_time;            //in seconds
-  double decay_time;            //in seconds
-  double sustain_level;        //as a percentage
-  double sustain_time;        //in seconds (we don't support positive rate here, as is possible on psx)
+  double hold_time;           // in seconds
+  double decay_time;          // in seconds
+  double sustain_level;       // as a percentage of amplitude
+  double sustain_time;        // in seconds (we don't support positive rate here, as is possible on psx)
   uint16_t release_transform;
-  double release_time;        //in seconds
+  double release_time;        // in seconds
 
 private:
   double m_attenDb {0};   // attenuation in decibels;

--- a/src/main/components/instr/VGMSamp.cpp
+++ b/src/main/components/instr/VGMSamp.cpp
@@ -8,6 +8,7 @@
 #include "VGMSamp.h"
 #include "VGMSampColl.h"
 #include "Root.h"
+#include "ScaleConversion.h"
 #include "helper.h"
 
 // *******
@@ -54,6 +55,10 @@ void VGMSamp::convertToStdWave(std::uint8_t* buf)
     for (std::size_t i = 0; i < dataLength; ++i)
       buf[i] ^= 0x80;
   }
+}
+
+void VGMSamp::setVolume(double volume) {
+  m_attenDb = convertPercentAmplitudeToAttenDB(volume);
 }
 
 bool VGMSamp::onSaveAsWav() {

--- a/src/main/components/instr/VGMSamp.h
+++ b/src/main/components/instr/VGMSamp.h
@@ -37,6 +37,9 @@ public:
   inline void setLoopLength(uint32_t theLoopLength) { loop.loopLength = theLoopLength; }
   inline void setLoopStartMeasure(LoopMeasure measure) { loop.loopStartMeasure = measure; }
   inline void setLoopLengthMeasure(LoopMeasure measure) { loop.loopLengthMeasure = measure; }
+  inline double attenDb() const { return m_attenDb; }
+  void setVolume(double volume);
+  inline void setAttenuation(double decibels) { m_attenDb = decibels;}
   inline bool reverse() { return m_reverse; }
   inline void setReverse(bool reverse) { m_reverse = reverse; }
 
@@ -56,15 +59,15 @@ public:
   Loop loop;
 
   /* FIXME: these placeholders value are not so clean... */
-  int8_t unityKey = -1;
-  short fineTune = 0;
-  double volume = -1;  // as percent of full volume.  This will be converted to attenuation for SynthFile
+  int8_t unityKey {-1};
+  short fineTune {0};
 
   long pan{0};
 
   VGMSampColl *parSampColl;
 
 private:
+  double m_attenDb {0};
   bool m_reverse = false;
 };
 

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -378,7 +378,7 @@ void SeqTrack::addNoteOnNoItem(int8_t key, int8_t velocity) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = velocity;
     if (parentSeq->usesLinearAmplitudeScale())
-      finalVel = convert7bitPercentVolValToStdMidiVal(velocity);
+      finalVel = convert7bitPercentAmpValToStdMidiVal(velocity);
 
     if (cDrumNote == -1) {
       pMidiTrack->addNoteOn(channel, key + cKeyCorrection + transpose, finalVel);
@@ -427,7 +427,7 @@ void SeqTrack::insertNoteOn(uint32_t offset,
 
   uint8_t finalVel = vel;
   if (parentSeq->usesLinearAmplitudeScale())
-    finalVel = convert7bitPercentVolValToStdMidiVal(vel);
+    finalVel = convert7bitPercentAmpValToStdMidiVal(vel);
 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true)) {
     addEvent(new NoteOnSeqEvent(this, key, vel, offset, length, sEventName));
@@ -521,7 +521,7 @@ void SeqTrack::addNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = vel;
     if (parentSeq->usesLinearAmplitudeScale())
-      finalVel = convert7bitPercentVolValToStdMidiVal(vel);
+      finalVel = convert7bitPercentAmpValToStdMidiVal(vel);
 
     if (cDrumNote == -1) {
       pMidiTrack->addNoteByDur(channel, key + cKeyCorrection + transpose, finalVel, dur);
@@ -550,7 +550,7 @@ void SeqTrack::addNoteByDurNoItem_Extend(int8_t key, int8_t vel, uint32_t dur) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = vel;
     if (parentSeq->usesLinearAmplitudeScale())
-      finalVel = convert7bitPercentVolValToStdMidiVal(vel);
+      finalVel = convert7bitPercentAmpValToStdMidiVal(vel);
 
     if (cDrumNote == -1) {
       pMidiTrack->addNoteByDur_TriAce(channel, key + cKeyCorrection + transpose, finalVel, dur);
@@ -620,7 +620,7 @@ void SeqTrack::insertNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur, uint3
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = vel;
     if (parentSeq->usesLinearAmplitudeScale())
-      finalVel = convert7bitPercentVolValToStdMidiVal(vel);
+      finalVel = convert7bitPercentAmpValToStdMidiVal(vel);
 
     pMidiTrack->insertNoteByDur(channel, key + cKeyCorrection + transpose, finalVel, dur, absTime);
   }
@@ -792,7 +792,7 @@ void SeqTrack::addVolSlide(uint32_t offset,
     addControllerSlide(dur,
                        vol,
                        targVol,
-                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentVolValToStdMidiVal : nullptr,
+                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpValToStdMidiVal : nullptr,
                        &MidiTrack::insertVol);
 }
 
@@ -843,7 +843,7 @@ void SeqTrack::addExpressionSlide(uint32_t offset,
     addControllerSlide(dur,
                        expression,
                        targExpr,
-                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentVolValToStdMidiVal : nullptr,
+                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpValToStdMidiVal : nullptr,
                        &MidiTrack::insertExpression);
 }
 
@@ -888,7 +888,7 @@ void SeqTrack::addMastVolSlide(uint32_t offset,
     addControllerSlide(dur,
                        mastVol,
                        targVol,
-                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentVolValToStdMidiVal : nullptr,
+                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpValToStdMidiVal : nullptr,
                        &MidiTrack::insertMasterVol);
 }
 

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -378,7 +378,7 @@ void SeqTrack::addNoteOnNoItem(int8_t key, int8_t velocity) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = velocity;
     if (parentSeq->usesLinearAmplitudeScale())
-      finalVel = convert7bitPercentAmpValToStdMidiVal(velocity);
+      finalVel = convert7bitPercentAmpToStdMidiVal(velocity);
 
     if (cDrumNote == -1) {
       pMidiTrack->addNoteOn(channel, key + cKeyCorrection + transpose, finalVel);
@@ -427,7 +427,7 @@ void SeqTrack::insertNoteOn(uint32_t offset,
 
   uint8_t finalVel = vel;
   if (parentSeq->usesLinearAmplitudeScale())
-    finalVel = convert7bitPercentAmpValToStdMidiVal(vel);
+    finalVel = convert7bitPercentAmpToStdMidiVal(vel);
 
   if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(offset, true)) {
     addEvent(new NoteOnSeqEvent(this, key, vel, offset, length, sEventName));
@@ -521,7 +521,7 @@ void SeqTrack::addNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = vel;
     if (parentSeq->usesLinearAmplitudeScale())
-      finalVel = convert7bitPercentAmpValToStdMidiVal(vel);
+      finalVel = convert7bitPercentAmpToStdMidiVal(vel);
 
     if (cDrumNote == -1) {
       pMidiTrack->addNoteByDur(channel, key + cKeyCorrection + transpose, finalVel, dur);
@@ -550,7 +550,7 @@ void SeqTrack::addNoteByDurNoItem_Extend(int8_t key, int8_t vel, uint32_t dur) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = vel;
     if (parentSeq->usesLinearAmplitudeScale())
-      finalVel = convert7bitPercentAmpValToStdMidiVal(vel);
+      finalVel = convert7bitPercentAmpToStdMidiVal(vel);
 
     if (cDrumNote == -1) {
       pMidiTrack->addNoteByDur_TriAce(channel, key + cKeyCorrection + transpose, finalVel, dur);
@@ -620,7 +620,7 @@ void SeqTrack::insertNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur, uint3
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = vel;
     if (parentSeq->usesLinearAmplitudeScale())
-      finalVel = convert7bitPercentAmpValToStdMidiVal(vel);
+      finalVel = convert7bitPercentAmpToStdMidiVal(vel);
 
     pMidiTrack->insertNoteByDur(channel, key + cKeyCorrection + transpose, finalVel, dur, absTime);
   }
@@ -792,7 +792,7 @@ void SeqTrack::addVolSlide(uint32_t offset,
     addControllerSlide(dur,
                        vol,
                        targVol,
-                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpValToStdMidiVal : nullptr,
+                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
                        &MidiTrack::insertVol);
 }
 
@@ -843,7 +843,7 @@ void SeqTrack::addExpressionSlide(uint32_t offset,
     addControllerSlide(dur,
                        expression,
                        targExpr,
-                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpValToStdMidiVal : nullptr,
+                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
                        &MidiTrack::insertExpression);
 }
 
@@ -888,7 +888,7 @@ void SeqTrack::addMastVolSlide(uint32_t offset,
     addControllerSlide(dur,
                        mastVol,
                        targVol,
-                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpValToStdMidiVal : nullptr,
+                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
                        &MidiTrack::insertMasterVol);
 }
 

--- a/src/main/conversion/DLSConversion.cpp
+++ b/src/main/conversion/DLSConversion.cpp
@@ -242,12 +242,13 @@ bool mainDLSCreation(
           realFineTune = rgn->fineTune;
 
         long realAttenuation;
-        if (rgn->volume == -1 && samp->volume == -1)
+        if (rgn->attenDb() == 0 && samp->volume == -1)
           realAttenuation = 0;
-        else if (rgn->volume == -1)
-          realAttenuation = static_cast<long>(-(convertLogScaleValToAtten(samp->volume) * DLS_DECIBEL_UNIT * 10));
-        else
-          realAttenuation = static_cast<long>(-(convertLogScaleValToAtten(rgn->volume) * DLS_DECIBEL_UNIT * 10));
+        else if (rgn->attenDb() == 0)
+          realAttenuation = static_cast<long>(convertPercentAmplitudeToAttenDB(samp->volume) * DLS_DECIBEL_UNIT * 10);
+        else {
+          realAttenuation = static_cast<long>(rgn->attenDb() * DLS_DECIBEL_UNIT * 10);
+        }
 
         long convAttack = static_cast<long>(std::round(secondsToTimecents(rgn->attack_time) * 65536));
         long convHold = static_cast<long>(std::round(secondsToTimecents(rgn->hold_time) * 65536));
@@ -257,7 +258,7 @@ bool mainDLSCreation(
           convSustainLev = 0x03e80000;        //sustain at full if no sustain level provided
         else {
           // the DLS envelope is a range from 0 to -96db.
-          double attenInDB = convertLogScaleValToAtten(rgn->sustain_level);
+          double attenInDB = convertPercentAmplitudeToAttenDB(rgn->sustain_level);
           convSustainLev = static_cast<long>(((96.0 - attenInDB) / 96.0) * 0x03e80000);
         }
 

--- a/src/main/conversion/DLSConversion.cpp
+++ b/src/main/conversion/DLSConversion.cpp
@@ -242,10 +242,10 @@ bool mainDLSCreation(
           realFineTune = rgn->fineTune;
 
         long realAttenuation;
-        if (rgn->attenDb() == 0 && samp->volume == -1)
+        if (rgn->attenDb() == 0 && samp->attenDb() == 0)
           realAttenuation = 0;
         else if (rgn->attenDb() == 0)
-          realAttenuation = static_cast<long>(convertPercentAmplitudeToAttenDB(samp->volume) * DLS_DECIBEL_UNIT * 10);
+          realAttenuation = static_cast<long>(samp->attenDb() * DLS_DECIBEL_UNIT * 10);
         else {
           realAttenuation = static_cast<long>(rgn->attenDb() * DLS_DECIBEL_UNIT * 10);
         }

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -215,13 +215,7 @@ SynthFile* createSynthFile(
         else
           realFineTune = rgn->fineTune;
 
-        double attenuation;
-        if (samp->volume != -1)
-          attenuation = convertPercentAmplitudeToAttenDB(samp->volume);
-        else
-          attenuation = 0;
-
-        sampInfo->setPitchInfo(realUnityKey, realFineTune, attenuation);
+        sampInfo->setPitchInfo(realUnityKey, realFineTune, samp->attenDb());
 
         double sustainLevAttenDb;
         if (rgn->sustain_level == -1)
@@ -274,10 +268,8 @@ void unpackSampColl(SynthFile &synthfile, const VGMSampColl *sampColl, std::vect
     } else
       sampInfo->setLoopInfo(samp->loop, samp);
 
-    double attenuation = (samp->volume != -1) ? convertPercentAmplitudeToAttenDB(samp->volume) : 0;
     uint8_t unityKey = (samp->unityKey != -1) ? samp->unityKey : 0x3C;
-    short fineTune = samp->fineTune;
-    sampInfo->setPitchInfo(unityKey, fineTune, attenuation);
+    sampInfo->setPitchInfo(unityKey, samp->fineTune, samp->attenDb());
   }
 }
 

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -116,7 +116,8 @@ SynthFile* createSynthFile(
         if (rgn->sampOffset != -1) {
           bool bFoundIt = false;
           for (uint32_t s = 0; s < sampColl->samples.size(); s++) {  //for every sample
-            if (rgn->sampOffset == sampColl->samples[s]->dwOffset - sampColl->dwOffset - sampColl->sampDataOffset) {
+            if (rgn->sampOffset == sampColl->samples[s]->dwOffset ||
+                rgn->sampOffset == sampColl->samples[s]->dwOffset - sampColl->dwOffset - sampColl->sampDataOffset) {
               realSampNum = s;
 
               //samples[m]->loop.loopStart = parInstrSet->aInstrs[i]->aRgns[k]->loop.loopStart;
@@ -160,6 +161,7 @@ SynthFile* createSynthFile(
         SynthRgn *newRgn = newInstr->addRgn();
         newRgn->setRanges(rgn->keyLow, rgn->keyHigh, rgn->velLow, rgn->velHigh);
         newRgn->setWaveLinkInfo(0, 0, 1, static_cast<uint32_t>(realSampNum));
+        newRgn->setAttenuationDb(rgn->attenDb());
 
         if (realSampNum >= finalSamps.size()) {
           L_ERROR("Sample {} does not exist. Instr index: {:d}, Instr num: {:d}, Region index: {:d}", realSampNum, i, vgminstr->instrNum, j);
@@ -214,10 +216,8 @@ SynthFile* createSynthFile(
           realFineTune = rgn->fineTune;
 
         double attenuation;
-        if (rgn->volume != -1)
-          attenuation = convertLogScaleValToAtten(rgn->volume);
-        else if (samp->volume != -1)
-          attenuation = convertLogScaleValToAtten(samp->volume);
+        if (samp->volume != -1)
+          attenuation = convertPercentAmplitudeToAttenDB(samp->volume);
         else
           attenuation = 0;
 
@@ -227,7 +227,7 @@ SynthFile* createSynthFile(
         if (rgn->sustain_level == -1)
           sustainLevAttenDb = 0.0;
         else
-          sustainLevAttenDb = convertPercentAmplitudeToAttenDB_SF2(rgn->sustain_level);
+          sustainLevAttenDb = convertPercentAmplitudeToAttenDB(rgn->sustain_level, 100.0);
 
         SynthArt *newArt = newRgn->addArt();
         newArt->addPan(rgn->pan);
@@ -274,7 +274,7 @@ void unpackSampColl(SynthFile &synthfile, const VGMSampColl *sampColl, std::vect
     } else
       sampInfo->setLoopInfo(samp->loop, samp);
 
-    double attenuation = (samp->volume != -1) ? convertLogScaleValToAtten(samp->volume) : 0;
+    double attenuation = (samp->volume != -1) ? convertPercentAmplitudeToAttenDB(samp->volume) : 0;
     uint8_t unityKey = (samp->unityKey != -1) ? samp->unityKey : 0x3C;
     short fineTune = samp->fineTune;
     sampInfo->setPitchInfo(unityKey, fineTune, attenuation);

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -221,7 +221,7 @@ SF2File::SF2File(SynthFile *synthfile)
     for (size_t j = 0; j < numRgns; j++) {
       sfInstBag instBag{};
       instBag.wInstGenNdx = instGenCounter;
-      instGenCounter += 12;
+      instGenCounter += 13;
       instBag.wInstModNdx = 0;
 
       memcpy(ibagCk->data + (rgnCounter++ * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
@@ -247,7 +247,7 @@ SF2File::SF2File(SynthFile *synthfile)
   // igen chunk
   //***********
   Chunk *igenCk = new Chunk("igen");
-  igenCk->setSize((numTotalRgns * sizeof(sfInstGenList) * 12) + sizeof(sfInstGenList));
+  igenCk->setSize((numTotalRgns * sizeof(sfInstGenList) * 13) + sizeof(sfInstGenList));
   igenCk->data = new uint8_t[igenCk->size()];
   dataPtr = 0;
   for (size_t i = 0; i < numInstrs; i++) {
@@ -296,6 +296,12 @@ SF2File::SF2File(SynthFile *synthfile)
       // overridingRootKey
       instGenList.sfGenOper = overridingRootKey;
       instGenList.genAmount.wAmount = rgn->sampinfo->usUnityNote;
+      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      dataPtr += sizeof(sfInstGenList);
+
+      // initialAttenuation - expressed in centibels
+      instGenList.sfGenOper = initialAttenuation;
+      instGenList.genAmount.wAmount = static_cast<u16>(rgn->attenDb * 10.0);
       memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -127,6 +127,10 @@ void SynthRgn::setWaveLinkInfo(uint16_t options, uint16_t phaseGroup, uint32_t t
   tableIndex = theTableIndex;
 }
 
+void SynthRgn::setAttenuationDb(double attenuation) {
+  attenDb = attenuation;
+}
+
 //  ********
 //  SynthArt
 //  ********

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -90,6 +90,7 @@ class SynthRgn {
   SynthSampInfo *addSampInfo();
   void setRanges(uint16_t keyLow = 0, uint16_t keyHigh = 0x7F, uint16_t velLow = 0, uint16_t velHigh = 0x7F);
   void setWaveLinkInfo(uint16_t options, uint16_t phaseGroup, uint32_t theChannel, uint32_t theTableIndex);
+  void setAttenuationDb(double attenuation);
 
   uint16_t usKeyLow {0};
   uint16_t usKeyHigh {0x7F};
@@ -100,6 +101,8 @@ class SynthRgn {
   uint16_t usPhaseGroup {0};  // ''
   uint32_t channel {1};       // ''
   uint32_t tableIndex {0};
+
+  double attenDb {0};   // attenuation in decibels
 
   SynthSampInfo *sampinfo {nullptr};
   SynthArt *art {nullptr};

--- a/src/main/formats/Akao/AkaoInstr.cpp
+++ b/src/main/formats/Akao/AkaoInstr.cpp
@@ -229,7 +229,7 @@ bool AkaoDrumKit::loadInstr() {
       addRgn(rgn);
       rgn->drumRelUnityKey = readByte(rgn_offset + 1);
       const uint16_t raw_volume = getWord(rgn_offset + 2);
-      rgn->setVolume(raw_volume / static_cast<double>(127 * 128));
+      rgn->setVolume(raw_volume / (127 * 128.0));
       rgn->addGeneralItem(rgn_offset, 1, "Associated Articulation ID");
       rgn->addGeneralItem(rgn_offset + 1, 1, "Relative Unity Key");
       rgn->addGeneralItem(rgn_offset + 2, 2, "Attenuation");

--- a/src/main/formats/CPS/CPS2Instr.cpp
+++ b/src/main/formats/CPS/CPS2Instr.cpp
@@ -441,7 +441,7 @@ bool CPS2Instr::loadInstr() {
       ticks = Dr ? (0xFFFF / Dr) : 0;
       rgn->decay_time = (Dr == 0xFFFF) ? 0 : ticks / UPDATE_RATE_IN_HZ;
     }
-    rgn->decay_time = linearAmpDecayTimeToLinDBDecayTime(rgn->decay_time, 0xFFFF / 8);
+    rgn->decay_time = linearAmpDecayTimeToLinDBDecayTime(rgn->decay_time);
 
     // Sustain level
     //    if the Decay rate is 0, then the sustain level is effectively max
@@ -455,11 +455,11 @@ bool CPS2Instr::loadInstr() {
     // Sustain rate 138D in sfa2
     ticks = Sr ? 0xFFFF / Sr : 0;
     rgn->sustain_time = (Sr == 0xFFFF) ? 0 : ticks / UPDATE_RATE_IN_HZ;
-    rgn->sustain_time = linearAmpDecayTimeToLinDBDecayTime(rgn->sustain_time, 0xFFFF / 8);
+    rgn->sustain_time = linearAmpDecayTimeToLinDBDecayTime(rgn->sustain_time);
 
     ticks = Rr ? 0xFFFF / Rr : 0xFFFF;
     rgn->release_time = (Rr == 0xFFFF) ? 0 : ticks / UPDATE_RATE_IN_HZ;
-    rgn->release_time = linearAmpDecayTimeToLinDBDecayTime(rgn->release_time, 0xFFFF / 8);
+    rgn->release_time = linearAmpDecayTimeToLinDBDecayTime(rgn->release_time);
 
     if (rgn->sampNum == 0xFFFF || rgn->sampNum >= (dynamic_cast<CPS2InstrSet*>(parInstrSet))->sampInfoTable->numSamples)
       rgn->sampNum = 0;

--- a/src/main/formats/CompileSnes/CompileSnesSeq.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesSeq.cpp
@@ -217,7 +217,7 @@ void CompileSnesTrack::addInitialMidiEvents(int trackNum) {
 
   double volumeScale;
   addProgramChangeNoItem(spcSRCN, true);
-  addVolNoItem(convert7bitPercentAmpValToStdMidiVal(spcVolume / 2));
+  addVolNoItem(convert7bitPercentAmpToStdMidiVal(spcVolume / 2));
   addPanNoItem(convert7bitLinearPercentPanValToStdMidiVal(static_cast<uint8_t>(spcPan + 0x80) / 2, &volumeScale));
   addExpressionNoItem(convertPercentAmpToStdMidiVal(volumeScale));
   addReverbNoItem(0);
@@ -355,7 +355,7 @@ bool CompileSnesTrack::readEvent() {
     case EVENT_VOLUME: {
       uint8_t newVolume = readByte(curOffset++);
       spcVolume = newVolume;
-      uint8_t midiVolume = convert7bitPercentAmpValToStdMidiVal(spcVolume / 2);
+      uint8_t midiVolume = convert7bitPercentAmpToStdMidiVal(spcVolume / 2);
       addVol(beginOffset, curOffset - beginOffset, midiVolume);
       break;
     }
@@ -381,7 +381,7 @@ bool CompileSnesTrack::readEvent() {
     case EVENT_VOLUME_REL: {
       int8_t delta = static_cast<int8_t>(readByte(curOffset++));
       spcVolume += delta;
-      uint8_t midiVolume = convert7bitPercentAmpValToStdMidiVal(spcVolume / 2);
+      uint8_t midiVolume = convert7bitPercentAmpToStdMidiVal(spcVolume / 2);
       addVol(beginOffset, curOffset - beginOffset, midiVolume, "Volume (Relative)");
       break;
     }

--- a/src/main/formats/CompileSnes/CompileSnesSeq.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesSeq.cpp
@@ -217,7 +217,7 @@ void CompileSnesTrack::addInitialMidiEvents(int trackNum) {
 
   double volumeScale;
   addProgramChangeNoItem(spcSRCN, true);
-  addVolNoItem(convert7bitPercentVolValToStdMidiVal(spcVolume / 2));
+  addVolNoItem(convert7bitPercentAmpValToStdMidiVal(spcVolume / 2));
   addPanNoItem(convert7bitLinearPercentPanValToStdMidiVal(static_cast<uint8_t>(spcPan + 0x80) / 2, &volumeScale));
   addExpressionNoItem(convertPercentAmpToStdMidiVal(volumeScale));
   addReverbNoItem(0);
@@ -355,7 +355,7 @@ bool CompileSnesTrack::readEvent() {
     case EVENT_VOLUME: {
       uint8_t newVolume = readByte(curOffset++);
       spcVolume = newVolume;
-      uint8_t midiVolume = convert7bitPercentVolValToStdMidiVal(spcVolume / 2);
+      uint8_t midiVolume = convert7bitPercentAmpValToStdMidiVal(spcVolume / 2);
       addVol(beginOffset, curOffset - beginOffset, midiVolume);
       break;
     }
@@ -381,7 +381,7 @@ bool CompileSnesTrack::readEvent() {
     case EVENT_VOLUME_REL: {
       int8_t delta = static_cast<int8_t>(readByte(curOffset++));
       spcVolume += delta;
-      uint8_t midiVolume = convert7bitPercentVolValToStdMidiVal(spcVolume / 2);
+      uint8_t midiVolume = convert7bitPercentAmpValToStdMidiVal(spcVolume / 2);
       addVol(beginOffset, curOffset - beginOffset, midiVolume, "Volume (Relative)");
       break;
     }

--- a/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
@@ -127,7 +127,7 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
     rgn->sampNum = sampNum;
     rgn->unityKey = unityKey;
     rgn->release_time = drumReleaseTime;
-    rgn->volume = volTable[d.attenuation];
+    rgn->setVolume(volTable[d.attenuation]);
 
     rgn->addChild(off, 1, "Sample Number");
     rgn->addChild(off + 1, 1, "Unity Key");

--- a/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
@@ -243,7 +243,7 @@ bool KonamiArcadeSampColl::parseSampleInfo() {
     sample->setLoopStatus(sampInfo.loops == 1);
     sample->setLoopOffset(relativeLoopOffset);
     sample->unityKey = 0x3C + 6;
-    sample->volume = volTable[sampInfo.attenuation];
+    sample->setVolume(volTable[sampInfo.attenuation]);
     sample->setReverse(sampInfo.reverse());
   }
   return true;

--- a/src/main/formats/MP2k/MP2kInstrSet.cpp
+++ b/src/main/formats/MP2k/MP2kInstrSet.cpp
@@ -75,7 +75,7 @@ int MP2kInstrSet::makeOrGetSample(size_t sample_pointer) {
   samp->unityKey = original_pitch;
   samp->fineTune = pitch_correction;
   samp->rate = m_operating_rate;
-  samp->volume = 1;
+  samp->setAttenuation(0);
   samp->bps = 8;
   samp->setName(fmt::format("{:#x}", sample_pointer));
 

--- a/src/main/formats/PrismSnes/PrismSnesInstr.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesInstr.cpp
@@ -173,7 +173,7 @@ PrismSnesRgn::PrismSnesRgn(PrismSnesInstr *instr,
   snesConvADSR<VGMRgn>(this, adsr1, adsr2, gain);
 
   // put a random release time, it would be better than plain key off (actual music engine never do key off)
-  release_time = linearAmpDecayTimeToLinDBDecayTime(0.002 * SDSP_COUNTER_RATES[0x14], 0x7ff);
+  release_time = linearAmpDecayTimeToLinDBDecayTime(0.002 * SDSP_COUNTER_RATES[0x14]);
 
   setGuessedLength();
 }

--- a/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
@@ -336,10 +336,10 @@ bool SonyPS2Instr::loadInstr() {
       uint8_t noteHigh = splitblock.splitRangeHigh;
       if (noteHigh < noteLow)
         noteHigh = 0x7F;
-      uint8_t sampSetVelLow = convert7bitPercentVolValToStdMidiVal(sampSetParam.velLimitLow);
-      uint8_t sampSetVelHigh = convert7bitPercentVolValToStdMidiVal(sampSetParam.velLimitHigh);
-      uint8_t velLow = convert7bitPercentVolValToStdMidiVal(sampParam.velRangeLow);//sampSetParam.velLimitLow;
-      uint8_t velHigh = convert7bitPercentVolValToStdMidiVal(sampParam.velRangeHigh);//sampSetParam.velLimitHigh;
+      uint8_t sampSetVelLow = convert7bitPercentAmpValToStdMidiVal(sampSetParam.velLimitLow);
+      uint8_t sampSetVelHigh = convert7bitPercentAmpValToStdMidiVal(sampSetParam.velLimitHigh);
+      uint8_t velLow = convert7bitPercentAmpValToStdMidiVal(sampParam.velRangeLow);//sampSetParam.velLimitLow;
+      uint8_t velHigh = convert7bitPercentAmpValToStdMidiVal(sampParam.velRangeHigh);//sampSetParam.velLimitHigh;
       if (velLow < sampSetVelLow)
         velLow = sampSetVelLow;
       if (velHigh > sampSetVelHigh)

--- a/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
@@ -336,10 +336,10 @@ bool SonyPS2Instr::loadInstr() {
       uint8_t noteHigh = splitblock.splitRangeHigh;
       if (noteHigh < noteLow)
         noteHigh = 0x7F;
-      uint8_t sampSetVelLow = convert7bitPercentAmpValToStdMidiVal(sampSetParam.velLimitLow);
-      uint8_t sampSetVelHigh = convert7bitPercentAmpValToStdMidiVal(sampSetParam.velLimitHigh);
-      uint8_t velLow = convert7bitPercentAmpValToStdMidiVal(sampParam.velRangeLow);//sampSetParam.velLimitLow;
-      uint8_t velHigh = convert7bitPercentAmpValToStdMidiVal(sampParam.velRangeHigh);//sampSetParam.velLimitHigh;
+      uint8_t sampSetVelLow = convert7bitPercentAmpToStdMidiVal(sampSetParam.velLimitLow);
+      uint8_t sampSetVelHigh = convert7bitPercentAmpToStdMidiVal(sampSetParam.velLimitHigh);
+      uint8_t velLow = convert7bitPercentAmpToStdMidiVal(sampParam.velRangeLow);//sampSetParam.velLimitLow;
+      uint8_t velHigh = convert7bitPercentAmpToStdMidiVal(sampParam.velRangeHigh);//sampSetParam.velLimitHigh;
       if (velLow < sampSetVelLow)
         velLow = sampSetVelLow;
       if (velHigh > sampSetVelHigh)

--- a/src/main/formats/common/PSXSPU.h
+++ b/src/main/formats/common/PSXSPU.h
@@ -247,7 +247,7 @@ void psxConvADSR(T *realADSR,
         samples = l;
       }
       double timeInSecs = samples / sampleRate;
-      realADSR->sustain_time = /*Sm ? timeInSecs : */linearAmpDecayTimeToLinDBDecayTime(timeInSecs, 0x800);
+      realADSR->sustain_time = /*Sm ? timeInSecs : */linearAmpDecayTimeToLinDBDecayTime(timeInSecs);
     }
   }
 
@@ -259,7 +259,7 @@ void psxConvADSR(T *realADSR,
 
   // If decay is going unused, and there's a sustain rate with sustain level close to max...
   //  we'll put the sustain_rate in place of the decay rate.
-  if ((realADSR->decay_time < 2 || (Dr == 0x0F && Sl >= 0x0C)) && Sr < 0x7E && Sd == 1) {
+  if ((realADSR->decay_time < 2 || (Dr >= 0x0E && Sl >= 0x0C)) && Sr < 0x7E && Sd == 1) {
     realADSR->sustain_level = 0;
     realADSR->decay_time = realADSR->sustain_time;
     //realADSR->decay_time = 0.5;
@@ -305,7 +305,7 @@ void psxConvADSR(T *realADSR,
   //if (Rm == 0) // if it's linear
   //	timeInSecs *=  LINEAR_RELEASE_COMPENSATION;
 
-  realADSR->release_time = /*Rm ? timeInSecs : */linearAmpDecayTimeToLinDBDecayTime(timeInSecs, 0x800);
+  realADSR->release_time = /*Rm ? timeInSecs : */linearAmpDecayTimeToLinDBDecayTime(timeInSecs);
 
   // We need to compensate the decay and release times to represent them as the time from full vol to -100db
   // where the drop in db is a fixed amount per time unit (SoundFont2 spec for vol envelopes, pg44.)

--- a/src/main/formats/common/SNESDSP.cpp
+++ b/src/main/formats/common/SNESDSP.cpp
@@ -96,7 +96,7 @@ uint32_t emulateSDSPGAIN(uint8_t gain,
     }
     else if (mode == 4) { // 4: linear decrease
       uint32_t total_samples_full = (0x800 / 0x20) * SDSP_COUNTER_RATES[rate];
-      sf2_time = linearAmpDecayTimeToLinDBDecayTime(total_samples_full / 32000.0, 0x800);
+      sf2_time = linearAmpDecayTimeToLinDBDecayTime(total_samples_full / 32000.0);
     }
     else if (mode == 5) { // 5: exponential decrease
       // Exponential decrease mode is almost exponential.
@@ -112,7 +112,7 @@ uint32_t emulateSDSPGAIN(uint8_t gain,
           double decibelAtStart = convertPercentAmplitudeToAttenDB(env_from / 2047.0);
           double decibelAtExpFinal = convertPercentAmplitudeToAttenDB(env_exp_final / 2047.0);
           double timeAtExpFinal = (tick_exp * SDSP_COUNTER_RATES[rate]) / 32000.0;
-          sf2_time = timeAtExpFinal * (-100.0 / (decibelAtExpFinal - decibelAtStart));
+          sf2_time = timeAtExpFinal * (100.0 / (decibelAtExpFinal - decibelAtStart));
         }
         else {
           // linear part (very small volume)
@@ -134,7 +134,7 @@ uint32_t emulateSDSPGAIN(uint8_t gain,
             double decibelAtStart = convertPercentAmplitudeToAttenDB(env_from / 2047.0);
             double decibelAtFinal = convertPercentAmplitudeToAttenDB(env_final / 2047.0);
             double timeAtExpFinal = (tick_total * SDSP_COUNTER_RATES[rate]) / 32000.0;
-            sf2_time = timeAtExpFinal * (-100.0 / (decibelAtFinal - decibelAtStart));
+            sf2_time = timeAtExpFinal * (100.0 / (decibelAtFinal - decibelAtStart));
           }
 
           // Alternate method:
@@ -223,7 +223,7 @@ void convertSNESADSR(uint8_t adsr1,
     // release
     // decrease envelope by 8 for every sample
     samples = (env_sustain_start + 7) / 8;
-    release_time = linearAmpDecayTimeToLinDBDecayTime(samples / 32000.0, 0x7ff);
+    release_time = linearAmpDecayTimeToLinDBDecayTime(samples / 32000.0);
   }
   else {
     uint8_t mode = gain >> 5;
@@ -237,7 +237,7 @@ void convertSNESADSR(uint8_t adsr1,
       // release
       // decrease envelope by 8 for every sample
       samples = (env_from + 7) / 8;
-      release_time = linearAmpDecayTimeToLinDBDecayTime(samples / 32000.0, 0x7ff);
+      release_time = linearAmpDecayTimeToLinDBDecayTime(samples / 32000.0);
     }
     else {
       env = env_from;
@@ -254,7 +254,7 @@ void convertSNESADSR(uint8_t adsr1,
         // release
         // decrease envelope by 8 for every sample
         samples = (env_to + 7) / 8;
-        release_time = linearAmpDecayTimeToLinDBDecayTime(samples / 32000.0, 0x7ff);
+        release_time = linearAmpDecayTimeToLinDBDecayTime(samples / 32000.0);
       }
       else {
         attack_time = 0.0;
@@ -265,7 +265,7 @@ void convertSNESADSR(uint8_t adsr1,
         // release
         // decrease envelope by 8 for every sample
         samples = (env_from + 7) / 8;
-        release_time = linearAmpDecayTimeToLinDBDecayTime(samples / 32000.0, 0x7ff);
+        release_time = linearAmpDecayTimeToLinDBDecayTime(samples / 32000.0);
       }
     }
   }

--- a/src/main/formats/common/SNESDSP.h
+++ b/src/main/formats/common/SNESDSP.h
@@ -84,7 +84,7 @@ void snesConvADSR(T *rgn, uint8_t adsr1, uint8_t adsr2, uint8_t gain) {
     }
     else if (rgn->sustain_time != -1) {
       double decibelAtSustainStart = convertPercentAmplitudeToAttenDB(rgn->sustain_level);
-      double decayTimeRate = decibelAtSustainStart / -100.0;
+      double decayTimeRate = decibelAtSustainStart / 100.0;
       rgn->decay_time = (rgn->decay_time * decayTimeRate) + (rgn->sustain_time * (1.0 - decayTimeRate));
 
       // sustain finishes at zero volume

--- a/src/main/util/ScaleConversion.cpp
+++ b/src/main/util/ScaleConversion.cpp
@@ -66,7 +66,7 @@ double linearAmpDecayTimeToLinDBDecayTime(double secondsToFullAtten,
   return secondsToFullAtten * (w * k_short + (1.0 - w) * k_long);
 }
 
-uint8_t convert7bitPercentAmpValToStdMidiVal(uint8_t percentVal) {
+uint8_t convert7bitPercentAmpToStdMidiVal(uint8_t percentVal) {
   return convertPercentAmpToStdMidiVal(percentVal / 127.0);
 }
 

--- a/src/main/util/ScaleConversion.h
+++ b/src/main/util/ScaleConversion.h
@@ -7,15 +7,29 @@
 
 #include <cstdint>
 
-double linearAmpDecayTimeToLinDBDecayTime(double secondsToFullAtten, int linearVolumeRange);
+static double linAmpTimeToLinDb_MatchInitialDbSlope(double secondsToFullAtten, double targetDb = 100.0);
+static double linAmpTimeToLinDb_LeastSquaresDB(double secondsToFullAtten, double targetDb = 100.0);
+static double linAmpTimeToLinDb_LoudnessThreshold(double secondsToFullAtten, double targetDb = 100.0, double thresholdDb = 50.0);
+static double smoothstep01(double x);
+// double linearAmpDecayTimeToLinDBDecayTime(double secondsToFullAtten,
+//                                        double targetDb_LeastSquares = 70.0,
+//                                        double targetDb_InitialSlope = 120.0,
+//                                        double shortThresholdSec = 0.2,
+//                                        double blendWidthSec    = 0.10);
+double linearAmpDecayTimeToLinDBDecayTime(double secondsToFullAtten,
+                                          double targetDb_LeastSquares = 70,
+                                          double targetDb_InitialSlope = 140);
+// double linearAmpDecayTimeToLinDBDecayTime(double secondsToFullAtten,
+//                                   double targetDb = 200.0,
+//                                   double tau = 0.25,     // seconds; try 0.2–0.35
+//                                   int samples = 64);      // integration resolution
 
-uint8_t convert7bitPercentVolValToStdMidiVal(uint8_t percentVal);
+uint8_t convert7bitPercentAmpValToStdMidiVal(uint8_t percentVal);
 uint8_t convertPercentAmpToStdMidiVal(double percent);
 uint16_t convertPercentAmpToStd14BitMidiVal(double percent);
 uint8_t convertDBAttenuationToStdMidiVal(double dbAtten);
 double convertLogScaleValToAtten(double percent);
-double convertPercentAmplitudeToAttenDB(double percent);
-double convertPercentAmplitudeToAttenDB_SF2(double percent);
+double convertPercentAmplitudeToAttenDB(double percent, double maxAtten = 100.0);
 
 double secondsToTimecents(double secs);
 uint8_t convertPercentPanValToStdMidiVal(double percent);

--- a/src/main/util/ScaleConversion.h
+++ b/src/main/util/ScaleConversion.h
@@ -7,23 +7,9 @@
 
 #include <cstdint>
 
-static double linAmpTimeToLinDb_MatchInitialDbSlope(double secondsToFullAtten, double targetDb = 100.0);
-static double linAmpTimeToLinDb_LeastSquaresDB(double secondsToFullAtten, double targetDb = 100.0);
-static double linAmpTimeToLinDb_LoudnessThreshold(double secondsToFullAtten, double targetDb = 100.0, double thresholdDb = 50.0);
-static double smoothstep01(double x);
-// double linearAmpDecayTimeToLinDBDecayTime(double secondsToFullAtten,
-//                                        double targetDb_LeastSquares = 70.0,
-//                                        double targetDb_InitialSlope = 120.0,
-//                                        double shortThresholdSec = 0.2,
-//                                        double blendWidthSec    = 0.10);
 double linearAmpDecayTimeToLinDBDecayTime(double secondsToFullAtten,
                                           double targetDb_LeastSquares = 70,
                                           double targetDb_InitialSlope = 140);
-// double linearAmpDecayTimeToLinDBDecayTime(double secondsToFullAtten,
-//                                   double targetDb = 200.0,
-//                                   double tau = 0.25,     // seconds; try 0.2–0.35
-//                                   int samples = 64);      // integration resolution
-
 uint8_t convert7bitPercentAmpToStdMidiVal(uint8_t percentVal);
 uint8_t convertPercentAmpToStdMidiVal(double percent);
 uint16_t convertPercentAmpToStd14BitMidiVal(double percent);

--- a/src/main/util/ScaleConversion.h
+++ b/src/main/util/ScaleConversion.h
@@ -24,7 +24,7 @@ double linearAmpDecayTimeToLinDBDecayTime(double secondsToFullAtten,
 //                                   double tau = 0.25,     // seconds; try 0.2–0.35
 //                                   int samples = 64);      // integration resolution
 
-uint8_t convert7bitPercentAmpValToStdMidiVal(uint8_t percentVal);
+uint8_t convert7bitPercentAmpToStdMidiVal(uint8_t percentVal);
 uint8_t convertPercentAmpToStdMidiVal(double percent);
 uint16_t convertPercentAmpToStd14BitMidiVal(double percent);
 uint8_t convertDBAttenuationToStdMidiVal(double dbAtten);


### PR DESCRIPTION
This is a collection of changes primarily to fix or improve volume calculation and ADSR decay/release timing.

The two most impactful changes:

1) I've removed `convertLogScaleValToAtten()`, which was used for converting instrument/sample attenuation and sustain level values in instrument sets. It assumed the given percent value was using a logarithmic scale of amplitude. I suspect that no format is expressing volume this way. Far more likely is that values represent a percent of amplitude. I've replaced all instances of usage with `convertPercentAmplitudeToAttenDB()`. I think things sound better, and I've spotted no problems. To be clear, I suspect I am the original creator of this function, and made this mistake very early in development.

2) Second, I've revamped `linearAmpDecayTimeToLinDBDecayTime()` - the function helps transforms a linear amplitude decay time into a time for linear decibel change (which SF2 and DLS perform) that is perceptibly similar. The old function didn't really make sense. ChatGPT was also confused:

<img width="678" height="162" alt="image" src="https://github.com/user-attachments/assets/31b5f915-54a9-4dc8-af6d-9f91358b31cc" />

More importantly, I was finding that with very short decay/release rates the result was too short. The new version uses two different algorithm for short and longer times.

A more granular list of changes below

## Description
- change VGMRgn::volume to m_attenDb, add set/add methods which accept either db or %amp values
- change VGMSamp::volume to m_attenDb, also with set methods for db or %amp.
- update SynthRgn to have an attenDb member
- add initialAttenuation generator to SF2 conversion. set SynthRgn::attenDb here rather than setting attenuation on the sample used by the region (multiple regions can use the same sample!)
- remove convertLogScaleValToAtten. replaces all usages with convertPercentAmplitudeToAttenDB
- Fix convertDBAttenuationToStdMidiVal();
- rename convert7bitPercentVolValToStdMidiVal to convert7bitPercentAmpValToStdMidiVal
- allow rgn->sampOffset to find a matching sample by simply comparing against a samples dwOffset rather than the dwOffset - the sampColl offset - the sample data offset.
- rewrite linearAmpDecayTimeToLinDBDecayTime. The new method uses two different algorithms, one for short decays and one for long

## Motivation and Context
These issues are being surfaced as I implement the Sega Saturn instrument format.

## How Has This Been Tested?
Breakpoints ensuring values are what they should be, and testing for deprecation by ear.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
