### PR TITLE
RhiHexView 3: HexViewRhiWindow

### DIFF
--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -99,6 +99,8 @@ add_executable(
   workarea/hexview/HexViewRhiRenderer.h
   workarea/hexview/HexViewRhiWidget.cpp
   workarea/hexview/HexViewRhiWidget.h
+  workarea/hexview/HexViewRhiWindow.cpp
+  workarea/hexview/HexViewRhiWindow.h
   workarea/MdiArea.cpp
   workarea/MdiArea.h
   workarea/RawFileListView.cpp

--- a/src/ui/qt/MainWindow.cpp
+++ b/src/ui/qt/MainWindow.cpp
@@ -175,43 +175,51 @@ void MainWindow::routeSignals() {
 
 void MainWindow::dragEnterEvent(QDragEnterEvent *event) {
   event->acceptProposedAction();
-  if (m_dragOverlay) {
-    updateDragOverlayGeometry();
-    m_dragOverlay->show();
-    m_dragOverlay->raise();
-  }
+  showDragOverlay();
 }
 
 void MainWindow::dragMoveEvent(QDragMoveEvent *event) {
   event->acceptProposedAction();
-  if (m_dragOverlay && !m_dragOverlay->isVisible()) {
-    m_dragOverlay->show();
-    m_dragOverlay->raise();
-  }
+  showDragOverlay();
 }
 
 void MainWindow::dragLeaveEvent(QDragLeaveEvent *event) {
   event->accept();
+  hideDragOverlay();
+}
+
+void MainWindow::dropEvent(QDropEvent *event) {
+  handleDroppedUrls(event->mimeData()->urls());
+  event->acceptProposedAction();
+}
+
+void MainWindow::showDragOverlay() {
+  if (!m_dragOverlay) {
+    return;
+  }
+  updateDragOverlayGeometry();
+  if (!m_dragOverlay->isVisible()) {
+    m_dragOverlay->show();
+  }
+  m_dragOverlay->raise();
+}
+
+void MainWindow::hideDragOverlay() {
   if (m_dragOverlay) {
     m_dragOverlay->hide();
   }
 }
 
-void MainWindow::dropEvent(QDropEvent *event) {
-  const auto &files = event->mimeData()->urls();
+void MainWindow::handleDroppedUrls(const QList<QUrl>& urls) {
+  hideDragOverlay();
 
-  if (m_dragOverlay) {
-    m_dragOverlay->hide();
-  }
-
-  if (files.isEmpty())
+  if (urls.isEmpty()) {
     return;
-
-  for (const auto &file : files) {
-    openFileInternal(file.toLocalFile());
   }
 
-  event->acceptProposedAction();
+  for (const auto &url : urls) {
+    openFileInternal(url.toLocalFile());
+  }
 }
 
 void MainWindow::openFile() {

--- a/src/ui/qt/MainWindow.h
+++ b/src/ui/qt/MainWindow.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <QList>
 #include <QMainWindow>
+#include <QUrl>
 #include "Root.h"
 
 class QWidget;
@@ -31,6 +33,9 @@ class MainWindow final : public QMainWindow {
 public:
   MainWindow();
   void showEvent(QShowEvent* event) override;
+  void showDragOverlay();
+  void hideDragOverlay();
+  void handleDroppedUrls(const QList<QUrl>& urls);
 
 protected:
   void dragEnterEvent(QDragEnterEvent *event) override;

--- a/src/ui/qt/main_ui.cpp
+++ b/src/ui/qt/main_ui.cpp
@@ -35,11 +35,13 @@ int main(int argc, char *argv[]) {
   QCoreApplication::setApplicationName("VGMTrans");
 
   QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::Round);
+  // Keep dock splitter/input behavior stable when embedding RHI QWindow containers.
+  QCoreApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
 
   VGMTransApplication app(argc, argv);
-  #ifdef _WIN32
+#ifdef _WIN32
   app.setStyle(QStyleFactory::create("fusion"));
-  #endif
+#endif
   qtVGMRoot.init();
 
   QFontDatabase::addApplicationFont(":/fonts/Roboto_Mono/RobotoMono-VariableFont_wght.ttf");

--- a/src/ui/qt/workarea/hexview/HexViewRhiHost.h
+++ b/src/ui/qt/workarea/hexview/HexViewRhiHost.h
@@ -12,6 +12,7 @@
 
 class HexView;
 class QResizeEvent;
+class QWindow;
 
 class HexViewRhiHost final : public QWidget {
   Q_OBJECT
@@ -31,4 +32,5 @@ protected:
 private:
   std::unique_ptr<HexViewRhiRenderer> m_renderer;
   QWidget* m_surface = nullptr;
+  QWindow* m_window = nullptr;
 };

--- a/src/ui/qt/workarea/hexview/HexViewRhiWindow.cpp
+++ b/src/ui/qt/workarea/hexview/HexViewRhiWindow.cpp
@@ -1,0 +1,378 @@
+/*
+* VGMTrans (c) 2002-2026
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+*/
+
+#include "HexViewRhiWindow.h"
+
+#include "HexView.h"
+#include "HexViewRhiRenderer.h"
+#include "LogManager.h"
+
+#include <rhi/qrhi.h>
+#include <rhi/qrhi_platform.h>
+
+#include <QDragEnterEvent>
+#include <QDragLeaveEvent>
+#include <QDragMoveEvent>
+#include <QDropEvent>
+#include <QEvent>
+#include <QExposeEvent>
+#include <QMimeData>
+#include <QResizeEvent>
+#include <QScrollBar>
+
+#if QT_CONFIG(opengl)
+#include <QOffscreenSurface>
+#include <QSurfaceFormat>
+#endif
+
+#if QT_CONFIG(vulkan)
+#include <QVulkanInstance>
+#endif
+
+namespace {
+constexpr int SCROLLBAR_FRAME_MS = 16;
+}  // namespace
+
+struct HexViewRhiWindow::BackendData {
+  QRhi::Implementation backend = QRhi::Null;
+  QRhiInitParams* initParams = nullptr;
+
+#if QT_CONFIG(opengl)
+  QRhiGles2InitParams glesParams;
+  std::unique_ptr<QOffscreenSurface> fallbackSurface;
+#endif
+
+#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+  QRhiVulkanInitParams vkParams;
+  std::unique_ptr<QVulkanInstance> vkInstance;
+#endif
+
+#if QT_CONFIG(metal)
+  QRhiMetalInitParams metalParams;
+#endif
+
+#if defined(Q_OS_WIN)
+  QRhiD3D11InitParams d3d11Params;
+#endif
+
+  QRhiNullInitParams nullParams;
+};
+
+HexViewRhiWindow::HexViewRhiWindow(HexView* view, HexViewRhiRenderer* renderer)
+    : m_view(view),
+      m_renderer(renderer),
+      m_eventForwarder(view, [this]() { requestUpdate(); }),
+      m_backend(std::make_unique<BackendData>()) {
+  setFlags(Qt::SubWindow | Qt::FramelessWindowHint);
+
+#if defined(Q_OS_WIN)
+  setSurfaceType(QSurface::Direct3DSurface);
+  m_backend->backend = QRhi::D3D11;
+#elif defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+  setSurfaceType(QSurface::MetalSurface);
+  m_backend->backend = QRhi::Metal;
+#elif QT_CONFIG(vulkan)
+  setSurfaceType(QSurface::VulkanSurface);
+  m_backend->backend = QRhi::Vulkan;
+#elif QT_CONFIG(opengl)
+  setSurfaceType(QSurface::OpenGLSurface);
+  m_backend->backend = QRhi::OpenGLES2;
+#else
+  setSurfaceType(QSurface::RasterSurface);
+  m_backend->backend = QRhi::Null;
+#endif
+
+#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+  if (m_backend->backend == QRhi::Vulkan) {
+    m_backend->vkInstance = std::make_unique<QVulkanInstance>();
+    m_backend->vkInstance->setExtensions(QRhiVulkanInitParams::preferredInstanceExtensions());
+    if (!m_backend->vkInstance->create()) {
+      qWarning("Failed to create QVulkanInstance for HexViewRhiWindow");
+      m_backend->vkInstance.reset();
+      setSurfaceType(QSurface::RasterSurface);
+      m_backend->backend = QRhi::Null;
+    } else {
+      setVulkanInstance(m_backend->vkInstance.get());
+    }
+  }
+#endif
+
+  m_scrollBarFrameTimer.setParent(this);
+  m_scrollBarFrameTimer.setInterval(SCROLLBAR_FRAME_MS);
+  m_scrollBarFrameTimer.setTimerType(Qt::PreciseTimer);
+  connect(&m_scrollBarFrameTimer, &QTimer::timeout, this, [this]() {
+    renderFrame();
+  });
+
+  if (m_view) {
+    if (auto* vbar = m_view->verticalScrollBar()) {
+      connect(vbar, &QScrollBar::sliderPressed, this, [this]() {
+        if (!m_scrollBarFrameTimer.isActive()) {
+          m_scrollBarFrameTimer.start();
+        }
+      });
+      connect(vbar, &QScrollBar::sliderReleased, this, [this]() {
+        if (m_scrollBarFrameTimer.isActive()) {
+          m_scrollBarFrameTimer.stop();
+        }
+        requestUpdate();
+      });
+    }
+  }
+}
+
+HexViewRhiWindow::~HexViewRhiWindow() {
+  releaseResources();
+}
+
+void HexViewRhiWindow::releaseSwapChain() {
+  if (m_hasSwapChain && m_sc) {
+    m_hasSwapChain = false;
+    m_sc->destroy();
+  }
+}
+
+bool HexViewRhiWindow::event(QEvent* e) {
+  if (e->type() == QEvent::UpdateRequest) {
+    if (m_scrollBarFrameTimer.isActive()) {
+      return true;
+    }
+    renderFrame();
+    return true;
+  }
+
+  if (m_eventForwarder.handleEvent(e, m_dragging)) {
+    return true;
+  }
+
+  if (!m_view || !m_view->viewport()) {
+    return QWindow::event(e);
+  }
+
+  switch (e->type()) {
+    case QEvent::DragEnter:
+    case QEvent::DragMove:
+    case QEvent::DragLeave:
+    case QEvent::Drop: {
+      switch (e->type()) {
+        case QEvent::DragEnter: {
+          auto* dragEvent = static_cast<QDragEnterEvent*>(e);
+          emit dragOverlayShowRequested();
+          dragEvent->acceptProposedAction();
+          break;
+        }
+        case QEvent::DragMove: {
+          auto* dragEvent = static_cast<QDragMoveEvent*>(e);
+          emit dragOverlayShowRequested();
+          dragEvent->acceptProposedAction();
+          break;
+        }
+        case QEvent::DragLeave:
+          emit dragOverlayHideRequested();
+          e->accept();
+          break;
+        case QEvent::Drop: {
+          auto* dropEvent = static_cast<QDropEvent*>(e);
+          emit dropUrlsRequested(dropEvent->mimeData()->urls());
+          dropEvent->acceptProposedAction();
+          break;
+        }
+        default:
+          break;
+      }
+      return true;
+    }
+
+    default:
+      break;
+  }
+
+  return QWindow::event(e);
+}
+
+void HexViewRhiWindow::exposeEvent(QExposeEvent*) {
+  if (!isExposed()) {
+    return;
+  }
+  initIfNeeded();
+  requestUpdate();
+}
+
+void HexViewRhiWindow::resizeEvent(QResizeEvent*) {
+  if (m_rhi) {
+    resizeSwapChain();
+  }
+  requestUpdate();
+}
+
+void HexViewRhiWindow::initIfNeeded() {
+  if (m_rhi || !m_backend) {
+    return;
+  }
+
+  switch (m_backend->backend) {
+    case QRhi::OpenGLES2:
+#if QT_CONFIG(opengl)
+      m_backend->glesParams.window = this;
+      m_backend->glesParams.format = QSurfaceFormat::defaultFormat();
+      m_backend->fallbackSurface.reset(
+          QRhiGles2InitParams::newFallbackSurface(m_backend->glesParams.format));
+      m_backend->glesParams.fallbackSurface = m_backend->fallbackSurface.get();
+      m_backend->initParams = &m_backend->glesParams;
+#else
+      m_backend->backend = QRhi::Null;
+      m_backend->initParams = &m_backend->nullParams;
+#endif
+      break;
+    case QRhi::Vulkan:
+#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+      if (!m_backend->vkInstance) {
+        qWarning("Vulkan backend requested but QVulkanInstance is missing");
+        m_backend->backend = QRhi::Null;
+        m_backend->initParams = &m_backend->nullParams;
+        break;
+      }
+      m_backend->vkParams.inst = m_backend->vkInstance.get();
+      m_backend->vkParams.window = this;
+      m_backend->initParams = &m_backend->vkParams;
+#else
+      m_backend->backend = QRhi::Null;
+      m_backend->initParams = &m_backend->nullParams;
+#endif
+      break;
+    case QRhi::Metal:
+#if QT_CONFIG(metal)
+      m_backend->initParams = &m_backend->metalParams;
+#else
+      m_backend->backend = QRhi::Null;
+      m_backend->initParams = &m_backend->nullParams;
+#endif
+      break;
+    case QRhi::D3D11:
+#if defined(Q_OS_WIN)
+      m_backend->initParams = &m_backend->d3d11Params;
+#else
+      m_backend->backend = QRhi::Null;
+      m_backend->initParams = &m_backend->nullParams;
+#endif
+      break;
+    case QRhi::Null:
+    default:
+      m_backend->initParams = &m_backend->nullParams;
+      break;
+  }
+  m_rhi = QRhi::create(m_backend->backend, m_backend->initParams);
+  if (!m_rhi) {
+    qWarning("Failed to create QRhi for HexViewRhiWindow");
+    return;
+  }
+
+  L_DEBUG("HexViewRhiWindow init: backend={} surface={} size={}x{} dpr={}",
+          int(m_rhi->backend()), int(surfaceType()), size().width(), size().height(),
+          devicePixelRatio());
+
+  if (m_renderer) {
+    m_renderer->initIfNeeded(m_rhi);
+  }
+
+  m_sc = m_rhi->newSwapChain();
+  m_sc->setWindow(this);
+  m_sc->setSampleCount(1);
+  m_rp = m_sc->newCompatibleRenderPassDescriptor();
+  m_sc->setRenderPassDescriptor(m_rp);
+  resizeSwapChain();
+}
+
+void HexViewRhiWindow::resizeSwapChain() {
+  if (!m_rhi || !m_sc) {
+    return;
+  }
+
+  const QSize pixelSize = size() * devicePixelRatio();
+  if (pixelSize.isEmpty()) {
+    L_DEBUG("HexViewRhiWindow resizeSwapChain skipped: empty pixel size size={}x{} dpr={}",
+            size().width(), size().height(), devicePixelRatio());
+    return;
+  }
+
+  if (!m_ds || m_ds->pixelSize() != pixelSize) {
+    delete m_ds;
+    m_ds = m_rhi->newRenderBuffer(QRhiRenderBuffer::DepthStencil, pixelSize, m_sc->sampleCount(),
+                                  QRhiRenderBuffer::UsedWithSwapChainOnly);
+    m_ds->create();
+    m_sc->setDepthStencil(m_ds);
+  }
+
+  m_hasSwapChain = m_sc->createOrResize();
+  L_DEBUG("HexViewRhiWindow swapchain resized pixelSize={}x{} sampleCount={}",
+          pixelSize.width(), pixelSize.height(), m_sc->sampleCount());
+}
+
+void HexViewRhiWindow::renderFrame() {
+  if (!isExposed()) {
+    return;
+  }
+
+  initIfNeeded();
+  if (!m_rhi || !m_sc || !m_view || !m_view->viewport() || !m_renderer) {
+    return;
+  }
+
+  // Apply at most one mouse, wheel move per frame.
+  m_eventForwarder.drainPendingInput();
+
+  const QSize currentPixelSize = m_sc->currentPixelSize();
+  if (currentPixelSize.isEmpty()) {
+    L_DEBUG("HexViewRhiWindow renderFrame skipped: swapchain pixel size empty");
+    return;
+  }
+
+  const QRhi::FrameOpResult result = m_rhi->beginFrame(m_sc);
+  if (result == QRhi::FrameOpSwapChainOutOfDate) {
+    L_DEBUG("HexViewRhiWindow frame: swapchain out of date");
+    resizeSwapChain();
+    if (!m_hasSwapChain) {
+      return;
+    }
+    requestUpdate();
+    return;
+  }
+  if (result != QRhi::FrameOpSuccess) {
+    L_DEBUG("HexViewRhiWindow frame: beginFrame failed {}", int(result));
+    return;
+  }
+
+  m_cb = m_sc->currentFrameCommandBuffer();
+  QRhiRenderTarget* rt = m_sc->currentFrameRenderTarget();
+
+  HexViewRhiRenderer::RenderTargetInfo info;
+  info.renderTarget = rt;
+  info.renderPassDesc = m_sc->renderPassDescriptor();
+  info.pixelSize = currentPixelSize;
+  info.sampleCount = m_sc->sampleCount();
+  info.dpr = devicePixelRatio();
+  m_renderer->renderFrame(m_cb, info);
+
+  m_rhi->endFrame(m_sc);
+}
+
+void HexViewRhiWindow::releaseResources() {
+  if (m_renderer) {
+    m_renderer->releaseResources();
+  }
+
+  delete m_rp;
+  m_rp = nullptr;
+  delete m_ds;
+  m_ds = nullptr;
+
+  releaseSwapChain();
+  delete m_sc;
+  m_sc = nullptr;
+
+  delete m_rhi;
+  m_rhi = nullptr;
+}

--- a/src/ui/qt/workarea/hexview/HexViewRhiWindow.h
+++ b/src/ui/qt/workarea/hexview/HexViewRhiWindow.h
@@ -1,0 +1,70 @@
+/*
+* VGMTrans (c) 2002-2026
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+*/
+
+#pragma once
+
+#include <QList>
+#include <QTimer>
+#include <QUrl>
+#include <QWindow>
+#include <memory>
+
+#include "HexViewRhiEventForwarder.h"
+
+class QEvent;
+class QExposeEvent;
+class QResizeEvent;
+class QRhi;
+class QRhiCommandBuffer;
+class QRhiRenderBuffer;
+class QRhiRenderPassDescriptor;
+class QRhiSwapChain;
+class HexView;
+class HexViewRhiRenderer;
+
+class HexViewRhiWindow final : public QWindow {
+  Q_OBJECT
+
+public:
+  explicit HexViewRhiWindow(HexView* view, HexViewRhiRenderer* renderer);
+  ~HexViewRhiWindow() override;
+
+protected:
+  bool event(QEvent* e) override;
+  void exposeEvent(QExposeEvent* event) override;
+  void resizeEvent(QResizeEvent* event) override;
+
+signals:
+  void dragOverlayShowRequested();
+  void dragOverlayHideRequested();
+  void dropUrlsRequested(const QList<QUrl>& urls);
+
+private:
+  struct BackendData;
+
+  void initIfNeeded();
+  void resizeSwapChain();
+  void renderFrame();
+  void releaseResources();
+  void releaseSwapChain();
+
+  HexView* m_view = nullptr;
+  HexViewRhiRenderer* m_renderer = nullptr;
+
+  std::unique_ptr<BackendData> m_backend;
+
+  QRhi* m_rhi = nullptr;
+  QRhiSwapChain* m_sc = nullptr;
+  QRhiRenderBuffer* m_ds = nullptr;
+  QRhiRenderPassDescriptor* m_rp = nullptr;
+  QRhiCommandBuffer* m_cb = nullptr;
+
+  bool m_dragging = false;
+  HexViewRhiEventForwarder m_eventForwarder;
+  QTimer m_scrollBarFrameTimer;
+
+  bool m_hasSwapChain = false;
+};


### PR DESCRIPTION
## Description
This PR adds the new HexViewRhiWindow class, which is used by Windows and macOS to fix the poor performance of HexViewRhiWidget. The cause of this platform-specific issue is unclear, but may be related to the fact we embed a QRhiWidget within a QSplitter or MDIArea.

`HexViewRhiHost` owns the RHI surface (either the Window or Widget class) and interfaces to it in a platform-agnostic way, allowing `HexView` to be happily ignorant of these details. When `HexViewRhiHost` instantiates a `HexViewRhiWindow`, it contains it within a Widget using `QWidget::createWindowContainer()`. 

A cleaner solution would be to get rid of `HexViewRhiWidget` and use `HexViewRhiWindow` on all platforms, but Qt laughs in our face and insists we be made to suffer. No, the Wayland architecture, which has widely replaced X - or more specifically, Qt's implementation on top of Wayland - does not like something about embedding a HexViewRhiWindow within the Widget of another window. This is probably because Wayland has no concept of "child windows". When we try to use HexViewRhiWindow, we get a permanently stuck, unresizable window on top of the rest of our app, and drawing breaks.

Thus, we need `HexViewRhiWidget`, `HexViewRhiWindow`, and their loving parent `HexViewRhiHost`.

`HexViewRhiWindow` differs from `HexViewRhiWidget` in that it has to own and handle the `RHI/swapchain` lifecycle, which includes handling window resizes. Both classes handle incoming QEvents (and share logic using `HexViewRhiEventForwarder`), but `HexViewRhiWindow`, being its own QWindow, also has to handle drag and drop related events. When such events are received, it emits signals which are routed to `MainWindow` via `HexViewRhiHost` so that `MainWindow` can own drag/drop behavior.

The MainWindow drag and drop behavior is thus organized into methods for easier integration as signal callbacks.

HexViewRhiWindow also has logic to limit the rate at which scroll bar events can trigger render calls. High-polling input devices can cause a deluge of update events, killing frame renders.

On Linux systems, we opt to use OpenGL over Vulkan. For whatever reason, using a Vulkan window surface causes app window decorations (title bar and its minimize, maximize, close buttons) to disappear.

This PR also sets the Qt::AA_DontCreateNativeWidgetSiblings attribute at startup. Without this attribute, the QSplitters that separate the MDIArea from our docks cannot be clicked and dragged consistently due to a complication with the Rhi Window. Setting this attribute has the adverse effect of making HexView's vertical scrollbar never appear on macOS, which is "transient" by default, meaning it appears and disappears only when used. Presumably it's no longer being drawn _on top of_ the surface. We fix this by making it non-transient in HexView's constructor, so it never fades in/out.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
