### PR TITLE
Add a flag for using linear amplitude scale at the SeqTrack level

### DIFF
--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -391,7 +391,7 @@ void SeqTrack::addNoteOn(uint32_t offset, uint32_t length, int8_t key, int8_t ve
 void SeqTrack::addNoteOnNoItem(int8_t key, int8_t velocity) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = velocity;
-    if (parentSeq->usesLinearAmplitudeScale())
+    if (usesLinearAmplitudeScale())
       finalVel = convert7bitPercentAmpToStdMidiVal(velocity);
 
     if (cDrumNote == -1) {
@@ -440,7 +440,7 @@ void SeqTrack::insertNoteOn(uint32_t offset,
   bool isNewOffset = onEvent(offset, length);
 
   uint8_t finalVel = vel;
-  if (parentSeq->usesLinearAmplitudeScale())
+  if (usesLinearAmplitudeScale())
     finalVel = convert7bitPercentAmpToStdMidiVal(vel);
 
   if (readMode == READMODE_ADD_TO_UI && isNewOffset) {
@@ -534,7 +534,7 @@ void SeqTrack::addNoteByDur(uint32_t offset,
 void SeqTrack::addNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = vel;
-    if (parentSeq->usesLinearAmplitudeScale())
+    if (usesLinearAmplitudeScale())
       finalVel = convert7bitPercentAmpToStdMidiVal(vel);
 
     if (cDrumNote == -1) {
@@ -563,7 +563,7 @@ void SeqTrack::addNoteByDur_Extend(uint32_t offset,
 void SeqTrack::addNoteByDurNoItem_Extend(int8_t key, int8_t vel, uint32_t dur) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = vel;
-    if (parentSeq->usesLinearAmplitudeScale())
+    if (usesLinearAmplitudeScale())
       finalVel = convert7bitPercentAmpToStdMidiVal(vel);
 
     if (cDrumNote == -1) {
@@ -634,7 +634,7 @@ void SeqTrack::insertNoteByDur(uint32_t offset,
 void SeqTrack::insertNoteByDurNoItem(int8_t key, int8_t vel, uint32_t dur, uint32_t absTime) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
     uint8_t finalVel = vel;
-    if (parentSeq->usesLinearAmplitudeScale())
+    if (usesLinearAmplitudeScale())
       finalVel = convert7bitPercentAmpToStdMidiVal(vel);
 
     pMidiTrack->insertNoteByDur(channel, key + cKeyCorrection + transpose, finalVel, dur, absTime);
@@ -678,7 +678,7 @@ double SeqTrack::applyLevelCorrection(double level, LevelController controller) 
     if (parentSeq->panVolumeCorrectionMode == relevantCorrectionMode)
       level *= panVolumeCorrectionRate;
   }
-  if (parentSeq->usesLinearAmplitudeScale())
+  if (usesLinearAmplitudeScale())
     level = sqrt(level);
   return level;
 }
@@ -807,7 +807,7 @@ void SeqTrack::addVolSlide(uint32_t offset,
     addControllerSlide(dur,
                        vol,
                        targVol,
-                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
+                       usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
                        &MidiTrack::insertVol);
 }
 
@@ -858,7 +858,7 @@ void SeqTrack::addExpressionSlide(uint32_t offset,
     addControllerSlide(dur,
                        expression,
                        targExpr,
-                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
+                       usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
                        &MidiTrack::insertExpression);
 }
 
@@ -903,7 +903,7 @@ void SeqTrack::addMastVolSlide(uint32_t offset,
     addControllerSlide(dur,
                        mastVol,
                        targVol,
-                       parentSeq->usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
+                       usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
                        &MidiTrack::insertMasterVol);
 }
 
@@ -917,7 +917,7 @@ void SeqTrack::addPan(uint32_t offset, uint32_t length, uint8_t pan, const std::
 
 void SeqTrack::addPanNoItem(uint8_t pan) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
-    const uint8_t midiPan = parentSeq->usesLinearAmplitudeScale()
+    const uint8_t midiPan = usesLinearAmplitudeScale()
       ? convert7bitLinearPercentPanValToStdMidiVal(pan, &panVolumeCorrectionRate)
       : pan;
     pMidiTrack->addPan(channel, midiPan);
@@ -962,7 +962,7 @@ void SeqTrack::insertPan(uint32_t offset,
   if (readMode == READMODE_ADD_TO_UI && isNewOffset)
     addEvent(new PanSeqEvent(this, pan, offset, length, sEventName));
   else if (readMode == READMODE_CONVERT_TO_MIDI) {
-    const uint8_t midiPan = parentSeq->usesLinearAmplitudeScale()
+    const uint8_t midiPan = usesLinearAmplitudeScale()
       ? convert7bitLinearPercentPanValToStdMidiVal(pan, &panVolumeCorrectionRate)
       : pan;
     pMidiTrack->insertPan(channel, midiPan, absTime);

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -77,6 +77,11 @@ class SeqTrack : public VGMItem {
  public:
   SeqTrack(VGMSeq *parentSeqFile, uint32_t offset = 0, uint32_t length = 0, std::string name = "Track");
 
+  [[nodiscard]] bool usesLinearAmplitudeScale() const {
+    return m_useLinearAmpScale || parentSeq->usesLinearAmplitudeScale();
+  }
+  void setUseLinearAmplitudeScale(bool set) { m_useLinearAmpScale = set; }
+
   virtual bool loadTrackInit(int trackNum, MidiTrack *preparedMidiTrack);
   virtual void loadTrackMainLoop(uint32_t stopOffset, int32_t stopTime);
 
@@ -274,6 +279,7 @@ protected:
   //SETTINGS
   bool bDetermineTrackLengthEventByEvent;
   bool bWriteGenericEventAsTextEvent;
+  bool m_useLinearAmpScale = false;
 
   std::unordered_set<uint32_t> visitedAddresses;
   uint32_t visitedAddressMax;

--- a/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
@@ -16,7 +16,7 @@ NamcoSnesSeq::NamcoSnesSeq(RawFile *file, NamcoSnesVersion ver, uint32_t seqdata
     : VGMSeqNoTrks(NamcoSnesFormat::name, file, seqdataOffset, newName),
       version(ver) {
   setAllowDiscontinuousTrackData(true);
-  setUseLinearAmplitudeScale(true);
+  VGMSeq::setUseLinearAmplitudeScale(true);
 
   setAlwaysWriteInitialTempo(60000000.0 / (SEQ_PPQN * (125 * 0x86)));
 

--- a/src/main/formats/SegSat/SegSatSeq.cpp
+++ b/src/main/formats/SegSat/SegSatSeq.cpp
@@ -15,7 +15,7 @@ DECLARE_FORMAT(SegSat);
 
 SegSatSeq::SegSatSeq(RawFile *file, uint32_t offset, std::string name)
     : VGMSeqNoTrks(SegSatFormat::name, file, offset, std::move(name)) {
-  setUseLinearAmplitudeScale(false);
+  VGMSeq::setUseLinearAmplitudeScale(false);
   setInitialVolume(0x7F);
   setInitialExpression(0x7F);
 }

--- a/src/main/formats/SonyPS2/SonyPS2Seq.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Seq.cpp
@@ -12,7 +12,7 @@ SonyPS2Seq::SonyPS2Seq(RawFile *file, uint32_t offset, std::string name)
     : VGMSeqNoTrks(SonyPS2Format::name, file, offset, std::move(name)),
       compOption(0),
       bSkipDeltaTime(0) {
-  setUseLinearAmplitudeScale(true);        // Onimusha: Kaede Theme track 2 for example of linear vol scale.
+  VGMSeq::setUseLinearAmplitudeScale(true);        // Onimusha: Kaede Theme track 2 for example of linear vol scale.
   useReverb();
 }
 


### PR DESCRIPTION
This is helpful for formats that use both sampled playback and FM synthesis chips. At least for the moment, we don't necessarily want to apply a linear scale to volume values on the FM tracks.

Like before, if the flag is set at the VGMSeq level, it will apply to all tracks in the sequence. Otherwise, the flag of each track will be respected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
