### PR TITLE
Fix a moc compilation issue afflicting debian qt6 package

### DIFF
--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -10,12 +10,12 @@
 
 #include "common.h"
 #include "VGMTag.h"
-#include "VGMFile.h"
-#include "VGMColl.h"
-#include "RawFile.h"
 
 class VGMScanner;
+class VGMColl;
 class VGMItem;
+class VGMFile;
+class RawFile;
 class VGMSeq;
 class VGMInstrSet;
 class VGMSampColl;

--- a/src/ui/qt/MenuBar.h
+++ b/src/ui/qt/MenuBar.h
@@ -19,11 +19,11 @@
 #include <vector>
 
 #include "services/MenuManager.h"
+#include "VGMFile.h"
+#include "VGMColl.h"
+#include "RawFile.h"
 
 class QDockWidget;
-class VGMFile;
-class VGMColl;
-class RawFile;
 class VGMFileView;
 
 class MenuBar final : public QMenuBar {


### PR DESCRIPTION
A user reported a compilation problem (issue #697) on Ubuntu 24.04 using Qt version 6.4.2+dfsg-21.1build5. The errors occur in the meta object compilation step and pertain to VGMFile, VGMColl, and RawFile being forward declared and not defined.

The build log includes lines like:
```
qt6/QtCore/qmetatype.h:842:23: error: invalid application of 'sizeof' to an incomplete type 'VGMColl'
```

In MenuBar.h - the file causing the errors - we have three QList containers of those classes:
```
QList<VGMFile*> m_selectedVGMFiles;
QList<VGMColl*> m_selectedVGMColls;
QList<RawFile*> m_selectedRawFiles;
```

It appears these lines are causing this version of Qt6 to run sizeof(VGMFile) etc during the moc step, which fails as size cannot be determined from forward declarations. This problem is not occurring on vanilla versions of Qt6.

The fix is simply adding the relevant header files in MenuBar.h instead of forward declaring the classes.

## Motivation and Context
Maximize build compatibility.

## How Has This Been Tested?
The user reports this fixed the compilation entirely.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
