### PR TITLE
NDS: Artificially compensate for attack time, dynamic ADSR

### DIFF
--- a/src/main/components/instr/Modulator.h
+++ b/src/main/components/instr/Modulator.h
@@ -1,0 +1,93 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#pragma once
+#include <cstdint>
+
+enum class ModDest : uint16_t {
+  None,
+  // Volume Envelope (EG1)
+  VolAttack,
+  VolHold,
+  VolDecay,
+  VolSustain,
+  VolRelease,
+  VolDelay,
+  // Modulation Envelope (EG2)
+  ModAttack,
+  ModHold,
+  ModDecay,
+  ModSustain,
+  ModRelease,
+  ModDelay,
+  // LFOs
+  VibLfoToPitch,
+  VibLfoFreq,
+  VibLfoDelay,
+  ModLfoToPitch,
+  ModLfoToFilterFc,
+  ModLfoToVolume,
+  ModLfoFreq,
+  ModLfoDelay,
+  // Modulation Envelope to Pitch/Filter
+  ModEnvToPitch,
+  ModEnvToFilterFc,
+  // General
+  Pan,
+  Attenuation,
+  Pitch,
+  FilterCutoff,
+  FilterQ,
+  ReverbSend,
+  ChorusSend,
+};
+
+enum class ModSourceType : uint8_t {
+  None,
+  CC,
+  PitchBend,
+  NoteOnVelocity,
+  NoteOnKeyNumber,
+  PolyPressure,
+  ChannelPressure,
+  VibratoLFO,
+  ModulationLFO,
+  ModulationEnvelope,
+  VolumeEnvelope,
+};
+
+// SF2-compatible flags for modulator sources
+enum class ModSourceFlag : uint16_t {
+  None = 0,
+  DirectionNegative = 0x0100,
+  PolarityBipolar = 0x0200,
+  TypeConcave = 0x0400,
+  TypeConvex = 0x0800,
+  TypeSwitch = 0x0C00
+};
+
+constexpr ModSourceFlag operator|(ModSourceFlag a, ModSourceFlag b) {
+  return static_cast<ModSourceFlag>(static_cast<uint16_t>(a) | static_cast<uint16_t>(b));
+}
+
+struct ModSource {
+  ModSourceType type{ModSourceType::None};
+  uint8_t index{0};                        // CC number or other index
+  ModSourceFlag flags{ModSourceFlag::None};
+
+  // Helpers for common source patterns
+  static constexpr ModSource CC(uint8_t ccNum, ModSourceFlag flags = ModSourceFlag::None) {
+    return {ModSourceType::CC, ccNum, flags};
+  }
+};
+
+struct Modulator {
+  ModSource source;
+  ModDest dest;
+  int16_t amount;
+  ModSource sourceAmt{ModSourceType::None}; // Same as SF2
+  uint16_t trans{0};  // Same as SF2 
+};

--- a/src/main/components/instr/VGMRgn.h
+++ b/src/main/components/instr/VGMRgn.h
@@ -1,4 +1,11 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
 #pragma once
+#include "Modulator.h"
 #include "SynthFile.h"
 #include "VGMItem.h"
 #include "Loop.h"
@@ -6,6 +13,7 @@
 class VGMInstr;
 class VGMRgnItem;
 class VGMSampColl;
+
 
 // ******
 // VGMRgn
