### PR TITLE
Add menu actions for Hex View font size changes

### DIFF
--- a/src/ui/qt/MenuBar.cpp
+++ b/src/ui/qt/MenuBar.cpp
@@ -22,6 +22,8 @@
 #include "VGMColl.h"
 #include "VGMFile.h"
 #include "RawFile.h"
+#include "workarea/MdiArea.h"
+#include "workarea/VGMFileView.h"
 
 
 MenuBar::MenuBar(QWidget *parent, const QList<QDockWidget *> &dockWidgets) : QMenuBar(parent) {
@@ -92,6 +94,62 @@ void MenuBar::appendViewMenu(const QList<QDockWidget *> &dockWidgets) {
 
   for (auto &widget : dockWidgets) {
     toolWindowsMenu->addAction(widget->toggleViewAction());
+  }
+
+  m_viewMenu->addSeparator();
+
+  menu_increase_hex_font = m_viewMenu->addAction(tr("Increase Font Size in Hex View"));
+  menu_increase_hex_font->setShortcut(QKeySequence::ZoomIn);
+  menu_increase_hex_font->setShortcutContext(Qt::WidgetShortcut);
+  connect(menu_increase_hex_font, &QAction::triggered, this, [this]() {
+    if (auto *view = currentVGMFileView()) {
+      view->increaseHexViewFont();
+    }
+  });
+
+  menu_decrease_hex_font = m_viewMenu->addAction(tr("Decrease Font Size in Hex View"));
+  menu_decrease_hex_font->setShortcut(QKeySequence::ZoomOut);
+  menu_decrease_hex_font->setShortcutContext(Qt::WidgetShortcut);
+  connect(menu_decrease_hex_font, &QAction::triggered, this, [this]() {
+    if (auto *view = currentVGMFileView()) {
+      view->decreaseHexViewFont();
+    }
+  });
+
+  menu_reset_hex_font = m_viewMenu->addAction(tr("Reset Font Size in Hex View"));
+  menu_reset_hex_font->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_0));
+  menu_reset_hex_font->setShortcutContext(Qt::WidgetShortcut);
+  connect(menu_reset_hex_font, &QAction::triggered, this, [this]() {
+    if (auto *view = currentVGMFileView()) {
+      view->resetHexViewFont();
+    }
+  });
+
+#if defined(Q_OS_MACOS)
+  // Add a separator between these actions and the automatically added "Enter Full Screen" action.
+  m_viewMenu->addSeparator();
+#endif
+
+  connect(MdiArea::the(), &QMdiArea::subWindowActivated, this,
+          [this](QMdiSubWindow *) { updateHexFontActions(); });
+  updateHexFontActions();
+}
+
+VGMFileView* MenuBar::currentVGMFileView() const {
+  return qobject_cast<VGMFileView*>(MdiArea::the()->activeSubWindow());
+}
+
+void MenuBar::updateHexFontActions() {
+  const bool hasActiveView = currentVGMFileView() != nullptr;
+
+  if (menu_reset_hex_font) {
+    menu_reset_hex_font->setEnabled(hasActiveView);
+  }
+  if (menu_increase_hex_font) {
+    menu_increase_hex_font->setEnabled(hasActiveView);
+  }
+  if (menu_decrease_hex_font) {
+    menu_decrease_hex_font->setEnabled(hasActiveView);
   }
 }
 

--- a/src/ui/qt/MenuBar.h
+++ b/src/ui/qt/MenuBar.h
@@ -24,6 +24,7 @@ class QDockWidget;
 class VGMFile;
 class VGMColl;
 class RawFile;
+class VGMFileView;
 
 class MenuBar final : public QMenuBar {
   Q_OBJECT
@@ -48,6 +49,8 @@ private:
   void appendViewMenu(const QList<QDockWidget *> &dockWidgets);
   void appendInfoMenu();
   void appendOptionsMenu();
+  void updateHexFontActions();
+  VGMFileView* currentVGMFileView() const;
 
   void refreshContextualMenus();
   void clearContextualMenus();
@@ -63,6 +66,10 @@ private:
   QMenu *m_viewMenu{};
   QMenu *m_optionsMenu{};
   QMenu *m_helpMenu{};
+
+  QAction *menu_reset_hex_font{};
+  QAction *menu_increase_hex_font{};
+  QAction *menu_decrease_hex_font{};
 
   // File actions
   QAction *menu_open_file{};

--- a/src/ui/qt/workarea/VGMFileView.h
+++ b/src/ui/qt/workarea/VGMFileView.h
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+#include <QFont>
 #include <QMdiSubWindow>
 
 class SnappingSplitter;
@@ -30,13 +31,18 @@ private:
   int hexViewWidthSansAscii() const;
   int hexViewWidthSansAsciiAndAddress() const;
   void updateHexViewFont(qreal sizeIncrement) const;
+  void applyHexViewFont(QFont font) const;
 
   VGMFileTreeView* m_treeview{};
   VGMFile* m_vgmfile{};
   QScrollArea* m_hexScrollArea;
   HexView* m_hexview{};
   SnappingSplitter* m_splitter;
+  QFont m_defaultHexFont;
 
 public slots:
   void onSelectionChange(VGMItem* item) const;
+  void resetHexViewFont();
+  void increaseHexViewFont();
+  void decreaseHexViewFont();
 };


### PR DESCRIPTION
Hex View font size can be changed with cmd/ctrl +/-, but the feature is completely hidden. This adds the actions into the View menu, and also adds a Reset Font Size in Hex View option via cmd/ctrl - 0.

We should probably make these changes persist for all newly opened hex views, and apply to all open hex views. That can be added later.

Code changes at a high level:
- VGMFileView: move hex view font size callbacks into their own methods
- MenuBar: add View menu actions for increasing, decreasing, and resetting hex view font size

## Motivation and Context
Make font size changes discoverable.

## Screenshots (if appropriate):
<img width="266" height="167" alt="image" src="https://github.com/user-attachments/assets/440b0b70-47e5-45c7-b814-349af9ef97fd" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
