### PR TITLE
Provide collection context for sequence conversion

### DIFF
--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -69,12 +69,14 @@ bool VGMSeq::load() {
   return true;
 }
 
-MidiFile *VGMSeq::convertToMidi() {
+MidiFile *VGMSeq::convertToMidi(const VGMColl* coll) {
   size_t numTracks = aTracks.size();
 
   if (!loadTracks(READMODE_FIND_DELTA_LENGTH)) {
       return nullptr;
   }
+
+  useColl(coll);
 
   // Find the greatest length of all tracks to use as stop point for every track
   long stopTime = 0;
@@ -313,8 +315,8 @@ void VGMSeq::addInstrumentRef(uint32_t progNum) {
   }
 }
 
-bool VGMSeq::saveAsMidi(const std::string &filepath) {
-  MidiFile *midi = this->convertToMidi();
+bool VGMSeq::saveAsMidi(const std::string &filepath, const VGMColl* coll) {
+  MidiFile *midi = this->convertToMidi(coll);
   if (!midi)
     return false;
   bool result = midi->saveMidiFile(filepath);

--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -37,7 +37,8 @@ class VGMSeq : public VGMFile {
   virtual bool parseHeader();
   virtual bool parseTrackPointers();  // Function to find all of the track pointers.   Returns number of total tracks.
   virtual void resetVars();
-  virtual MidiFile *convertToMidi();
+  virtual void useColl(const VGMColl* coll) {}
+  virtual MidiFile *convertToMidi(const VGMColl* coll = nullptr);
   virtual MidiTrack *firstMidiTrack();
   void setPPQN(uint16_t ppqn);
   [[nodiscard]] uint16_t ppqn() const;
@@ -92,7 +93,7 @@ class VGMSeq : public VGMFile {
   [[nodiscard]] bool allowDiscontinuousTrackData() const { return m_allow_discontinuous_track_data; }
   void setAllowDiscontinuousTrackData(bool allow) { m_allow_discontinuous_track_data = allow; }
 
-  bool saveAsMidi(const std::string &filepath);
+  bool saveAsMidi(const std::string &filepath, const VGMColl* coll = nullptr);
 
   void deactivateAllTracks();
 

--- a/src/main/components/seq/VGMSeqNoTrks.cpp
+++ b/src/main/components/seq/VGMSeqNoTrks.cpp
@@ -86,8 +86,10 @@ bool VGMSeqNoTrks::loadEvents(long stopTime) {
   return true;
 }
 
-MidiFile *VGMSeqNoTrks::convertToMidi() {
+MidiFile *VGMSeqNoTrks::convertToMidi(const VGMColl* coll) {
   this->SeqTrack::readMode = this->VGMSeq::readMode = READMODE_FIND_DELTA_LENGTH;
+
+  useColl(coll);
 
   if (!loadEvents())
     return nullptr;

--- a/src/main/components/seq/VGMSeqNoTrks.h
+++ b/src/main/components/seq/VGMSeqNoTrks.h
@@ -48,7 +48,7 @@ public:
 
   bool loadMain() override;  // Function to load all the information about the sequence
   virtual bool loadEvents(long stopTime = 1000000);
-  MidiFile *convertToMidi() override;
+  MidiFile *convertToMidi(const VGMColl* coll) override;
   MidiTrack *firstMidiTrack() override;
 
   uint32_t dwEventsOffset;

--- a/src/main/conversion/VGMExport.h
+++ b/src/main/conversion/VGMExport.h
@@ -39,12 +39,12 @@ bool saveAsOriginal(const VGMFile& file, const std::string& filepath);
 bool saveAsOriginal(const RawFile& rawfile, const std::string& filepath);
 
 template <Target options>
-void saveAs(VGMColl &coll, const std::string &dir_path) {
+void saveAs(const VGMColl &coll, const std::string &dir_path) {
   auto filename = ConvertToSafeFileName(coll.name());
   auto filepath = dir_path + "/" + filename;
 
   if constexpr ((options & Target::MIDI) != 0) {
-    coll.seq()->saveAsMidi(filepath + ".mid");
+    coll.seq()->saveAsMidi(filepath + ".mid", &coll);
   }
 
   if constexpr ((options & Target::DLS) != 0) {

--- a/src/main/formats/Format.h
+++ b/src/main/formats/Format.h
@@ -43,6 +43,9 @@ class VGMScanner;
 #define USING_COLL(coll) \
   virtual VGMColl* newCollection() { return new coll(); }
 
+#define USES_COLLECTION_FOR_SEQ_CONVERSION() \
+  bool usesCollectionDataForSeqConversion() override { return true; }
+
 class Format;
 class VGMFile;
 class VGMSeq;
@@ -69,6 +72,7 @@ public:
   virtual bool onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file);
   virtual bool onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file);
   virtual bool onMatch(std::vector<VGMFile *> &) { return true; }
+  virtual bool usesCollectionDataForSeqConversion() { return false; }
 
   Matcher *matcher;
   VGMScanner *scanner;

--- a/src/ui/cli/CLIVGMRoot.cpp
+++ b/src/ui/cli/CLIVGMRoot.cpp
@@ -160,7 +160,7 @@ bool CLIVGMRoot::saveMidi(const VGMColl* coll) {
   if (coll->seq() != nullptr) {
     string collName = coll->name();
     string filepath = UI_getSaveFilePath(collName, "mid");
-    if (!coll->seq()->saveAsMidi(filepath)) {
+    if (!coll->seq()->saveAsMidi(filepath, coll)) {
       L_ERROR("Failed to save MIDI file");
       return false;
     }

--- a/src/ui/qt/SequencePlayer.cpp
+++ b/src/ui/qt/SequencePlayer.cpp
@@ -183,7 +183,7 @@ bool SequencePlayer::playCollection(const VGMColl *coll) {
     return false;
   }
 
-  MidiFile *midi = seq->convertToMidi();
+  MidiFile *midi = seq->convertToMidi(coll);
   std::vector<uint8_t> raw_midi;
   midi->writeMidiToBuffer(raw_midi);
   /* Set up the MIDI stream */

--- a/src/ui/qt/services/commands/SaveCommands.h
+++ b/src/ui/qt/services/commands/SaveCommands.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "Format.h"
 #include "services/MenuManager.h"
 #include "VGMSeq.h"
 #include "VGMInstrSet.h"
@@ -161,7 +162,26 @@ public:
   SaveAsMidiCommand() : SaveCommand<VGMSeq, VGMFile>(false) {}
 
   void save(const std::string& path, VGMSeq* seq) const override {
-    seq->saveAsMidi(path);
+    int numAssocColls = seq->assocColls.size();
+    if (numAssocColls > 0) {
+      if (numAssocColls > 1 && seq->format()->usesCollectionDataForSeqConversion()) {
+        pRoot->UI_toast("This sequence format uses collection data as context for "
+          "conversion, however, more than one collection is associated with the sequence. The first "
+          "associated collection was used.\n\nYou can resolve this by selecting a conversion action "
+          "on a collection directly.",
+          ToastType::Info, 15000);
+      }
+      seq->saveAsMidi(path, seq->assocColls[0]);
+    } else {
+      if (seq->format()->usesCollectionDataForSeqConversion()) {
+        pRoot->UI_toast("This sequence format uses collection data as context for "
+          "conversion, however, there is currently no collection containing the sequence. Conversion "
+          "results may improve if the sequence is first grouped into a collection with an "
+          "associated instrument set.",
+          ToastType::Info, 15000);
+      }
+      seq->saveAsMidi(path);
+    }
   }
   [[nodiscard]] std::string name() const override { return "Save as MIDI"; }
   [[nodiscard]] std::string extension() const override { return "mid"; }


### PR DESCRIPTION
This adds the `VGMSeq::useColl()` method, which is called before conversion and can be overridden to give sequences access to collection data. 

This also adds an effective flag on `Format` to indicate that the format uses collection data for sequence data. This flag is checked to display warning toasts when a user converts a sequence with no collection data, or when it's unclear which collection to use.

## Motivation and Context
Some sequence formats require instrument set data for accurate conversion. For example, the Sega Saturn sequence format uses instrument set data for determining velocity values, pitch bend ranges, and portamento timing. The standard SDK PS1 sequence format also requires instrument data, which we haven't utilized yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
