### PR TITLE
add useMatcher param to VGMFile::loadVGMFile() to bypass matching

### DIFF
--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -21,7 +21,7 @@ public:
 
   [[nodiscard]] std::string description() override;
 
-  virtual bool loadVGMFile() = 0;
+  virtual bool loadVGMFile(bool useMatcher) = 0;
   virtual bool load() = 0;
   Format* format() const;
   [[nodiscard]] std::string formatName();

--- a/src/main/components/VGMMiscFile.cpp
+++ b/src/main/components/VGMMiscFile.cpp
@@ -21,14 +21,16 @@ bool VGMMiscFile::loadMain() {
   return true;
 }
 
-bool VGMMiscFile::loadVGMFile() {
+bool VGMMiscFile::loadVGMFile(bool useMatcher) {
   bool val = load();
   if (!val) {
     return false;
   }
 
-  if (auto fmt = format(); fmt) {
-    fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
+  if (useMatcher) {
+    if (auto fmt = format(); fmt) {
+      fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
+    }
   }
 
   return val;

--- a/src/main/components/VGMMiscFile.h
+++ b/src/main/components/VGMMiscFile.h
@@ -18,7 +18,7 @@ public:
   VGMMiscFile(const std::string &format, RawFile *file, uint32_t offset, uint32_t length = 0,
               std::string name = "VGMMiscFile");
 
-  bool loadVGMFile() override;
+  bool loadVGMFile(bool useMatcher = true) override;
   virtual bool loadMain();
   bool load() override;
 };

--- a/src/main/components/VGMSampColl.cpp
+++ b/src/main/components/VGMSampColl.cpp
@@ -32,14 +32,16 @@ VGMSampColl::VGMSampColl(const std::string &format, RawFile *rawfile, VGMInstrSe
       parInstrSet(instrset) {
 }
 
-bool VGMSampColl::loadVGMFile() {
+bool VGMSampColl::loadVGMFile(bool useMatcher) {
   bool val = load();
   if (!val) {
     return false;
   }
 
-  if (auto fmt = format(); fmt) {
-    fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
+  if (useMatcher) {
+    if (auto fmt = format(); fmt) {
+      fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
+    }
   }
 
   return val;

--- a/src/main/components/VGMSampColl.h
+++ b/src/main/components/VGMSampColl.h
@@ -17,7 +17,7 @@ class VGMSampColl : public VGMFile {
                 uint32_t length = 0, std::string theName = "VGMSampColl");
   void useInstrSet(VGMInstrSet *instrset) { parInstrSet = instrset; }
 
-  bool loadVGMFile() override;
+  bool loadVGMFile(bool useMatcher = true) override;
   bool load() override;
   virtual bool parseHeader();        // retrieve any header data
   virtual bool parseSampleInfo();        // retrieve sample info, including pointers to data, # channels, rate, etc.

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -38,14 +38,16 @@ VGMInstr *VGMInstrSet::addInstr(uint32_t offset, uint32_t length, uint32_t bank,
   return instr;
 }
 
-bool VGMInstrSet::loadVGMFile() {
+bool VGMInstrSet::loadVGMFile(bool useMatcher) {
   bool val = load();
   if (!val) {
     return false;
   }
 
-  if (auto fmt = format(); fmt) {
-    fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
+  if (useMatcher) {
+    if (auto fmt = format(); fmt) {
+      fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
+    }
   }
 
   return val;

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -20,7 +20,7 @@ public:
               std::string name = "VGMInstrSet", VGMSampColl *theSampColl = nullptr);
   ~VGMInstrSet() override;
 
-  bool loadVGMFile() override;
+  bool loadVGMFile(bool useMatcher = true) override;
   bool load() override;
   virtual bool parseHeader();
   virtual bool parseInstrPointers();

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -46,7 +46,7 @@ VGMSeq::~VGMSeq() {
   delete midi;
 }
 
-bool VGMSeq::loadVGMFile() {
+bool VGMSeq::loadVGMFile(bool useMatcher) {
   if (!load()) {
     return false;
   }
@@ -55,8 +55,10 @@ bool VGMSeq::loadVGMFile() {
     VGMMiscFile *>>(this));
   pRoot->addVGMFile(this);
 
-  if (auto fmt = format(); fmt) {
-    fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
+  if (useMatcher) {
+    if (auto fmt = format(); fmt) {
+      fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
+    }
   }
 
   return true;

--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -32,7 +32,7 @@ class VGMSeq : public VGMFile {
          std::string name = "VGM Sequence");
   ~VGMSeq() override;
 
-  bool loadVGMFile() override;
+  bool loadVGMFile(bool useMatcher = true) override;
   bool load() override;
   virtual bool parseHeader();
   virtual bool parseTrackPointers();  // Function to find all of the track pointers.   Returns number of total tracks.

--- a/src/main/formats/SegSat/SegSatScanner.cpp
+++ b/src/main/formats/SegSat/SegSatScanner.cpp
@@ -204,7 +204,7 @@ std::vector<SegSatSeq*> SegSatScanner::searchForSeqs(RawFile *file, bool useMatc
 
       auto name = fmt::format("{} {:d}_{:d}", file->name(), seqTableCounter, n);
       SegSatSeq* seq = new SegSatSeq(file, i + seqPtr, name);
-      if (useMatcher ? !seq->loadVGMFile() : !seq->load())
+      if (!seq->loadVGMFile(useMatcher))
         delete seq;
       else {
         bParsedSeq = true;


### PR DESCRIPTION
The Matcher class is useful when we're receiving files in an undefined order and heuristics can be used to associate files with each other. Sometimes we load files together and we already know how they're associated. For these circumstances, it's more sensible to load the collection within the Scanner class. 

We currently do this with arcade formats. With these, we don't bother defining a Matcher on the format, so there's no conflict. However, with Sega Saturn, we want the option to bypass the Matcher if we're loading an SSF file (which gives us access to the bank list in memory) or use the FilegroupMatcher if we're loading from any other source.

To achieve this, I added a useMatcher bool parameter to VGMFile::loadVGMFile().

## Motivation and Context
I unwittingly broke UI behavior with #654. Sega Saturn sequences in SSF files are not being added to the Detected Files list. I think this is a better change than simply reverting that PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