@@ -33,7 +41,6 @@ class VGMRgn : public VGMItem {
   void addPan(uint8_t pan, uint32_t offset, uint32_t length = 1, const std::string& name = "Pan");
   void setVolume(double volume);
   void setAttenuation(double decibels);
-  double attenDb() { return m_attenDb; }
   void addVolume(double volume, uint32_t offset, uint32_t length = 1);
   void addAttenuation(double decibels, uint32_t offset, uint32_t length = 1);
   void addUnityKey(uint8_t unityKey, uint32_t offset, uint32_t length = 1);
@@ -49,11 +56,11 @@ class VGMRgn : public VGMItem {
   void setLfoVibFreqHz(double freq) { m_lfoVibFreqHz = freq; }
   void setLfoVibDepthCents(double cents) { m_lfoVibDepthCents = cents; }
   void setLfoVibDelaySeconds(double seconds) { m_lfoVibDelaySeconds = seconds; }
+  [[nodiscard]] double attenDb() const { return m_attenDb; }
   [[nodiscard]] double lfoVibFreqHz() const { return m_lfoVibFreqHz; }
   [[nodiscard]] double lfoVibDepthCents() const { return m_lfoVibDepthCents; }
   [[nodiscard]] double lfoVibDelaySeconds() const { return m_lfoVibDelaySeconds; }
 
-public:
   VGMInstr *parInstr;
   u8 keyLow       {0};
   u8 keyHigh      {0x7F};
@@ -85,7 +92,13 @@ public:
   u16 release_transform {no_transform};
   double release_time   {0};     // in seconds
 
+  // Real-time modulation
+  void addModulator(Modulator mod) { m_modulators.push_back(mod); }
+  const std::vector<Modulator> &modulators() const { return m_modulators; }
+
 private:
+  std::vector<Modulator> m_modulators;
+
   double m_attenDb      {0};     // attenuation in decibels;
 
   double m_lfoVibFreqHz       {0};

--- a/src/main/conversion/DLSConversion.cpp
+++ b/src/main/conversion/DLSConversion.cpp
@@ -280,18 +280,23 @@ bool mainDLSCreation(
             case ModSourceType::CC: {
               uint8_t cc = mod.source.index;
               switch (cc) {
+                default:
+                  L_WARN("Converting {}: modulator with unsupported CC {} (DLS limitation). Some players may not support this modulator.",
+                         set->name(), cc);
+                  [[fallthrough]];
                 case 1:  // Mod Wheel
+                  [[fallthrough]];
                 case 7:  // Volume
+                  [[fallthrough]];
                 case 10: // Pan
+                  [[fallthrough]];
                 case 11: // Expression
+                  [[fallthrough]];
                 case 91: // Reverb
+                  [[fallthrough]];
                 case 93: // Chorus
                   src = 0x0080 | cc;
                   break;
-                default:
-                  L_WARN("Converting {}: skipping modulator with unsupported CC {} (DLS limitation).",
-                         set->name(), cc);
-                  continue;
               }
               break;
             }
@@ -394,7 +399,7 @@ bool mainDLSCreation(
 
           int32_t scale = static_cast<int32_t>(mod.amount * 65536.0 * scaleFactor);
           if (src != CONN_SRC_NONE && dest != CONN_DST_NONE) {
-             newArt->addConnectionBlock(src, CONN_SRC_NONE, dest, transform, scale);
+             newArt->addConnectionBlock(src, control, dest, transform, scale);
           }
         }
 

--- a/src/main/conversion/DLSConversion.cpp
+++ b/src/main/conversion/DLSConversion.cpp
@@ -142,8 +142,9 @@ bool mainDLSCreation(
         if (rgn->sampOffset != -1) {
           bool bFoundIt = false;
           for (uint32_t s = 0; s < sampColl->samples.size(); s++) {             //for every sample
-            if (rgn->sampOffset == sampColl->samples[s]->offset() ||
-                rgn->sampOffset == sampColl->samples[s]->offset() - sampColl->offset() - sampColl->sampDataOffset) {
+            auto samp_offset = sampColl->samples[s]->offset();
+            if (static_cast<uint32_t>(rgn->sampOffset) == samp_offset ||
+                static_cast<uint32_t>(rgn->sampOffset) == samp_offset - sampColl->offset() - sampColl->sampDataOffset) {
               realSampNum = s;
 
               //samples[m]->loop.loopStart = parInstrSet->aInstrs[i]->aRgns[k]->loop.loopStart;
@@ -267,6 +268,134 @@ bool mainDLSCreation(
           int32_t vibFreq = hertzToDlsPitch(rgn->lfoVibFreqHz());
           int32_t vibDelay = secondsToDlsTimecents(rgn->lfoVibDelaySeconds());
           newArt->addVibrato(vibDepth, vibFreq, vibDelay);
+        }
+
+        for (const auto &mod : rgn->modulators()) {
+          uint16_t src = CONN_SRC_NONE;
+          uint16_t dest = CONN_DST_NONE;
+          uint16_t transform = CONN_TRN_NONE;
+
+          // Map Source
+          switch (mod.source.type) {
+            case ModSourceType::CC: {
+              uint8_t cc = mod.source.index;
+              switch (cc) {
+                case 1:  // Mod Wheel
+                case 7:  // Volume
+                case 10: // Pan
+                case 11: // Expression
+                case 91: // Reverb
+                case 93: // Chorus
+                  src = 0x0080 | cc;
+                  break;
+                default:
+                  L_WARN("Converting {}: skipping modulator with unsupported CC {} (DLS limitation).",
+                         set->name(), cc);
+                  continue;
+              }
+              break;
+            }
+            case ModSourceType::PitchBend:
+              src = CONN_SRC_PITCHWHEEL;
+              break;
+            case ModSourceType::NoteOnVelocity:
+              src = CONN_SRC_KEYONVELOCITY;
+              break;
+            case ModSourceType::NoteOnKeyNumber:
+              src = CONN_SRC_KEYNUMBER;
+              break;
+            default:
+              L_WARN("Converting {}: skipping modulator with unsupported source type 0x{:x} (DLS limitation).",
+                     set->name(), static_cast<int>(mod.source.type));
+              continue; // Unsupported DLS source
+          }
+
+          uint16_t control = CONN_SRC_NONE;
+          if (mod.sourceAmt.type == ModSourceType::CC) {
+            control = 0x0080 | mod.sourceAmt.index;
+          }
+
+          // Map Destination
+          switch (mod.dest) {
+            case ModDest::VolAttack:
+              dest = CONN_DST_EG1_ATTACKTIME;
+              break;
+            case ModDest::VolDecay:
+              dest = CONN_DST_EG1_DECAYTIME;
+              break;
+            case ModDest::VolRelease:
+              dest = CONN_DST_EG1_RELEASETIME;
+              break;
+            case ModDest::VolSustain:
+              dest = CONN_DST_EG1_SUSTAINLEVEL;
+              break;
+            case ModDest::VolHold:
+              dest = CONN_DST_EG1_HOLDTIME;
+              break;
+            case ModDest::VolDelay:
+              dest = CONN_DST_EG1_DELAYTIME;
+              break;
+            case ModDest::ModAttack:
+              dest = CONN_DST_EG2_ATTACKTIME;
+              break;
+            case ModDest::ModDecay:
+              dest = CONN_DST_EG2_DECAYTIME;
+              break;
+            case ModDest::ModRelease:
+              dest = CONN_DST_EG2_RELEASETIME;
+              break;
+            case ModDest::ModSustain:
+              dest = CONN_DST_EG2_SUSTAINLEVEL;
+              break;
+            case ModDest::ModHold:
+              dest = CONN_DST_EG2_HOLDTIME;
+              break;
+            case ModDest::ModDelay:
+              dest = CONN_DST_EG2_DELAYTIME;
+              break;
+            case ModDest::Pan:
+              dest = CONN_DST_PAN;
+              break;
+            case ModDest::Attenuation:
+              dest = CONN_DST_ATTENUATION;
+              break;
+            case ModDest::Pitch:
+              dest = CONN_DST_PITCH;
+              break;
+            case ModDest::FilterCutoff:
+              dest = CONN_DST_FILTER_CUTOFF;
+              break;
+            case ModDest::FilterQ:
+              dest = CONN_DST_FILTER_Q;
+              break;
+            case ModDest::ReverbSend:
+              dest = CONN_DST_REVERB_SEND;
+              break;
+            case ModDest::ChorusSend:
+              dest = CONN_DST_CHORUS_SEND;
+              break;
+            case ModDest::VibLfoFreq:
+              dest = CONN_DST_LFO_FREQUENCY;
+              break;
+            case ModDest::VibLfoDelay:
+              dest = CONN_DST_LFO_STARTDELAY;
+              break;
+            default:
+              continue;
+          }
+
+          double scaleFactor = 1.0;
+          if (mod.dest == ModDest::VolSustain) {
+            // Convert SF2 cB (0.1 dB) to DLS Level units (~0.096 dB)
+            // 1000 DLS units = 96 dB. 1 SF2 unit = 0.1 dB.
+            // Factor = 0.1 / 0.096 = 1.041666...
+            scaleFactor = 1.04166667;
+          }
+
+          int32_t scale = static_cast<int32_t>(mod.amount * 65536.0 * scaleFactor);
+          if (src != CONN_SRC_NONE && dest != CONN_DST_NONE) {
+             newArt->addConnectionBlock(src, CONN_SRC_NONE, dest, transform, scale);
+          }
         }
 
         newWsmp->setPitchInfo(realUnityKey, totalFineTune, totalAttenuation);

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -330,6 +330,12 @@ void DLSArt::addVibrato(int32_t depth, int32_t frequency, int32_t delay) {
       CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_LFO_STARTDELAY, CONN_TRN_NONE, delay));
 }
 
+void DLSArt::addConnectionBlock(uint16_t source, uint16_t control, uint16_t destination,
+                                uint16_t transform, int32_t scale) {
+  m_blocks.emplace_back(std::make_unique<ConnectionBlock>(source, control, destination, transform,
+                                                          scale));
+}
+
 //  ***************
 //  ConnectionBlock
 //  ***************

--- a/src/main/conversion/DLSFile.h
+++ b/src/main/conversion/DLSFile.h
@@ -43,6 +43,12 @@ class VGMSamp;
 #define CONN_DST_RESERVED 0x0002
 #define CONN_DST_PITCH 0x0003
 #define CONN_DST_PAN 0x0004
+#define CONN_DST_REVERB_SEND 0x0005
+#define CONN_DST_CHORUS_SEND 0x0006
+
+/* Filter Destinations */
+#define CONN_DST_FILTER_CUTOFF 0x0100
+#define CONN_DST_FILTER_Q 0x0101
 
 /* LFO Destinations */
 #define CONN_DST_LFO_FREQUENCY 0x0104
@@ -191,6 +197,8 @@ public:
                long sustain_lev, long release_time, uint16_t rls_transform);
   void addPan(long pan);
   void addVibrato(int32_t depth, int32_t frequency, int32_t delay);
+  void addConnectionBlock(uint16_t source, uint16_t control, uint16_t destination,
+                          uint16_t transform, int32_t scale);
 
   uint32_t GetSize() const;
   void Write(std::vector<uint8_t> &buf) const;

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -1,8 +1,9 @@
 /*
- * VGMTrans (c) 2002-2024
+ * VGMTrans (c) 2002-2026
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
 */
+
 #include "SF2Conversion.h"
 #include "SF2File.h"
 #include "SynthFile.h"
@@ -36,14 +37,14 @@ SF2File* createSF2File(
 ) {
   if (coll)
     coll->preSynthFileCreation();
-  SynthFile *synthfile = createSynthFile(instrsets, sampcolls);
+  SynthFile* synthfile = createSynthFile(instrsets, sampcolls);
   if (coll)
     coll->postSynthFileCreation();
   if (!synthfile) {
     L_ERROR("SF2 conversion failed");
     return nullptr;
   }
-  SF2File *sf2file = new SF2File(synthfile);
+  SF2File* sf2file = new SF2File(synthfile);
   delete synthfile;
   return sf2file;
 }
@@ -171,6 +172,10 @@ SynthFile* createSynthFile(
         newRgn->setLfoVibFreqHz(rgn->lfoVibFreqHz());
         newRgn->setLfoVibDepthCents(rgn->lfoVibDepthCents());
         newRgn->setLfoVibDelaySeconds(rgn->lfoVibDelaySeconds());
+
+        for (const auto& mod : rgn->modulators()) {
+          newRgn->addModulator(mod);
+        }
 
         if (realSampNum >= finalSamps.size()) {
           L_ERROR("Sample {} does not exist. Instr index: {:d}, Instr num: {:d}, Region index: {:d}", realSampNum, i, vgminstr->instrNum, j);

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -1,7 +1,15 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
 #pragma once
 
-#include "RiffFile.h"
 #include <vector>
+
+#include "Modulator.h"
+#include "RiffFile.h"
 
 struct Loop;
 class VGMSamp;
@@ -120,10 +128,15 @@ class SynthRgn {
   SynthSampInfo *sampinfo {nullptr};
   SynthArt *art {nullptr};
 
+  void addModulator(Modulator mod) { m_modulators.push_back(mod); }
+  const std::vector<Modulator> &modulators() const { return m_modulators; }
+
 private:
   double m_lfoVibFreqHz       {0};
   double m_lfoVibDepthCents   {0};
   double m_lfoVibDelaySeconds {0};
+
+  std::vector<Modulator> m_modulators;
 };
 
 class SynthArt {

--- a/src/main/formats/NDS/NDSInstrSet.cpp
+++ b/src/main/formats/NDS/NDSInstrSet.cpp
@@ -16,9 +16,11 @@
 #include "VGMRgn.h"
 #include "LogManager.h"
 
-// INTR_FREQUENCY is the interval in seconds between updates to the vol for articulation.
-// 2728 ticks = 5.2095ms (~192Hz).
-constexpr double INTR_FREQUENCY = 0.0052095;
+// INTR_FREQUENCY is the interval in seconds between updates to the volume envelope.
+// The NDS sound engine updates envelopes every 64 sound timer intervals.
+// Each sound timer interval is 2728 ARM7 clock cycles.
+// (2728 * 64) / 33,513,982 Hz = ~0.0052095 seconds (approx. 191.95 Hz).
+constexpr double INTR_FREQUENCY = (2728.0 * 64.0) / 33513982.0;
 
 // Maps 0-127 sustain value to dB attenuation (in 10ths of dB)
 static const int16_t DECIBEL_SQUARE_TABLE[128] = {

--- a/src/main/formats/NDS/NDSInstrSet.cpp
+++ b/src/main/formats/NDS/NDSInstrSet.cpp
@@ -1,14 +1,12 @@
 /**
- * VGMTrans (c) - 2002-2024
+ * VGMTrans (c) - 2002-2026
  * Licensed under the zlib license
  * See the included LICENSE for more information
  */
 
-#include <cmath>
 #include <numeric>
 #include <string>
 #include <vector>
-#include <spdlog/fmt/fmt.h>
 #include "Loop.h"
 #include "NDSFormat.h"
 #include "VGMSampColl.h"
@@ -244,6 +242,14 @@ void NDSInstr::getArticData(VGMRgn* rgn, uint32_t offset) const {
     rgn->pan = 0.5;
   else
     rgn->pan = static_cast<double>(Pan) / 127;
+
+
+  // Real time controllers used by ADSR commands
+  rgn->addModulator({ModSource::CC(72), ModDest::VolRelease, 1200});
+  rgn->addModulator({ModSource::CC(73), ModDest::VolAttack, 1200});
+  rgn->addModulator({ModSource::CC(75), ModDest::VolDecay, 1200});
+  rgn->addModulator({ModSource::CC(79, ModSourceFlag::DirectionNegative), ModDest::VolSustain, 1440});
+  rgn->addModulator({ModSource::CC(91), ModDest::ReverbSend, 200});
 }
 
 uint16_t NDSInstr::getFallingRate(uint8_t DecayTime) const {
@@ -542,7 +548,7 @@ NDSPSGSamp::NDSPSGSamp(VGMSampColl* sampcoll, uint8_t duty_cycle) : VGMSamp(samp
   setLoopLengthMeasure(LM_SAMPLES);
   ulUncompressedSize = 32768 * bytesPerSample();
 
-  setName("PSG_duty_" + std::to_string(duty_cycle));
+  setName("PSG_duty_" + std::to_string(m_duty_cycle));
 }
 
 std::vector<uint8_t> NDSPSGSamp::decodeToNativePcm() {

--- a/src/main/formats/NDS/NDSInstrSet.cpp
+++ b/src/main/formats/NDS/NDSInstrSet.cpp
@@ -600,7 +600,8 @@ std::vector<uint8_t> NDSPSGSamp::decodeToNativePcm() {
                                      });
 
       /* We have to go from F64 to S16 */
-      int16_t out_value = static_cast<int16_t>(std::round(value * 0x7FFF));
+      /* Scale by 2.0 to normalize range from [-0.5, 0.5] to [-1.0, 1.0] */
+      int16_t out_value = static_cast<int16_t>(std::clamp(std::round(value * 0x7FFF * 2.0), -32768.0, 32767.0));
       output[i] = out_value;
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Compensate NDSInstr ADSR attack time for exporting to DLS/SF2.
Implement missing ADSR commands with a SF2 modulator. This makes them work in any SF2-compliant synth.
DLS does not support this, as it can't have arbitrary CC sources. 

## Motivation and Context
We notoriously produce long attack times for NDS conversions.
We cannot be exact, since the curve for DLS and SF2 is completely different; this compensation is a compromise. The attack is not completely accurate, but much closer. 

The difference is noticeable. One extreme case is "Luigi Is Rescued - Yoshi's Island DS".

On the topic of improving ADSR, the newly impleented commands fix #748 

## How Has This Been Tested?
Various NDS games.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
