### PR TITLE
Improve SegSat collection matching for SSFs

### DIFF
--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -1367,6 +1367,7 @@ void SeqTrack::addBankSelect(uint32_t offset, uint32_t length, uint8_t bank, con
   onEvent(offset, length);
 
   if (readMode == READMODE_ADD_TO_UI) {
+    parentSeq->addBankReference(bank);
     addEvent(new BankSelectSeqEvent(this, bank, offset, length, sEventName));
   }
   addBankSelectNoItem(bank);

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -295,6 +295,7 @@ void VGMSeq::resetVars() {
 
   if (readMode == READMODE_ADD_TO_UI) {
     aInstrumentsUsed.clear();
+    m_referencedBanks.clear();
   }
 }
 
@@ -313,6 +314,14 @@ void VGMSeq::addInstrumentRef(uint32_t progNum) {
   if (std::ranges::find(aInstrumentsUsed, progNum) == aInstrumentsUsed.end()) {
     aInstrumentsUsed.push_back(progNum);
   }
+}
+
+void VGMSeq::addBankReference(uint16_t bank) {
+  m_referencedBanks.insert(bank);
+}
+
+const std::set<uint16_t>& VGMSeq::referencedBanks() const {
+  return m_referencedBanks;
 }
 
 bool VGMSeq::saveAsMidi(const std::string &filepath, const VGMColl* coll) {

--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -8,6 +8,7 @@
 #include "VGMFile.h"
 #include "RawFile.h"
 #include "MidiFile.h"
+#include <set>
 
 class SeqTrack;
 class SeqEvent;
@@ -44,6 +45,8 @@ class VGMSeq : public VGMFile {
   [[nodiscard]] uint16_t ppqn() const;
   // void setTimeSignature(uint8_t numer, denom);
   void addInstrumentRef(uint32_t progNum);
+  void addBankReference(uint16_t bank);
+  [[nodiscard]] const std::set<uint16_t>& referencedBanks() const;
 
   void useReverb() { m_use_reverb = true; }
 
@@ -147,6 +150,8 @@ private:
   std::vector<ISeqSlider *> aSliders;
 
 private:
+  std::set<uint16_t> m_referencedBanks;
+
   uint16_t m_ppqn;
 
   uint8_t m_initial_volume;

--- a/src/main/formats/SegSat/SegSatInstrSet.h
+++ b/src/main/formats/SegSat/SegSatInstrSet.h
@@ -70,6 +70,7 @@ public:
 
   virtual bool parseHeader();
   virtual bool parseInstrPointers();
+  void assignBankNumber(u8 bankNum);
   std::vector<SegSatMixerTable> mixerTables() { return m_mixerTables; }
   std::vector<SegSatVLTable> vlTables() { return  m_vlTables; }
   std::vector<SegSatPlfoTable> plfoTables() { return  m_plfoTables; }
@@ -127,6 +128,7 @@ public:
   SegSatRgn(SegSatInstr* instr, uint32_t offset, const std::string& name);
   ~SegSatRgn() = default;
 
+  bool isRegionValid();
   u32 sampleLoopStart() const { return m_sampLoopStart; }
   u32 sampleLoopEnd() const { return m_sampLoopEnd; }
   u32 sampleLoopLength() const { return m_sampLoopEnd - m_sampLoopStart; }

--- a/src/main/formats/SegSat/SegSatScanner.h
+++ b/src/main/formats/SegSat/SegSatScanner.h
@@ -8,12 +8,15 @@
 #include "common.h"
 #include <span>
 
+class SegSatSeq;
+class SegSatInstrSet;
+
 class SegSatScanner : public VGMScanner {
  public:
   explicit SegSatScanner(Format* format) : VGMScanner(format) {}
 
   virtual void scan(RawFile *file, void *info = 0);
-  void searchForSequences(RawFile *file);
-  bool validateBankAt(RawFile* file, u32 base);
-  void searchForInstrumentSets(RawFile *file);
+  std::vector<SegSatSeq *> searchForSequences(RawFile *file, bool match);
+  bool validateBankAt(RawFile *file, u32 base);
+  std::vector<SegSatInstrSet *> searchForInstrumentSets(RawFile *file, bool match);
 };

--- a/src/main/formats/SegSat/SegSatSeq.cpp
+++ b/src/main/formats/SegSat/SegSatSeq.cpp
@@ -258,7 +258,10 @@ bool SegSatSeq::readEvent() {
           break;
         case Midi::BANK_SELECT_LSB:
           m_bank[ch] = controllerValue;
-          addBankSelect(beginOffset, curOffset - beginOffset, m_bank[ch]);
+          // Skip bank select during MIDI conversion if the seq uses only a single bank
+          if (VGMSeq::readMode == READMODE_ADD_TO_UI || parentSeq->referencedBanks().size() > 1) {
+            addBankSelect(beginOffset, curOffset - beginOffset, m_bank[ch]);
+          }
           break;
         case Midi::SUSTAIN_SWITCH:
           addSustainEvent(beginOffset, curOffset - beginOffset, controllerValue);


### PR DESCRIPTION
Mostly an improvement to Sega Saturn collection matching. The table of loaded banks is stored in ram at 0x500, each given an id corresponding to sequence bank events.

- VGMSeq: add referencedBanks() and addBankReference()
- SegSatInstrSet: add assignBankNumber() to update all instruments to use a specified bank number
- SegSatInstrSet: add isRegionValid()
- SegSatInstrSet: update condition for substituting decay2 for decay - if sustain_level is max then decay1 is irrelevant
- SegSatScanner: skip FilegroupMatcher for ssf files - instead read bank list from memory and assign based on referenced banks in each sequence
- SegSatScanner: don't skip over entire instrument set after it's loaded - this breaks some poorly ripped SSFs with overlapping bank data
- SegSatScanner: expand the number of allowed PEG tables and add an exception for velocity level table count for a specific game
- SegSatSeq: skip writing MIDI bank select events for sequences referencing only 1 bank

## How Has This Been Tested?
Lots and lots of SSF loading.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
