### PR TITLE
Use visitedAddresses over isItemAtOffset

### DIFF
--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -11,31 +11,6 @@
 #include "VGMSeqNoTrks.h"
 #include "helper.h"
 
-std::size_t SeqTrack::ControlFlowStateHasher::operator()(const ControlFlowState &state) const noexcept {
-  auto hashCombine = [](std::size_t &seed, uint32_t value) {
-    seed ^= std::hash<uint32_t>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-  };
-
-  std::size_t seed = std::hash<uint32_t>{}(state.offset);
-
-  if (!state.returnStack.empty()) {
-    hashCombine(seed, static_cast<uint32_t>(state.returnStack.size()));
-    for (uint32_t value : state.returnStack) {
-      hashCombine(seed, value);
-    }
-  }
-
-  if (!state.loopStack.empty()) {
-    hashCombine(seed, static_cast<uint32_t>(state.loopStack.size()));
-    for (const auto &loop : state.loopStack) {
-      hashCombine(seed, loop.endOffset);
-      hashCombine(seed, loop.remainingCount);
-    }
-  }
-
-  return seed;
-}
-
 SeqTrack::SeqTrack(VGMSeq *parentFile, uint32_t offset, uint32_t length, std::string name)
     : VGMItem(parentFile, offset, length, std::move(name), Type::Track),
       dwStartOffset(offset),


### PR DESCRIPTION
This builds off of a small change in the control flow PR #686. SeqTrack::onEvent() now returns a bool indicating if an offset has been visited yet. This replaces all calls to `isItemAtOffset()` in SeqTrack with this return value, which is derived from a hash table lookup and is therefore much more performant.

## How Has This Been Tested?
Tested for regressions on almost every format.
