### PR TITLE
Misc fixes for SF2/VGMSamp conversion

### DIFF
--- a/src/main/components/instr/VGMRgn.cpp
+++ b/src/main/components/instr/VGMRgn.cpp
@@ -140,6 +140,11 @@ void VGMRgn::addUnityKey(uint8_t uk, uint32_t offset, uint32_t length) {
   addChild(new VGMRgnItem(this, VGMRgnItem::RIT_UNITYKEY, offset, length, "Unity Key"));
 }
 
+void VGMRgn::addCoarseTune(int16_t relativeSemitones, uint32_t offset, uint32_t length) {
+  this->coarseTune = relativeSemitones;
+  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_FINETUNE, offset, length, "Coarse Tune"));
+}
+
 void VGMRgn::addFineTune(int16_t relativePitchCents, uint32_t offset, uint32_t length) {
   this->fineTune = relativePitchCents;
   addChild(new VGMRgnItem(this, VGMRgnItem::RIT_FINETUNE, offset, length, "Fine Tune"));

--- a/src/main/components/instr/VGMSamp.h
+++ b/src/main/components/instr/VGMSamp.h
@@ -42,6 +42,10 @@ public:
   inline void setAttenuation(double decibels) { m_attenDb = decibels;}
   inline bool reverse() { return m_reverse; }
   inline void setReverse(bool reverse) { m_reverse = reverse; }
+  inline Endianness endianness() const { return m_endianness; }
+  inline void setEndianness(Endianness e) { m_endianness = e; }
+  inline Signedness signedness() const { return m_signedness; }
+  inline void setSignedness(Signedness s) { m_signedness = s; }
 
   bool onSaveAsWav();
   bool saveAsWav(const std::string &filepath);
@@ -69,6 +73,9 @@ public:
 private:
   double m_attenDb {0};
   bool m_reverse = false;
+  Endianness m_endianness = Endianness::Little;
+  Signedness m_signedness = Signedness::Signed;
+
 };
 
 

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -193,7 +193,7 @@ void SynthSampInfo::setPitchInfo(uint16_t unityNote, short fineTune, double atte
 //  SynthWave
 //  *********
 
-void SynthWave::convertTo16bitSigned() {
+void SynthWave::convertTo16bit() {
   if (wBitsPerSample == 8) {
     this->wBitsPerSample = 16;
     this->wBlockAlign = 16 / 8 * this->wChannels;
@@ -201,7 +201,7 @@ void SynthWave::convertTo16bitSigned() {
 
     int16_t *newData = new int16_t[this->dataSize];
     for (unsigned int i = 0; i < this->dataSize; i++)
-      newData[i] = (static_cast<int16_t>(this->data[i]) - 128) << 8;
+      newData[i] = static_cast<int16_t>(this->data[i]) << 8;
     delete[] this->data;
     this->data = reinterpret_cast<uint8_t*>(newData);
     this->dataSize *= 2;

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -69,14 +69,14 @@ public:
   void setLoopInfo(Loop &loop, VGMSamp *samp);
   void setPitchInfo(uint16_t unityNote, int16_t fineTune, double attenuation);
 
-  uint16_t usUnityNote;
-  int16_t sFineTune;
-  double attenuation;  // in decibels.
-  int8_t cSampleLoops;
+  uint16_t usUnityNote{0x3C};
+  int16_t sFineTune{0};
+  double attenuation{0};  // in decibels.
+  int8_t cSampleLoops{0};
 
-  uint32_t ulLoopType;
-  uint32_t ulLoopStart;
-  uint32_t ulLoopLength;
+  uint32_t ulLoopType{0};
+  uint32_t ulLoopStart{0};
+  uint32_t ulLoopLength{0};
 };
 
 class SynthRgn {
@@ -153,7 +153,7 @@ class SynthWave {
 
   SynthSampInfo *addSampInfo();
 
-  void convertTo16bitSigned();
+  void convertTo16bit();
 
  public:
   SynthSampInfo *sampinfo;

--- a/src/main/util/common.h
+++ b/src/main/util/common.h
@@ -76,3 +76,6 @@ struct SizeOffsetPair {
 
   SizeOffsetPair(std::uint32_t offset_, std::uint32_t size_) : size(size_), offset(offset_) {}
 };
+
+enum class Endianness { Little, Big };
+enum class Signedness { Signed, Unsigned };


### PR DESCRIPTION
- VGMSamp: samples now have endianness and signedness, default to little endian signed.
- VGMSamp: convertToStdWave() now consistently converts big endian samples to little endian and unsigned to signed.
- SF2File: remove redundant initialAttenuation generator
- SF2File: clamp initialAttenuation value to valid range
- SynthFile: rename convertTo16bitSigned() -> convertTo16Bit() and remove signed conversion logic here. Samples come in signed now
- SynthFile: add default values for members
- VGMRgn: add addCoarseTune()

## Motivation and Context
These fixes came up while working on Saturn instrument conversion. The expected format of samples for VGMSamp is confusing. Adding setEndianness() and setSignedness() makes things clearer.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
