### PR TITLE
Replace VGMItem::dwOffset and unLength with getter/setter methods

### DIFF
--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -54,11 +54,11 @@ RawFile *VGMFile::rawFile() const {
 }
 
 uint32_t VGMFile::readBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) const {
-  // if unLength != 0, verify that we're within the bounds of the file, and truncate num read
+  // if length() != 0, verify that we're within the bounds of the file, and truncate num read
   // bytes to end of file
-  if (unLength != 0) {
-    uint32_t endOff = dwOffset + unLength;
-    assert(nIndex >= dwOffset && nIndex < endOff);
+  if (length() != 0) {
+    uint32_t endOff = offset() + length();
+    assert(nIndex >= offset() && nIndex < endOff);
     if (nIndex + nCount > endOff)
       nCount = endOff - nIndex;
   }

--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -33,7 +33,7 @@ public:
   void removeCollAssoc(VGMColl *coll);
   [[nodiscard]] RawFile *rawFile() const;
 
-  [[nodiscard]] size_t size() const noexcept { return unLength; }
+  [[nodiscard]] size_t size() const noexcept { return length(); }
 
   uint32_t readBytes(uint32_t nIndex, uint32_t nCount, void *pBuffer) const;
 
@@ -44,7 +44,7 @@ public:
   inline uint32_t readWordBE(uint32_t offset) const { return m_rawfile->readWordBE(offset); }
   inline bool isValidOffset(uint32_t offset) const { return m_rawfile->isValidOffset(offset); }
 
-  uint32_t startOffset() const { return dwOffset; }
+  uint32_t startOffset() const { return offset(); }
   /*
    * For whatever reason, you can create null-length VGMItems.
    * The only safe way for now is to
@@ -52,7 +52,7 @@ public:
    */
   uint32_t endOffset() const { return static_cast<uint32_t>(m_rawfile->size()); }
 
-  [[nodiscard]] const char *data() const { return m_rawfile->data() + dwOffset; }
+  [[nodiscard]] const char *data() const { return m_rawfile->data() + offset(); }
 
   std::vector<VGMColl*> assocColls;
 

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -105,6 +105,11 @@ public:
   virtual void addToUI(VGMItem *parent, void *UI_specific);
 
   const std::vector<VGMItem*>& children() { return m_children; }
+  [[nodiscard]] uint32_t offset() const noexcept { return m_offset; }
+  [[nodiscard]] uint32_t length() const noexcept { return m_length; }
+  void setOffset(uint32_t offset);
+  void setLength(uint32_t length);
+  void setRange(uint32_t offset, uint32_t length);
   VGMItem* addChild(VGMItem* child);
   VGMItem* addChild(uint32_t offset, uint32_t length, const std::string &name);
   VGMItem* addUnknownChild(uint32_t offset, uint32_t length);
@@ -116,6 +121,9 @@ public:
   requires std::convertible_to<std::ranges::range_value_t<Range>, VGMItem*>
   void addChildren(const Range& items) {
     std::ranges::copy(items, std::back_inserter(m_children));
+    for (auto *child : m_children) {
+      child->m_parent = this;
+    }
   }
 
   void sortChildrenByOffset();
@@ -131,16 +139,17 @@ protected:
   // FIXME: clearChildren() is a workaround for VGMSeqNoTrks' multiple inheritance diamond problem
 
 public:
-  uint32_t dwOffset;  // offset in the pDoc data buffer
-  uint32_t unLength;  // num of bytes the event engulfs
   const Type type;
 
 private:
   std::vector<VGMItem *> m_children;
   VGMFile *m_vgmfile;
+  VGMItem *m_parent = nullptr;
+  uint32_t m_offset;  // offset in the pDoc data buffer
+  uint32_t m_length;  // num of bytes the event engulfs
   std::string m_name;
 };
 
 struct ItemPtrOffsetCmp {
-  bool operator()(const VGMItem *a, const VGMItem *b) const { return (a->dwOffset < b->dwOffset); }
+  bool operator()(const VGMItem *a, const VGMItem *b) const { return (a->offset() < b->offset()); }
 };

--- a/src/main/components/VGMMiscFile.cpp
+++ b/src/main/components/VGMMiscFile.cpp
@@ -40,7 +40,7 @@ bool VGMMiscFile::load() {
   if (!loadMain()) {
     return false;
   }
-  if (unLength == 0) {
+  if (length() == 0) {
     return false;
   }
 

--- a/src/main/components/VGMMultiSectionSeq.cpp
+++ b/src/main/components/VGMMultiSectionSeq.cpp
@@ -70,7 +70,7 @@ bool VGMMultiSectionSeq::postLoad() {
     }
     addChildren(aSections);
     setGuessedLength();
-    if (unLength == 0) {
+    if (length() == 0) {
       return false;
     }
   } else if (readMode == READMODE_CONVERT_TO_MIDI) {
@@ -117,11 +117,11 @@ bool VGMMultiSectionSeq::readEvent(long /*stopTime*/) {
 }
 
 void VGMMultiSectionSeq::addSection(VGMSeqSection *section) {
-  if (dwOffset > section->dwOffset) {
-    uint32_t distance = dwOffset - section->dwOffset;
-    dwOffset = section->dwOffset;
-    if (unLength != 0) {
-      unLength += distance;
+  if (offset() > section->offset()) {
+    uint32_t distance = offset() - section->offset();
+    setOffset(section->offset());
+    if (length() != 0) {
+      setLength(length() + (distance));
     }
   }
   aSections.push_back(section);
@@ -141,7 +141,7 @@ bool VGMMultiSectionSeq::addLoopForeverNoItem() {
 VGMSeqSection *VGMMultiSectionSeq::getSectionAtOffset(uint32_t offset) {
   for (size_t sectionIndex = 0; sectionIndex < aSections.size(); sectionIndex++) {
     VGMSeqSection *section = aSections[sectionIndex];
-    if (section->dwOffset == offset) {
+    if (section->offset() == offset) {
       return section;
     }
   }

--- a/src/main/components/VGMSampColl.cpp
+++ b/src/main/components/VGMSampColl.cpp
@@ -61,23 +61,23 @@ bool VGMSampColl::load() {
 
   addChildren(samples);
 
-  if (unLength == 0) {
+  if (length() == 0) {
     for (std::vector<VGMSamp *>::iterator itr = samples.begin(); itr != samples.end(); ++itr) {
       VGMSamp *samp = *itr;
 
       // Some formats can have negative sample offset
       // For example, Konami's SNES format and Hudson's SNES format
       // TODO: Fix negative sample offset without breaking instrument
-      //assert(dwOffset <= samp->dwOffset);
+      //assert(offset() <= samp->offset());
 
-      //if (dwOffset > samp->dwOffset)
+      //if (offset() > samp->offset())
       //{
-      //	unLength += samp->dwOffset - dwOffset;
-      //	dwOffset = samp->dwOffset;
+      //	setLength(length() + (samp->offset() - offset()));
+      //	setOffset(samp->offset());
       //}
 
-      if (dwOffset + unLength < samp->dwOffset + samp->unLength) {
-        unLength = (samp->dwOffset + samp->unLength) - dwOffset;
+      if (offset() + length() < samp->offset() + samp->length()) {
+        setLength((samp->offset() + samp->length()) - offset());
       }
     }
   }

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -68,7 +68,7 @@ bool VGMInstrSet::load() {
   if (m_auto_add_instruments_as_children)
     addChildren(aInstrs);
 
-  if (unLength == 0) {
+  if (length() == 0) {
     setGuessedLength();
   }
 

--- a/src/main/components/matcher/FilegroupMatcher.cpp
+++ b/src/main/components/matcher/FilegroupMatcher.cpp
@@ -70,7 +70,7 @@ bool FilegroupMatcher::onCloseSampColl(VGMSampColl *sampcoll) {
 
 void FilegroupMatcher::lookForMatch() {
   // 1. Sort all three containers by descending file‑offset
-  auto byOffsetDesc = [](auto* a, auto* b) { return a->dwOffset > b->dwOffset; };
+  auto byOffsetDesc = [](auto* a, auto* b) { return a->offset() > b->offset(); };
   seqs.sort(byOffsetDesc);
   instrsets.sort(byOffsetDesc);
   sampcolls.sort(byOffsetDesc);

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -279,17 +279,17 @@ void SeqTrack::addEvent(SeqEvent *pSeqEvent) {
 
   // care for a case where the new event is located before the start address
   // (example: Donkey Kong Country - Map, Track 7 of 8)
-  if (dwOffset > pSeqEvent->dwOffset) {
+  if (offset() > pSeqEvent->offset()) {
     if (bDetermineTrackLengthEventByEvent) {
-      unLength += (dwOffset - pSeqEvent->dwOffset);
+      setLength(length() + ((offset() - pSeqEvent->offset())));
     }
-    dwOffset = pSeqEvent->dwOffset;
+    setOffset(pSeqEvent->offset());
   }
 
   if (bDetermineTrackLengthEventByEvent) {
-    uint32_t length = pSeqEvent->dwOffset + pSeqEvent->unLength - dwOffset;
-    if (unLength < length)
-      unLength = length;
+    uint32_t newTrkLen = pSeqEvent->offset() + pSeqEvent->length() - offset();
+    if (length() < newTrkLen)
+      setLength(newTrkLen);
   }
 }
 

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -118,7 +118,7 @@ bool VGMSeq::postLoad() {
     addChildren(aTracks);
 
     setGuessedLength();
-    if (unLength == 0) {
+    if (length() == 0) {
       return false;
     }
   } else if (readMode == READMODE_CONVERT_TO_MIDI) {
@@ -153,21 +153,21 @@ void VGMSeq::loadTracksMain(uint32_t stopTime) {
   for (uint32_t trackNum = 0; trackNum < nNumTracks; trackNum++) {
     if (readMode == READMODE_ADD_TO_UI) {
       aStopOffset[trackNum] = endOffset();
-      if (unLength != 0) {
-        aStopOffset[trackNum] = dwOffset + unLength;
+      if (length() != 0) {
+        aStopOffset[trackNum] = offset() + length();
       } else {
         if (!m_allow_discontinuous_track_data) {
           // set length from the next track by offset
           for (uint32_t j = 0; j < nNumTracks; j++) {
-            if (aTracks[j]->dwOffset > aTracks[trackNum]->dwOffset &&
-                aTracks[j]->dwOffset < aStopOffset[trackNum]) {
-              aStopOffset[trackNum] = aTracks[j]->dwOffset;
+            if (aTracks[j]->offset() > aTracks[trackNum]->offset() &&
+                aTracks[j]->offset() < aStopOffset[trackNum]) {
+              aStopOffset[trackNum] = aTracks[j]->offset();
             }
           }
         }
       }
     } else {
-      aStopOffset[trackNum] = aTracks[trackNum]->dwOffset + aTracks[trackNum]->unLength;
+      aStopOffset[trackNum] = aTracks[trackNum]->offset() + aTracks[trackNum]->length();
     }
   }
 

--- a/src/main/components/seq/VGMSeqNoTrks.h
+++ b/src/main/components/seq/VGMSeqNoTrks.h
@@ -24,8 +24,10 @@ public:
   using VGMSeq::readWord;
   using VGMSeq::readShortBE;
   using VGMSeq::readWordBE;
-  [[nodiscard]] inline uint32_t &offset() { return VGMSeq::dwOffset; }
-  [[nodiscard]] inline uint32_t &length() { return VGMSeq::unLength; }
+  [[nodiscard]] inline uint32_t offset() const { return VGMSeq::offset(); }
+  [[nodiscard]] inline uint32_t length() const { return VGMSeq::length(); }
+  inline void setOffset(uint32_t offset) { VGMSeq::setOffset(offset); }
+  inline void setLength(uint32_t length) { VGMSeq::setLength(length); }
   [[nodiscard]] inline std::string name() { return VGMSeq::name(); }
 
   [[nodiscard]] inline RawFile* rawFile() { return VGMSeq::rawFile(); }
@@ -36,7 +38,7 @@ public:
   inline void setEventsOffset(uint32_t offset) {
     dwEventsOffset = offset;
     if (SeqTrack::readMode == READMODE_ADD_TO_UI) {
-      SeqTrack::dwOffset = offset;
+      SeqTrack::setOffset(offset);
     }
   }
 

--- a/src/main/conversion/DLSConversion.cpp
+++ b/src/main/conversion/DLSConversion.cpp
@@ -142,8 +142,8 @@ bool mainDLSCreation(
         if (rgn->sampOffset != -1) {
           bool bFoundIt = false;
           for (uint32_t s = 0; s < sampColl->samples.size(); s++) {             //for every sample
-            if (rgn->sampOffset == sampColl->samples[s]->dwOffset ||
-                rgn->sampOffset == sampColl->samples[s]->dwOffset - sampColl->dwOffset - sampColl->sampDataOffset) {
+            if (rgn->sampOffset == sampColl->samples[s]->offset() ||
+                rgn->sampOffset == sampColl->samples[s]->offset() - sampColl->offset() - sampColl->sampDataOffset) {
               realSampNum = s;
 
               //samples[m]->loop.loopStart = parInstrSet->aInstrs[i]->aRgns[k]->loop.loopStart;

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -117,8 +117,8 @@ SynthFile* createSynthFile(
           bool bFoundIt = false;
           for (uint32_t s = 0; s < sampColl->samples.size(); s++) {  //for every sample
             auto sample = sampColl->samples[s];
-            if (rgn->sampOffset == sample->dwOffset ||
-                rgn->sampOffset == sample->dwOffset - sampColl->dwOffset - sampColl->sampDataOffset) {
+            if (rgn->sampOffset == sample->offset() ||
+                rgn->sampOffset == sample->offset() - sampColl->offset() - sampColl->sampDataOffset) {
               if (rgn->sampDataLength != -1 && rgn->sampDataLength != sample->dataLength) {
                 continue;
               }

--- a/src/main/conversion/VGMExport.cpp
+++ b/src/main/conversion/VGMExport.cpp
@@ -107,6 +107,6 @@ bool saveAsOriginal(const RawFile& rawfile, const fs::path& filepath) {
 }
 
 bool saveAsOriginal(const VGMFile& file, const fs::path& filepath) {
-  return saveDataToFile(file.rawFile()->begin() + file.dwOffset, file.unLength, filepath);
+  return saveDataToFile(file.rawFile()->begin() + file.offset(), file.length(), filepath);
 }
 }  // namespace conversion

--- a/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
@@ -229,7 +229,7 @@ bool AkaoSnesRgn::initializeRegion(uint8_t srcn,
                                    uint32_t /*spcDirAddr*/,
                                    uint16_t addrADSRTable)
 {
-  uint16_t addrTuningTable = dwOffset;
+  uint16_t addrTuningTable = offset();
   uint8_t adsr1;
   uint8_t adsr2;
   if (version == AKAOSNES_V1) {

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -49,8 +49,8 @@ void AkaoSnesSeq::resetVars() {
 bool AkaoSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, 0);
-  uint32_t curOffset = dwOffset;
+  VGMHeader *header = addHeader(offset(), 0);
+  uint32_t curOffset = offset();
   if (version == AKAOSNES_V1 || version == AKAOSNES_V2) {
     // Earlier versions are not relocatable
     // All addresses are plain APU addresses
@@ -80,10 +80,10 @@ bool AkaoSnesSeq::parseHeader() {
     }
 
     // calculate sequence length
-    if (addrSequenceEnd < dwOffset) {
+    if (addrSequenceEnd < offset()) {
       return false;
     }
-    unLength = addrSequenceEnd - dwOffset;
+    setLength(addrSequenceEnd - offset());
   }
 
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
@@ -104,7 +104,7 @@ bool AkaoSnesSeq::parseHeader() {
 
 
 bool AkaoSnesSeq::parseTrackPointers(void) {
-  uint32_t curOffset = dwOffset;
+  uint32_t curOffset = offset();
   if (version == AKAOSNES_V3) {
     if (minorVersion != AKAOSNES_V3_FFMQ) {
       curOffset += 2;

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesInstr.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesInstr.cpp
@@ -30,7 +30,7 @@ bool AsciiShuichiSnesInstrSet::parseHeader() {
 bool AsciiShuichiSnesInstrSet::parseInstrPointers() {
   usedSRCNs.clear();
   for (int instr = 0; instr < 0x40; instr++) {
-    const uint32_t instrHeaderAddress = dwOffset + (4 * instr);
+    const uint32_t instrHeaderAddress = offset() + (4 * instr);
     if (instrHeaderAddress + 4 > 0x10000) {
       return false;
     }
@@ -81,7 +81,7 @@ AsciiShuichiSnesInstr::AsciiShuichiSnesInstr(VGMInstrSet *instrSet,
 }
 
 bool AsciiShuichiSnesInstr::loadInstr() {
-  const uint8_t srcn = readByte(dwOffset);
+  const uint8_t srcn = readByte(offset());
   const uint32_t dirEntryOffset = spcDirAddress + (srcn * 4);
   if (dirEntryOffset + 4 > 0x10000) {
     return false;
@@ -94,7 +94,7 @@ bool AsciiShuichiSnesInstr::loadInstr() {
   }
   const auto spcFineTuning = static_cast<int8_t>(readByte(fineTuningTableAddress + srcn));
 
-  const auto rgn = new AsciiShuichiSnesRgn(this, dwOffset, spcFineTuning);
+  const auto rgn = new AsciiShuichiSnesRgn(this, offset(), spcFineTuning);
   rgn->sampOffset = sampleStartAddress - spcDirAddress;
   addRgn(rgn);
 

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
@@ -48,8 +48,8 @@ void AsciiShuichiSnesSeq::resetVars() {
 bool AsciiShuichiSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, 2 * MAX_TRACKS);
-  if (dwOffset + header->unLength > 0x10000) {
+  VGMHeader *header = addHeader(offset(), 2 * MAX_TRACKS);
+  if (offset() + header->length() > 0x10000) {
     return false;
   }
 
@@ -57,8 +57,8 @@ bool AsciiShuichiSnesSeq::parseHeader() {
     string trackNameLow = fmt::format("Track Pointer {:d} (Low)", trackIndex + 1);
     string trackNameHigh = fmt::format("Track Pointer {:d} (High)", trackIndex + 1);
 
-    header->addChild(dwOffset + trackIndex, 1, trackNameLow);
-    header->addChild(dwOffset + MAX_TRACKS + trackIndex, 1, trackNameHigh);
+    header->addChild(offset() + trackIndex, 1, trackNameLow);
+    header->addChild(offset() + MAX_TRACKS + trackIndex, 1, trackNameHigh);
   }
 
   return true;
@@ -67,8 +67,8 @@ bool AsciiShuichiSnesSeq::parseHeader() {
 
 bool AsciiShuichiSnesSeq::parseTrackPointers() {
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
-    const uint8_t lo = readByte(dwOffset + trackIndex);
-    const uint8_t hi = readByte(dwOffset + MAX_TRACKS + trackIndex);
+    const uint8_t lo = readByte(offset() + trackIndex);
+    const uint8_t hi = readByte(offset() + MAX_TRACKS + trackIndex);
     const auto trackStartAddress = static_cast<uint16_t>(lo | (hi << 8));
 
     const auto track = new AsciiShuichiSnesTrack(this, trackStartAddress);

--- a/src/main/formats/CPS/CPS1Instr.h
+++ b/src/main/formats/CPS/CPS1Instr.h
@@ -335,7 +335,7 @@ public:
   ~CPS1OPMInstr() override = default;
 
   bool loadInstr() override {
-    this->readBytes(dwOffset, sizeof(OPMType), &opmData);
+    this->readBytes(offset(), sizeof(OPMType), &opmData);
     return true;
   }
 

--- a/src/main/formats/CPS/CPS2Seq.cpp
+++ b/src/main/formats/CPS/CPS2Seq.cpp
@@ -42,19 +42,19 @@ bool CPS2Seq::parseHeader() {
 bool CPS2Seq::parseTrackPointers() {
   // CPS1 games sometimes have this set. Suggests 4 byte seq.
   // Oddly, some tracks have first byte set to 0x92 in D&D Shadow Over Mystara
-  if ((readByte(dwOffset) & 0x80) > 0)
+  if ((readByte(offset()) & 0x80) > 0)
     return false;
 
-  this->addHeader(dwOffset, 1, "Sequence Flags");
-  VGMHeader *header = this->addHeader(dwOffset + 1, readShortBE(dwOffset + 1) - 1, "Track Pointers");
+  this->addHeader(offset(), 1, "Sequence Flags");
+  VGMHeader *header = this->addHeader(offset() + 1, readShortBE(offset() + 1) - 1, "Track Pointers");
 
   for (int i = 0; i < 16; i++) {
-    uint32_t offset = readShortBE(dwOffset + 1 + i * 2);
-    if (offset == 0) {
-      header->addChild(dwOffset + 1 + (i * 2), 2, "No Track");
+    uint32_t trkOff = readShortBE(offset() + 1 + i * 2);
+    if (trkOff == 0) {
+      header->addChild(offset() + 1 + (i * 2), 2, "No Track");
       continue;
     }
-    //if (GetShortBE(offset+dwOffset) == 0xE017)	//Rest, EndTrack (used by empty tracks)
+    //if (GetShortBE(offset+offset()) == 0xE017)	//Rest, EndTrack (used by empty tracks)
     //	continue;
 
     SeqTrack *newTrack;
@@ -65,13 +65,13 @@ bool CPS2Seq::parseTrackPointers() {
       case CPS2_V210:
       case CPS2_V211:
       case CPS3:
-        newTrack = new CPS2TrackV2(this, offset + dwOffset);
+        newTrack = new CPS2TrackV2(this, trkOff + offset());
         break;
       default:
-        newTrack = new CPS2TrackV1(this, offset + dwOffset);
+        newTrack = new CPS2TrackV1(this, trkOff + offset());
     }
     aTracks.push_back(newTrack);
-    header->addChild(dwOffset + 1 + (i * 2), 2, "Track Pointer");
+    header->addChild(offset() + 1 + (i * 2), 2, "Track Pointer");
   }
   if (aTracks.size() == 0)
     return false;

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -27,7 +27,7 @@ bool CapcomSnesInstrSet::parseHeader() {
 bool CapcomSnesInstrSet::parseInstrPointers() {
   usedSRCNs.clear();
   for (int instr = 0; instr <= 0xff; instr++) {
-    uint32_t addrInstrHeader = dwOffset + (6 * instr);
+    uint32_t addrInstrHeader = offset() + (6 * instr);
     if (addrInstrHeader + 6 > 0x10000) {
       return false;
     }
@@ -94,7 +94,7 @@ CapcomSnesInstr::CapcomSnesInstr(VGMInstrSet *instrSet,
 CapcomSnesInstr::~CapcomSnesInstr() {}
 
 bool CapcomSnesInstr::loadInstr() {
-  uint8_t srcn = readByte(dwOffset);
+  uint8_t srcn = readByte(offset());
   uint32_t offDirEnt = spcDirAddr + (srcn * 4);
   if (offDirEnt + 4 > 0x10000) {
     return false;
@@ -102,7 +102,7 @@ bool CapcomSnesInstr::loadInstr() {
 
   uint16_t addrSampStart = readShort(offDirEnt);
 
-  CapcomSnesRgn *rgn = new CapcomSnesRgn(this, dwOffset);
+  CapcomSnesRgn *rgn = new CapcomSnesRgn(this, offset());
   rgn->sampOffset = addrSampStart - spcDirAddr;
   addRgn(rgn);
 

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -58,8 +58,8 @@ void CapcomSnesSeq::resetVars() {
 bool CapcomSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *seqHeader = addHeader(dwOffset, (priorityInHeader ? 1 : 0) + MAX_TRACKS * 2, "Sequence Header");
-  uint32_t curHeaderOffset = dwOffset;
+  VGMHeader *seqHeader = addHeader(offset(), (priorityInHeader ? 1 : 0) + MAX_TRACKS * 2, "Sequence Header");
+  uint32_t curHeaderOffset = offset();
 
   if (priorityInHeader) {
     seqHeader->addChild(curHeaderOffset, 1, "Priority");
@@ -77,7 +77,7 @@ bool CapcomSnesSeq::parseHeader() {
 
 bool CapcomSnesSeq::parseTrackPointers() {
   for (int i = MAX_TRACKS - 1; i >= 0; i--) {
-    uint16_t trkOff = readShortBE(dwOffset + (priorityInHeader ? 1 : 0) + i * 2);
+    uint16_t trkOff = readShortBE(offset() + (priorityInHeader ? 1 : 0) + i * 2);
     if (trkOff != 0)
       aTracks.push_back(new CapcomSnesTrack(this, trkOff));
   }

--- a/src/main/formats/ChunSnes/ChunSnesInstr.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesInstr.cpp
@@ -30,7 +30,7 @@ ChunSnesInstrSet::~ChunSnesInstrSet() {
 }
 
 bool ChunSnesInstrSet::parseHeader() {
-  uint32_t curOffset = dwOffset;
+  uint32_t curOffset = offset();
   if (curOffset + 2 > 0x10000) {
     return false;
   }
@@ -54,7 +54,7 @@ bool ChunSnesInstrSet::parseHeader() {
 bool ChunSnesInstrSet::parseInstrPointers() {
   usedSRCNs.clear();
 
-  uint32_t curOffset = dwOffset;
+  uint32_t curOffset = offset();
   unsigned int nNumInstrs = readByte(curOffset);
   if (version == CHUNSNES_SUMMER) {
     curOffset += 1;
@@ -81,8 +81,8 @@ bool ChunSnesInstrSet::parseInstrPointers() {
         usedSRCNs.push_back(srcn);
       }
 
-      if (addrInstr < dwOffset) {
-        dwOffset = addrInstr;
+      if (addrInstr < offset()) {
+        setOffset(addrInstr);
       }
 
       ChunSnesInstr *newInstr = new ChunSnesInstr(this, version, instrNum, addrInstr,
@@ -123,8 +123,8 @@ ChunSnesInstr::ChunSnesInstr(VGMInstrSet *instrSet,
 ChunSnesInstr::~ChunSnesInstr() {}
 
 bool ChunSnesInstr::loadInstr() {
-  uint8_t srcn = readByte(dwOffset);
-  addChild(dwOffset, 1, "Sample Number");
+  uint8_t srcn = readByte(offset());
+  addChild(offset(), 1, "Sample Number");
   if (srcn == 0xff) {
     return false;
   }
@@ -156,17 +156,17 @@ bool ChunSnesInstr::loadInstr() {
 ChunSnesRgn::ChunSnesRgn(ChunSnesInstr *instr, ChunSnesVersion ver, uint8_t srcn, uint16_t addrRgn, uint32_t spcDirAddr) :
     VGMRgn(instr, addrRgn, 8),
     version(ver) {
-  addUnknown(dwOffset, 2);
-  addChild(dwOffset + 2, 1, "ADSR(1)");
-  addChild(dwOffset + 3, 1, "ADSR(2)");
-  addChild(dwOffset + 4, 1, "GAIN");
-  addChild(dwOffset + 5, 2, "Tuning");
-  addUnknown(dwOffset + 7, 1);
+  addUnknown(offset(), 2);
+  addChild(offset() + 2, 1, "ADSR(1)");
+  addChild(offset() + 3, 1, "ADSR(2)");
+  addChild(offset() + 4, 1, "GAIN");
+  addChild(offset() + 5, 2, "Tuning");
+  addUnknown(offset() + 7, 1);
 
-  const uint8_t adsr1 = readByte(dwOffset + 2);
-  const uint8_t adsr2 = readByte(dwOffset + 3);
-  const uint8_t gain = readByte(dwOffset + 4);
-  const int16_t pitch_scale = getShortBE(dwOffset + 5);
+  const uint8_t adsr1 = readByte(offset() + 2);
+  const uint8_t adsr2 = readByte(offset() + 3);
+  const uint8_t gain = readByte(offset() + 4);
+  const int16_t pitch_scale = getShortBE(offset() + 5);
 
   const double pitch_fixer = (version == CHUNSNES_SUMMER) ? (7902.0 / 8192.0) : (7938.0 / 8192.0); // from pitch table
   double coarse_tuning;

--- a/src/main/formats/ChunSnes/ChunSnesSeq.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesSeq.cpp
@@ -49,8 +49,8 @@ void ChunSnesSeq::resetVars() {
 bool ChunSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, 0);
-  uint32_t curOffset = dwOffset;
+  VGMHeader *header = addHeader(offset(), 0);
+  uint32_t curOffset = offset();
   if (curOffset + 2 > 0x10000) {
     return false;
   }
@@ -73,7 +73,7 @@ bool ChunSnesSeq::parseHeader() {
       addrTrackStart = ofsTrackStart;
     }
     else {
-      addrTrackStart = dwOffset + ofsTrackStart;
+      addrTrackStart = offset() + ofsTrackStart;
     }
 
     auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);

--- a/src/main/formats/CompileSnes/CompileSnesInstr.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesInstr.cpp
@@ -103,7 +103,7 @@ bool CompileSnesInstr::loadInstr() {
 
   uint16_t addrSampStart = readShort(offDirEnt);
 
-  CompileSnesRgn *rgn = new CompileSnesRgn(this, version, dwOffset, addrPitchTablePtrs);
+  CompileSnesRgn *rgn = new CompileSnesRgn(this, version, offset(), addrPitchTablePtrs);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   addRgn(rgn);
 
@@ -157,7 +157,7 @@ CompileSnesRgn::CompileSnesRgn(CompileSnesInstr *instr,
   }
   else {
     uint8_t pitchTableIndex = readByte(addrTuningTableItem + 1);
-    addChild(dwOffset + 1, 1, "Pitch Table Index");
+    addChild(offset() + 1, 1, "Pitch Table Index");
 
     if (pitchTableIndex == 0) {
       pitchTable.assign(std::begin(REGULAR_PITCH_TABLE), std::end(REGULAR_PITCH_TABLE));

--- a/src/main/formats/CompileSnes/CompileSnesSeq.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesSeq.cpp
@@ -47,15 +47,15 @@ void CompileSnesSeq::resetVars() {
 bool CompileSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, 0);
+  VGMHeader *header = addHeader(offset(), 0);
 
-  header->addChild(dwOffset, 1, "Number of Tracks");
-  nNumTracks = readByte(dwOffset);
+  header->addChild(offset(), 1, "Number of Tracks");
+  nNumTracks = readByte(offset());
   if (nNumTracks == 0 || nNumTracks > 8) {
     return false;
   }
 
-  uint32_t curOffset = dwOffset + 1;
+  uint32_t curOffset = offset() + 1;
   for (uint8_t trackIndex = 0; trackIndex < nNumTracks; trackIndex++) {
     auto trackName = fmt::format("Track {}", trackIndex + 1);
 
@@ -81,7 +81,7 @@ bool CompileSnesSeq::parseHeader() {
 
 
 bool CompileSnesSeq::parseTrackPointers(void) {
-  uint32_t curOffset = dwOffset + 1;
+  uint32_t curOffset = offset() + 1;
   for (uint8_t trackIndex = 0; trackIndex < nNumTracks; trackIndex++) {
     uint16_t ofsTrackStart = readShort(curOffset + 8);
 

--- a/src/main/formats/FFT/FFTInstr.cpp
+++ b/src/main/formats/FFT/FFTInstr.cpp
@@ -32,8 +32,8 @@ WdsInstrSet::~WdsInstrSet(void) {
 bool WdsInstrSet::parseHeader() {
 
   //"hdr"構造体へそのまま転送
-  readBytes(dwOffset, sizeof(WdsHdr), &hdr);
-  unLength = hdr.szHeader1 + hdr.szSampColl;    //header size + samp coll size
+  readBytes(offset(), sizeof(WdsHdr), &hdr);
+  setLength(hdr.szHeader1 + hdr.szSampColl);    //header size + samp coll size
   setId(hdr.iBank);                        //Bank number.
 
   if (hdr.sig == 0x73647764)
@@ -45,22 +45,22 @@ bool WdsInstrSet::parseHeader() {
   setName(fmt::format("wds {:d}", id()));
 
   //ヘッダーobjectの生成
-  VGMHeader *wdsHeader = addHeader(dwOffset, sizeof(WdsHdr));
-  wdsHeader->addSig(dwOffset, sizeof(long));
-  wdsHeader->addUnknownChild(dwOffset + 0x04, sizeof(long));
-  wdsHeader->addChild(dwOffset + 0x08, sizeof(long), "Header size? (0)");
-  wdsHeader->addUnknownChild(dwOffset + 0x0C, sizeof(long));
-  wdsHeader->addChild(dwOffset + 0x10, sizeof(long), "Header size? (1)");
-  wdsHeader->addChild(dwOffset + 0x14, sizeof(long), "AD-PCM body(.VB) size");
-  wdsHeader->addChild(dwOffset + 0x18, sizeof(long), "Header size? (2)");
-  wdsHeader->addChild(dwOffset + 0x1C, sizeof(long), "Number of Instruments");
-  wdsHeader->addChild(dwOffset + 0x20, sizeof(long), "Bank number");
-  wdsHeader->addUnknownChild(dwOffset + 0x24, sizeof(long));
-  wdsHeader->addUnknownChild(dwOffset + 0x28, sizeof(long));
-  wdsHeader->addUnknownChild(dwOffset + 0x2C, sizeof(long));
+  VGMHeader *wdsHeader = addHeader(offset(), sizeof(WdsHdr));
+  wdsHeader->addSig(offset(), sizeof(long));
+  wdsHeader->addUnknownChild(offset() + 0x04, sizeof(long));
+  wdsHeader->addChild(offset() + 0x08, sizeof(long), "Header size? (0)");
+  wdsHeader->addUnknownChild(offset() + 0x0C, sizeof(long));
+  wdsHeader->addChild(offset() + 0x10, sizeof(long), "Header size? (1)");
+  wdsHeader->addChild(offset() + 0x14, sizeof(long), "AD-PCM body(.VB) size");
+  wdsHeader->addChild(offset() + 0x18, sizeof(long), "Header size? (2)");
+  wdsHeader->addChild(offset() + 0x1C, sizeof(long), "Number of Instruments");
+  wdsHeader->addChild(offset() + 0x20, sizeof(long), "Bank number");
+  wdsHeader->addUnknownChild(offset() + 0x24, sizeof(long));
+  wdsHeader->addUnknownChild(offset() + 0x28, sizeof(long));
+  wdsHeader->addUnknownChild(offset() + 0x2C, sizeof(long));
 
   //波形objectの生成
-  sampColl = new PSXSampColl(FFTFormat::name, this, dwOffset + hdr.szHeader1, hdr.szSampColl);
+  sampColl = new PSXSampColl(FFTFormat::name, this, offset() + hdr.szHeader1, hdr.szSampColl);
 //	sampColl->Load();				//VGMInstrSet::Load()関数内でやっている。
 //	sampColl->UseInstrSet(this);	//"WD.cpp"では、同様の事をやっている。
 
@@ -76,7 +76,7 @@ bool WdsInstrSet::parseHeader() {
 //==============================================================
 bool    WdsInstrSet::parseInstrPointers() {
 
-  uint32_t iOffset = dwOffset + sizeof(WdsHdr);    //pointer of attribute table
+  uint32_t iOffset = offset() + sizeof(WdsHdr);    //pointer of attribute table
 
   //音色数だけ繰り返す。
   for (unsigned int i = 0; i <= hdr.iNumInstrs; i++) {
@@ -114,8 +114,8 @@ WdsInstr::~WdsInstr() {}
 bool WdsInstr::loadInstr() {
   WdsInstrSet *parInstrSet = static_cast<WdsInstrSet*>(this->parInstrSet);
 
-  readBytes(dwOffset, sizeof(WdsRgnData), &rgndata);
-  VGMRgn *rgn = new VGMRgn(this, dwOffset, unLength);
+  readBytes(offset(), sizeof(WdsRgnData), &rgndata);
+  VGMRgn *rgn = new VGMRgn(this, offset(), length());
   rgn->sampOffset = rgndata.ptBody;
   if (parInstrSet->version == WdsInstrSet::VERSION_WDS) {
     rgn->sampOffset *= 8;
@@ -126,13 +126,13 @@ bool WdsInstr::loadInstr() {
   // see the declaration of iFineTune for info on where to find the actual code and table for this in FFT
   rgn->fineTune = static_cast<int16_t>(rgndata.iFineTune * (100.0 / 256.0));
 
-  rgn->addGeneralItem(dwOffset + 0x00, sizeof(uint32_t), "Sample Offset");
-  rgn->addGeneralItem(dwOffset + 0x04, sizeof(uint16_t), "Loop Offset");
-  rgn->addGeneralItem(dwOffset + 0x06, sizeof(uint16_t), "Pitch Fine Tune");
+  rgn->addGeneralItem(offset() + 0x00, sizeof(uint32_t), "Sample Offset");
+  rgn->addGeneralItem(offset() + 0x04, sizeof(uint16_t), "Loop Offset");
+  rgn->addGeneralItem(offset() + 0x06, sizeof(uint16_t), "Pitch Fine Tune");
 
   if (parInstrSet->version == WdsInstrSet::VERSION_WDS) {
-    uint32_t adsr_rate = getWord(dwOffset + 0x08);
-    uint16_t adsr_mode = readShort(dwOffset + 0x0c);
+    uint32_t adsr_rate = getWord(offset() + 0x08);
+    uint16_t adsr_mode = readShort(offset() + 0x0c);
 
     // Xenogears: function 0x8003e5bc
     // These values will be set to SPU by function 0x8003e900
@@ -145,14 +145,14 @@ bool WdsInstr::loadInstr() {
     uint8_t Sm = (adsr_mode >> 4) & 0x07;
     uint8_t Rm = (adsr_mode >> 8) & 0x07;
 
-    rgn->addADSRValue(dwOffset + 0x08, sizeof(uint8_t), "ADSR Attack Rate");
-    rgn->addADSRValue(dwOffset + 0x09, sizeof(uint8_t), "ADSR Decay Rate & Sustain Level");
-    rgn->addADSRValue(dwOffset + 0x0a, sizeof(uint8_t), "ADSR Sustain Rate");
-    rgn->addADSRValue(dwOffset + 0x0b, sizeof(uint8_t), "ADSR Release Rate");
-    rgn->addADSRValue(dwOffset + 0x0c, sizeof(uint8_t), "ADSR Attack Mode & Sustain Mode / Direction");
-    rgn->addADSRValue(dwOffset + 0x0d, sizeof(uint8_t), "ADSR Release Mode");
-    rgn->addUnknown(dwOffset + 0x0e, sizeof(uint8_t));
-    rgn->addUnknown(dwOffset + 0x0f, sizeof(uint8_t));
+    rgn->addADSRValue(offset() + 0x08, sizeof(uint8_t), "ADSR Attack Rate");
+    rgn->addADSRValue(offset() + 0x09, sizeof(uint8_t), "ADSR Decay Rate & Sustain Level");
+    rgn->addADSRValue(offset() + 0x0a, sizeof(uint8_t), "ADSR Sustain Rate");
+    rgn->addADSRValue(offset() + 0x0b, sizeof(uint8_t), "ADSR Release Rate");
+    rgn->addADSRValue(offset() + 0x0c, sizeof(uint8_t), "ADSR Attack Mode & Sustain Mode / Direction");
+    rgn->addADSRValue(offset() + 0x0d, sizeof(uint8_t), "ADSR Release Mode");
+    rgn->addUnknown(offset() + 0x0e, sizeof(uint8_t));
+    rgn->addUnknown(offset() + 0x0f, sizeof(uint8_t));
 
     psxConvADSR(rgn, Am >> 2, Ar, Dr, Sl, Sm >> 2, (Sm >> 1) & 1, Sr, Rm >> 2, Rr, false);
     addRgn(rgn);
@@ -161,14 +161,14 @@ bool WdsInstr::loadInstr() {
     psxConvADSR(rgn, rgndata.Am > 1, rgndata.Ar, rgndata.Dr, rgndata.Sl, 1, 1, rgndata.Sr, 1, rgndata.Rr, false);
     addRgn(rgn);
 
-    rgn->addADSRValue(dwOffset + 0x08, sizeof(uint8_t), "Attack Rate");
-    rgn->addADSRValue(dwOffset + 0x09, sizeof(uint8_t), "Decay Rate");
-    rgn->addADSRValue(dwOffset + 0x0A, sizeof(uint8_t), "Sustain Rate");
-    rgn->addADSRValue(dwOffset + 0x0B, sizeof(uint8_t), "Release Rate");
-    rgn->addADSRValue(dwOffset + 0x0C, sizeof(uint8_t), "Sustain Level");
-    rgn->addADSRValue(dwOffset + 0x0D, sizeof(uint8_t), "Attack Rate Mode?");
-    rgn->addUnknown(dwOffset + 0x0E, sizeof(uint8_t));
-    rgn->addUnknown(dwOffset + 0x0F, sizeof(uint8_t));
+    rgn->addADSRValue(offset() + 0x08, sizeof(uint8_t), "Attack Rate");
+    rgn->addADSRValue(offset() + 0x09, sizeof(uint8_t), "Decay Rate");
+    rgn->addADSRValue(offset() + 0x0A, sizeof(uint8_t), "Sustain Rate");
+    rgn->addADSRValue(offset() + 0x0B, sizeof(uint8_t), "Release Rate");
+    rgn->addADSRValue(offset() + 0x0C, sizeof(uint8_t), "Sustain Level");
+    rgn->addADSRValue(offset() + 0x0D, sizeof(uint8_t), "Attack Rate Mode?");
+    rgn->addUnknown(offset() + 0x0E, sizeof(uint8_t));
+    rgn->addUnknown(offset() + 0x0F, sizeof(uint8_t));
   }
 
   return true;

--- a/src/main/formats/FFT/FFTSeq.cpp
+++ b/src/main/formats/FFT/FFTSeq.cpp
@@ -32,35 +32,35 @@ bool FFTSeq::parseHeader(void) {
 //	2009. 6.17 (Wed.)
 //	2009. 6.30 (Thu.)
 //-----------------------------------------------------------
-  unLength = readShort(dwOffset + 0x08);
-  nNumTracks = readByte(dwOffset + 0x14);    //uint8_t (8bit)		GetWord() から修正
-  // uint8_t cNumPercussion = GetByte(dwOffset + 0x15);    //uint8_t (8bit)	Quantity of Percussion struct
-  assocWdsID = readShort(dwOffset + 0x16);    //uint16_t (16bit)	Default program bank No.
-  uint16_t ptSongTitle = readShort(dwOffset + 0x1E);    //uint16_t (16bit)	Pointer of music title (AscII strings)
-  uint16_t ptPercussionTbl = readShort(dwOffset + 0x20);    //uint16_t (16bit)	Pointer of Percussion struct
+  setLength(readShort(offset() + 0x08));
+  nNumTracks = readByte(offset() + 0x14);    //uint8_t (8bit)		GetWord() から修正
+  // uint8_t cNumPercussion = GetByte(offset() + 0x15);    //uint8_t (8bit)	Quantity of Percussion struct
+  assocWdsID = readShort(offset() + 0x16);    //uint16_t (16bit)	Default program bank No.
+  uint16_t ptSongTitle = readShort(offset() + 0x1E);    //uint16_t (16bit)	Pointer of music title (AscII strings)
+  uint16_t ptPercussionTbl = readShort(offset() + 0x20);    //uint16_t (16bit)	Pointer of Percussion struct
 
   int titleLength = ptPercussionTbl - ptSongTitle;
   char *songtitle = new char[titleLength];
-  readBytes(dwOffset + ptSongTitle, titleLength, songtitle);
+  readBytes(offset() + ptSongTitle, titleLength, songtitle);
   setName(std::string(songtitle, songtitle + titleLength - 1));
   delete[] songtitle;
 
-  VGMHeader *hdr = addHeader(dwOffset, 0x22);
-  hdr->addSig(dwOffset, 4);
-  hdr->addChild(dwOffset + 0x08, 2, "Size");
-  hdr->addChild(dwOffset + 0x14, 1, "Track count");
-  hdr->addChild(dwOffset + 0x15, 1, "Drum instrument count");
-  hdr->addChild(dwOffset + 0x16, 1, "Associated Sample Set ID");
-  hdr->addChild(dwOffset + 0x1E, 2, "Song title Pointer");
-  hdr->addChild(dwOffset + 0x20, 2, "Drumkit Data Pointer");
+  VGMHeader *hdr = addHeader(offset(), 0x22);
+  hdr->addSig(offset(), 4);
+  hdr->addChild(offset() + 0x08, 2, "Size");
+  hdr->addChild(offset() + 0x14, 1, "Track count");
+  hdr->addChild(offset() + 0x15, 1, "Drum instrument count");
+  hdr->addChild(offset() + 0x16, 1, "Associated Sample Set ID");
+  hdr->addChild(offset() + 0x1E, 2, "Song title Pointer");
+  hdr->addChild(offset() + 0x20, 2, "Drumkit Data Pointer");
 
-  VGMHeader *trackPtrs = addHeader(dwOffset + 0x22, nNumTracks * 2, "Track Pointers");
+  VGMHeader *trackPtrs = addHeader(offset() + 0x22, nNumTracks * 2, "Track Pointers");
   for (unsigned int i = 0; i < nNumTracks; i++)
-    trackPtrs->addChild(dwOffset + 0x22 + i * 2, 2, "Track Pointer");
-  addHeader(dwOffset + ptSongTitle, titleLength, "Song Name");
+    trackPtrs->addChild(offset() + 0x22 + i * 2, 2, "Track Pointer");
+  addHeader(offset() + ptSongTitle, titleLength, "Song Name");
 
 //	if(cNumPercussion!=0){										//これ、やっぱ、いらない。
-//		hdr->addSimpleChild(dwOffset+ptPercussionTbl, cNumPercussion*5, "Drumkit Struct");
+//		hdr->addSimpleChild(offset()+ptPercussionTbl, cNumPercussion*5, "Drumkit Struct");
 //	}
 //-----------------------------------------------------------
 
@@ -68,13 +68,13 @@ bool FFTSeq::parseHeader(void) {
 
 //	while (j && j != '.')
 //	{
-////		j = GetByte(dwOffset+0x22+nNumTracks*2+2 + i++);		//修正
-//		j = GetByte(dwOffset + ptSongTitle + (i++));
+////		j = GetByte(offset()+0x22+nNumTracks*2+2 + i++);		//修正
+//		j = GetByte(offset() + ptSongTitle + (i++));
 //		name += (char)j;
 //	}
 
 
-//	hdr->addSimpleChild(dwOffset + ptMusicTile, i, "Music title");		//やっぱ書かないでいいや。
+//	hdr->addSimpleChild(offset() + ptMusicTile, i, "Music title");		//やっぱ書かないでいいや。
 
 
   return true;
@@ -83,7 +83,7 @@ bool FFTSeq::parseHeader(void) {
 
 bool FFTSeq::parseTrackPointers(void) {
   for (unsigned int i = 0; i < nNumTracks; i++)
-    aTracks.push_back(new FFTTrack(this, readShort(dwOffset + 0x22 + (i * 2)) + dwOffset));
+    aTracks.push_back(new FFTTrack(this, readShort(offset() + 0x22 + (i * 2)) + offset()));
   return true;
 }
 

--- a/src/main/formats/FalcomSnes/FalcomSnesInstr.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesInstr.cpp
@@ -36,7 +36,7 @@ bool FalcomSnesInstrSet::parseInstrPointers() {
 
   usedSRCNs.clear();
   for (int instr = 0; instr < 255 / kInstrItemSize; instr++) {
-    uint32_t addrInstrHeader = dwOffset + (kInstrItemSize * instr);
+    uint32_t addrInstrHeader = offset() + (kInstrItemSize * instr);
     if (addrInstrHeader + kInstrItemSize > 0x10000) {
       break;
     }
@@ -125,7 +125,7 @@ bool FalcomSnesInstr::loadInstr() {
 
   uint16_t addrSampStart = readShort(offDirEnt);
 
-  FalcomSnesRgn *rgn = new FalcomSnesRgn(this, version, dwOffset, srcn);
+  FalcomSnesRgn *rgn = new FalcomSnesRgn(this, version, offset(), srcn);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   addRgn(rgn);
 

--- a/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
@@ -60,12 +60,12 @@ void FalcomSnesSeq::resetVars() {
 bool FalcomSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, 0);
-  if (dwOffset + 0x20 > 0x10000) {
+  VGMHeader *header = addHeader(offset(), 0);
+  if (offset() + 0x20 > 0x10000) {
     return false;
   }
 
-  uint32_t curOffset = dwOffset;
+  uint32_t curOffset = offset();
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t ofsTrackStart = readShort(curOffset);
     if (ofsTrackStart != 0) {
@@ -78,21 +78,21 @@ bool FalcomSnesSeq::parseHeader() {
     curOffset += 2;
   }
 
-  header->addChild(dwOffset + 0x18, 7, "Duration Table");
-  for (uint8_t offset = 0; offset < 7; offset++) {
-    NoteDurTable.push_back(readByte(dwOffset + 0x18 + offset));
+  header->addChild(offset() + 0x18, 7, "Duration Table");
+  for (uint8_t off = 0; off < 7; off++) {
+    NoteDurTable.push_back(readByte(offset() + 0x18 + off));
   }
 
   return true;
 }
 
 bool FalcomSnesSeq::parseTrackPointers() {
-  uint32_t curOffset = dwOffset;
+  uint32_t curOffset = offset();
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t ofsTrackStart = readShort(curOffset);
     curOffset += 2;
     if (ofsTrackStart != 0) {
-      uint16_t addrTrackStart = dwOffset + ofsTrackStart;
+      uint16_t addrTrackStart = offset() + ofsTrackStart;
       FalcomSnesTrack *track = new FalcomSnesTrack(this, addrTrackStart);
       aTracks.push_back(track);
     }

--- a/src/main/formats/GraphResSnes/GraphResSnesSeq.cpp
+++ b/src/main/formats/GraphResSnes/GraphResSnesSeq.cpp
@@ -43,12 +43,12 @@ void GraphResSnesSeq::resetVars() {
 bool GraphResSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, 3 * MAX_TRACKS);
-  if (dwOffset + header->unLength > 0x10000) {
+  VGMHeader *header = addHeader(offset(), 3 * MAX_TRACKS);
+  if (offset() + header->length() > 0x10000) {
     return false;
   }
 
-  uint32_t curOffset = dwOffset;
+  uint32_t curOffset = offset();
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
 
@@ -68,13 +68,13 @@ bool GraphResSnesSeq::parseHeader() {
 
 
 bool GraphResSnesSeq::parseTrackPointers(void) {
-  uint32_t curOffset = dwOffset;
-  uint16_t addrTrackBase = readShort(dwOffset + 1);
+  uint32_t curOffset = offset();
+  uint16_t addrTrackBase = readShort(offset() + 1);
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     bool trackUsed = (readByte(curOffset++) != 0);
     uint16_t addrTrackStartVirt = readShort(curOffset);
     curOffset += 2;
-    uint16_t addrTrackStart = 24 + addrTrackStartVirt - addrTrackBase + dwOffset;
+    uint16_t addrTrackStart = 24 + addrTrackStartVirt - addrTrackBase + offset();
 
     if (trackUsed) {
       GraphResSnesTrack *track = new GraphResSnesTrack(this, addrTrackStart);

--- a/src/main/formats/HOSA/HOSAScanner.cpp
+++ b/src/main/formats/HOSA/HOSAScanner.cpp
@@ -101,7 +101,7 @@ HOSAInstrSet *HOSAScanner::searchForHOSAInstrSet(RawFile *file, const PSXSampCol
 
   uint32_t *sampOffsets = new uint32_t[numSamples];
   for (int i = 0; i < numSamples; i++)
-    sampOffsets[i] = sampcoll->samples[i]->dwOffset - sampcoll->dwOffset;
+    sampOffsets[i] = sampcoll->samples[i]->offset() - sampcoll->offset();
 
   size_t nFileLength = file->size();
   for (uint32_t i = 0x20; i + 0x14 < nFileLength; i++) {

--- a/src/main/formats/HOSA/HOSASeq.cpp
+++ b/src/main/formats/HOSA/HOSASeq.cpp
@@ -34,16 +34,16 @@ HOSASeq::~HOSASeq(void) {
 //		VGMSeq::LoadMain() から call される。
 //==============================================================
 bool HOSASeq::parseHeader(void) {
-//	About the unLength, if (unLength==0), 
-//	"VGMSeq::LoadMain()" will calculate the unLength after "SeqTrack::LoadTrack()".
-  nNumTracks = readByte(dwOffset + 0x06);    //uint8_t (8bit)
+//	About the length(), if (length() == 0, 
+//	"VGMSeq::LoadMain()" will calculate the length() after "SeqTrack::LoadTrack()".
+  nNumTracks = readByte(offset() + 0x06);    //uint8_t (8bit)
   assocHOSA_ID = 0x00;
 
 //	Add the new object "VGMHeader" in this object "HOSASeq"（Super class："VGMContainerItem")
 //	Delect object is in "VGMContainerItem::~VGMContainerItem()"
-  VGMHeader *hdr = addHeader(dwOffset, 0x0050);
-  hdr->addSig(dwOffset, 4);
-  hdr->addChild(dwOffset + 0x06, 1, "Quantity of Tracks");
+  VGMHeader *hdr = addHeader(offset(), 0x0050);
+  hdr->addSig(offset(), 4);
+  hdr->addChild(offset() + 0x06, 1, "Quantity of Tracks");
 
   setPPQN(0x30);                                //Timebase
 
@@ -62,7 +62,7 @@ bool HOSASeq::parseHeader(void) {
 //==============================================================
 bool HOSASeq::parseTrackPointers(void) {
   for (unsigned int i = 0; i < nNumTracks; i++)
-    aTracks.push_back(new HOSATrack(this, readShort(dwOffset + 0x50 + (i * 2)) + dwOffset));
+    aTracks.push_back(new HOSATrack(this, readShort(offset() + 0x50 + (i * 2)) + offset()));
   //delect object is in "VGMSeq::~VGMSeq()"
   return true;
 }
@@ -179,7 +179,7 @@ bool HOSATrack::readEvent(void) {
 
     //--------
     //[4]Update the default Length
-    iLengthTimeNote = readShort(parentSeq->dwOffset + 0x10 + cCom_bit0 * 2);
+    iLengthTimeNote = readShort(parentSeq->offset() + 0x10 + cCom_bit0 * 2);
     if (iLengthTimeNote == 0) {
 //      iLengthTimeNote = ReadVarLen(curOffset);		//No count curOffset
       iLengthTimeNote = decodeVariable();
@@ -345,7 +345,7 @@ void    HOSATrack::ReadDeltaTime(unsigned char cCom_bit5, unsigned int *iVariabl
       break;
       //----
     case (3):    //	3 : From header
-      *iVariable = readShort(parentSeq->dwOffset + 0x10 + (readByte(curOffset++) & 0x1f) * 2);
+      *iVariable = readShort(parentSeq->offset() + 0x10 + (readByte(curOffset++) & 0x1f) * 2);
       break;
       //----
     default:

--- a/src/main/formats/HeartBeatPS1/HeartBeatPS1Seq.cpp
+++ b/src/main/formats/HeartBeatPS1/HeartBeatPS1Seq.cpp
@@ -14,7 +14,7 @@ DECLARE_FORMAT(HeartBeatPS1)
 
 HeartBeatPS1Seq::HeartBeatPS1Seq(RawFile *file, uint32_t offset, uint32_t length, const std::string &name)
     : VGMSeqNoTrks(HeartBeatPS1Format::name, file, offset, name) {
-  this->length() = length;
+  setLength(length);
 
   useReverb();
 }
@@ -69,7 +69,7 @@ bool HeartBeatPS1Seq::parseHeader() {
 
   // set file length if not specified
   if (length() == 0) {
-    length() = total_size;
+    setLength(total_size);
   }
 
   // save sequence data offset

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesInstr.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesInstr.cpp
@@ -36,13 +36,13 @@ bool HeartBeatSnesInstrSet::parseHeader() {
 bool HeartBeatSnesInstrSet::parseInstrPointers() {
   usedSRCNs.clear();
 
-  uint8_t nNumInstrs = unLength / 6;
+  uint8_t nNumInstrs = length() / 6;
   if (nNumInstrs == 0) {
     return false;
   }
 
   for (uint8_t instrNum = 0; instrNum < nNumInstrs; instrNum++) {
-    uint32_t addrInstrHeader = dwOffset + (instrNum * 6);
+    uint32_t addrInstrHeader = offset() + (instrNum * 6);
     if (addrInstrHeader + 6 > 0x10000) {
       break;
     }
@@ -62,7 +62,7 @@ bool HeartBeatSnesInstrSet::parseInstrPointers() {
 
     if (!SNESSampColl::isValidSampleDir(rawFile(), offDirEnt, true)) {
       // safety logic
-      unLength = instrNum * 6;
+      setLength(instrNum * 6);
       break;
     }
 
@@ -114,7 +114,7 @@ HeartBeatSnesInstr::~HeartBeatSnesInstr() {
 }
 
 bool HeartBeatSnesInstr::loadInstr() {
-  uint8_t sampleIndex = readByte(dwOffset) + (songIndex * 0x10);
+  uint8_t sampleIndex = readByte(offset()) + (songIndex * 0x10);
   if (addrSRCNTable + sampleIndex + 1 > 0x10000) {
     return false;
   }
@@ -128,7 +128,7 @@ bool HeartBeatSnesInstr::loadInstr() {
 
   uint16_t addrSampStart = readShort(offDirEnt);
 
-  HeartBeatSnesRgn *rgn = new HeartBeatSnesRgn(this, version, dwOffset);
+  HeartBeatSnesRgn *rgn = new HeartBeatSnesRgn(this, version, offset());
   rgn->sampOffset = addrSampStart - spcDirAddr;
   addRgn(rgn);
 

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesSeq.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesSeq.cpp
@@ -57,8 +57,8 @@ void HeartBeatSnesSeq::resetVars() {
 bool HeartBeatSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, 0);
-  uint32_t curOffset = dwOffset;
+  VGMHeader *header = addHeader(offset(), 0);
+  uint32_t curOffset = offset();
   if (curOffset + 2 > 0x10000) {
     return false;
   }
@@ -85,7 +85,7 @@ bool HeartBeatSnesSeq::parseHeader() {
 }
 
 bool HeartBeatSnesSeq::parseTrackPointers(void) {
-  uint32_t curOffset = dwOffset;
+  uint32_t curOffset = offset();
 
   curOffset += 2;
 
@@ -96,8 +96,8 @@ bool HeartBeatSnesSeq::parseTrackPointers(void) {
       break;
     }
 
-    uint16_t addrTrackStart = dwOffset + ofsTrackStart;
-    if (addrTrackStart < dwOffset) {
+    uint16_t addrTrackStart = offset() + ofsTrackStart;
+    if (addrTrackStart < offset()) {
       return false;
     }
 
@@ -599,7 +599,7 @@ bool HeartBeatSnesTrack::readEvent() {
     case EVENT_GOTO: {
       int16_t destOffset = readShort(curOffset);
       curOffset += 2;
-      uint16_t dest = parentSeq->dwOffset + destOffset;
+      uint16_t dest = parentSeq->offset() + destOffset;
       desc = fmt::format("Destination: ${:04X}", dest);
       uint32_t length = curOffset - beginOffset;
 
@@ -616,7 +616,7 @@ bool HeartBeatSnesTrack::readEvent() {
     case EVENT_CALL: {
       int16_t destOffset = readShort(curOffset);
       curOffset += 2;
-      uint16_t dest = parentSeq->dwOffset + destOffset;
+      uint16_t dest = parentSeq->offset() + destOffset;
       desc = fmt::format("Destination: ${:04X}", dest);
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
@@ -624,7 +624,7 @@ bool HeartBeatSnesTrack::readEvent() {
                       desc,
                       Type::RepeatStart);
 
-      subReturnOffset = curOffset - parentSeq->dwOffset;
+      subReturnOffset = curOffset - parentSeq->offset();
 
       curOffset = dest;
       break;
@@ -632,7 +632,7 @@ bool HeartBeatSnesTrack::readEvent() {
 
     case EVENT_RET: {
       addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern End", desc, Type::RepeatEnd);
-      curOffset = parentSeq->dwOffset + subReturnOffset;
+      curOffset = parentSeq->offset() + subReturnOffset;
       break;
     }
 
@@ -728,7 +728,7 @@ bool HeartBeatSnesTrack::readEvent() {
         case SUBEVENT_LOOP_AGAIN: {
           int16_t destOffset = readShort(curOffset);
           curOffset += 2;
-          uint16_t dest = parentSeq->dwOffset + destOffset;
+          uint16_t dest = parentSeq->offset() + destOffset;
           desc = fmt::format("Destination: ${:04X}", dest);
           addGenericEvent(beginOffset,
                           curOffset - beginOffset,

--- a/src/main/formats/HudsonSnes/HudsonSnesInstr.cpp
+++ b/src/main/formats/HudsonSnes/HudsonSnesInstr.cpp
@@ -34,8 +34,8 @@ bool HudsonSnesInstrSet::parseHeader() {
 
 bool HudsonSnesInstrSet::parseInstrPointers() {
   usedSRCNs.clear();
-  for (uint8_t instrNum = 0; instrNum < unLength / 4; instrNum++) {
-    uint32_t ofsInstrEntry = dwOffset + (instrNum * 4);
+  for (uint8_t instrNum = 0; instrNum < length() / 4; instrNum++) {
+    uint32_t ofsInstrEntry = offset() + (instrNum * 4);
     if (ofsInstrEntry + 4 > 0x10000) {
       break;
     }
@@ -92,7 +92,7 @@ HudsonSnesInstr::~HudsonSnesInstr() {
 }
 
 bool HudsonSnesInstr::loadInstr() {
-  uint8_t srcn = readByte(dwOffset);
+  uint8_t srcn = readByte(offset());
 
   uint32_t offDirEnt = spcDirAddr + (srcn * 4);
   if (offDirEnt + 4 > 0x10000) {
@@ -106,7 +106,7 @@ bool HudsonSnesInstr::loadInstr() {
     return false;
   }
 
-  HudsonSnesRgn *rgn = new HudsonSnesRgn(this, version, dwOffset, ofsTuningEnt);
+  HudsonSnesRgn *rgn = new HudsonSnesRgn(this, version, offset(), ofsTuningEnt);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   addRgn(rgn);
 
@@ -123,15 +123,15 @@ HudsonSnesRgn::HudsonSnesRgn(HudsonSnesInstr *instr,
                              uint32_t addrTuningEntry) :
     VGMRgn(instr, offset, 4),
     version(ver) {
-//  uint8_t srcn = GetByte(dwOffset);
-  uint8_t adsr1 = readByte(dwOffset + 1);
-  uint8_t adsr2 = readByte(dwOffset + 2);
-  uint8_t gain = readByte(dwOffset + 3);
+//  uint8_t srcn = GetByte(offset());
+  uint8_t adsr1 = readByte(offset + 1);
+  uint8_t adsr2 = readByte(offset + 2);
+  uint8_t gain = readByte(offset + 3);
 
-  addChild(dwOffset, 1, "SRCN");
-  addChild(dwOffset + 1, 1, "ADSR(1)");
-  addChild(dwOffset + 2, 1, "ADSR(2)");
-  addChild(dwOffset + 3, 1, "GAIN");
+  addChild(offset, 1, "SRCN");
+  addChild(offset + 1, 1, "ADSR(1)");
+  addChild(offset + 2, 1, "ADSR(2)");
+  addChild(offset + 3, 1, "GAIN");
 
   const double pitch_fixer = 4286.0 / 4096.0;  // from pitch table ($10be vs $1000)
   const double pitch_scale = getShortBE(addrTuningEntry) / 256.0;

--- a/src/main/formats/HudsonSnes/HudsonSnesSeq.cpp
+++ b/src/main/formats/HudsonSnes/HudsonSnesSeq.cpp
@@ -48,8 +48,8 @@ void HudsonSnesSeq::resetVars() {
 bool HudsonSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, 0);
-  uint32_t curOffset = dwOffset;
+  VGMHeader *header = addHeader(offset(), 0);
+  uint32_t curOffset = offset();
 
   // track addresses
   if (version == HUDSONSNES_V0 || version == HUDSONSNES_V1) {
@@ -89,7 +89,7 @@ bool HudsonSnesSeq::parseHeader() {
         aHeader->addChild(curOffset, 1, "Timebase");
         TimebaseShift = readByte(curOffset++) & 3;
 
-        aHeader->unLength = curOffset - beginOffset;
+        aHeader->setLength(curOffset - beginOffset);
         break;
       }
 
@@ -99,7 +99,7 @@ bool HudsonSnesSeq::parseHeader() {
         if (!parseTrackPointersInHeader(trackPtrHeader, curOffset)) {
           return false;
         }
-        trackPtrHeader->unLength = curOffset - beginOffset;
+        trackPtrHeader->setLength(curOffset - beginOffset);
         break;
       }
 
@@ -129,7 +129,7 @@ bool HudsonSnesSeq::parseHeader() {
         }
         curOffset += tableSize;
 
-        instrHeader->unLength = curOffset - beginOffset;
+        instrHeader->setLength(curOffset - beginOffset);
         break;
       }
 
@@ -158,7 +158,7 @@ bool HudsonSnesSeq::parseHeader() {
         }
         curOffset += tableSize;
 
-        percHeader->unLength = curOffset - beginOffset;
+        percHeader->setLength(curOffset - beginOffset);
         break;
       }
 
@@ -188,7 +188,7 @@ bool HudsonSnesSeq::parseHeader() {
         }
         curOffset += tableSize;
 
-        instrHeader->unLength = curOffset - beginOffset;
+        instrHeader->setLength(curOffset - beginOffset);
         break;
       }
 
@@ -217,7 +217,7 @@ bool HudsonSnesSeq::parseHeader() {
         }
         curOffset += tableSize;
 
-        percHeader->unLength = curOffset - beginOffset;
+        percHeader->setLength(curOffset - beginOffset);
         break;
       }
 
@@ -234,7 +234,7 @@ bool HudsonSnesSeq::parseHeader() {
         aHeader->addUnknownChild(curOffset, tableSize);
         curOffset += tableSize;
 
-        aHeader->unLength = curOffset - beginOffset;
+        aHeader->setLength(curOffset - beginOffset);
         break;
       }
 
@@ -251,7 +251,7 @@ bool HudsonSnesSeq::parseHeader() {
         aHeader->addUnknownChild(curOffset, tableSize);
         curOffset += tableSize;
 
-        aHeader->unLength = curOffset - beginOffset;
+        aHeader->setLength(curOffset - beginOffset);
         break;
       }
 
@@ -277,7 +277,7 @@ bool HudsonSnesSeq::parseHeader() {
           curOffset++;
         }
 
-        aHeader->unLength = curOffset - beginOffset;
+        aHeader->setLength(curOffset - beginOffset);
         break;
       }
 
@@ -291,7 +291,7 @@ bool HudsonSnesSeq::parseHeader() {
           NoteEventHasVelocity = true;
         }
 
-        aHeader->unLength = curOffset - beginOffset;
+        aHeader->setLength(curOffset - beginOffset);
         break;
       }
 
@@ -308,7 +308,7 @@ bool HudsonSnesSeq::parseHeader() {
         aHeader->addUnknownChild(curOffset, tableSize);
         curOffset += tableSize;
 
-        aHeader->unLength = curOffset - beginOffset;
+        aHeader->setLength(curOffset - beginOffset);
         break;
       }
 

--- a/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
@@ -34,22 +34,22 @@ void ItikitiSnesSeq::resetVars() {
 bool ItikitiSnesSeq::parseHeader() {
   setPPQN(kItikitiSnesSeqTimebase);
 
-  VGMHeader *header = addHeader(dwOffset, 0);
-  header->addUnknownChild(dwOffset, 1);
-  header->addChild(dwOffset + 1, 1, "Number of Tracks");
+  VGMHeader *header = addHeader(offset(), 0);
+  header->addUnknownChild(offset(), 1);
+  header->addChild(offset() + 1, 1, "Number of Tracks");
 
-  nNumTracks = readByte(dwOffset + 1);
+  nNumTracks = readByte(offset() + 1);
   if (nNumTracks == 0 || nNumTracks > 8)
     return false;
 
-  const uint16_t first_offset = readShort(dwOffset + 2);
-  const auto first_address = dwOffset + 2 + (2 * nNumTracks);
+  const uint16_t first_offset = readShort(offset() + 2);
+  const auto first_address = offset() + 2 + (2 * nNumTracks);
   m_base_offset = static_cast<uint16_t>(first_address) - first_offset;
 
   for (unsigned int track_index = 0; track_index < nNumTracks; track_index++) {
     std::string track_name = fmt::format("Track {}", track_index + 1);
 
-    const uint32_t offset_to_pointer = dwOffset + 2 + (2 * track_index);
+    const uint32_t offset_to_pointer = offset() + 2 + (2 * track_index);
     header->addChild(offset_to_pointer, 2, track_name);
   }
 
@@ -60,7 +60,7 @@ bool ItikitiSnesSeq::parseHeader() {
 
 bool ItikitiSnesSeq::parseTrackPointers() {
   for (unsigned int track_index = 0; track_index < nNumTracks; track_index++) {
-    const uint32_t offset_to_pointer = dwOffset + 2 + (2 * track_index);
+    const uint32_t offset_to_pointer = offset() + 2 + (2 * track_index);
     const uint32_t offset = readDecodedOffset(offset_to_pointer);
     auto track = std::make_unique<ItikitiSnesTrack>(this, offset);
     aTracks.push_back(track.release());

--- a/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
@@ -59,8 +59,8 @@ void KonamiArcadeInstrSet::addSampleInfoChildren(VGMItem* sampInfoItem, u32 off)
 
 bool KonamiArcadeInstrSet::parseInstrPointers() {
 
-  u32 instrSampleTableOffset = m_fmtVer == MysticWarrior ? readShort(dwOffset) : readWordBE(dwOffset);
-  u32 sfxSampleTableOffset = m_fmtVer == MysticWarrior ? readShort(dwOffset + 2) : readWordBE(dwOffset + 4);
+  u32 instrSampleTableOffset = m_fmtVer == MysticWarrior ? readShort(offset()) : readWordBE(offset());
+  u32 sfxSampleTableOffset = m_fmtVer == MysticWarrior ? readShort(offset() + 2) : readWordBE(offset() + 4);
 
   disableAutoAddInstrumentsAsChildren();
 
@@ -190,22 +190,22 @@ u32 KonamiArcadeSampColl::determineSampleSize(u32 startOffset,
   }
 
   if (reverse) {
-    for (u32 off = startOffset-2; off >= dwOffset + 2; off -= inc) {
+    for (u32 off = startOffset-2; off >= offset() + 2; off -= inc) {
       if (readShort(off) == endMarker) {
         return startOffset - off;
       }
     }
     return startOffset;
   }
-  for (u32 off = startOffset; off < unLength + 2; off += inc) {
+  for (u32 off = startOffset; off < length() + 2; off += inc) {
     if (readShort(off) == endMarker) {
       return off - startOffset;
     }
   }
   if (reverse) {
-    return startOffset - dwOffset;
+    return startOffset - offset();
   } else {
-    return unLength - startOffset;
+    return length() - startOffset;
   }
 }
 

--- a/src/main/formats/KonamiArcade/KonamiArcadeScanner.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeScanner.cpp
@@ -281,7 +281,7 @@ const std::vector<KonamiArcadeSeq*> KonamiArcadeScanner::loadSeqTable(
     }
   }
 
-  seqTable->unLength = offset - seqTable->startOffset();
+  seqTable->setLength(offset - seqTable->startOffset());
 
   return seqs;
 }

--- a/src/main/formats/KonamiPS1/KonamiPS1Scanner.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Scanner.cpp
@@ -24,7 +24,7 @@ void KonamiPS1Scanner::scan(RawFile *file, void *info) {
 
       KonamiPS1Seq *newSeq = new KonamiPS1Seq(file, offset, name);
       if (newSeq->loadVGMFile()) {
-        offset += newSeq->unLength;
+        offset += newSeq->length();
         numSeqFiles++;
         continue;
       } else {

--- a/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
@@ -26,32 +26,32 @@ void KonamiPS1Seq::resetVars() {
 }
 
 bool KonamiPS1Seq::parseHeader() {
-  if (!isKDT1Seq(rawFile(), dwOffset)) {
+  if (!isKDT1Seq(rawFile(), offset())) {
     return false;
   }
 
-  VGMHeader *header = addHeader(dwOffset, kHeaderSize);
-  header->addSig(dwOffset, 4);
-  header->addChild(dwOffset + kOffsetToFileSize, 4, "Size");
-  header->addChild(dwOffset + kOffsetToTimebase, 4, "Timebase");
-  setPPQN(readWord(dwOffset + kOffsetToTimebase));
-  header->addChild(dwOffset + kOffsetToTrackCount, 4, "Number Of Tracks");
+  VGMHeader *header = addHeader(offset(), kHeaderSize);
+  header->addSig(offset(), 4);
+  header->addChild(offset() + kOffsetToFileSize, 4, "Size");
+  header->addChild(offset() + kOffsetToTimebase, 4, "Timebase");
+  setPPQN(readWord(offset() + kOffsetToTimebase));
+  header->addChild(offset() + kOffsetToTrackCount, 4, "Number Of Tracks");
 
-  uint32_t numTracks = readWord(dwOffset + kOffsetToTrackCount);
-  VGMHeader *trackSizeHeader = addHeader(dwOffset + kHeaderSize, 2 * numTracks, "Track Size");
+  uint32_t numTracks = readWord(offset() + kOffsetToTrackCount);
+  VGMHeader *trackSizeHeader = addHeader(offset() + kHeaderSize, 2 * numTracks, "Track Size");
   for (uint32_t trackIndex = 0; trackIndex < numTracks; trackIndex++) {
     std::string itemName = fmt::format("Track {} size", trackIndex + 1);
-    trackSizeHeader->addChild(trackSizeHeader->dwOffset + (trackIndex * 2), 2, itemName);
+    trackSizeHeader->addChild(trackSizeHeader->offset() + (trackIndex * 2), 2, itemName);
   }
 
   return true;
 }
 
 bool KonamiPS1Seq::parseTrackPointers() {
-  uint32_t numTracks = readWord(dwOffset + kOffsetToTrackCount);
-  uint32_t trackStart = dwOffset + kHeaderSize + (numTracks * 2);
+  uint32_t numTracks = readWord(offset() + kOffsetToTrackCount);
+  uint32_t trackStart = offset() + kHeaderSize + (numTracks * 2);
   for (uint32_t trackIndex = 0; trackIndex < numTracks; trackIndex++) {
-    uint16_t trackSize = readShort(dwOffset + kHeaderSize + (trackIndex * 2));
+    uint16_t trackSize = readShort(offset() + kHeaderSize + (trackIndex * 2));
     KonamiPS1Track *track = new KonamiPS1Track(this, trackStart, trackSize);
     aTracks.push_back(track);
     trackStart += trackSize;

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -47,7 +47,7 @@ bool KonamiSnesInstrSet::parseInstrPointers() {
     uint32_t addrInstrHeader;
     if (instr < firstBankedInstr) {
       // common samples
-      addrInstrHeader = dwOffset + (instrItemSize * instr);
+      addrInstrHeader = offset() + (instrItemSize * instr);
     }
     else {
       // switchable samples
@@ -132,7 +132,7 @@ bool KonamiSnesInstr::loadInstr() {
     return true;
   }
 
-  uint8_t srcn = readByte(dwOffset);
+  uint8_t srcn = readByte(offset());
   uint32_t offDirEnt = spcDirAddr + (srcn * 4);
   if (offDirEnt + 4 > 0x10000) {
     return false;
@@ -140,7 +140,7 @@ bool KonamiSnesInstr::loadInstr() {
 
   uint16_t addrSampStart = readShort(offDirEnt);
 
-  KonamiSnesRgn *rgn = new KonamiSnesRgn(this, version, dwOffset, percussion);
+  KonamiSnesRgn *rgn = new KonamiSnesRgn(this, version, offset(), percussion);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   addRgn(rgn);
 

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -75,9 +75,9 @@ bool KonamiSnesSeq::parseHeader(void) {
   // For instance: Ganbare Goemon 3 - Title
   nNumTracks = MAX_TRACKS;
 
-  VGMHeader *seqHeader = addHeader(dwOffset, nNumTracks * 2, "Sequence Header");
+  VGMHeader *seqHeader = addHeader(offset(), nNumTracks * 2, "Sequence Header");
   for (uint32_t trackNumber = 0; trackNumber < nNumTracks; trackNumber++) {
-    uint32_t trackPointerOffset = dwOffset + (trackNumber * 2);
+    uint32_t trackPointerOffset = offset() + (trackNumber * 2);
     if (trackPointerOffset + 2 > 0x10000) {
       return false;
     }
@@ -85,13 +85,13 @@ bool KonamiSnesSeq::parseHeader(void) {
     uint16_t trkOff = readShort(trackPointerOffset);
     seqHeader->addPointer(trackPointerOffset, 2, trkOff, true, "Track Pointer");
 
-    assert(trkOff >= dwOffset);
+    assert(trkOff >= offset());
 
-    if (trkOff - dwOffset < nNumTracks * 2) {
-      nNumTracks = (trkOff - dwOffset) / 2;
+    if (trkOff - offset() < nNumTracks * 2) {
+      nNumTracks = (trkOff - offset()) / 2;
     }
   }
-  seqHeader->unLength = nNumTracks * 2;
+  seqHeader->setLength(nNumTracks * 2);
 
   return true;
 }
@@ -99,7 +99,7 @@ bool KonamiSnesSeq::parseHeader(void) {
 
 bool KonamiSnesSeq::parseTrackPointers(void) {
   for (uint32_t trackNumber = 0; trackNumber < nNumTracks; trackNumber++) {
-    uint16_t trkOff = readShort(dwOffset + trackNumber * 2);
+    uint16_t trkOff = readShort(offset() + trackNumber * 2);
     aTracks.push_back(new KonamiSnesTrack(this, trkOff));
   }
   return true;
@@ -946,7 +946,7 @@ bool KonamiSnesTrack::readEvent(void) {
       desc = fmt::format("Destination: ${:04X}", dest);
       uint32_t length = curOffset - beginOffset;
 
-      assert(dest >= dwOffset);
+      assert(dest >= offset());
 
       if (curOffset < 0x10000 && readByte(curOffset) == 0xff) {
         addGenericEvent(curOffset, 1, "End of Track", "", Type::TrackEnd);
@@ -970,7 +970,7 @@ bool KonamiSnesTrack::readEvent(void) {
       addGenericEvent(beginOffset, curOffset - beginOffset, "Pattern Play", desc,
                       Type::RepeatStart);
 
-      assert(dest >= dwOffset);
+      assert(dest >= offset());
 
       subReturnAddr = curOffset;
       inSubroutine = true;

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2Instr.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2Instr.cpp
@@ -136,11 +136,11 @@ bool KonamiTMNT2SampleInstrSet::parseDrums() {
   );
   auto drumsItem = addChild(
     0,
-    unLength,
+    length(),
     "Drums"
   );
 
-  VGMInstr* drumKit = new VGMInstr(this, dwOffset, unLength, 1, 0, "Drum Kit");
+  VGMInstr* drumKit = new VGMInstr(this, offset(), length(), 1, 0, "Drum Kit");
 
   minDrumOffset = -1;
   maxDrumOffset = 0;
@@ -193,8 +193,8 @@ bool KonamiTMNT2SampleInstrSet::parseDrums() {
     }
   }
   aInstrs.emplace_back(drumKit);
-  drumsItem->dwOffset = minDrumOffset;
-  drumsItem->unLength = (maxDrumOffset + sizeof(konami_tmnt2_drum_info)) - minDrumOffset;
+  drumsItem->setOffset(minDrumOffset);
+  drumsItem->setLength((maxDrumOffset + sizeof(konami_tmnt2_drum_info)) - minDrumOffset);
   return true;
 }
 
@@ -232,7 +232,7 @@ bool KonamiTMNT2SampColl::parseSampleInfo() {
 
     auto name = fmt::format("Sample {:d}", sampNum++);
     VGMSamp* sample;
-    if (sampleOffset + sampleSize > unLength) {
+    if (sampleOffset + sampleSize > length()) {
       sample = new EmptySamp(this);
     }
     else if (sampInfo.isAdpcm) {

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2OPMInstr.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2OPMInstr.cpp
@@ -19,13 +19,13 @@ KonamiTMNT2OPMInstrSet::KonamiTMNT2OPMInstrSet(
 }
 
 bool KonamiTMNT2OPMInstrSet::parseInstrPointers() {
-  auto instrTableItem = addChild(dwOffset, 0, "Instrument Table");
+  auto instrTableItem = addChild(offset(), 0, "Instrument Table");
   for (int i = 0; ; ++i) {
-    u32 offset = dwOffset + (i * 2);
-    u16 instrPtr = readShort(offset);
-    if (instrPtr < dwOffset || instrPtr > dwOffset + 0x2000)
+    u32 instrPtrOff = offset() + (i * 2);
+    u16 instrPtr = readShort(instrPtrOff);
+    if (instrPtr < offset() || instrPtr > offset() + 0x2000)
       break;
-    instrTableItem->addChild(offset, 2, fmt::format("Instrument {} Pointer", i));
+    instrTableItem->addChild(instrPtrOff, 2, fmt::format("Instrument {} Pointer", i));
 
     std::string name = fmt::format("Instrument {:03d}", i);
     konami_tmnt2_ym2151_instr instrData{};

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2Scanner.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2Scanner.cpp
@@ -211,7 +211,7 @@ std::vector<KonamiTMNT2Seq*> KonamiTMNT2Scanner::loadSeqTable(
     }
   }
   auto lastSeq = seqTable->children().back();
-  seqTable->unLength = (lastSeq->dwOffset + lastSeq->unLength) - seqTable->dwOffset;
+  seqTable->setLength((lastSeq->offset() + lastSeq->length()) - seqTable->offset());
   if (!seqTable->loadVGMFile()) {
     delete seqTable;
   }

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2Seq.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2Seq.cpp
@@ -757,7 +757,7 @@ bool KonamiTMNT2Track::readEvent() {
         auto desc = fmt::format("Destination: {:X}", dest);
         addGenericEvent(beginOffset, 3, "Jump", desc, Type::Loop);
       }
-      if (dest < parentSeq->dwOffset) {
+      if (dest < parentSeq->offset()) {
         L_ERROR("KonamiArcadeEvent FD attempted jump to offset outside the sequence at {:X}.  Jump offset: {:X}", beginOffset, dest);
         return false;
       }
@@ -801,7 +801,7 @@ bool KonamiTMNT2Track::readEvent() {
       if (m_callOrigin[callIdx] == 0) {
         m_callOrigin[callIdx] = curOffset + 2;
         u16 dest = readShort(curOffset);
-        if (dest < parentSeq->dwOffset) {
+        if (dest < parentSeq->offset()) {
           return false;
         }
         auto desc = fmt::format("Call - destination: {:X}", dest);

--- a/src/main/formats/KonamiTMNT2/KonamiVendettaInstr.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiVendettaInstr.cpp
@@ -162,7 +162,7 @@ bool KonamiVendettaSampleInstrSet::parseDrums() {
     drumInfos.emplace_back(drumInfo);
   }
   auto lastDrum = drumsItem->children().back();
-  drumsItem->unLength = (lastDrum->dwOffset + lastDrum->unLength) - m_drumsOffset;
+  drumsItem->setLength((lastDrum->offset() + lastDrum->length()) - m_drumsOffset);
 
   if (drumInfos.size() == 0)
     return false;
@@ -171,7 +171,7 @@ bool KonamiVendettaSampleInstrSet::parseDrums() {
 
   auto drumBanksItem = addChild(m_drumBanksOffset, numDrumTables * 0x20, "Drum Banks");
 
-  VGMInstr* drumKit = new VGMInstr(this, dwOffset, unLength, 1, 0, "Drum Kit");
+  VGMInstr* drumKit = new VGMInstr(this, offset(), length(), 1, 0, "Drum Kit");
 
   int drumNum = 0;
   for (u32 i = 0; i < numDrumTables; ++i) {
@@ -264,7 +264,7 @@ konami_vendetta_drum_info KonamiVendettaSampleInstrSet::parseVendettaDrum(
         u16 dest = programRom->readShort(offset + 1);
         drumItem->addChild(offset, 3, fmt::format("Instruction - JP {:02X}", dest));
         offset += 3;
-        drumItem->unLength = offset - drumItem->dwOffset;
+        drumItem->setLength(offset - drumItem->offset());
         return drumInfo;
       }
       default: {
@@ -274,6 +274,6 @@ konami_vendetta_drum_info KonamiVendettaSampleInstrSet::parseVendettaDrum(
       }
     }
   }
-  drumItem->unLength = offset - drumItem->dwOffset;
+  drumItem->setLength(offset - drumItem->offset());
   return drumInfo;
 }

--- a/src/main/formats/MoriSnes/MoriSnesInstr.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesInstr.cpp
@@ -74,8 +74,8 @@ bool MoriSnesInstrSet::parseInstrPointers() {
       instrSetEndAddress = instrEndAddress;
     }
   }
-  dwOffset = instrSetStartAddress;
-  unLength = instrSetEndAddress - instrSetStartAddress;
+  setOffset(instrSetStartAddress);
+  setLength(instrSetEndAddress - instrSetStartAddress);
 
   // load each instruments
   for (uint8_t instrNum = 0; instrNum < instrumentAddresses.size(); instrNum++) {
@@ -151,7 +151,7 @@ MoriSnesInstr::~MoriSnesInstr() {
 }
 
 bool MoriSnesInstr::loadInstr() {
-  addChild(dwOffset, 1, "Melody/Percussion");
+  addChild(offset(), 1, "Melody/Percussion");
 
   if (!instrHintDir.percussion) {
     MoriSnesInstrHint *instrHint = &instrHintDir.instrHint;
@@ -180,7 +180,7 @@ bool MoriSnesInstr::loadInstr() {
       }
 
       auto seqOffsetName = fmt::format("Sequence Offset {}", percNoteKey);
-      addChild(dwOffset + 1 + (percNoteKey * 2), 2, seqOffsetName);
+      addChild(offset() + 1 + (percNoteKey * 2), 2, seqOffsetName);
 
       auto seqName = fmt::format("Envelope Sequence {}", percNoteKey);
       addChild(instrHint->seqAddress, instrHint->seqSize, seqName);

--- a/src/main/formats/MoriSnes/MoriSnesSeq.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesSeq.cpp
@@ -43,8 +43,8 @@ void MoriSnesSeq::resetVars() {
 bool MoriSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  uint32_t curOffset = dwOffset;
-  VGMHeader *header = addHeader(dwOffset, 0);
+  uint32_t curOffset = offset();
+  VGMHeader *header = addHeader(offset(), 0);
 
   // reset track start addresses
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
@@ -650,7 +650,7 @@ bool MoriSnesTrack::readEvent() {
     }
   }
 
-  //assert(curOffset >= dwOffset);
+  //assert(curOffset >= offset());
 
   //ostringstream ssTrace;
   //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;

--- a/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
@@ -48,7 +48,7 @@ bool NamcoSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
   nNumTracks = MAX_TRACKS;
 
-  setEventsOffset(VGMSeq::dwOffset);
+  setEventsOffset(offset());
   return true;
 }
 

--- a/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
+++ b/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
@@ -31,25 +31,25 @@ void NeverlandSnesSeq::resetVars(void) {
 bool NeverlandSnesSeq::parseHeader(void) {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, 0);
+  VGMHeader *header = addHeader(offset(), 0);
   if (version == NEVERLANDSNES_SFC) {
-    header->unLength = 0x40;
+    header->setLength(0x40);
   }
   else if (version == NEVERLANDSNES_S2C) {
-    header->unLength = 0x50;
+    header->setLength(0x50);
   }
 
-  if (dwOffset + header->unLength >= 0x10000) {
+  if (offset() + header->length() >= 0x10000) {
     return false;
   }
 
-  header->addChild(dwOffset, 3, "Signature");
-  header->addUnknownChild(dwOffset + 3, 1);
+  header->addChild(offset(), 3, "Signature");
+  header->addUnknownChild(offset() + 3, 1);
 
   const size_t NAME_SIZE = 12;
   char rawName[NAME_SIZE + 1] = {0};
-  readBytes(dwOffset + 4, NAME_SIZE, rawName);
-  header->addChild(dwOffset + 4, 12, "Song Name");
+  readBytes(offset() + 4, NAME_SIZE, rawName);
+  header->addChild(offset() + 4, 12, "Song Name");
 
   // trim name text
   for (int i = NAME_SIZE - 1; i >= 0; i--) {
@@ -68,13 +68,13 @@ bool NeverlandSnesSeq::parseHeader(void) {
   }
 
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
-    uint16_t trackSignPtr = dwOffset + 0x10 + trackIndex;
+    uint16_t trackSignPtr = offset() + 0x10 + trackIndex;
     uint8_t trackSign = readByte(trackSignPtr);
 
     auto trackSignName = fmt::format("Track {:d} Entry", trackIndex + 1);
     header->addChild(trackSignPtr, 1, trackSignName);
 
-    uint16_t sectionListOffsetPtr = dwOffset + 0x20 + (trackIndex * 2);
+    uint16_t sectionListOffsetPtr = offset() + 0x20 + (trackIndex * 2);
     if (trackSign != 0xff) {
       uint16_t sectionListAddress = getShortAddress(sectionListOffsetPtr);
 
@@ -100,12 +100,12 @@ void NeverlandSnesSeq::loadEventMap() {
   // TODO: NeverlandSnesSeq::LoadEventMap
 }
 
-uint16_t NeverlandSnesSeq::convertToApuAddress(uint16_t offset) {
+uint16_t NeverlandSnesSeq::convertToApuAddress(uint16_t off) {
   if (version == NEVERLANDSNES_S2C) {
-    return dwOffset + offset;
+    return offset() + off;
   }
   else {
-    return offset;
+    return off;
   }
 }
 

--- a/src/main/formats/NeverlandSnes/NeverlandSnesSeq.h
+++ b/src/main/formats/NeverlandSnes/NeverlandSnesSeq.h
@@ -26,7 +26,7 @@ class NeverlandSnesSeq
   NeverlandSnesVersion version;
   std::map<uint8_t, NeverlandSnesSeqEventType> EventMap;
 
-  uint16_t convertToApuAddress(uint16_t offset);
+  uint16_t convertToApuAddress(uint16_t off);
   uint16_t getShortAddress(uint32_t offset);
 
  private:

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -38,7 +38,7 @@ bool NinSnesInstrSet::parseInstrPointers() {
   usedSRCNs.clear();
   for (int instr = 0; instr <= instr_max; instr++) {
     uint32_t instrItemSize = NinSnesInstr::expectedSize(version);
-    uint32_t addrInstrHeader = dwOffset + (instrItemSize * instr);
+    uint32_t addrInstrHeader = offset() + (instrItemSize * instr);
     if (addrInstrHeader + instrItemSize > 0x10000) {
       return false;
     }
@@ -138,7 +138,7 @@ NinSnesInstr::~NinSnesInstr() {
 }
 
 bool NinSnesInstr::loadInstr() {
-  uint8_t srcn = readByte(dwOffset);
+  uint8_t srcn = readByte(offset());
   uint32_t offDirEnt = spcDirAddr + (srcn * 4);
   if (offDirEnt + 4 > 0x10000) {
     return false;
@@ -146,7 +146,7 @@ bool NinSnesInstr::loadInstr() {
 
   uint16_t addrSampStart = readShort(offDirEnt);
 
-  NinSnesRgn *rgn = new NinSnesRgn(this, version, dwOffset, konamiTuningTableAddress, konamiTuningTableSize);
+  NinSnesRgn *rgn = new NinSnesRgn(this, version, offset(), konamiTuningTableAddress, konamiTuningTableSize);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   addRgn(rgn);
 

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -104,11 +104,11 @@ bool NinSnesSeq::readEvent(long stopTime) {
     return false;
   }
 
-  if (curOffset < header->dwOffset) {
-    uint32_t distance = header->dwOffset - curOffset;
-    header->dwOffset = curOffset;
-    if (header->unLength != 0) {
-      header->unLength += distance;
+  if (curOffset < header->offset()) {
+    uint32_t distance = header->offset() - curOffset;
+    header->setOffset(curOffset);
+    if (header->length() != 0) {
+      header->setLength(header->length() + distance);
     }
   }
 
@@ -200,11 +200,11 @@ bool NinSnesSeq::readEvent(long stopTime) {
     if (doJump) {
       curOffset = dest;
 
-      if (curOffset < dwOffset) {
-        uint32_t distance = dwOffset - curOffset;
-        dwOffset = curOffset;
-        if (unLength != 0) {
-          unLength += distance;
+      if (curOffset < offset()) {
+        uint32_t distance = offset() - curOffset;
+        setOffset(curOffset);
+        if (length() != 0) {
+          setLength(length() + (distance));
         }
       }
     }
@@ -630,7 +630,7 @@ NinSnesSection::NinSnesSection(NinSnesSeq *parentFile, uint32_t offset, uint32_t
 
 bool NinSnesSection::parseTrackPointers() {
   NinSnesSeq *parentSeq = (NinSnesSeq *) this->parentSeq;
-  uint32_t curOffset = dwOffset;
+  uint32_t curOffset = offset();
 
   VGMHeader *header = addHeader(curOffset, 16);
   uint8_t numActiveTracks = 0;
@@ -648,11 +648,11 @@ bool NinSnesSection::parseTrackPointers() {
 
       // correct sequence address
       // probably it's not necessary for regular case, but just in case...
-      if (startAddress < dwOffset) {
-        uint32_t distance = dwOffset - startAddress;
-        dwOffset = startAddress;
-        if (unLength != 0) {
-          unLength += distance;
+      if (startAddress < offset()) {
+        uint32_t distance = offset() - startAddress;
+        setOffset(startAddress);
+        if (length() != 0) {
+          setLength(length() + (distance));
         }
       }
 

--- a/src/main/formats/Org/OrgSeq.cpp
+++ b/src/main/formats/Org/OrgSeq.cpp
@@ -10,28 +10,28 @@ OrgSeq::~OrgSeq(void) {
 }
 
 bool OrgSeq::parseHeader(void) {
-  waitTime = readShort(dwOffset + 6);
-  beatsPerMeasure = readByte(dwOffset + 8);
-  setPPQN(readByte(dwOffset + 9));
+  waitTime = readShort(offset() + 6);
+  beatsPerMeasure = readByte(offset() + 8);
+  setPPQN(readByte(offset() + 9));
 
   uint32_t notesSoFar = 0;        //this must be used to determine the length of the entire seq
 
   for (int i = 0; i < 16; i++) {
-    if (readShort(dwOffset + 0x16 + i * 6))            //if there are notes in this track
+    if (readShort(offset() + 0x16 + i * 6))            //if there are notes in this track
     {
       nNumTracks++;                    //well then, we might as well say it exists
       OrgTrack
-          *newOrgTrack = new OrgTrack(this, dwOffset + 0x12 + 16 * 6 + notesSoFar * 8, readShort(0x16 + i * 6) * 8, i);
-      newOrgTrack->numNotes = readShort(dwOffset + 0x16 + i * 6);
-      newOrgTrack->freq = readShort(dwOffset + 0x12 + i * 6);
-      newOrgTrack->waveNum = readByte(dwOffset + 0x14 + i * 6);
-      newOrgTrack->numNotes = readShort(dwOffset + 0x16 + i * 6);
+          *newOrgTrack = new OrgTrack(this, offset() + 0x12 + 16 * 6 + notesSoFar * 8, readShort(0x16 + i * 6) * 8, i);
+      newOrgTrack->numNotes = readShort(offset() + 0x16 + i * 6);
+      newOrgTrack->freq = readShort(offset() + 0x12 + i * 6);
+      newOrgTrack->waveNum = readByte(offset() + 0x14 + i * 6);
+      newOrgTrack->numNotes = readShort(offset() + 0x16 + i * 6);
       aTracks.push_back(newOrgTrack);
 
       notesSoFar += newOrgTrack->numNotes;
     }
   }
-  unLength = 0x12 + 6 * 16 + notesSoFar * 8;
+  setLength(0x12 + 6 * 16 + notesSoFar * 8);
 
   return true;        //successful
 }
@@ -59,7 +59,7 @@ bool OrgTrack::loadTrack(uint32_t trackNum, uint32_t stopOffset, long stopDelta)
     addProgramChange(0, 0, waveNum);
 
   bInLoop = false;
-  curOffset = dwOffset;    //start at beginning of track
+  curOffset = offset();    //start at beginning of track
   curNote = 0;
   for (uint16_t i = 0; i < numNotes; i++)
     readEvent();

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesInstr.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesInstr.cpp
@@ -132,7 +132,7 @@ bool PandoraBoxSnesInstr::loadInstr() {
 
   uint16_t addrSampStart = readShort(offDirEnt);
 
-  PandoraBoxSnesRgn *rgn = new PandoraBoxSnesRgn(this, version, dwOffset, srcn, spcDirAddr, adsr);
+  PandoraBoxSnesRgn *rgn = new PandoraBoxSnesRgn(this, version, offset(), srcn, spcDirAddr, adsr);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   addRgn(rgn);
 
@@ -155,7 +155,7 @@ PandoraBoxSnesRgn::PandoraBoxSnesRgn(PandoraBoxSnesInstr *instr,
   uint8_t adsr1 = adsr >> 8;
   uint8_t adsr2 = adsr & 0xff;
 
-  addChild(dwOffset, 1, "Global Instrument #");
+  addChild(offset, 1, "Global Instrument #");
 
   sampNum = srcn;
   unityKey = 45; // o3a = $1000

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesSeq.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesSeq.cpp
@@ -37,25 +37,25 @@ PandoraBoxSnesSeq::~PandoraBoxSnesSeq() {
 void PandoraBoxSnesSeq::resetVars() {
   VGMSeq::resetVars();
 
-  setAlwaysWriteInitialTempo(readByte(dwOffset + 6));
+  setAlwaysWriteInitialTempo(readByte(offset() + 6));
 }
 
 bool PandoraBoxSnesSeq::parseHeader() {
   uint32_t curOffset;
 
-  VGMHeader *header = addHeader(dwOffset, 0);
-  if (dwOffset + 0x20 > 0x10000) {
+  VGMHeader *header = addHeader(offset(), 0);
+  if (offset() + 0x20 > 0x10000) {
     return false;
   }
 
-  addChild(dwOffset + 6, 1, "Tempo");
-  addChild(dwOffset + 7, 1, "Timebase");
+  addChild(offset() + 6, 1, "Tempo");
+  addChild(offset() + 7, 1, "Timebase");
 
-  uint8_t timebase = readByte(dwOffset + 7);
+  uint8_t timebase = readByte(offset() + 7);
   assert((timebase % 4) == 0);
   setPPQN(timebase / 4);
 
-  curOffset = dwOffset + 0x10;
+  curOffset = offset() + 0x10;
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t ofsTrackStart = readShort(curOffset);
     if (ofsTrackStart != 0xffff) {
@@ -72,12 +72,12 @@ bool PandoraBoxSnesSeq::parseHeader() {
 }
 
 bool PandoraBoxSnesSeq::parseTrackPointers() {
-  uint32_t curOffset = dwOffset + 0x10;
+  uint32_t curOffset = offset() + 0x10;
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     uint16_t ofsTrackStart = readShort(curOffset);
     curOffset += 2;
     if (ofsTrackStart != 0xffff) {
-      uint16_t addrTrackStart = dwOffset + ofsTrackStart;
+      uint16_t addrTrackStart = offset() + ofsTrackStart;
       PandoraBoxSnesTrack *track = new PandoraBoxSnesTrack(this, addrTrackStart);
       aTracks.push_back(track);
     }

--- a/src/main/formats/PrismSnes/PrismSnesSeq.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesSeq.cpp
@@ -48,11 +48,11 @@ void PrismSnesSeq::demandEnvelopeContainer(uint32_t offset) {
     envContainer = addHeader(offset, 0, "Envelopes");
   }
 
-  if (offset < envContainer->dwOffset) {
-    if (envContainer->unLength != 0) {
-      envContainer->unLength += envContainer->dwOffset - offset;
+  if (offset < envContainer->offset()) {
+    if (envContainer->length() != 0) {
+      envContainer->setLength(envContainer->length() + (envContainer->offset() - offset));
     }
-    envContainer->dwOffset = offset;
+    envContainer->setOffset(offset);
   }
 }
 
@@ -65,9 +65,9 @@ void PrismSnesSeq::resetVars() {
 bool PrismSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, 0);
+  VGMHeader *header = addHeader(offset(), 0);
 
-  uint32_t curOffset = dwOffset;
+  uint32_t curOffset = offset();
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS + 1; trackIndex++) {
     if (curOffset + 1 > 0x10000) {
       return false;
@@ -674,8 +674,8 @@ bool PrismSnesTrack::readEvent() {
         bContinue = addLoopForever(beginOffset, length, "Jump");
       }
 
-      if (curOffset < dwOffset) {
-        dwOffset = curOffset;
+      if (curOffset < offset()) {
+        setOffset(curOffset);
       }
 
       break;
@@ -890,7 +890,7 @@ bool PrismSnesTrack::readEvent() {
     }
   }
 
-  //assert(curOffset >= parentSeq->dwOffset);
+  //assert(curOffset >= parentSeq->offset());
 
   //std::ostringstream ssTrace;
   //ssTrace << "" << std::hex << std::setfill('0') << std::setw(8) << std::uppercase << beginOffset << ": " << std::setw(2) << (int)statusByte  << " -> " << std::setw(8) << curOffset << std::endl;
@@ -988,7 +988,7 @@ void PrismSnesTrack::addVolumeEnvelope(uint16_t envelopeAddress) {
       break;
     }
 
-    envHeader->unLength = envOffset;
+    envHeader->setLength(envOffset);
   }
 }
 
@@ -1023,7 +1023,7 @@ void PrismSnesTrack::addPanEnvelope(uint16_t envelopeAddress) {
       break;
     }
 
-    envHeader->unLength = envOffset;
+    envHeader->setLength(envOffset);
   }
 }
 
@@ -1063,7 +1063,7 @@ void PrismSnesTrack::addEchoVolumeEnvelope(uint16_t envelopeAddress) {
       break;
     }
 
-    envHeader->unLength = envOffset;
+    envHeader->setLength(envOffset);
   }
 }
 
@@ -1099,7 +1099,7 @@ void PrismSnesTrack::addGAINEnvelope(uint16_t envelopeAddress) {
       break;
     }
 
-    envHeader->unLength = envOffset;
+    envHeader->setLength(envOffset);
   }
 }
 

--- a/src/main/formats/RareSnes/RareSnesInstr.cpp
+++ b/src/main/formats/RareSnes/RareSnesInstr.cpp
@@ -52,9 +52,9 @@ void RareSnesInstrSet::Initialize() {
     }
   }
 
-  unLength = 0x100;
-  if (dwOffset + unLength > rawFile()->size()) {
-    unLength = rawFile()->size() - dwOffset;
+  setLength(0x100);
+  if (offset() + length() > rawFile()->size()) {
+    setLength(rawFile()->size() - offset());
   }
   ScanAvailableInstruments();
 }
@@ -63,8 +63,8 @@ void RareSnesInstrSet::ScanAvailableInstruments() {
   availInstruments.clear();
 
   bool firstZero = true;
-  for (uint32_t inst = 0; inst < unLength; inst++) {
-    uint8_t srcn = readByte(dwOffset + inst);
+  for (uint32_t inst = 0; inst < length(); inst++) {
+    uint8_t srcn = readByte(offset() + inst);
 
     if (srcn == 0) {
       if (firstZero) {
@@ -117,7 +117,7 @@ bool RareSnesInstrSet::parseInstrPointers() {
   std::map<uint16_t, uint8_t> addrToInstrLookups;
   for (auto itr = instrUnityKeyHints.begin(); itr != instrUnityKeyHints.end(); ++itr) {
     uint8_t inst = (*itr).first;
-    uint8_t srcn = readByte(dwOffset + inst);
+    uint8_t srcn = readByte(offset() + inst);
 
     uint32_t offDirEnt = spcDirAddr + (srcn * 4);
     if (addrToInstrLookups.count(offDirEnt) == 0) {
@@ -127,7 +127,7 @@ bool RareSnesInstrSet::parseInstrPointers() {
 
   for (std::vector<uint8_t>::iterator itr = availInstruments.begin(); itr != availInstruments.end(); ++itr) {
     uint8_t inst = (*itr);
-    uint8_t srcn = readByte(dwOffset + inst);
+    uint8_t srcn = readByte(offset() + inst);
 
     uint8_t inst_remapped = inst;
     uint32_t offDirEnt = spcDirAddr + (srcn * 4);
@@ -157,7 +157,7 @@ bool RareSnesInstrSet::parseInstrPointers() {
     }
 
     RareSnesInstr *newInstr = new RareSnesInstr(
-      this, dwOffset + inst, inst >> 7, inst & 0x7f, spcDirAddr, transpose,
+      this, offset() + inst, inst >> 7, inst & 0x7f, spcDirAddr, transpose,
       pitch, adsr, fmt::format("Instrument: {:#x}", inst));
     aInstrs.push_back(newInstr);
   }
@@ -192,7 +192,7 @@ RareSnesInstr::~RareSnesInstr() {
 }
 
 bool RareSnesInstr::loadInstr() {
-  uint8_t srcn = readByte(dwOffset);
+  uint8_t srcn = readByte(offset());
   uint32_t offDirEnt = spcDirAddr + (srcn * 4);
   if (offDirEnt + 4 > 0x10000) {
     return false;
@@ -200,7 +200,7 @@ bool RareSnesInstr::loadInstr() {
 
   uint16_t addrSampStart = readShort(offDirEnt);
 
-  RareSnesRgn *rgn = new RareSnesRgn(this, dwOffset, transpose, pitch, adsr);
+  RareSnesRgn *rgn = new RareSnesRgn(this, offset(), transpose, pitch, adsr);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   addRgn(rgn);
   return true;

--- a/src/main/formats/RareSnes/RareSnesSeq.cpp
+++ b/src/main/formats/RareSnes/RareSnesSeq.cpp
@@ -66,8 +66,8 @@ void RareSnesSeq::resetVars(void) {
 bool RareSnesSeq::parseHeader(void) {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *seqHeader = addHeader(dwOffset, MAX_TRACKS * 2 + 2, "Sequence Header");
-  uint32_t curHeaderOffset = dwOffset;
+  VGMHeader *seqHeader = addHeader(offset(), MAX_TRACKS * 2 + 2, "Sequence Header");
+  uint32_t curHeaderOffset = offset();
   for (int i = 0; i < MAX_TRACKS; i++) {
     uint16_t trkOff = readShort(curHeaderOffset);
     seqHeader->addPointer(curHeaderOffset, 2, trkOff, (trkOff != 0), "Track Pointer");
@@ -83,7 +83,7 @@ bool RareSnesSeq::parseHeader(void) {
 
 bool RareSnesSeq::parseTrackPointers(void) {
   for (int i = 0; i < MAX_TRACKS; i++) {
-    uint16_t trkOff = readShort(dwOffset + i * 2);
+    uint16_t trkOff = readShort(offset() + i * 2);
     if (trkOff != 0)
       aTracks.push_back(new RareSnesTrack(this, trkOff));
   }

--- a/src/main/formats/SegSat/SegSatScanner.cpp
+++ b/src/main/formats/SegSat/SegSatScanner.cpp
@@ -102,7 +102,7 @@ void SegSatScanner::handleSsfFile(RawFile* file) {
         continue;
 
       for (const auto instrSet : instrSets) {
-        if (instrSet->dwOffset == bankPtr) {
+        if (instrSet->offset() == bankPtr) {
           instrSet->assignBankNumber(bankNum);
           banks[bankNum] = instrSet;
         }
@@ -346,7 +346,7 @@ std::vector<SegSatInstrSet*> SegSatScanner::searchForInstrSets(RawFile* file, Se
 
       // We can safely skip ahead: the instrument table runs until base + ptrMixes
       // Jumping avoids re-scanning in the middle of a confirmed bank.
-      base = std::min(base + instrSet->unLength, fileLength - 8);
+      base = std::min(base + instrSet->length(), fileLength - 8);
     } else {
       ++base;
     }

--- a/src/main/formats/SoftCreatSnes/SoftCreatSnesSeq.cpp
+++ b/src/main/formats/SoftCreatSnes/SoftCreatSnesSeq.cpp
@@ -36,13 +36,13 @@ void SoftCreatSnesSeq::resetVars(void) {
 bool SoftCreatSnesSeq::parseHeader(void) {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, headerAlignSize * MAX_TRACKS);
-  if (dwOffset + headerAlignSize * MAX_TRACKS > 0x10000) {
+  VGMHeader *header = addHeader(offset(), headerAlignSize * MAX_TRACKS);
+  if (offset() + headerAlignSize * MAX_TRACKS > 0x10000) {
     return false;
   }
 
   for (uint8_t trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
-    uint32_t addrTrackLowPtr = dwOffset + (trackIndex * 2 * headerAlignSize);
+    uint32_t addrTrackLowPtr = offset() + (trackIndex * 2 * headerAlignSize);
     uint32_t addrTrackHighPtr = addrTrackLowPtr + headerAlignSize;
     if (addrTrackLowPtr + 1 > 0x10000 || addrTrackHighPtr + 1 > 0x10000) {
       return false;

--- a/src/main/formats/SquarePS2/SquarePS2Seq.cpp
+++ b/src/main/formats/SquarePS2/SquarePS2Seq.cpp
@@ -16,19 +16,19 @@ BGMSeq::BGMSeq(RawFile *file, uint32_t offset)
 }
 
 bool BGMSeq::parseHeader() {
-  VGMHeader *header = addHeader(dwOffset, 0x20, "Header");
-  header->addChild(dwOffset, 4, "Signature");
-  header->addChild(dwOffset + 0x4, 2, "ID");
-  header->addChild(dwOffset + 0x6, 2, "Associated WD ID");
-  header->addChild(dwOffset + 0x8, 1, "Number of Tracks");
-  header->addChild(dwOffset + 0xE, 2, "PPQN");
-  header->addChild(dwOffset + 0x10, 4, "File length");
+  VGMHeader *header = addHeader(offset(), 0x20, "Header");
+  header->addChild(offset(), 4, "Signature");
+  header->addChild(offset() + 0x4, 2, "ID");
+  header->addChild(offset() + 0x6, 2, "Associated WD ID");
+  header->addChild(offset() + 0x8, 1, "Number of Tracks");
+  header->addChild(offset() + 0xE, 2, "PPQN");
+  header->addChild(offset() + 0x10, 4, "File length");
 
-  nNumTracks = readByte(dwOffset + 8);
-  seqID = readShort(dwOffset + 4);
-  assocWDID = readShort(dwOffset + 6);
-  setPPQN(readShort(dwOffset + 0xE));
-  unLength = readWord(dwOffset + 0x10);
+  nNumTracks = readByte(offset() + 8);
+  seqID = readShort(offset() + 4);
+  assocWDID = readShort(offset() + 6);
+  setPPQN(readShort(offset() + 0xE));
+  setLength(readWord(offset() + 0x10));
 
   ostringstream theName;
   theName << "BGM " << seqID;
@@ -39,7 +39,7 @@ bool BGMSeq::parseHeader() {
 }
 
 bool BGMSeq::parseTrackPointers() {
-  uint32_t pos = dwOffset + 0x20;    //start at first track (fixed offset)
+  uint32_t pos = offset() + 0x20;    //start at first track (fixed offset)
   for (unsigned int i = 0; i < nNumTracks; i++) {
     //HACK FOR TRUNCATED BGMS (ex. FFXII 113 Eastersand.psf2)
     if (pos >= rawFile()->size())

--- a/src/main/formats/SquarePS2/WD.cpp
+++ b/src/main/formats/SquarePS2/WD.cpp
@@ -49,32 +49,32 @@ WDInstrSet::WDInstrSet(RawFile *file, uint32_t offset)
     : VGMInstrSet(SquarePS2Format::name, file, offset) {}
 
 bool WDInstrSet::parseHeader() {
-  VGMHeader *header = addHeader(dwOffset, 0x10, "Header");
-  header->addChild(dwOffset + 0x2, 2, "ID");
-  header->addChild(dwOffset + 0x4, 4, "Sample Section Size");
-  header->addChild(dwOffset + 0x8, 4, "Number of Instruments");
-  header->addChild(dwOffset + 0xC, 4, "Number of Regions");
+  VGMHeader *header = addHeader(offset(), 0x10, "Header");
+  header->addChild(offset() + 0x2, 2, "ID");
+  header->addChild(offset() + 0x4, 4, "Sample Section Size");
+  header->addChild(offset() + 0x8, 4, "Number of Instruments");
+  header->addChild(offset() + 0xC, 4, "Number of Regions");
 
-  setId(readShort(0x2 + dwOffset));
-  dwSampSectSize = readWord(0x4 + dwOffset);
-  dwNumInstrs = readWord(0x8 + dwOffset);
-  dwTotalRegions = readWord(0xC + dwOffset);
+  setId(readShort(0x2 + offset()));
+  dwSampSectSize = readWord(0x4 + offset());
+  dwNumInstrs = readWord(0x8 + offset());
+  dwTotalRegions = readWord(0xC + offset());
 
   if (dwSampSectSize < 0x40)  // Some songs in the Bouncer have bizarre values here
     dwSampSectSize = 0;
 
   setName(fmt::format("WD {}", id()));
 
-  uint32_t sampCollOff = dwOffset + readWord(dwOffset + 0x20) + (dwTotalRegions * 0x20);
+  uint32_t sampCollOff = offset() + readWord(offset() + 0x20) + (dwTotalRegions * 0x20);
 
   sampColl = new PSXSampColl(SquarePS2Format::name, this, sampCollOff, dwSampSectSize);
-  unLength = sampCollOff + dwSampSectSize - dwOffset;
+  setLength(sampCollOff + dwSampSectSize - offset());
 
   return true;
 }
 
 bool WDInstrSet::parseInstrPointers() {
-  uint32_t j = 0x20 + dwOffset;
+  uint32_t j = 0x20 + offset();
 
   // check for bouncer WDs with 0xFFFFFFFF as the last instr pointer.  If it's there ignore it
   for (uint32_t i = 0; i < dwNumInstrs; i++) {
@@ -87,9 +87,9 @@ bool WDInstrSet::parseInstrPointers() {
     if (i != dwNumInstrs - 1)  // while not the last instr
       instrLength = readWord(j + ((i + 1) * 4)) - readWord(j + (i * 4));
     else
-      instrLength = sampColl->dwOffset - (readWord(j + (i * 4)) + dwOffset);
+      instrLength = sampColl->offset() - (readWord(j + (i * 4)) + offset());
 
-    auto *newWDInstr = new WDInstr(this, dwOffset + readWord(j + (i * 4)), instrLength,
+    auto *newWDInstr = new WDInstr(this, offset() + readWord(j + (i * 4)), instrLength,
       0, i, fmt::format("Instrument {}", i));
     aInstrs.push_back(newWDInstr);
   }
@@ -107,40 +107,40 @@ WDInstr::WDInstr(VGMInstrSet *instrSet, uint32_t offset, uint32_t length, uint32
 
 bool WDInstr::loadInstr() {
   unsigned int k = 0;
-  while (k * 0x20 < unLength) {
-    auto *rgn = new WDRgn(this, k * 0x20 + dwOffset);
+  while (k * 0x20 < length()) {
+    auto *rgn = new WDRgn(this, k * 0x20 + offset());
     addRgn(rgn);
 
-    rgn->addChild(k * 0x20 + dwOffset, 1, "Stereo Region Flag");
-    rgn->addChild(k * 0x20 + 1 + dwOffset, 1, "First/Last Region Flags");
-    rgn->addChild(k * 0x20 + 2 + dwOffset, 2, "Unknown Flag");
-    rgn->addChild(k * 0x20 + 0x4 + dwOffset, 4, "Sample Offset");
-    rgn->addChild(k * 0x20 + 0x8 + dwOffset, 4, "Loop Start");
-    rgn->addChild(k * 0x20 + 0xC + dwOffset, 2, "ADSR1");
-    rgn->addChild(k * 0x20 + 0xE + dwOffset, 2, "ADSR2");
-    rgn->addChild(k * 0x20 + 0x12 + dwOffset, 1, "Finetune");
-    rgn->addChild(k * 0x20 + 0x13 + dwOffset, 1, "UnityKey");
-    rgn->addChild(k * 0x20 + 0x14 + dwOffset, 1, "Key High");
-    rgn->addChild(k * 0x20 + 0x15 + dwOffset, 1, "Unknown");
-    rgn->addChild(k * 0x20 + 0x16 + dwOffset, 1, "Attenuation");
-    rgn->addChild(k * 0x20 + 0x17 + dwOffset, 1, "Pan");
+    rgn->addChild(k * 0x20 + offset(), 1, "Stereo Region Flag");
+    rgn->addChild(k * 0x20 + 1 + offset(), 1, "First/Last Region Flags");
+    rgn->addChild(k * 0x20 + 2 + offset(), 2, "Unknown Flag");
+    rgn->addChild(k * 0x20 + 0x4 + offset(), 4, "Sample Offset");
+    rgn->addChild(k * 0x20 + 0x8 + offset(), 4, "Loop Start");
+    rgn->addChild(k * 0x20 + 0xC + offset(), 2, "ADSR1");
+    rgn->addChild(k * 0x20 + 0xE + offset(), 2, "ADSR2");
+    rgn->addChild(k * 0x20 + 0x12 + offset(), 1, "Finetune");
+    rgn->addChild(k * 0x20 + 0x13 + offset(), 1, "UnityKey");
+    rgn->addChild(k * 0x20 + 0x14 + offset(), 1, "Key High");
+    rgn->addChild(k * 0x20 + 0x15 + offset(), 1, "Unknown");
+    rgn->addChild(k * 0x20 + 0x16 + offset(), 1, "Attenuation");
+    rgn->addChild(k * 0x20 + 0x17 + offset(), 1, "Pan");
 
-    rgn->bStereoRegion = readByte(k * 0x20 + dwOffset) & 0x1u;
-    rgn->bUnknownFlag2 = readByte(k * 0x20 + 2 + dwOffset) & 0x1u;
-    rgn->bFirstRegion = readByte(k * 0x20 + 1 + dwOffset) & 0x1u;
-    rgn->bLastRegion = (readByte(k * 0x20 + 1 + dwOffset) & 0x2u) >> 1u;
-    rgn->sampOffset = getWord(k * 0x20 + 0x4 + dwOffset) & 0xFFFFFFF0;  // The & is there because FFX points to 0x----C offsets for some very odd reason
-    rgn->loop.loopStart = getWord(k * 0x20 + 0x8 + dwOffset);
-    rgn->ADSR1 = readShort(k * 0x20 + 0xC + dwOffset);
-    rgn->ADSR2 = readShort(k * 0x20 + 0xE + dwOffset);
-    rgn->fineTune = readByte(k * 0x20 + 0x12 + dwOffset);
-    rgn->unityKey = 0x3A - readByte(k * 0x20 + 0x13 + dwOffset);
-    rgn->keyHigh = readByte(k * 0x20 + 0x14 + dwOffset);
+    rgn->bStereoRegion = readByte(k * 0x20 + offset()) & 0x1u;
+    rgn->bUnknownFlag2 = readByte(k * 0x20 + 2 + offset()) & 0x1u;
+    rgn->bFirstRegion = readByte(k * 0x20 + 1 + offset()) & 0x1u;
+    rgn->bLastRegion = (readByte(k * 0x20 + 1 + offset()) & 0x2u) >> 1u;
+    rgn->sampOffset = getWord(k * 0x20 + 0x4 + offset()) & 0xFFFFFFF0;  // The & is there because FFX points to 0x----C offsets for some very odd reason
+    rgn->loop.loopStart = getWord(k * 0x20 + 0x8 + offset());
+    rgn->ADSR1 = readShort(k * 0x20 + 0xC + offset());
+    rgn->ADSR2 = readShort(k * 0x20 + 0xE + offset());
+    rgn->fineTune = readByte(k * 0x20 + 0x12 + offset());
+    rgn->unityKey = 0x3A - readByte(k * 0x20 + 0x13 + offset());
+    rgn->keyHigh = readByte(k * 0x20 + 0x14 + offset());
 
-    uint8_t vol = readByte(k * 0x20 + 0x16 + dwOffset);
+    uint8_t vol = readByte(k * 0x20 + 0x16 + offset());
     rgn->setVolume(vol / 127.0);
 
-    rgn->pan = (double) readByte(k * 0x20 + 0x17 + dwOffset);        //need to convert
+    rgn->pan = (double) readByte(k * 0x20 + 0x17 + offset());        //need to convert
 
     if (rgn->pan == 255)
       rgn->pan = 1.0;

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
@@ -41,8 +41,8 @@ void SuzukiSnesSeq::resetVars() {
 bool SuzukiSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  VGMHeader *header = addHeader(dwOffset, 0);
-  uint32_t curOffset = dwOffset;
+  VGMHeader *header = addHeader(offset(), 0);
+  uint32_t curOffset = offset();
 
   // skip unknown stream
   if (version != SUZUKISNES_SD3) {

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
@@ -13,15 +13,15 @@ TamSoftPS1InstrSet::~TamSoftPS1InstrSet() {
 }
 
 bool TamSoftPS1InstrSet::parseHeader() {
-  if (dwOffset + 0x800 > vgmFile()->endOffset()) {
+  if (offset() + 0x800 > vgmFile()->endOffset()) {
     return false;
   }
 
   uint32_t sampCollSize = readWord(0x3fc);
-  if (dwOffset + 0x800 + sampCollSize > vgmFile()->endOffset()) {
+  if (offset() + 0x800 + sampCollSize > vgmFile()->endOffset()) {
     return false;
   }
-  unLength = 0x800 + sampCollSize;
+  setLength(0x800 + sampCollSize);
 
   return true;
 }
@@ -31,9 +31,9 @@ bool TamSoftPS1InstrSet::parseInstrPointers() {
 
   for (uint32_t instrNum = 0; instrNum < 256; instrNum++) {
     bool vagLoop;
-    uint32_t vagOffset = 0x800 + readWord(dwOffset + 4 * instrNum);
-    if (vagOffset < unLength) {
-      SizeOffsetPair vagLocation(vagOffset - 0x800, PSXSamp::getSampleLength(rawFile(), vagOffset, dwOffset + unLength, vagLoop));
+    uint32_t vagOffset = 0x800 + readWord(offset() + 4 * instrNum);
+    if (vagOffset < length()) {
+      SizeOffsetPair vagLocation(vagOffset - 0x800, PSXSamp::getSampleLength(rawFile(), vagOffset, offset() + length(), vagLoop));
       vagLocations.push_back(vagLocation);
 
       TamSoftPS1Instr *newInstr = new TamSoftPS1Instr(this, instrNum,
@@ -46,7 +46,7 @@ bool TamSoftPS1InstrSet::parseInstrPointers() {
     return false;
   }
 
-  sampColl = new PSXSampColl(TamSoftPS1Format::name, this, dwOffset + 0x800, unLength - 0x800, vagLocations);
+  sampColl = new PSXSampColl(TamSoftPS1Format::name, this, offset() + 0x800, length() - 0x800, vagLocations);
   return true;
 }
 
@@ -55,7 +55,7 @@ bool TamSoftPS1InstrSet::parseInstrPointers() {
 // ***************
 
 TamSoftPS1Instr::TamSoftPS1Instr(TamSoftPS1InstrSet *instrSet, uint8_t instrNum, const std::string &name) :
-    VGMInstr(instrSet, instrSet->dwOffset + 4 * instrNum, 0x400 + 4, 0, instrNum, name) {
+    VGMInstr(instrSet, instrSet->offset() + 4 * instrNum, 0x400 + 4, 0, instrNum, name) {
 }
 
 TamSoftPS1Instr::~TamSoftPS1Instr() {
@@ -64,9 +64,9 @@ TamSoftPS1Instr::~TamSoftPS1Instr() {
 bool TamSoftPS1Instr::loadInstr() {
   TamSoftPS1InstrSet *parInstrSet = (TamSoftPS1InstrSet *) this->parInstrSet;
 
-  addChild(dwOffset, 4, "Sample Offset");
+  addChild(offset(), 4, "Sample Offset");
 
-  TamSoftPS1Rgn *rgn = new TamSoftPS1Rgn(this, dwOffset + 0x400, parInstrSet->ps2);
+  TamSoftPS1Rgn *rgn = new TamSoftPS1Rgn(this, offset() + 0x400, parInstrSet->ps2);
   rgn->sampNum = instrNum;
   addRgn(rgn);
   return true;

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Scanner.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Scanner.cpp
@@ -44,7 +44,7 @@ void TamSoftPS1Scanner::scan(RawFile *file, void *info) {
       std::string seqname = fmt::format("{} ({})", basename, songIndex);
       TamSoftPS1Seq *newSeq = new TamSoftPS1Seq(file, 0, songIndex, seqname);
       if (newSeq->loadVGMFile()) {
-        newSeq->unLength = file->size();
+        newSeq->setLength(file->size());
       } else {
         delete newSeq;
       }
@@ -58,7 +58,7 @@ void TamSoftPS1Scanner::scan(RawFile *file, void *info) {
 
     TamSoftPS1InstrSet *newInstrSet = new TamSoftPS1InstrSet(file, 0, ps2, basename);
     if (newInstrSet->loadVGMFile()) {
-      newInstrSet->unLength = file->size();
+      newInstrSet->setLength(file->size());
     } else {
       delete newInstrSet;
     }

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
@@ -60,7 +60,7 @@ void TamSoftPS1Seq::resetVars() {
 bool TamSoftPS1Seq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
-  uint32_t dwSongItemOffset = dwOffset + 4 * song;
+  uint32_t dwSongItemOffset = offset() + 4 * song;
   if (dwSongItemOffset + 4 > vgmFile()->endOffset()) {
     return false;
   }
@@ -79,7 +79,7 @@ bool TamSoftPS1Seq::parseHeader() {
 
   if (type == 0) {
     // BGM
-    uint32_t dwHeaderOffset = dwOffset + seqHeaderRelOffset;
+    uint32_t dwHeaderOffset = offset() + seqHeaderRelOffset;
 
     // ignore (corrupted) silence sequence
     if (readWord(dwHeaderOffset) != 0xfffff0) {
@@ -142,7 +142,7 @@ bool TamSoftPS1Seq::parseHeader() {
   }
   else {
     // SFX (single track)
-    uint32_t dwTrackOffset = dwOffset + seqHeaderRelOffset;
+    uint32_t dwTrackOffset = offset() + seqHeaderRelOffset;
 
     // ignore silence sequence
     if (readShort(dwTrackOffset) != 0xfff0) {

--- a/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
@@ -21,23 +21,23 @@ TriAcePS1InstrSet::~TriAcePS1InstrSet(void) {
 //		VGMInstrSet::Load()関数から呼ばれる
 //==============================================================
 bool TriAcePS1InstrSet::parseHeader() {
-  VGMHeader *header = addHeader(dwOffset, sizeof(TriAcePS1InstrSet::_InstrHeader));    //1,Sep.2009 revise
-  header->addChild(dwOffset, 4, "InstrSet Size");
-  header->addChild(dwOffset + 4, 2, "Instr Section Size");
-  //header->addSimpleChild(dwOffset+6, 1, "Number of Instruments");
+  VGMHeader *header = addHeader(offset(), sizeof(TriAcePS1InstrSet::_InstrHeader));    //1,Sep.2009 revise
+  header->addChild(offset(), 4, "InstrSet Size");
+  header->addChild(offset() + 4, 2, "Instr Section Size");
+  //header->addSimpleChild(offset()+6, 1, "Number of Instruments");
 
   //-----------------------
   //1,Sep.2009 revise		to do こうしたい。
   //-----------------------
-  //	GetBytes(dwOffset, sizeof(TriAcePS1InstrSet::_InstrHeader), &InstrHeader);
+  //	GetBytes(offset(), sizeof(TriAcePS1InstrSet::_InstrHeader), &InstrHeader);
   //		↑　↑　↑
-  unLength = readWord(dwOffset);                     // to do delete
-  instrSectionSize = readShort(dwOffset + 4);        // to do delete
+  setLength(readWord(offset()));                     // to do delete
+  instrSectionSize = readShort(offset() + 4);        // to do delete
   //-----------------------
 
 
-  //sampColl = new TriAcePS1SampColl(this, dwOffset+instrSectionSize, unLength-instrSectionSize);
-  sampColl = new PSXSampColl(TriAcePS1Format::name, this, dwOffset + instrSectionSize, unLength - instrSectionSize);
+  //sampColl = new TriAcePS1SampColl(this, offset()+instrSectionSize, length()-instrSectionSize);
+  sampColl = new PSXSampColl(TriAcePS1Format::name, this, offset() + instrSectionSize, length() - instrSectionSize);
 
 
   return true;
@@ -51,11 +51,11 @@ bool TriAcePS1InstrSet::parseHeader() {
 //==============================================================
 bool TriAcePS1InstrSet::parseInstrPointers() {
 
-  uint32_t firstWord = readWord(dwOffset + sizeof(TriAcePS1InstrSet::_InstrHeader));        //1,Sep.2009 revise
+  uint32_t firstWord = readWord(offset() + sizeof(TriAcePS1InstrSet::_InstrHeader));        //1,Sep.2009 revise
 
   //0xFFFFFFFFになるまで繰り返す。
-  for (uint32_t i = dwOffset + sizeof(TriAcePS1InstrSet::_InstrHeader);                    //1,Sep.2009 revise
-       ((firstWord != 0xFFFFFFFF) && (i < dwOffset + unLength));
+  for (uint32_t i = offset() + sizeof(TriAcePS1InstrSet::_InstrHeader);                    //1,Sep.2009 revise
+       ((firstWord != 0xFFFFFFFF) && (i < offset() + length()));
        i += sizeof(TriAcePS1Instr::InstrInfo), firstWord = readWord(i)) {
     TriAcePS1Instr *newInstr = new TriAcePS1Instr(this, i, 0, 0, 0);
     aInstrs.push_back(newInstr);
@@ -88,13 +88,13 @@ TriAcePS1Instr::TriAcePS1Instr(VGMInstrSet *instrSet,
 //		Make the Object "WdsRgn" (Attribute table)
 //--------------------------------------------------------------
 bool TriAcePS1Instr::loadInstr() {
-  unLength = sizeof(InstrInfo) + sizeof(RgnInfo) * instrinfo.numRgns;
+  setLength(sizeof(InstrInfo) + sizeof(RgnInfo) * instrinfo.numRgns);
 
 //	TriAcePS1InstrSet*	_parInstrSet	=	(TriAcePS1InstrSet*)parInstrSet;
 
   // Get the rgn data
   rgns = new RgnInfo[instrinfo.numRgns];
-  readBytes((dwOffset + sizeof(InstrInfo)), (sizeof(RgnInfo) * instrinfo.numRgns), rgns);
+  readBytes((offset() + sizeof(InstrInfo)), (sizeof(RgnInfo) * instrinfo.numRgns), rgns);
 
   // Set the program num and bank num, adjusting for values > 0x7F
   this->instrNum =  instrinfo.progNum & 0x7F;                                        //1,Sep.2009 revise
@@ -114,25 +114,25 @@ bool TriAcePS1Instr::loadInstr() {
   for (int i = 0; i < instrinfo.numRgns; i++) {
     RgnInfo *rgninfo = &rgns[i];
     VGMRgn *rgn = new VGMRgn(this,
-                             dwOffset + sizeof(InstrInfo) + sizeof(RgnInfo) * i,
+                             offset() + sizeof(InstrInfo) + sizeof(RgnInfo) * i,
                              sizeof(RgnInfo));        //1,Sep.2009 revise
-    rgn->addKeyLow(rgninfo->note_range_low, rgn->dwOffset);
-    rgn->addKeyHigh(rgninfo->note_range_high, rgn->dwOffset + 1);
-    rgn->addVelLow(rgninfo->vel_range_high == 0 ? 0 : rgninfo->vel_range_low, rgn->dwOffset + 2);
-    rgn->addVelHigh(rgninfo->vel_range_high == 0 ? 0x7F : rgninfo->vel_range_high, rgn->dwOffset + 3);
-    rgn->addChild(rgn->dwOffset + 4, 4, "Sample Offset");
-    rgn->sampOffset = rgninfo->sampOffset; //+ ((VGMInstrSet*)this->vgmfile)->sampColl->dwOffset;
-    rgn->addChild(rgn->dwOffset + 8, 4, "Sample Loop Point");
+    rgn->addKeyLow(rgninfo->note_range_low, rgn->offset());
+    rgn->addKeyHigh(rgninfo->note_range_high, rgn->offset() + 1);
+    rgn->addVelLow(rgninfo->vel_range_high == 0 ? 0 : rgninfo->vel_range_low, rgn->offset() + 2);
+    rgn->addVelHigh(rgninfo->vel_range_high == 0 ? 0x7F : rgninfo->vel_range_high, rgn->offset() + 3);
+    rgn->addChild(rgn->offset() + 4, 4, "Sample Offset");
+    rgn->sampOffset = rgninfo->sampOffset; //+ ((VGMInstrSet*)this->vgmfile)->sampColl->offset();
+    rgn->addChild(rgn->offset() + 8, 4, "Sample Loop Point");
     //rgn->loop.loopStatus = (rgninfo->loopOffset != rgninfo->sampOffset) && (rgninfo->loopOffset != 0);
     rgn->loop.loopStart = rgninfo->loopOffset;
-    rgn->addChild(rgn->dwOffset + 12, 1, "Attenuation");
+    rgn->addChild(rgn->offset() + 12, 1, "Attenuation");
     rgn->addUnityKey((int8_t) 0x3B - rgninfo->pitchTuneSemitones,
-                     rgn->dwOffset + 13);  //You would think it would be 0x3C (middle c)
-    rgn->addChild(rgn->dwOffset + 14, 1, "Pitch Fine Tune");
+                     rgn->offset() + 13);  //You would think it would be 0x3C (middle c)
+    rgn->addChild(rgn->offset() + 14, 1, "Pitch Fine Tune");
     const int kTuningOffset = 22; // approx. 21.500638 from pitch table (0x10be vs 0x1000)
     rgn->fineTune = (short)((double)rgninfo->pitchTuneFine / 64.0 * 100) - kTuningOffset;
     rgn->sampCollPtr = ((VGMInstrSet *) this->vgmFile())->sampColl;
-    rgn->addChild(rgn->dwOffset + 15, 5, "Unknown values");
+    rgn->addChild(rgn->offset() + 15, 5, "Unknown values");
 
 
     psxConvADSR(rgn, instrinfo.ADSR1, instrinfo.ADSR2, false);

--- a/src/main/formats/common/KonamiAdpcm.cpp
+++ b/src/main/formats/common/KonamiAdpcm.cpp
@@ -74,14 +74,14 @@ std::vector<uint8_t> KonamiAdpcmSamp::decodeToNativePcm() {
      //   - step the address backwards one byte at a time
      //   - still decode low nibble first, then high nibble
   if (reverse()) {
-    for (u32 off = dwOffset + unLength;  off-- > dwOffset; ) {
+    for (u32 off = offset() + length();  off-- > offset(); ) {
       u8 b = readByte(off);
       emit( b & 0x0F );
       emit( (b >> 4) & 0x0F );
     }
   }
   else {
-    for (u32 off = dwOffset; off < dwOffset + unLength; ++off) {
+    for (u32 off = offset(); off < offset() + length(); ++off) {
       u8 b = readByte(off);
       emit( b & 0x0F );
       emit( (b >> 4) & 0x0F );

--- a/src/main/formats/common/OkiAdpcm.cpp
+++ b/src/main/formats/common/OkiAdpcm.cpp
@@ -155,7 +155,7 @@ std::vector<uint8_t> DialogicAdpcmSamp::decodeToNativePcm() {
   DialogicAdpcmSamp::okiAdpcmState.reset();
 
   int sampleNum = 0;
-  for (uint32_t off = dwOffset; off < (dwOffset + unLength); ++off) {
+  for (uint32_t off = offset(); off < (offset() + length()); ++off) {
     uint8_t byte = readByte(off);
 
     for (int n = 0; n < 2; ++n) {

--- a/src/main/formats/common/SNESDSP.cpp
+++ b/src/main/formats/common/SNESDSP.cpp
@@ -441,17 +441,17 @@ std::vector<uint8_t> SNESSamp::decodeToNativePcm() {
   assert(dataLength % 9 == 0);
   for (uint32_t k = 0; k + 9 <= dataLength; k += 9)  //for every adpcm chunk
   {
-    if (dwOffset + k + 9 > rawFile()->size()) {
+    if (offset() + k + 9 > rawFile()->size()) {
       L_WARN("Unexpected EOF ({})", (name()));
       break;
     }
 
-    theBlock.flag.range = (readByte(dwOffset + k) & 0xf0) >> 4;
-    theBlock.flag.filter = (readByte(dwOffset + k) & 0x0c) >> 2;
-    theBlock.flag.end = (readByte(dwOffset + k) & 0x01) != 0;
-    theBlock.flag.loop = (readByte(dwOffset + k) & 0x02) != 0;
+    theBlock.flag.range = (readByte(offset() + k) & 0xf0) >> 4;
+    theBlock.flag.filter = (readByte(offset() + k) & 0x0c) >> 2;
+    theBlock.flag.end = (readByte(offset() + k) & 0x01) != 0;
+    theBlock.flag.loop = (readByte(offset() + k) & 0x02) != 0;
 
-    rawFile()->readBytes(dwOffset + k + 1, 8, theBlock.brr);
+    rawFile()->readBytes(offset() + k + 1, 8, theBlock.brr);
     const size_t blockIndex = k / 9;
     decompBRRBlk(output + blockIndex * 16,
                  &theBlock,
@@ -460,9 +460,9 @@ std::vector<uint8_t> SNESSamp::decodeToNativePcm() {
 
     if (theBlock.flag.end) {
       if (theBlock.flag.loop) {
-        if (brrLoopOffset <= dwOffset + k) {
-          setLoopOffset(brrLoopOffset - dwOffset);
-          setLoopLength((k + 9) - (brrLoopOffset - dwOffset));
+        if (brrLoopOffset <= offset() + k) {
+          setLoopOffset(brrLoopOffset - offset());
+          setLoopLength((k + 9) - (brrLoopOffset - offset()));
           setLoopStatus(1);
         }
       }

--- a/src/ui/qt/services/NotificationCenter.cpp
+++ b/src/ui/qt/services/NotificationCenter.cpp
@@ -27,7 +27,7 @@ void NotificationCenter::updateStatusForItem(VGMItem* item) {
   QString formattedName = QString{"<b>%1</b>"}.arg(name);
   QIcon icon = iconForItemType(item->type);
 
-  emit statusUpdated(formattedName, description, &icon, item->dwOffset, item->unLength);
+  emit statusUpdated(formattedName, description, &icon, item->offset(), item->length());
 }
 
 void NotificationCenter::selectVGMFile(VGMFile* vgmfile, QWidget* caller) {

--- a/src/ui/qt/workarea/VGMFileTreeView.cpp
+++ b/src/ui/qt/workarea/VGMFileTreeView.cpp
@@ -258,14 +258,14 @@ void VGMFileTreeView::setItemText(VGMItem* item, VGMTreeItem* treeItem) const {
     if (item->description().empty()) {
       treeItem->setText(0, QString{"<b>%1</b><br>Offset: 0x%2 | Length: 0x%3"}
                                .arg(name,
-                                    QString::number(item->dwOffset, 16),
-                                    QString::number(item->unLength, 16)));
+                                    QString::number(item->offset(), 16),
+                                    QString::number(item->length(), 16)));
     } else {
       treeItem->setText(0, QString{"<b>%1</b><br>%2<br>Offset: 0x%3 | Length: 0x%4"}
                                .arg(name,
                                     QString::fromStdString(item->description()),
-                                    QString::number(item->dwOffset, 16),
-                                    QString::number(item->unLength, 16)));
+                                    QString::number(item->offset(), 16),
+                                    QString::number(item->length(), 16)));
     }
   } else {
     treeItem->setText(0, name);

--- a/src/ui/qt/workarea/VGMFileTreeView.h
+++ b/src/ui/qt/workarea/VGMFileTreeView.h
@@ -50,7 +50,7 @@ public:
   ~VGMTreeItem() override = default;
 
   [[nodiscard]] inline auto item_parent() const noexcept { return m_parent; }
-  [[nodiscard]] inline auto item_offset() const noexcept { return m_item->dwOffset; }
+  [[nodiscard]] inline auto item_offset() const noexcept { return m_item->offset(); }
   [[nodiscard]] inline auto item() const noexcept { return m_item; }
 
 private:


### PR DESCRIPTION
Lots of changes, but straightforward changes:
- renamed `dwOffset` -> `m_offset`, `unLength` -> `m_length`
- added get/set methods for m_offset and m_length


## How Has This Been Tested?
I loaded a large number number of formats and tested that they're previewing correctly and that the HexView / File Tree structure looks normal for sequences and instrument sets.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
