### PR TITLE
update github workflow to use macos-15 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   macos:
     name: macOS 11.x+
-    runs-on: ${{ (matrix.target == 'intel' && 'macos-13') || 'macos-14' }}
+    runs-on: ${{ (matrix.target == 'intel' && 'macos-15') || 'macos-15' }}
     strategy:
       matrix:
         target: [ "intel", "arm64" ]


### PR DESCRIPTION
The macos-13 github action images [are deprecated](https://github.com/actions/runner-images/issues/13046). This updates intel and arm to macos-15 images.