### PR TITLE
Fix mp2k sample unsigning

### DIFF
--- a/src/main/formats/MP2k/MP2kInstrSet.cpp
+++ b/src/main/formats/MP2k/MP2kInstrSet.cpp
@@ -353,9 +353,6 @@ void MP2kSamp::convertToStdWave(u8 *buf) {
   switch (m_type) {
     case MP2kWaveType::PCM8: {
       readBytes(dataOff, dataLength, buf);
-      for (unsigned int i = 0; i < dataLength; i++) {
-        buf[i] ^= 0x80;
-      }
       break;
     }
 


### PR DESCRIPTION
This probably broke as a result of my changes to VGMSamp.

I was unable to test BDPCM conversion because I couldn't find an example that uses it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
