### PR TITLE
Update cmake presets to use ninja on mac and linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
       - name: "Build project"
         # $(sysctl -n hw.logicalcpu) is required to not make XCode spawn infinite threads...
         run: cmake --build --preset "macos-${{ matrix.target }}-release" \
-          --parallel $(sysctl -n hw.logicalcpu) \
           --target vgmtrans
 
       - name: "Package DMG (macOS)"
@@ -146,7 +145,6 @@ jobs:
           export CC=clang-20
           export CXX=clang++-20
           cmake --preset linux-x64 \
-            -G "Ninja Multi-Config" \
             -DCMAKE_INSTALL_PREFIX=/usr
 
       - name: "Build project"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,6 @@ jobs:
         run: cmake --preset "macos-${{ matrix.target }}"
 
       - name: "Build project"
-        # $(sysctl -n hw.logicalcpu) is required to not make XCode spawn infinite threads...
         run: cmake --build --preset "macos-${{ matrix.target }}-release" \
           --target vgmtrans
 
@@ -50,7 +49,7 @@ jobs:
         working-directory: "build/macos-${{ matrix.target }}/"
         run: |
           macdeployqt \
-            bin/VGMTrans.app \
+            bin/Release/VGMTrans.app \
             -verbose=3 -always-overwrite -appstore-compliant
 
       - name: "Checkout create-dmg"
@@ -67,7 +66,7 @@ jobs:
           ./create-dmg/create-dmg \
             --no-internet-enable \
             --volname "VGMTrans" \
-            --volicon "bin/VGMTrans.app/Contents/Resources/appicon.icns" \
+            --volicon "bin/Release/VGMTrans.app/Contents/Resources/appicon.icns" \
             --background "${{ github.workspace }}/bin/dmg/bg.tif" \
             --text-size 12 \
             --window-pos 400 400 \
@@ -78,20 +77,20 @@ jobs:
             --app-drop-link 520 97 \
             --add-file "Unblock & Sign" "${{ github.workspace }}/bin/dmg/selfsign" 313 280 \
             --add-file "README.txt" "${{ github.workspace }}/bin/dmg/README.txt" 520 280 \
-            "bin/VGMTrans-${{ github.sha }}.dmg" \
-            "bin"
+            "bin/Release/VGMTrans-${{ github.sha }}.dmg" \
+            "bin/Release"
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3
         if: ${{ github.event_name != 'pull_request' }}
         with:
           subject-name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-${{ matrix.target }}-${{ runner.os }}
-          subject-path: "build/macos-${{ matrix.target }}/bin/VGMTrans-${{ github.sha }}.dmg"
+          subject-path: "build/macos-${{ matrix.target }}/bin/Release/VGMTrans-${{ github.sha }}.dmg"
 
       - name: "Upload artifact"
         uses: actions/upload-artifact@v4
         with:
           name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-${{ matrix.target }}-${{ runner.os }}.dmg
-          path: "build/macos-${{ matrix.target }}/bin/VGMTrans-${{ github.sha }}.dmg"
+          path: "build/macos-${{ matrix.target }}/bin/Release/VGMTrans-${{ github.sha }}.dmg"
           
   linux:
     runs-on: ubuntu-22.04

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,6 +62,7 @@
         },
         {
             "name": "macos-base",
+            "generator": "Ninja Multi-Config",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "hidden": true,
             "environment": {
@@ -100,6 +101,7 @@
         },
         {
             "name": "linux-x64",
+            "generator": "Ninja Multi-Config",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "displayName": "Linux x64",
             "description": "Build VGMTrans for Linux x64",

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -143,24 +143,17 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set_source_files_properties("${CMAKE_CURRENT_LIST_DIR}/resources/appicon.icns"
                               PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
+  get_target_property(BASS_DLL_LOCATION BASS::BASS IMPORTED_LOCATION)
+  get_target_property(BASSMIDI_DLL_LOCATION BASS::MIDI IMPORTED_LOCATION)
+
   add_custom_command(
     TARGET vgmtrans
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/bin/mame_roms.xml"
-    "${BUNDLE_PATH}/Contents/Resources/")
-
-  get_target_property(BASS_DLL_LOCATION BASS::BASS IMPORTED_LOCATION)
-  add_custom_command(
-    TARGET vgmtrans
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BASS_DLL_LOCATION}"
-            "${BUNDLE_PATH}/Contents/MacOS/")
-  get_target_property(BASSMIDI_DLL_LOCATION BASS::MIDI IMPORTED_LOCATION)
-  add_custom_command(
-    TARGET vgmtrans
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BASSMIDI_DLL_LOCATION}"
-            "${BUNDLE_PATH}/Contents/MacOS/")
+          "$<TARGET_FILE_DIR:vgmtrans>/../Resources"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BASS_DLL_LOCATION}"  "$<TARGET_FILE_DIR:vgmtrans>/"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BASSMIDI_DLL_LOCATION}"  "$<TARGET_FILE_DIR:vgmtrans>/"
+  )
 elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
   # Make sure the executable ends up in the binary directory without any
   # additional folders


### PR DESCRIPTION
- Update CMakePresets.json to use the "Ninja Multi-Config" generator on macos and linux.
- Update src/ui/qt/CMakeLists.txt to fix macOS POST_BUILD copy_if_different paths with Ninja.
- Update .github/workflows/build.yml to remove redundant parameters after making ninja the default generator

## Description
I would like to know if there are good reasons against making ninja the default for all platforms. The benefit is simplicity and a better building experience in CLion. Make doesn't automatically use all logical cores like ninja, which is a pain in the ass. It's elegant to be able to build quickly across all platforms using the same simple commands, for example:

```
cmake --preset macos-x64-clang
cmake --build --preset macos-x64-clang-release --target vgmtrans
```

## How Has This Been Tested?
Successfully built using the above command template on macOS Sonoma, Windows 10, and Ubuntu 22.04.