### PR TITLE
RhiHexView: stop SequencePlayer when playing VGMColl is removed

### DIFF
--- a/src/ui/qt/SequencePlayer.cpp
+++ b/src/ui/qt/SequencePlayer.cpp
@@ -15,6 +15,7 @@
 #include "VGMSeq.h"
 #include "LogManager.h"
 #include "SF2Conversion.h"
+#include "QtVGMRoot.h"
 
 /**
  * @brief Routines to read file data from memory.
@@ -95,6 +96,12 @@ SequencePlayer::SequencePlayer() {
     }
   });
   m_seekupdate_timer->start(TICK_POLL_INTERVAL_MS);
+
+  connect(&qtVGMRoot, &QtVGMRoot::UI_removeVGMColl, this, [this](VGMColl* coll) {
+    if (m_active_vgmcoll == coll) {
+      stop();
+    }
+  });
 }
 
 SequencePlayer::~SequencePlayer() {


### PR DESCRIPTION
This connects SequencePlayer to VGMRoot's `UI_removeVGMColl` signal to stop playback if the removed VGMColl is the same as `SequencePlayer::m_active_vgmcoll`, which would otherwise be a dangling pointer with no way to verify. This was an issue in the new HexView implementation.

I think stopping playback is the preferable behavior any way.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
