### PR TITLE
RhiHexView: Refactor VGMItem::getItemAtOffset() to avoid the O(n) lookup. 

### DIFF
--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -46,9 +46,22 @@ VGMItem* VGMItem::getItemAtOffset(uint32_t offset, bool matchStartOffset) {
     }
   }
 
-  for (const auto child : m_children) {
-    if (VGMItem *foundItem = child->getItemAtOffset(offset, matchStartOffset))
+  ensureChildrenSorted();
+  // Binary search by start offset, then scan backwards only across potentially overlapping items.
+  const auto begin = m_children.begin();
+  const auto end = m_children.end();
+  auto it = std::upper_bound(begin, end, offset,
+      [](uint32_t off, const VGMItem* child) { return off < child->dwOffset; });
+
+  for (auto idx = static_cast<size_t>(it - begin); idx > 0; --idx) {
+    VGMItem* child = m_children[idx - 1];
+    if (VGMItem* foundItem = child->getItemAtOffset(offset, matchStartOffset)) {
       return foundItem;
+    }
+    if (!m_childrenPrefixMaxEnd.empty() &&
+        m_childrenPrefixMaxEnd[idx - 1] <= static_cast<uint64_t>(offset)) {
+      break;
+    }
   }
 
   return nullptr;
@@ -95,40 +108,82 @@ bool VGMItem::isValidOffset(uint32_t offset) const {
 VGMItem* VGMItem::addChild(VGMItem *item) {
   item->m_vgmfile = vgmFile();
   m_children.emplace_back(item);
+  m_childrenSorted = false;
+  m_childrenPrefixMaxEnd.clear();
   return item;
 }
 
 VGMItem* VGMItem::addChild(uint32_t offset, uint32_t length, const std::string &name) {
   auto child = new VGMItem(vgmFile(), offset, length, name, Type::Header);
   m_children.emplace_back(child);
+  m_childrenSorted = false;
+  m_childrenPrefixMaxEnd.clear();
   return child;
 }
 
 VGMItem* VGMItem::addUnknownChild(uint32_t offset, uint32_t length) {
   auto child = new VGMItem(vgmFile(), offset, length, "Unknown");
   m_children.emplace_back(child);
+  m_childrenSorted = false;
+  m_childrenPrefixMaxEnd.clear();
   return child;
 }
 
 VGMHeader* VGMItem::addHeader(uint32_t offset, uint32_t length, const std::string &name) {
   auto *header = new VGMHeader(this, offset, length, name);
   m_children.emplace_back(header);
+  m_childrenSorted = false;
+  m_childrenPrefixMaxEnd.clear();
   return header;
 }
 
 void VGMItem::removeChildren() {
   m_children.clear();
+  m_childrenSorted = true;
+  m_childrenPrefixMaxEnd.clear();
 }
 
 void VGMItem::transferChildren(VGMItem* destination) {
   destination->addChildren(m_children);
   m_children.clear();
+  m_childrenSorted = true;
+  m_childrenPrefixMaxEnd.clear();
+}
+
+void VGMItem::ensureChildrenSorted() {
+  // Lazy path: only sort/rebuild when a lookup needs it.
+  if (m_children.size() < 2) {
+    m_childrenSorted = true;
+  }
+  if (!m_childrenSorted) {
+    std::sort(m_children.begin(), m_children.end(),
+              [](const VGMItem* a, const VGMItem* b) { return a->dwOffset < b->dwOffset; });
+    m_childrenSorted = true;
+    rebuildChildPrefixMaxEnd();
+    return;
+  }
+  if (m_childrenPrefixMaxEnd.size() != m_children.size()) {
+    rebuildChildPrefixMaxEnd();
+  }
+}
+
+void VGMItem::rebuildChildPrefixMaxEnd() {
+  m_childrenPrefixMaxEnd.clear();
+  m_childrenPrefixMaxEnd.reserve(m_children.size());
+  uint64_t maxEnd = 0;
+  for (const auto* child : m_children) {
+    const uint64_t end = static_cast<uint64_t>(child->dwOffset) + child->unLength;
+    maxEnd = std::max(maxEnd, end);
+    m_childrenPrefixMaxEnd.push_back(maxEnd);
+  }
 }
 
 void VGMItem::sortChildrenByOffset() {
   std::ranges::sort(m_children, [](const VGMItem *a, const VGMItem *b) {
     return a->dwOffset < b->dwOffset;
   });
+  m_childrenSorted = true;
+  rebuildChildPrefixMaxEnd();
 
   // Recursively sort the children of each child, if they have any children
   for (VGMItem* child : m_children) {

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -116,6 +116,8 @@ public:
   requires std::convertible_to<std::ranges::range_value_t<Range>, VGMItem*>
   void addChildren(const Range& items) {
     std::ranges::copy(items, std::back_inserter(m_children));
+    m_childrenSorted = false;
+    m_childrenPrefixMaxEnd.clear();
   }
 
   void sortChildrenByOffset();
@@ -137,7 +139,13 @@ public:
 
 private:
   std::vector<VGMItem *> m_children;
+  // Maintains sort + prefix-max end cache for fast offset lookups.
+  bool m_childrenSorted = true;
+  std::vector<uint64_t> m_childrenPrefixMaxEnd;
   VGMFile *m_vgmfile;
+
+  void ensureChildrenSorted();
+  void rebuildChildPrefixMaxEnd();
   std::string m_name;
 };
 


### PR DESCRIPTION
## Description

Currently, VGMItem::getItemAtOffset() iterates through all children linearly, which can be slow with large child lists, and it also needs to handle items with overlapping ranges correctly. This PR significantly speeds up lookup by using a binary search tree in conjunction with a bounded backward scan, which allows us to quickly find the list of items that overlap an offset so we can iterate over a small subset of sibling items rather than all siblings.

Codex wrote this and does a better job summarizing the details:
- Approach: keep children sorted by dwOffset, binary‑search for the first child whose start is after the target offset, then scan backward through only the potentially overlapping items.
- Prefix‑max bound: maintain a cached array where prefixMaxEnd[i] is the maximum end offset among children [0..i]. While scanning backward, if prefixMaxEnd[i] <= offset, then no earlier child can overlap the offset, so the scan can stop safely.
- Complexity: O(log n + k), where k is the number of overlapping candidates.
- Implementation notes: cache invalidated on child mutations; rebuilt lazily when a lookup needs it.

## Motivation and Context
This is one part of a much larger change: a rewrite of HexView using Qt's "Rendering Hardware Interface" (RHI) so that we can highlight active events in real-time during playback. The CPU-bound rendering of Qt Widgets, which our current HexView uses, is simply too slow. RHI let's us utilize the platform's 3d API (D3D, Metal, OpenGL). It was necessary to improve the performance of getItemAtOffset() for real-time highlighting.

The branch `event-tracking3` contains the latest work on the RHI HexView with real-time highlighting. It's finished, short of some possible cleanup / commenting.

## How Has This Been Tested?
I've been using this on the new HexView and tested many. I have yet to see any problems.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
