### PR TITLE
Interface ConversionOptions with Settings

### DIFF
--- a/src/ui/qt/MenuBar.cpp
+++ b/src/ui/qt/MenuBar.cpp
@@ -1,5 +1,5 @@
 /*
- * VGMTrans (c) 2002-2019
+ * VGMTrans (c) 2002-2025
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
  */
@@ -11,6 +11,7 @@
 #include "Options.h"
 #include "Root.h"
 #include "LogManager.h"
+#include "services/Settings.h"
 
 MenuBar::MenuBar(QWidget *parent, const QList<QDockWidget *> &dockWidgets) : QMenuBar(parent) {
   appendFileMenu();
@@ -35,20 +36,23 @@ void MenuBar::appendOptionsMenu(const QList<QDockWidget *> &dockWidgets) {
   QMenu *options_dropdown = addMenu("Options");
   auto bs = options_dropdown->addMenu("Bank select style");
 
+  auto bankSelectStyle = Settings::the()->conversion.bankSelectStyle();
+
   QActionGroup *bs_grp = new QActionGroup(this);
   auto act = bs->addAction("GS (Default)");
   act->setCheckable(true);
-  act->setChecked(true);
+  act->setChecked(bankSelectStyle == BankSelectStyle::GS);
   bs_grp->addAction(act);
   act = bs->addAction("MMA");
   act->setCheckable(true);
+  act->setChecked(bankSelectStyle == BankSelectStyle::MMA);
   bs_grp->addAction(act);
 
   connect(bs_grp, &QActionGroup::triggered, [](const QAction *bs_style) {
     if (auto text = bs_style->text(); text == "GS (Default)") {
-      ConversionOptions::the().setBankSelectStyle(BankSelectStyle::GS);
+      Settings::the()->conversion.setBankSelectStyle(BankSelectStyle::GS);
     } else if (text == "MMA") {
-      ConversionOptions::the().setBankSelectStyle(BankSelectStyle::MMA);
+      Settings::the()->conversion.setBankSelectStyle(BankSelectStyle::MMA);
       L_WARN("MMA style (CC0 * 128 + CC32) bank select was chosen and "
              "it will be used for bank select events in generated MIDIs. This "
              "will cause in-program playback to sound incorrect!");

--- a/src/ui/qt/services/Settings.cpp
+++ b/src/ui/qt/services/Settings.cpp
@@ -1,5 +1,5 @@
 /*
-* VGMTrans (c) 2002-2024
+* VGMTrans (c) 2002-2025
 * Licensed under the zlib license,
 * refer to the included LICENSE.txt file
  */
@@ -10,9 +10,13 @@
 SettingsGroup::SettingsGroup(Settings* parent) : parent(parent), settings(parent->settings) {
 }
 
-Settings::Settings(QObject *parent) :
-      VGMFileTreeView(this)
-{}
+Settings::Settings(QObject *parent)
+  : QObject(parent),
+    VGMFileTreeView(this),
+    conversion(this)
+{
+  conversion.loadIntoOptionsStore();
+}
 
 void Settings::VGMFileTreeViewSettings::setShowDetails(bool showDetails) const {
   settings.beginGroup("VGMFileTreeView");
@@ -27,4 +31,26 @@ bool Settings::VGMFileTreeViewSettings::showDetails() const {
   settings.endGroup();
 
   return showDetails;
+}
+
+/// Put settings into an OptionStore and have ConversionOptions load from it
+void Settings::ConversionSettings::loadIntoOptionsStore() const {
+  QtOptionsStore store(settings);
+  ConversionOptions::the().load(store);
+}
+
+/// Put settings into an OptionStore and have ConversionOptions save into it
+void Settings::ConversionSettings::saveFromOptionsStore() const {
+  QtOptionsStore store(settings);
+  ConversionOptions::the().save(store);
+}
+
+void Settings::ConversionSettings::setBankSelectStyle(BankSelectStyle s) const {
+  ConversionOptions::the().setBankSelectStyle(s);
+  saveFromOptionsStore();
+}
+
+void Settings::ConversionSettings::setNumSequenceLoops(int n) const {
+  ConversionOptions::the().setNumSequenceLoops(n);
+  saveFromOptionsStore();
 }


### PR DESCRIPTION
We have two classes for storing options:
- the main code has a `ConversionOptions` class
- the qt code has a `Settings` class, which stores UI-specific options

`Settings` uses `QSettings`, which persists to disk. `ConversionOptions` does not persist.

This PR makes `Settings` a superset of the `ConversionOptions` class while preserving the UI-agnosticism of the main codebase. This allows us to centralize all user-configurable options into the `Settings` class and persist `ConversionOptions`.

We achieve this by making a simple key-value interface - `OptionStore` which `ConversionOptions` can load from and save into. On the Qt side, we implement a `QtOptionStore` which wraps a `QSettings` object. We wrap the various ConversionOptions into Settings and save/load the QtOptionStore when they are set to update the ConversionOptions singleton.

I envision we may expand the main codebase options down the road and change `ConversionOptions` into `Options` with different subset groups of options. Hence why I think it's reasonable to keep `beginGroup()` in OptionStore.
 
## Description

Breakdown of changes: 
- add OptionStore key-value interface
- add ConversionOptions::load() / save() to interface with OptionStore
- add QtOptionStore adaptor that wraps QSettings
- add Settings::ConversionSettings to wrap ConversionOptions
- update MenuBar to use Settings for bank select style

## Motivation and Context
As more options are added into the app, we want to ensure they are persisted consistently.

## How Has This Been Tested?
Verified that Bank Select Style is persisting.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
