### PR TITLE
Add VGMRgn::sampDataLength and YM2151InstrSet Menu commands

### DIFF
--- a/src/main/components/instr/VGMRgn.h
+++ b/src/main/components/instr/VGMRgn.h
@@ -66,8 +66,9 @@ public:
 
   Loop loop;
 
-  u32 sampNum     {0};
-  s32 sampOffset  {-1};     //optional value. If a sample offset is provided, then find the sample
+  u32 sampNum        {0};
+  s32 sampOffset     {-1};  // optional value. If a sample offset is provided, then find the sample
+  s32 sampDataLength {-1};  // optional value. Refines sample matching in case of collisions.
   // number based on this offset. It will match a sample with an identical absolute offset, or
   // sample's offset relative to the beginning of sample data (VGMSampColl::sampDataOffset)
 

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -116,8 +116,13 @@ SynthFile* createSynthFile(
         if (rgn->sampOffset != -1) {
           bool bFoundIt = false;
           for (uint32_t s = 0; s < sampColl->samples.size(); s++) {  //for every sample
-            if (rgn->sampOffset == sampColl->samples[s]->dwOffset ||
-                rgn->sampOffset == sampColl->samples[s]->dwOffset - sampColl->dwOffset - sampColl->sampDataOffset) {
+            auto sample = sampColl->samples[s];
+            if (rgn->sampOffset == sample->dwOffset ||
+                rgn->sampOffset == sample->dwOffset - sampColl->dwOffset - sampColl->sampDataOffset) {
+              if (rgn->sampDataLength != -1 && rgn->sampDataLength != sample->dataLength) {
+                continue;
+              }
+
               realSampNum = s;
 
               //samples[m]->loop.loopStart = parInstrSet->aInstrs[i]->aRgns[k]->loop.loopStart;

--- a/src/main/formats/common/YM2151.h
+++ b/src/main/formats/common/YM2151.h
@@ -1,3 +1,8 @@
+/*
+ * VGMTrans (c) 2002-2025
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
 #pragma once
 
 #include <spdlog/fmt/fmt.h>

--- a/src/main/formats/common/YM2151InstrSet.cpp
+++ b/src/main/formats/common/YM2151InstrSet.cpp
@@ -1,3 +1,8 @@
+/*
+ * VGMTrans (c) 2002-2025
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
 #include "YM2151InstrSet.h"
 
 #include "Root.h"

--- a/src/main/formats/common/YM2151InstrSet.h
+++ b/src/main/formats/common/YM2151InstrSet.h
@@ -1,3 +1,8 @@
+/*
+ * VGMTrans (c) 2002-2025
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
 #pragma once
 
 #include "VGMInstrSet.h"
@@ -6,7 +11,6 @@
 #include <cstdint>
 #include <string>
 #include <vector>
-#include <utility>
 
 struct OPMInstrument {
   OPMData data;

--- a/src/ui/qt/services/MenuManager.cpp
+++ b/src/ui/qt/services/MenuManager.cpp
@@ -10,6 +10,15 @@
 #include "services/commands/SaveCommands.h"
 
 MenuManager::MenuManager() {
+  // Order matters: most-derived types should be placed at the top
+  registerCommands<YM2151InstrSet, VGMItem>({
+    std::make_shared<OpenCommand>(),
+    std::make_shared<CommandSeparator>(),
+    std::make_shared<CloseVGMFileCommand>(),
+    std::make_shared<CommandSeparator>(),
+    std::make_shared<SaveAsOPMCommand>(),
+    std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
+  });
   registerCommands<VGMSeq, VGMItem>({
       std::make_shared<OpenCommand>(),
       std::make_shared<CommandSeparator>(),
@@ -26,14 +35,6 @@ MenuManager::MenuManager() {
       std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<CloseVGMFileCommand>(),
-  });
-  registerCommands<CPS1OPMInstrSet, VGMItem>({
-      std::make_shared<OpenCommand>(),
-      std::make_shared<CommandSeparator>(),
-      std::make_shared<CloseVGMFileCommand>(),
-      std::make_shared<CommandSeparator>(),
-      std::make_shared<SaveAsOPMCommand>(),
-      std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
   });
   registerCommands<VGMSampColl, VGMItem>({
       std::make_shared<OpenCommand>(),

--- a/src/ui/qt/services/commands/SaveCommands.h
+++ b/src/ui/qt/services/commands/SaveCommands.h
@@ -13,7 +13,7 @@
 #include "VGMSampColl.h"
 #include "VGMExport.h"
 #include "VGMColl.h"
-#include "formats/CPS/CPS1Instr.h"
+#include "formats/common/YM2151InstrSet.h"
 
 namespace fs = std::filesystem;
 using MenuPath = Command::MenuPath;
@@ -216,11 +216,11 @@ public:
   [[nodiscard]] std::optional<MenuPath> menuPath() const override { return MenuPaths::Convert; }
 };
 
-class SaveAsOPMCommand : public SaveCommand<CPS1OPMInstrSet, VGMFile> {
+class SaveAsOPMCommand : public SaveCommand<YM2151InstrSet, VGMFile> {
 public:
-  SaveAsOPMCommand() : SaveCommand<CPS1OPMInstrSet, VGMFile>(false) {}
+  SaveAsOPMCommand() : SaveCommand<YM2151InstrSet, VGMFile>(false) {}
 
-  void save(const std::string& path, CPS1OPMInstrSet* instrSet) const override {
+  void save(const std::string& path, YM2151InstrSet* instrSet) const override {
     instrSet->saveAsOPMFile(path);
   }
   [[nodiscard]] std::string name() const override { return "Save as OPM"; }


### PR DESCRIPTION
Some more changes pulled out of the `konami-tmnt2` branch.

- add YM2151InstrSet MenuManager commands
- add VGMRgn::sampDataLength for more precise sample matching
- add copyright notices

VGMRgn::sampDataLength supplements VGMRgn::sampOffset, allowing a region to accurately match when there exist multiple samples with the same start offset. This can happen when reversed samples exist (they read backward) or, for whatever reason, two samples use the same offset but different lengths.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
