### PR TITLE
Fix cps3 pitch bend range

### DIFF
--- a/src/main/formats/CPS/CPS2Seq.cpp
+++ b/src/main/formats/CPS/CPS2Seq.cpp
@@ -26,6 +26,8 @@ CPS2Seq::CPS2Seq(RawFile *file, uint32_t offset, CPS2FormatVer fmtVersion, std::
   setAlwaysWriteInitialVol(127);
   setAlwaysWriteInitialMonoMode(true);
   setUseLinearAmplitudeScale(true);
+  if (fmt_version >= CPS2_V200)
+    setAlwaysWriteInitialPitchBendRange(12 * 100);
 }
 
 CPS2Seq::~CPS2Seq() {

--- a/src/main/formats/FFT/FFTInstr.cpp
+++ b/src/main/formats/FFT/FFTInstr.cpp
@@ -3,7 +3,7 @@
 #include "VGMSamp.h"
 #include "PSXSPU.h"
 
-using namespace std;
+const float defaultFFTReverbPercent = 0.5;
 
 /****************************************************************/
 /*																*/


### PR DESCRIPTION
This fixes a regression that broke pitch bend range for CPS3 games. These games use a range of a full octave.

It also reduces the reverb amount applied with the FFT format.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
