### PR TITLE
make Mac playback slider behavior universal across platforms

### DIFF
--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -74,6 +74,8 @@ add_executable(
   util/LambdaEventFilter.h
   util/UIHelpers.cpp
   util/UIHelpers.h
+  widgets/ClickJumpSlider.cpp
+  widgets/ClickJumpSlider.h
   widgets/MarqueeLabel.cpp
   widgets/MarqueeLabel.h
   widgets/SnappingSplitter.cpp

--- a/src/ui/qt/IconBar.cpp
+++ b/src/ui/qt/IconBar.cpp
@@ -15,6 +15,7 @@
 #include "SequencePlayer.h"
 #include "Helpers.h"
 #include "MarqueeLabel.h"
+#include "ClickJumpSlider.h"
 
 IconBar::IconBar(QWidget *parent) : QWidget(parent) {
   setLayout(new QHBoxLayout());
@@ -52,7 +53,7 @@ void IconBar::setupControls() {
   connect(m_stop, &QPushButton::pressed, this, &IconBar::stopPressed);
   layout()->addWidget(m_stop);
 
-  m_slider = new QSlider(Qt::Horizontal);
+  m_slider = new ClickJumpSlider(Qt::Horizontal);
   /* Needed to make sure the slider is properly rendered */
   m_slider->setRange(0, 1);
   m_slider->setValue(0);

--- a/src/ui/qt/IconBar.h
+++ b/src/ui/qt/IconBar.h
@@ -12,6 +12,7 @@ class QSlider;
 class QPushButton;
 class QLabel;
 class MarqueeLabel;
+class ClickJumpSlider;
 
 class IconBar final : public QWidget {
   Q_OBJECT
@@ -36,7 +37,7 @@ private:
   QPushButton *m_create{};
   QPushButton *m_play{};
   QPushButton *m_stop{};
-  QSlider *m_slider{};
+  ClickJumpSlider *m_slider{};
   MarqueeLabel *m_title;
   inline static QIcon s_playicon;
   inline static QIcon s_pauseicon;

--- a/src/ui/qt/widgets/ClickJumpSlider.cpp
+++ b/src/ui/qt/widgets/ClickJumpSlider.cpp
@@ -1,0 +1,44 @@
+/*
+ * VGMTrans (c) 2002-2025
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#include "ClickJumpSlider.h"
+
+void ClickJumpSlider::mousePressEvent(QMouseEvent* e) {
+    if (e->button() == Qt::LeftButton) {
+        QStyleOptionSlider opt;
+        initStyleOption(&opt);
+
+        // Where is the handle? If we clicked it, fall back to normal dragging.
+        const QRect handleRect = style()->subControlRect(QStyle::CC_Slider, &opt,
+                                                         QStyle::SC_SliderHandle, this);
+        if (!handleRect.contains(e->pos())) {
+            // Compute a value from the click position using style metrics.
+            const int sliderLength = style()->pixelMetric(QStyle::PM_SliderLength, &opt, this);
+            const int halfLen      = sliderLength / 2;
+
+            int pos, span;
+            if (orientation() == Qt::Horizontal) {
+                pos  = std::clamp(int(e->position().x()), halfLen, width() - halfLen);
+                span = width() - sliderLength;
+            } else {
+                pos  = std::clamp(int(e->position().y()), halfLen, height() - halfLen);
+                span = height() - sliderLength;
+            }
+
+            const int newVal = QStyle::sliderValueFromPosition(
+                minimum(), maximum(), pos - halfLen, std::max(1, span), opt.upsideDown);
+
+            // Set the value and start a drag from the new spot (feels natural).
+            setValue(newVal);
+
+            // Mark as handled so base class won’t also treat it as a page step.
+            // But still pass to base afterwards to let it grab the handle for dragging.
+        }
+    }
+
+    // Let QSlider do its normal press/drag handling (now at the new position).
+    QSlider::mousePressEvent(e);
+}

--- a/src/ui/qt/widgets/ClickJumpSlider.h
+++ b/src/ui/qt/widgets/ClickJumpSlider.h
@@ -1,0 +1,19 @@
+/*
+ * VGMTrans (c) 2002-2025
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#pragma once
+#include <QSlider>
+#include <QStyleOptionSlider>
+#include <QMouseEvent>
+
+class ClickJumpSlider : public QSlider {
+    Q_OBJECT
+public:
+    using QSlider::QSlider; // inherit ctors
+
+protected:
+    void mousePressEvent(QMouseEvent* e) override;
+};


### PR DESCRIPTION
This adds a new subclass of QSlider called `ClickJumpSlider` and uses it for the playback slider in place of a vanilla `QSlider`. Instead of requiring the user to click and drag the handle element to change position (as is required on Windows and Linux), the user can simply click any position on the slider to jump to it. This is the macOS behavior.

Logically, this is pretty basic. We override `QSlider::mousePressEvent()` and handle left button mouse clicks. If a user clicks the handle element, we allow the default behavior to run. Otherwise, we calculate the new value of the slider based on click position.

The calculation is straightforward - we get the click position relative to the width of the bar, but we also factor out the width of the handle. The handle element doesn't extend beyond the widget, so if the user clicks at the beginning of the bar at an x position <= half the handle width, it's the same as clicking position 0. Likewise, if the user clicks the end of the bar up to half the handle width, it's treated as position 1.


## Motivation and Context
I think the macOS slider behavior is much more usable and should be universal.

## How Has This Been Tested?
Tested on macOS, Win10, and Ubuntu 22.04.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
