### PR TITLE
update LICENSE formatting for github detection of zlib

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-VGMTrans Copyright (c) 2002-2025 The VGMTrans Team
+Copyright (c) 2002-2025 The VGMTrans Team
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages


### PR DESCRIPTION
Per the [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#detecting-a-license), github uses the [licensee](https://github.com/licensee/licensee) ruby script.

I removed a word in the copyright header and verified the license is now detected properly with licensee.

