### PR TITLE
RhiHexview 5: Event outlines

### DIFF
--- a/src/ui/qt/MainWindow.h
+++ b/src/ui/qt/MainWindow.h
@@ -43,6 +43,7 @@ protected:
   void dragLeaveEvent(QDragLeaveEvent *event) override;
   void dropEvent(QDropEvent *event) override;
   void resizeEvent(QResizeEvent *event) override;
+  bool eventFilter(QObject* obj, QEvent* event) override;
 
 private:
   void createElements();

--- a/src/ui/qt/services/NotificationCenter.cpp
+++ b/src/ui/qt/services/NotificationCenter.cpp
@@ -34,6 +34,10 @@ void NotificationCenter::selectVGMFile(VGMFile* vgmfile, QWidget* caller) {
   emit vgmFileSelected(vgmfile, caller);
 }
 
+void NotificationCenter::setSeekModifierActive(bool active) {
+  emit seekModifierChanged(active);
+}
+
 void NotificationCenter::updateContextualMenusForVGMFiles(const QList<VGMFile*>& files) {
   emit vgmFileContextCommandsChanged(files);
 }

--- a/src/ui/qt/services/NotificationCenter.h
+++ b/src/ui/qt/services/NotificationCenter.h
@@ -35,6 +35,7 @@ public:
                     uint32_t size = -1);
   void updateStatusForItem(VGMItem* item);
   void selectVGMFile(VGMFile* vgmfile, QWidget* caller);
+  void setSeekModifierActive(bool active);
   void updateContextualMenusForVGMFiles(const QList<VGMFile*>& files);
   void updateContextualMenusForVGMColls(const QList<VGMColl*>& colls);
   void updateContextualMenusForRawFiles(const QList<RawFile*>& files);
@@ -47,6 +48,7 @@ private:
 signals:
   void statusUpdated(const QString& name, const QString& description, const QIcon* icon, int offset, int size);
   void vgmFileSelected(VGMFile *file, QWidget* caller);
+  void seekModifierChanged(bool active);
   void vgmFileContextCommandsChanged(const QList<VGMFile*>& files);
   void vgmCollContextCommandsChanged(const QList<VGMColl*>& colls);
   void rawFileContextCommandsChanged(const QList<RawFile*>& files);

--- a/src/ui/qt/workarea/hexview/HexView.cpp
+++ b/src/ui/qt/workarea/hexview/HexView.cpp
@@ -8,6 +8,7 @@
 #include "Helpers.h"
 #include "HexViewInput.h"
 #include "HexViewRhiHost.h"
+#include "services/NotificationCenter.h"
 #include "VGMFile.h"
 
 #include <QApplication>
@@ -130,6 +131,15 @@ HexView::HexView(VGMFile* vgmfile, QWidget* parent)
     m_scrollBarDragging = false;
     m_pendingScrollY = verticalScrollBar()->value();
   });
+
+  connect(NotificationCenter::the(), &NotificationCenter::seekModifierChanged, this,
+          [this](bool active) {
+            if (m_seekModifierActive == active) {
+              return;
+            }
+            m_seekModifierActive = active;
+            requestRhiUpdate();
+          });
 
 }
 
