### PR TITLE
Add "Skip MIDI Channel 10" conversion option

### DIFF
--- a/src/main/Options.h
+++ b/src/main/Options.h
@@ -20,6 +20,8 @@ struct OptionStore {
 
   virtual int getInt(std::string_view key, int def) const = 0;
   virtual void setInt(std::string_view key, int value) = 0;
+  virtual int getBool(std::string_view key, bool def) const = 0;
+  virtual void setBool(std::string_view key, bool value) = 0;
 };
 
 enum class BankSelectStyle {
@@ -49,18 +51,23 @@ public:
   int numSequenceLoops() const { return m_sequence_loops; }
   void setNumSequenceLoops(int numLoops) { m_sequence_loops = numLoops; }
 
+  bool skipChannel10() const { return m_skip_channel_10; }
+  void setSkipChannel10(bool should) { m_skip_channel_10 = should; }
+
   void load(OptionStore& store) {
     auto g = store.beginGroup("ConversionOptions");
     const int bs = store.getInt("bankSelectStyle", static_cast<int>(BankSelectStyle::GS));
     m_bs_style = (bs == static_cast<int>(BankSelectStyle::MMA)) ? BankSelectStyle::MMA
                                                                 : BankSelectStyle::GS;
     m_sequence_loops = store.getInt("sequenceLoops", 1);
+    m_skip_channel_10 = store.getBool("skipChannel10", true);
   }
 
   void save(OptionStore& store) const {
     auto g = store.beginGroup("ConversionOptions");
     store.setInt("bankSelectStyle", static_cast<int>(m_bs_style));
     store.setInt("sequenceLoops",   m_sequence_loops);
+    store.setBool("skipChannel10", m_skip_channel_10);
   }
 
 private:
@@ -68,4 +75,5 @@ private:
 
   BankSelectStyle m_bs_style{BankSelectStyle::GS};
   int m_sequence_loops{1};
+  bool m_skip_channel_10{true};
 };

--- a/src/main/components/seq/VGMSeqNoTrks.h
+++ b/src/main/components/seq/VGMSeqNoTrks.h
@@ -43,7 +43,7 @@ public:
   void setTime(uint32_t newTime) override;
   void addTime(uint32_t delta) override;
 
-  void setCurTrack(uint32_t trackNum);
+  void setChannel(u8 newChannel);
   void tryExpandMidiTracks(uint32_t numTracks);
 
   bool loadMain() override;  // Function to load all the information about the sequence
@@ -54,6 +54,8 @@ public:
   uint32_t dwEventsOffset;
 
 protected:
+  void setCurTrack(uint32_t trackNum);
+
   // an array of midi tracks... we will change pMidiTrack, which all the SeqTrack functions write
   // to, to the corresponding MidiTrack in this vector before we write every event
   std::vector<MidiTrack *> midiTracks;

