### PR TITLE
Fix logic bug in AkaoMatcher

### DIFF
--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -101,7 +101,7 @@ bool AkaoMatcher::tryCreateCollection(int id) {
         sampCollsToCheck.push_back(*it);
       } else {
         // PSF files may optimize out the IDs, so be lenient
-        if (isPsfFile(seq->rawFile()))
+        if (!isPsfFile(seq->rawFile()))
           return false;
       }
     }


### PR DESCRIPTION
Fixing a mistake that was made when updating AkaoMatcher's logic for the PSF overlay update. The logical error causes some PSF sets to not create collections.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