@@ -570,6 +580,7 @@ HexViewFrame::Data HexView::captureRhiFrameData(float dpr) {
   frame.shouldDrawOffset = m_shouldDrawOffset;
   frame.shouldDrawAscii = m_shouldDrawAscii;
   frame.addressAsHex = m_addressAsHex;
+  frame.seekModifierActive = m_seekModifierActive;
 
   frame.overlayOpacity = m_overlayOpacity;
   frame.shadowBlur = m_shadowBlur;

--- a/src/ui/qt/workarea/hexview/HexView.h
+++ b/src/ui/qt/workarea/hexview/HexView.h
@@ -121,6 +121,7 @@ private:
   VGMItem* m_selectedItem = nullptr;
   uint32_t m_selectedOffset = 0;
   bool m_isDragging = false;
+  bool m_seekModifierActive = false;
   VGMItem* m_lastSeekItem = nullptr;
   std::vector<SelectionRange> m_selections;
   std::vector<SelectionRange> m_fadeSelections;

--- a/src/ui/qt/workarea/hexview/HexViewFrameData.h
+++ b/src/ui/qt/workarea/hexview/HexViewFrameData.h
@@ -48,6 +48,7 @@ struct Data {
   bool shouldDrawOffset = true;
   bool shouldDrawAscii = true;
   bool addressAsHex = true;
+  bool seekModifierActive = false;
 
   qreal overlayOpacity = 0.0;
   qreal shadowBlur = 0.0;

--- a/src/ui/qt/workarea/hexview/HexViewRhiRenderer.h
+++ b/src/ui/qt/workarea/hexview/HexViewRhiRenderer.h
@@ -126,6 +126,8 @@ private:
 
   void ensurePipelines(QRhiRenderPassDescriptor* outputRp, int outputSampleCount);
   void ensureGlyphTexture(QRhiResourceUpdateBatch* u, const HexViewFrame::Data& frame);
+  void ensureItemIdTexture(QRhiResourceUpdateBatch* u, int startLine, int endLine, int totalLines,
+                           const HexViewFrame::Data& frame);
   void updateCompositeSrb();
   void updateUniforms(QRhiResourceUpdateBatch* u, float scrollY, const QSize& pixelSize,
                       const HexViewFrame::Data& frame);
@@ -183,6 +185,7 @@ private:
   QRhiBuffer* m_ubuf = nullptr;
   QRhiBuffer* m_compositeUbuf = nullptr;
   QRhiTexture* m_glyphTex = nullptr;
+  QRhiTexture* m_itemIdTex = nullptr;
   QRhiSampler* m_glyphSampler = nullptr;
   QRhiSampler* m_maskSampler = nullptr;
   QRhiShaderResourceBindings* m_rectSrb = nullptr;
@@ -213,6 +216,11 @@ private:
   bool m_selectionDirty = true;
   bool m_baseBufferDirty = false;
   bool m_selectionBufferDirty = false;
+  bool m_itemIdDirty = true;
+  bool m_outlineEnabled = false;
+  float m_outlineAlpha = 0.0f;
+  int m_itemIdStartLine = 0;
+  QSize m_itemIdSize;
   bool m_compositeSrbDirty = false;
   bool m_inited = false;
 };

--- a/src/ui/qt/workarea/hexview/shaders/hexcomposite.frag
+++ b/src/ui/qt/workarea/hexview/shaders/hexcomposite.frag
@@ -4,26 +4,98 @@ layout(location = 0) in vec2 vUv;
 
 layout(binding = 1) uniform sampler2D contentTex;
 layout(binding = 2) uniform sampler2D maskTex;
+layout(binding = 3) uniform sampler2D itemIdTex;
 
 layout(std140, binding = 0) uniform Ubuf {
   mat4 mvp;
   vec4 overlayAndShadow;   // x=overlayOpacity
   vec4 columnLayout;       // x=hexStart, y=hexWidth, z=asciiStart, w=asciiWidth
-  vec4 viewInfo;           // x=viewWidth, y=viewHeight, z=flipY
+  vec4 viewInfo;           // x=viewWidth, y=viewHeight, z=flipY, w=devicePixelRatio
+  vec4 outlineColor;       // rgba
+  vec4 itemIdWindow;       // x=lineHeight, y=scrollY, z=itemIdStartLine, w=itemIdHeight
 };
 
 layout(location = 0) out vec4 fragColor;
+
+float decodeItemId(vec2 uv) {
+  vec2 rg = texture(itemIdTex, uv).rg * 255.0 + 0.5;
+  return rg.r + rg.g * 256.0;
+}
+
+float computeOutlineMask(float xPx, float yPx, bool inHex, bool inAscii, float dpr) {
+  float lineHeightPx = itemIdWindow.x;
+  if (outlineColor.a <= 0.0 || lineHeightPx <= 0.0 || itemIdWindow.w <= 0.0) {
+    return 0.0;
+  }
+  if (!(inHex || inAscii)) {
+    return 0.0;
+  }
+
+  const float bytesPerLine = 16.0;
+  float lineF = floor((yPx + itemIdWindow.y) / lineHeightPx);
+  float lineIdx = lineF - itemIdWindow.z;
+  if (lineIdx < 0.0 || lineIdx >= itemIdWindow.w) {
+    return 0.0;
+  }
+
+  float localY = (yPx + itemIdWindow.y) - lineF * lineHeightPx;
+  float cellW = inHex ? (columnLayout.y / bytesPerLine) : (columnLayout.w / bytesPerLine);
+  float localX = inHex ? (xPx - columnLayout.x) : (xPx - columnLayout.z);
+  if (cellW <= 0.0 || localX < 0.0) {
+    return 0.0;
+  }
+
+  float byteIdx = floor(localX / cellW);
+  if (byteIdx < 0.0 || byteIdx >= bytesPerLine) {
+    return 0.0;
+  }
+  localX -= byteIdx * cellW;
+
+  vec2 texSize = vec2(bytesPerLine, itemIdWindow.w);
+  vec2 texel = vec2(1.0) / texSize;
+  vec2 centerUv = vec2(byteIdx + 0.5, lineIdx + 0.5) / texSize;
+  float id = decodeItemId(centerUv);
+  if (id < 0.5) {
+    return 0.0;
+  }
+
+  float leftId = (byteIdx > 0.0) ? decodeItemId(centerUv - vec2(texel.x, 0.0)) : id;
+  float rightId = (byteIdx < bytesPerLine - 1.0) ? decodeItemId(centerUv + vec2(texel.x, 0.0)) : id;
+  float upId = (lineIdx > 0.0) ? decodeItemId(centerUv - vec2(0.0, texel.y)) : id;
+  float downId = (lineIdx < itemIdWindow.w - 1.0) ? decodeItemId(centerUv + vec2(0.0, texel.y)) : id;
+
+  float edgePx = 2.0 / max(dpr, 1.0);
+  float leftEdge = step(localX, edgePx);
+  float rightEdge = step(cellW - edgePx, localX);
+  float topEdge = step(localY, edgePx);
+  float bottomEdge = step(lineHeightPx - edgePx, localY);
+
+  float drawLeft = (leftId < 0.5 || id < leftId) ? 1.0 : 0.0;
+  float drawRight = (rightId < 0.5 || id < rightId) ? 1.0 : 0.0;
+  float drawUp = (upId < 0.5 || id < upId) ? 1.0 : 0.0;
+  float drawDown = (downId < 0.5 || id < downId) ? 1.0 : 0.0;
+
+  float edge = leftEdge * drawLeft * step(0.5, abs(id - leftId)) +
+               rightEdge * drawRight * step(0.5, abs(id - rightId)) +
+               topEdge * drawUp * step(0.5, abs(id - upId)) +
+               bottomEdge * drawDown * step(0.5, abs(id - downId));
+  return clamp(edge, 0.0, 1.0);
+}
 
 void main() {
   vec4 base = texture(contentTex, vUv);
   float selected = clamp(texture(maskTex, vUv).r, 0.0, 1.0);
 
   float x = vUv.x * viewInfo.x;
+  float logicalY = mix(1.0 - vUv.y, vUv.y, viewInfo.z);
+  float y = logicalY * viewInfo.y;
   bool inHex = (x >= columnLayout.x) && (x < columnLayout.x + columnLayout.y);
   bool inAscii = (columnLayout.w > 0.0) && (x >= columnLayout.z) && (x < columnLayout.z + columnLayout.w);
   float inColumns = (inHex || inAscii) ? 1.0 : 0.0;
+  float outlineMask = computeOutlineMask(x, y, inHex, inAscii, viewInfo.w);
 
   vec3 dimmed = mix(base.rgb, vec3(0.0), overlayAndShadow.x * inColumns);
-  vec3 restored = mix(dimmed, base.rgb, selected);
+  vec3 withOutline = mix(dimmed, outlineColor.rgb, outlineMask * outlineColor.a);
+  vec3 restored = mix(withOutline, base.rgb, selected);
   fragColor = vec4(restored, base.a);
 }


### PR DESCRIPTION
## Description
This adds event outline drawing when the alt key is pressed. Key state is captured at the app level, pushed into HexView frame state, and consumed by the RHI composite shader to draw per-item borders in the hex/ascii columns.

Outlines are not drawn as separate border geometry, but via a shader. The renderer builds an item-id texture for the visible byte grid, where each texel encodes which logical item owns that byte cell. In `shaders/hexcomposite.frag`, the composite shader samples neighbor item ids (left/right/up/down) and draws an edge only when ownership changes. It uses an ownership rule so only one side of a boundary draws, which prevents doubled/thick seams between adjacent items.

Render flow for this branch is:
1. content pass (`contentTex`) for base text/background,
2. selection mask pass (`maskTex`),
3. composite pass that applies dimming + modifier outline + selection restoration.

That last part is important: unselected columns are dimmed first, then outline color is composited, then selected cells are restored from mask so selected content stays readable while modifier outlines are visible.

On input/state plumbing, `MainWindow.cpp` forwards Alt press/release to `NotificationCenter.cpp`; HexView receives that state and includes it in frame data (`seekModifierActive`) consumed by `HexViewRhiRenderer.cpp`. The renderer also gates outlines by minimum cell size so outlines don’t render when zoom/scale is too small to draw cleanly.

A future PR will add an animation to fade in/out the outline when alt is pressed/released.

## Motivation and Context
The outline helps distinguish events from each other, but is a bit "busy" and less aesthetically pleasing, in my opinion. I am considering adding an option to make it always on.

## Screenshots (if appropriate):
<img width="382" height="182" alt="image" src="https://github.com/user-attachments/assets/3c610adb-d9b5-4f6a-bdfb-0de6a05d7ec5" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
