### PR TITLE
RhiHexView 4: Add HexView seek to event

### DIFF
--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -49,6 +49,7 @@ VGMFileView::VGMFileView(VGMFile *vgmfile)
   m_defaultHexFont = m_hexview->font();
 
   connect(m_hexview, &HexView::selectionChanged, this, &VGMFileView::onSelectionChange);
+  connect(m_hexview, &HexView::seekToEventRequested, this, &VGMFileView::seekToEvent);
 
   connect(m_treeview, &VGMFileTreeView::currentItemChanged,
           [&](const QTreeWidgetItem *item, QTreeWidgetItem *) {

--- a/src/ui/qt/workarea/hexview/HexView.h
+++ b/src/ui/qt/workarea/hexview/HexView.h
@@ -54,6 +54,7 @@ public:
 
 signals:
   void selectionChanged(VGMItem* item);
+  void seekToEventRequested(VGMItem* item);
 
 protected:
   bool viewportEvent(QEvent* event) override;
@@ -120,6 +121,7 @@ private:
   VGMItem* m_selectedItem = nullptr;
   uint32_t m_selectedOffset = 0;
   bool m_isDragging = false;
+  VGMItem* m_lastSeekItem = nullptr;
   std::vector<SelectionRange> m_selections;
   std::vector<SelectionRange> m_fadeSelections;
 


### PR DESCRIPTION
## Description
This branch adds seek to event for the HexView.

- Added a new signal on HexView: `seekToEventRequested(VGMItem*)`.
- Added seek behavior in HexView mouse handling:
  - While the configured seek modifier is held (`HexViewInput::kModifier`), HexView emits seek requests based on the item under the cursor. The modifier is set to Alt.
  - Emissions are deduplicated so dragging across the same item doesn’t spam repeated requests.
  - Normal (non-modifier) selection behavior remains unchanged.
- Wired HexView seek requests to existing playback seek logic in VGMFileView:
  - `HexView::seekToEventRequested` now connects to `VGMFileView::seekToEvent`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
