### PR TITLE
Fix region finetune application in SoundFont files

### DIFF
--- a/src/main/components/instr/VGMRgn.h
+++ b/src/main/components/instr/VGMRgn.h
@@ -62,7 +62,8 @@ class VGMRgn : public VGMItem {
   uint8_t velHigh;
 
   int8_t unityKey;
-  int16_t fineTune;
+  int16_t coarseTune;     // in semitones
+  int16_t fineTune;       // in cents
 
   Loop loop;
 

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -161,6 +161,7 @@ SynthFile* createSynthFile(
         SynthRgn *newRgn = newInstr->addRgn();
         newRgn->setRanges(rgn->keyLow, rgn->keyHigh, rgn->velLow, rgn->velHigh);
         newRgn->setWaveLinkInfo(0, 0, 1, static_cast<uint32_t>(realSampNum));
+        newRgn->setFineTune(rgn->coarseTune, rgn->fineTune);
         newRgn->setAttenuationDb(rgn->attenDb());
 
         if (realSampNum >= finalSamps.size()) {
@@ -210,10 +211,7 @@ SynthFile* createSynthFile(
           realUnityKey = 0x3C;
 
         short realFineTune;
-        if (rgn->fineTune == 0)
-          realFineTune = samp->fineTune;
-        else
-          realFineTune = rgn->fineTune;
+        realFineTune = samp->fineTune;
 
         sampInfo->setPitchInfo(realUnityKey, realFineTune, samp->attenDb());
 

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -221,7 +221,7 @@ SF2File::SF2File(SynthFile *synthfile)
     for (size_t j = 0; j < numRgns; j++) {
       sfInstBag instBag{};
       instBag.wInstGenNdx = instGenCounter;
-      instGenCounter += 13;
+      instGenCounter += 15;
       instBag.wInstModNdx = 0;
 
       memcpy(ibagCk->data + (rgnCounter++ * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
@@ -247,7 +247,7 @@ SF2File::SF2File(SynthFile *synthfile)
   // igen chunk
   //***********
   Chunk *igenCk = new Chunk("igen");
-  igenCk->setSize((numTotalRgns * sizeof(sfInstGenList) * 13) + sizeof(sfInstGenList));
+  igenCk->setSize((numTotalRgns * sizeof(sfInstGenList) * 15) + sizeof(sfInstGenList));
   igenCk->data = new uint8_t[igenCk->size()];
   dataPtr = 0;
   for (size_t i = 0; i < numInstrs; i++) {
@@ -296,6 +296,18 @@ SF2File::SF2File(SynthFile *synthfile)
       // overridingRootKey
       instGenList.sfGenOper = overridingRootKey;
       instGenList.genAmount.wAmount = rgn->sampinfo->usUnityNote;
+      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      dataPtr += sizeof(sfInstGenList);
+
+      // coarseTune
+      instGenList.sfGenOper = coarseTune;
+      instGenList.genAmount.shAmount = rgn->coarseTuneSemitones;
+      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      dataPtr += sizeof(sfInstGenList);
+
+      // fineTune
+      instGenList.sfGenOper = fineTune;
+      instGenList.genAmount.shAmount = rgn->fineTuneCents;
       memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -127,6 +127,11 @@ void SynthRgn::setWaveLinkInfo(uint16_t options, uint16_t phaseGroup, uint32_t t
   tableIndex = theTableIndex;
 }
 
+void SynthRgn::setFineTune(int16_t semitones, int16_t cents) {
+  coarseTuneSemitones = semitones;
+  fineTuneCents = cents;
+}
+
 void SynthRgn::setAttenuationDb(double attenuation) {
   attenDb = attenuation;
 }

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -90,6 +90,7 @@ class SynthRgn {
   SynthSampInfo *addSampInfo();
   void setRanges(uint16_t keyLow = 0, uint16_t keyHigh = 0x7F, uint16_t velLow = 0, uint16_t velHigh = 0x7F);
   void setWaveLinkInfo(uint16_t options, uint16_t phaseGroup, uint32_t theChannel, uint32_t theTableIndex);
+  void setFineTune(int16_t semitones, int16_t fineTune);
   void setAttenuationDb(double attenuation);
 
   uint16_t usKeyLow {0};
@@ -101,6 +102,9 @@ class SynthRgn {
   uint16_t usPhaseGroup {0};  // ''
   uint32_t channel {1};       // ''
   uint32_t tableIndex {0};
+
+  int16_t coarseTuneSemitones {0};
+  int16_t fineTuneCents {0};
 
   double attenDb {0};   // attenuation in decibels
 


### PR DESCRIPTION
When a finetune is assigned to a VGMRgn, we've been applying it to its associated sample instead of to the region in generated SF2 files. This fixes that, and also adds coarse tune.

## Motivation and Context
Multiple regions can be associated with the same sample, but use different finetunes. Moreover, a sample and regions using that sample can each have unique finetunes applied. The old logic broke under these scenarios.

## How Has This Been Tested?
Sequences with finetune are sounding correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
