### PR TITLE
add NDEBUG definition for non-debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.21)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20)
+add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:NDEBUG>)
 
 # Use ccache if present on the system
 find_program(CCACHE ccache)


### PR DESCRIPTION
When building the app with our CMake presets, NDEBUG is never defined for release builds. This causes failing assert() calls to crash the app.

## How Has This Been Tested?
Confirmed that failling asserts no longer crash release builds. Debug builds still throw on failed asserts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