--- a/src/main/formats/HeartBeatPS1/HeartBeatPS1Seq.cpp
+++ b/src/main/formats/HeartBeatPS1/HeartBeatPS1Seq.cpp
@@ -145,8 +145,7 @@ bool HeartBeatPS1Seq::readEvent() {
   else
     runningStatus = status_byte;
 
-  channel = status_byte & 0x0F;
-  setCurTrack(channel);
+  setChannel(status_byte & 0x0F);
 
   switch (status_byte & 0xF0) {
     //note off

--- a/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
@@ -130,8 +130,7 @@ bool NamcoSnesSeq::readEvent() {
   }
 
   // default first track
-  channel = 0;
-  setCurTrack(channel);
+  setChannel(0);
 
   switch (eventType) {
     case EVENT_UNKNOWN0:
@@ -363,8 +362,7 @@ bool NamcoSnesSeq::readEvent() {
           }
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            channel = trackIndex;
-            setCurTrack(channel);
+            setChannel(trackIndex);
 
             // key off previous note
             if (prevNoteKey[trackIndex] != -1) {
@@ -492,8 +490,7 @@ bool NamcoSnesSeq::readEvent() {
           desc += fmt::format(" [{:d}] {:d}", trackIndex + 1, newValue);
 
           if (VGMSeq::readMode == READMODE_CONVERT_TO_MIDI) {
-            channel = trackIndex;
-            setCurTrack(channel);
+            setChannel(trackIndex);
 
             switch (controlType) {
               case CONTROL_PROGCHANGE:
@@ -577,8 +574,7 @@ bool NamcoSnesSeq::postLoad() {
 void NamcoSnesSeq::keyOffAllNotes() {
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     if (prevNoteKey[trackIndex] != -1) {
-      channel = trackIndex;
-      setCurTrack(channel);
+      setChannel(trackIndex);
 
       addNoteOffNoItem(prevNoteKey[trackIndex]);
       prevNoteKey[trackIndex] = -1;

--- a/src/main/formats/PS1/PS1Seq.cpp
+++ b/src/main/formats/PS1/PS1Seq.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "PS1Seq.h"
+#include "Options.h"
 #include "formats/PS1/PS1Format.h"
 
 DECLARE_FORMAT(PS1)
@@ -127,9 +128,7 @@ bool PS1Seq::readEvent() {
   else
     m_runningStatus = status_byte;
 
-
-  channel = status_byte & 0x0F;
-  setCurTrack(channel);
+  setChannel(status_byte & 0x0F);
 
   switch (status_byte & 0xF0) {
     //note event

--- a/src/main/formats/SegSat/SegSatSeq.cpp
+++ b/src/main/formats/SegSat/SegSatSeq.cpp
@@ -61,13 +61,12 @@ bool SegSatSeq::readEvent() {
 
   if (status_byte <= 0x7F)            // note on
   {
-    channel = status_byte & 0x0F;
+    setChannel(status_byte & 0x0F);
     u16 durBit8 = (status_byte & 0x40) << 2;
     u16 deltaBit8 = (status_byte & 0x20) << 3;
     if ((status_byte & 0x10) > 0) {
       L_DEBUG("found 0x10 bit on for note on status byte {:x}", beginOffset);
     }
-    setCurTrack(channel);
     auto key = readByte(curOffset++);
     auto vel = readByte(curOffset++);
     u16 noteDuration = readByte(curOffset++) | durBit8;
@@ -80,8 +79,7 @@ bool SegSatSeq::readEvent() {
   else {
     if ((status_byte & 0xF0) == Midi::CONTROL_CHANGE) {
       // BX are midi controller events
-      channel = status_byte & 0x0F;
-      setCurTrack(channel);
+      setChannel(status_byte & 0x0F);
       u8 controllerType = readByte(curOffset++);
       u8 controllerValue = readByte(curOffset++);
       u8 deltaTime = readByte(curOffset++);
@@ -116,15 +114,13 @@ bool SegSatSeq::readEvent() {
       }
     }
     else if ((status_byte & 0xF0) == 0xC0) {
-      channel = status_byte & 0x0F;
-      setCurTrack(channel);
+      setChannel(status_byte & 0x0F);
       u8 progNum = readByte(curOffset++);
       addTime(readByte(curOffset++));
       addProgramChange(beginOffset, curOffset - beginOffset, progNum);
     }
     else if ((status_byte & 0xF0) == 0xE0) {
-      channel = status_byte & 0x0F;
-      setCurTrack(channel);
+      setChannel(status_byte & 0x0F);
       s16 bend = (static_cast<s32>(readByte(curOffset++)) << 7) - 8192;
       addTime(readByte(curOffset++));
       addPitchBend(beginOffset, curOffset - beginOffset, bend);

--- a/src/main/formats/SonyPS2/SonyPS2Seq.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Seq.cpp
@@ -48,8 +48,7 @@ bool SonyPS2Seq::parseHeader() {
   }
 
   nNumTracks = 16;
-  channel = 0;
-  setCurTrack(channel);
+  setChannel(0);
   return true;
 }
 
@@ -83,8 +82,7 @@ bool SonyPS2Seq::readEvent(void) {
     runningStatus = status_byte;
 
 
-  channel = status_byte & 0x0F;
-  setCurTrack(channel);
+  setChannel(status_byte & 0x0F);
 
   switch (status_byte & 0xF0) {
     //note off event. Unlike SMF, there is no velocity data byte, just the note val.

--- a/src/ui/qt/MenuBar.cpp
+++ b/src/ui/qt/MenuBar.cpp
@@ -59,6 +59,16 @@ void MenuBar::appendOptionsMenu(const QList<QDockWidget *> &dockWidgets) {
     }
   });
 
+  act = options_dropdown->addAction("Skip MIDI channel 10");
+  act->setCheckable(true);
+  act->setChecked(Settings::the()->conversion.skipChannel10());
+  connect(act, &QAction::toggled,
+[](bool skip) {
+  if (!skip)
+    pRoot->UI_toast("Tracks using MIDI channel 10 will be silent during in-app playback.", ToastType::Info);
+  Settings::the()->conversion.setSkipChannel10(skip);
+});
+
   options_dropdown->addSeparator();
 
   for (auto &widget : dockWidgets) {

--- a/src/ui/qt/services/Settings.cpp
+++ b/src/ui/qt/services/Settings.cpp
@@ -54,3 +54,9 @@ void Settings::ConversionSettings::setNumSequenceLoops(int n) const {
   ConversionOptions::the().setNumSequenceLoops(n);
   saveFromOptionsStore();
 }
+
+void Settings::ConversionSettings::setSkipChannel10(bool skip) const {
+  ConversionOptions::the().setSkipChannel10(skip);
+  saveFromOptionsStore();
+}
+

--- a/src/ui/qt/services/Settings.h
+++ b/src/ui/qt/services/Settings.h
@@ -34,6 +34,14 @@ public:
     m_settings.setValue(QString::fromUtf8(key.data(), int(key.size())), value);
   }
 
+  int getBool(std::string_view key, bool def) const override {
+    return m_settings.value(QString::fromUtf8(key.data(), int(key.size())), def).toBool();
+  }
+
+  void setBool(std::string_view key, bool value) override {
+    m_settings.setValue(QString::fromUtf8(key.data(), int(key.size())), value);
+  }
+
 private:
   QSettings& m_settings;
 };
@@ -83,6 +91,11 @@ public:
       return ConversionOptions::the().numSequenceLoops();
     }
     void setNumSequenceLoops(int n) const;
+
+    bool skipChannel10() const {
+      return ConversionOptions::the().skipChannel10();
+    }
+    void setSkipChannel10(bool skip) const;
   };
   ConversionSettings conversion;
 


### PR DESCRIPTION
This adds an option to for skipping MIDI channel 9 (10 in base 1) during conversion. Our code is inconsistent about skipping channel 9, with trackless formats (VGMSeqNoTrks) using channel 9, and regular VGMSeq skipping it. This PR gives more control to the user and clarifies behavior.

_(Side note: VGMMultiSectionSeq also uses channel 9, but that subclass is only utilized by NinSnesSeq, which uses only 8 tracks. NinSnesSeq uses channel 9 for percussion note events, which are seemingly broken independent of this change. I will look into fixing that soon)._

Skipping channel 9 is potentially useful because the channel is reserved by MIDI, SoundFont and DLS for drumkits, some DAWs (and FluidSynth / libbass) will not allow melodic instrument playback by default on the channel. We currently don't mark instruments as drumkits during conversion, because most formats don't make the distinction, and SoundFont / DLS define slightly different playback behavior on the channel.

## Description
Breakdown of changes:
- Options: add m_skip_channel_10 to ConversionOptions
- MenuBar: add "Skip MIDI Channel 10" to Options menu and show toast warning of silent tracks when disabled
- VGMSeqNoTrks: update `tryExpandMidiTrack()` to handle skipping channel 10
- VGMSeqNoTrks: add `setChannel()` method to obviate setting the MIDI track and handle the skip-MIDI-ch-10 option
- update VGMSeqNoTrks formats to utilize `VGMSeqNoTrks::setChannel()`
- SeqTrack: rewrite `setChannelAndGroupFromTrkNum()` with cleaner code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
