### PR TITLE
Track duration of note on/off events for SeqEventTimeIndex

### DIFF
--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -144,6 +144,8 @@ private:
   void addLevelNoItem(double level, LevelController controller, Resolution res, int absTime = -1);
   void purgePrevDurEvents(uint32_t absTime);
   void clearPrevDurEvents();
+  void trackActiveNoteIndex(int8_t key, SeqEventTimeIndex::Index idx);
+  void endActiveNoteIndex(int8_t key, uint32_t endTick);
 
  public:
   void addGenericEvent(uint32_t offset, uint32_t length, const std::string &sEventName, const std::string &sEventDesc, Type type);
@@ -319,6 +321,7 @@ private:
   std::vector<LoopState> loopStack;
   std::unordered_set<ControlFlowState, ControlFlowStateHasher> visitedControlFlowStates;
   std::vector<SeqEventTimeIndex::Index> prevDurEventIndices;
+  std::unordered_map<int, std::vector<SeqEventTimeIndex::Index>> m_activeNoteEventIndices;
 
   uint32_t m_lastEventOffset = 0;
   uint32_t m_lastEventLength = 0;


### PR DESCRIPTION
## Description

As mentioned in the [prior PR](https://github.com/vgmtrans/vgmtrans/pull/736), this adds duration tracking for NoteOnSeqEvent / NoteOffSeqEvent (ie, not DurNoteSeqEvent).

This is pretty straight-forward. We add an unordered_map of key (int) to a vector of `SeqEventTimeIndex::Index`. The vector allows for multiple overlapping notes of the same key (it happens a lot in SquarePS2 😐) The new logic only applies during READMODE_CONVERT_TO_MIDI.

- when we add a NoteOn, we record its Index into the map.
- on a note off, we check for active notes of that key and pop the last one. If found, we update its duration. If the vector is empty, we erase the vector

That's it. Why SquarePS2 allows overlapping notes of the same key is a mystery I haven't explored. I'm not sure if it uses LIFO or FIFO for note off, but it does match overlapping note ons with an equal number of note offs.

## How Has This Been Tested?
Note on / off formats are working in the HexView rewrite that visualizes active notes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.