### PR TITLE
Qt UI: CMake: call find_package after setting vendored Qt6_DIR

### DIFF
--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -25,6 +25,7 @@ if(NOT Qt6_FOUND AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
       SEND_ERROR
         "Did you forget to run `git submodule update --init --recursive`?")
   endif()
+  find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Svg)
 endif()
 
 message(STATUS "Using Qt ${Qt6_VERSION}")


### PR DESCRIPTION
When Qt6 is not found on Windows, the fallback sets Qt6_DIR but never calls find_package again to actually load Qt6, causing qt_add_resources and other Qt CMake functions to be undefined.

  ## Description
  Add a second `find_package(Qt6 ...)` call after setting `Qt6_DIR` for the vendored Qt6 fallback path on Windows.

  ## Motivation and Context
  When building on Windows without a system Qt6 installation, CMake sets `Qt6_DIR` to point to the vendored Qt6 but never calls `find_package` again. This causes CMake to fail with "Unknown CMake command qt_add_resources" because the Qt6 package was never actually loaded.

  ## How Has This Been Tested?
  Built on Windows 11 x64 using the `win-x64` preset with MSVC. Configuration and build complete successfully with the vendored Qt6.

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
