### PR TITLE
Fix manually created collections not appearing

### DIFF
--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -30,19 +30,37 @@ VGMCollListViewModel::VGMCollListViewModel(QObject *parent) : QAbstractListModel
   };
 
   auto beginLoad = [this]() {
+    isLoadingRawFile = true;
     collsBeforeLoad = pRoot->vgmColls().size();
   };
 
   auto endLoad = [this]() {
     int filesLoaded = pRoot->vgmColls().size() - collsBeforeLoad;
-    if (filesLoaded <= 0)
+    if (filesLoaded <= 0) {
+      isLoadingRawFile = false;
       return;
+    }
     beginInsertRows(QModelIndex(), collsBeforeLoad, collsBeforeLoad + filesLoaded - 1);
+    endInsertRows();
+    isLoadingRawFile = false;
+  };
+
+  auto addCollection = [this]() {
+    if (isLoadingRawFile)
+      return;
+
+    int newIndex = static_cast<int>(pRoot->vgmColls().size()) - 1;
+    if (newIndex < 0)
+      return;
+
+    beginInsertRows(QModelIndex(), newIndex, newIndex);
     endInsertRows();
   };
 
+
   connect(&qtVGMRoot, &QtVGMRoot::UI_beginLoadRawFile, beginLoad);
   connect(&qtVGMRoot, &QtVGMRoot::UI_endLoadRawFile, endLoad);
+  connect(&qtVGMRoot, &QtVGMRoot::UI_addedVGMColl, addCollection);
   connect(&qtVGMRoot, &QtVGMRoot::UI_beginRemoveVGMColls, startResettingModel);
   connect(&qtVGMRoot, &QtVGMRoot::UI_endRemoveVGMColls, endResettingModel);
 }

--- a/src/ui/qt/workarea/VGMCollListView.h
+++ b/src/ui/qt/workarea/VGMCollListView.h
@@ -23,6 +23,7 @@ public:
 
 private:
   size_t collsBeforeLoad;
+  bool isLoadingRawFile = false;
 };
 
 class VGMCollNameEditor : public QStyledItemDelegate {


### PR DESCRIPTION
The [PR](https://github.com/vgmtrans/vgmtrans/pull/693) that improved list view performance added a bug that causes the collection list view to not refresh when a collection is added manually.

This fixes the bug by adding a handler for UI_addedVGMColl in VGMCollListView which only runs when we're not loading a raw file (since, for a rawfile load, we want to  perform only a single update after all collections are created).


## How Has This Been Tested?
Tested that the Collection View is handling manual collection creation and rawfile loads correctly. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
