### PR TITLE
Minimum sequence size option

### DIFF
--- a/src/main/Options.h
+++ b/src/main/Options.h
@@ -54,6 +54,9 @@ public:
   bool skipChannel10() const { return m_skip_channel_10; }
   void setSkipChannel10(bool should) { m_skip_channel_10 = should; }
 
+  int minSequenceSize() const { return m_min_sequence_size; }
+  void setMinSequenceSize(int size) { m_min_sequence_size = size; }
+
   void load(OptionStore& store) {
     auto g = store.beginGroup("ConversionOptions");
     const int bs = store.getInt("bankSelectStyle", static_cast<int>(BankSelectStyle::GS));
@@ -61,6 +64,7 @@ public:
                                                                 : BankSelectStyle::GS;
     m_sequence_loops = store.getInt("sequenceLoops", 1);
     m_skip_channel_10 = store.getBool("skipChannel10", true);
+    m_min_sequence_size = store.getInt("minSequenceSize", 0);
   }
 
   void save(OptionStore& store) const {
@@ -68,6 +72,7 @@ public:
     store.setInt("bankSelectStyle", static_cast<int>(m_bs_style));
     store.setInt("sequenceLoops",   m_sequence_loops);
     store.setBool("skipChannel10", m_skip_channel_10);
+    store.setInt("minSequenceSize", m_min_sequence_size);
   }
 
 private:
@@ -76,4 +81,5 @@ private:
   BankSelectStyle m_bs_style{BankSelectStyle::GS};
   int m_sequence_loops{1};
   bool m_skip_channel_10{true};
+  int m_min_sequence_size{0};
 };

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -47,26 +47,27 @@ VGMSeq::~VGMSeq() {
 }
 
 bool VGMSeq::loadVGMFile() {
-  bool val = load();
-  if (!val) {
+  if (!load()) {
     return false;
   }
+
+  if (unLength < ConversionOptions::the().minSequenceSize()) {
+    return false;
+  }
+
+  rawFile()->addContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
+    VGMMiscFile *>>(this));
+  pRoot->addVGMFile(this);
 
   if (auto fmt = format(); fmt) {
     fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
   }
 
-  return val;
+  return true;
 }
 
 bool VGMSeq::load() {
-  if (!loadMain())
-    return false;
-
-  rawFile()->addContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
-    VGMMiscFile *>>(this));
-  pRoot->addVGMFile(this);
-  return true;
+  return loadMain();
 }
 
 MidiFile *VGMSeq::convertToMidi(const VGMColl* coll) {

--- a/src/ui/qt/MenuBar.cpp
+++ b/src/ui/qt/MenuBar.cpp
@@ -8,6 +8,7 @@
 
 #include <QActionGroup>
 #include <QDockWidget>
+#include <vector>
 #include "Options.h"
 #include "Root.h"
 #include "LogManager.h"
@@ -16,6 +17,7 @@
 MenuBar::MenuBar(QWidget *parent, const QList<QDockWidget *> &dockWidgets) : QMenuBar(parent) {
   appendFileMenu();
   appendConversionMenu();
+  appendDetectionMenu();
   appendWindowsMenu(dockWidgets);
   appendInfoMenu();
 }
@@ -71,6 +73,29 @@ void MenuBar::appendConversionMenu() {
   });
 
   options_dropdown->addSeparator();
