### PR TITLE
fix: explicitly include <cstdint> for fixed-width int types

### DIFF
--- a/src/main/util/helper.h
+++ b/src/main/util/helper.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <list>
 #include <string>
+#include <cstdint>
 
 template <class T>
 void deleteVect(std::vector<T *> &vect) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a build failure

## Motivation and Context
Build failure observed in https://github.com/bandithedoge/nur-packages/actions/runs/20771992030/job/59649881534#step:6:27470

## How Has This Been Tested?
`cmake -B build && cmake --build build`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
