### PR TITLE
Fix unset default values for KonamiArcadeSeq vars

### DIFF
--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
@@ -102,6 +102,7 @@ void KonamiArcadeTrack::resetVars() {
   m_percussionFlag2 = false;
   m_driverTranspose = 0;
   m_prevNoteAbsTime = 0;
+  m_prevNoteDur = 0;
   m_prevNoteDelta = 0;
   m_prevFinalKey = 0;
   m_tiePrevNote = false;
@@ -116,6 +117,7 @@ void KonamiArcadeTrack::resetVars() {
   m_panSlideDuration = 0;
   m_panSlideTarget = 0;
   m_panSlideIncrement = 0;
+  m_portamentoTime = 0;
   m_slideModeDelay = 0;
   m_slideModeDuration = 0;
   m_slideModeDepth = 0;


### PR DESCRIPTION
I forgot to reset a couple state variables in KonamiArcadeTrack::resetVars(). Unfortunately, this isn't surfacing as a problem in the macOS build, but it is apparent on Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