+}
+
+void MenuBar::appendDetectionMenu() {
+  QMenu *options_dropdown = addMenu("Detection");
+  auto minSizeMenu = options_dropdown->addMenu("Minimum sequence size");
+
+  const int currentSize = Settings::the()->detection.minSequenceSize();
+
+  QActionGroup *sizeGroup = new QActionGroup(this);
+  const std::vector<int> sizes = {0, 0x80, 0x100, 0x200, 0x500, 0x1000};
+  for (int size : sizes) {
+    QString text = size == 0 ? QString("No minimum") :
+                               QString("0x%1 Bytes").arg(size, 0, 16);
+    QAction *act = minSizeMenu->addAction(text);
+    act->setCheckable(true);
+    act->setChecked(currentSize == size);
+    act->setData(size);
+    sizeGroup->addAction(act);
+  }
+
+  connect(sizeGroup, &QActionGroup::triggered, [](const QAction *action) {
+    Settings::the()->detection.setMinSequenceSize(action->data().toInt());
+  });
 }
 
 void MenuBar::appendWindowsMenu(const QList<QDockWidget *> &dockWidgets) {

--- a/src/ui/qt/MenuBar.cpp
+++ b/src/ui/qt/MenuBar.cpp
@@ -16,8 +16,8 @@
 
 MenuBar::MenuBar(QWidget *parent, const QList<QDockWidget *> &dockWidgets) : QMenuBar(parent) {
   appendFileMenu();
-  appendConversionMenu();
   appendDetectionMenu();
+  appendConversionMenu();
   appendWindowsMenu(dockWidgets);
   appendInfoMenu();
 }
@@ -85,7 +85,7 @@ void MenuBar::appendDetectionMenu() {
   const std::vector<int> sizes = {0, 0x80, 0x100, 0x200, 0x500, 0x1000};
   for (int size : sizes) {
     QString text = size == 0 ? QString("No minimum") :
-                               QString("0x%1 Bytes").arg(size, 0, 16);
+                               QString("0x%1 bytes").arg(size, 0, 16);
     QAction *act = minSizeMenu->addAction(text);
     act->setCheckable(true);
     act->setChecked(currentSize == size);

--- a/src/ui/qt/MenuBar.h
+++ b/src/ui/qt/MenuBar.h
@@ -25,6 +25,7 @@ signals:
 private:
   void appendFileMenu();
   void appendConversionMenu();
+  void appendDetectionMenu();
   void appendWindowsMenu(const QList<QDockWidget *> &dockWidgets);
   void appendInfoMenu();
 

--- a/src/ui/qt/services/Settings.cpp
+++ b/src/ui/qt/services/Settings.cpp
@@ -13,9 +13,11 @@ SettingsGroup::SettingsGroup(Settings* parent) : parent(parent), settings(parent
 Settings::Settings(QObject *parent)
   : QObject(parent),
     VGMFileTreeView(this),
-    conversion(this)
+    conversion(this),
+    detection(this)
 {
   conversion.loadIntoOptionsStore();
+  detection.loadIntoOptionsStore();
 }
 
 void Settings::VGMFileTreeViewSettings::setShowDetails(bool showDetails) const {
@@ -57,6 +59,23 @@ void Settings::ConversionSettings::setNumSequenceLoops(int n) const {
 
 void Settings::ConversionSettings::setSkipChannel10(bool skip) const {
   ConversionOptions::the().setSkipChannel10(skip);
+  saveFromOptionsStore();
+}
+
+/// Put settings into an OptionStore and have ConversionOptions load from it
+void Settings::DetectionSettings::loadIntoOptionsStore() const {
+  QtOptionsStore store(settings);
+  ConversionOptions::the().load(store);
+}
+
+/// Put settings into an OptionStore and have ConversionOptions save into it
+void Settings::DetectionSettings::saveFromOptionsStore() const {
+  QtOptionsStore store(settings);
+  ConversionOptions::the().save(store);
+}
+
+void Settings::DetectionSettings::setMinSequenceSize(int size) const {
+  ConversionOptions::the().setMinSequenceSize(size);
   saveFromOptionsStore();
 }
 

--- a/src/ui/qt/services/Settings.h
+++ b/src/ui/qt/services/Settings.h
@@ -99,6 +99,17 @@ public:
   };
   ConversionSettings conversion;
 
+  struct DetectionSettings : public SettingsGroup {
+    using SettingsGroup::SettingsGroup;
+
+    void loadIntoOptionsStore() const;
+    void saveFromOptionsStore() const;
+
+    int minSequenceSize() const { return ConversionOptions::the().minSequenceSize(); }
+    void setMinSequenceSize(int size) const;
+  };
+  DetectionSettings detection;
+
 private:
   explicit Settings(QObject *parent = nullptr);
   QSettings settings;


### PR DESCRIPTION
This adds a menu option to filter out sequences beneath a size threshold. This is useful for Sega Saturn and CPS titles, where sequences are often loaded via tables that contain sound effect sequences. It's also generally useful for *sf formats, which sometimes contain leftover sfx sequences in ram.

I'm still trying to figure out how best to frame these options in the UI. Do we have separate menus for conversion options vs scanning / loading options? The proposed change in this PR is a new "Detection" menu. I guess we can iterate on it as more options are added.

The logic checks the size of sequences after loading completes, but before they are added to the UI via VGMRoot calls.

I would like to add a toast notification indicating how many files were skipped, but this will require a bit more work.


## How Has This Been Tested?
Tested on CPS sets and psf files with extraneous minor sequences.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
