### PR TITLE
AkaoInstr: fix skipping instruments when zeroed instr pointers exist

### DIFF
--- a/src/main/formats/Akao/AkaoInstr.cpp
+++ b/src/main/formats/Akao/AkaoInstr.cpp
@@ -70,11 +70,13 @@ AkaoInstrSet::AkaoInstrSet(RawFile *file, uint32_t offset,
 bool AkaoInstrSet::parseInstrPointers() {
   if (bMelInstrs) {
     VGMHeader *SSEQHdr = addHeader(instrSetOff, 0x10, "Instr Ptr Table");
-    int i = 0;
-    //-1 aka 0xFFFF if signed or 0 and past the first pointer value
-    for (int j = instrSetOff; (readShort(j) != static_cast<uint16_t>(-1)) && ((readShort(j) != 0) || i == 0) && i < 16; j += 2) {
-      SSEQHdr->addChild(j, 2, "Instr Pointer");
-      aInstrs.push_back(new AkaoInstr(this, instrSetOff + 0x20 + readShort(j), 0, 1, i++));
+    for (int i = 0; i < 16; ++i) {
+      u32 ptrOff = instrSetOff + (i * 2);
+      u16 instrPtr = readShort(ptrOff);
+      if (instrPtr == 0xFFFF || (instrPtr == 0 && i != 0))
+        continue;
+      SSEQHdr->addChild(ptrOff, 2, "Instr Pointer");
+      aInstrs.push_back(new AkaoInstr(this, instrSetOff + 0x20 + instrPtr, 0, 1, i));
     }
   }
   else if (!custom_instrument_addresses.empty()) {


### PR DESCRIPTION
Cleaned up the loop that parses instrument pointers in `AkaoInstrSet::parseInstrPointers()`. 

`continue` on invalid pointers rather than break. Fixes #618 

## How Has This Been Tested?
Other Akao sets are loading fine with the change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
