### PR TITLE
RhiHexView 8: Add glow pipeline

### DIFF
--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -143,6 +143,8 @@ qt_add_shaders(
     workarea/hexview/shaders/hexglyph.vert
     workarea/hexview/shaders/hexglyph.frag
     workarea/hexview/shaders/hexscreen.vert
+    workarea/hexview/shaders/hexedge.vert
+    workarea/hexview/shaders/hexedge.frag
     workarea/hexview/shaders/hexcomposite.frag
 )
 

--- a/src/ui/qt/workarea/hexview/HexView.cpp
+++ b/src/ui/qt/workarea/hexview/HexView.cpp
@@ -52,6 +52,11 @@ constexpr float SHADOW_OFFSET_Y = 0.0f;
 constexpr float SHADOW_BLUR_RADIUS = SELECTION_PADDING * 1.0f;
 constexpr float SHADOW_STRENGTH = 0.5;
 constexpr float SHADOW_EDGE_CURVE = 1.1f;
+constexpr float PLAYBACK_GLOW_STRENGTH = 0.55f;
+constexpr float PLAYBACK_GLOW_RADIUS = 1.8f;
+constexpr float PLAYBACK_GLOW_EDGE_CURVE = 0.85f;
+const QColor PLAYBACK_GLOW_LOW(40, 40, 40);
+const QColor PLAYBACK_GLOW_HIGH(230, 230, 230);
 constexpr uint16_t STYLE_UNASSIGNED = std::numeric_limits<uint16_t>::max();
 
 #ifdef Q_OS_MAC
@@ -120,7 +125,12 @@ HexView::HexView(VGMFile* vgmfile, QWidget* parent)
   QFont font("Roboto Mono", appFontPointSize + 1.0);
   font.setPointSizeF(appFontPointSize + 1.0);
   setShadowStrength(SHADOW_STRENGTH);
+  m_playbackGlowLow = PLAYBACK_GLOW_LOW;
+  m_playbackGlowHigh = PLAYBACK_GLOW_HIGH;
+  m_playbackGlowStrength = PLAYBACK_GLOW_STRENGTH;
+  m_playbackGlowRadius = PLAYBACK_GLOW_RADIUS;
   m_shadowEdgeCurve = SHADOW_EDGE_CURVE;
+  m_playbackGlowEdgeCurve = PLAYBACK_GLOW_EDGE_CURVE;
 
   setFont(font);
   rebuildStyleMap();
@@ -711,7 +721,12 @@ HexViewFrame::Data HexView::captureRhiFrameData(float dpr) {
   frame.shadowBlur = m_shadowBlur;
   frame.shadowStrength = m_shadowStrength;
   frame.shadowOffset = m_shadowOffset;
+  frame.playbackGlowLow = m_playbackGlowLow;
+  frame.playbackGlowHigh = m_playbackGlowHigh;
+  frame.playbackGlowStrength = m_playbackGlowStrength;
+  frame.playbackGlowRadius = m_playbackGlowRadius;
   frame.shadowEdgeCurve = m_shadowEdgeCurve;
+  frame.playbackGlowEdgeCurve = m_playbackGlowEdgeCurve;
 
   frame.windowColor = palette().color(QPalette::Window);
   frame.windowTextColor = palette().color(QPalette::WindowText);

--- a/src/ui/qt/workarea/hexview/HexView.h
+++ b/src/ui/qt/workarea/hexview/HexView.h
@@ -168,7 +168,12 @@ private:
   qreal m_shadowStrength = 1.0;
   QElapsedTimer m_playbackFadeClock;
   QBasicTimer m_playbackFadeTimer;
+  QColor m_playbackGlowLow;
+  QColor m_playbackGlowHigh;
+  float m_playbackGlowStrength = 1.0f;
+  float m_playbackGlowRadius = 0.5f;
   float m_shadowEdgeCurve = 1.0f;
+  float m_playbackGlowEdgeCurve = 1.0f;
   bool m_scrollBarDragging = false;
   int m_pendingScrollY = 0;
 

--- a/src/ui/qt/workarea/hexview/HexViewFrameData.h
+++ b/src/ui/qt/workarea/hexview/HexViewFrameData.h
@@ -59,7 +59,12 @@ struct Data {
   qreal shadowBlur = 0.0;
   qreal shadowStrength = 0.0;
   QPointF shadowOffset{0.0, 0.0};
+  QColor playbackGlowLow;
+  QColor playbackGlowHigh;
+  float playbackGlowStrength = 1.0f;
+  float playbackGlowRadius = 0.5f;
   float shadowEdgeCurve = 1.0f;
+  float playbackGlowEdgeCurve = 1.0f;
 
   QColor windowColor;
   QColor windowTextColor;

--- a/src/ui/qt/workarea/hexview/shaders/hexcomposite.frag
+++ b/src/ui/qt/workarea/hexview/shaders/hexcomposite.frag
@@ -4,21 +4,39 @@ layout(location = 0) in vec2 vUv;
 
 layout(binding = 1) uniform sampler2D contentTex;
 layout(binding = 2) uniform sampler2D maskTex;
-layout(binding = 3) uniform sampler2D itemIdTex;
+layout(binding = 3) uniform sampler2D edgeTex;
+layout(binding = 4) uniform sampler2D itemIdTex;
 
 layout(std140, binding = 0) uniform Ubuf {
   mat4 mvp;
-  vec4 overlayAndShadow;   // x=overlayOpacity
+  vec4 overlayAndShadow;   // x=overlayOpacity, y=shadowStrength, z=shadowOffsetX, w=shadowOffsetY
   vec4 columnLayout;       // x=hexStart, y=hexWidth, z=asciiStart, w=asciiWidth
-  vec4 viewInfo;           // x=viewWidth, y=viewHeight, z=flipY, w=devicePixelRatio
+  vec4 viewAndTime;        // x=viewWidth, y=viewHeight, z=flipY, w=timeSeconds
+  vec4 shadowColor;
+  vec4 glowLowAndStrength; // rgb=glowLow, a=glowStrength
+  vec4 glowHighAndDpr;     // rgb=glowHigh, a=devicePixelRatio
   vec4 outlineColor;       // rgba
   vec4 itemIdWindow;       // x=lineHeight, y=scrollY, z=itemIdStartLine, w=itemIdHeight
 };
 
 layout(location = 0) out vec4 fragColor;
 
+float hash2(vec2 p) {
+  return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+float noise2(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  float a = hash2(i);
+  float b = hash2(i + vec2(1.0, 0.0));
+  float c = hash2(i + vec2(0.0, 1.0));
+  float d = hash2(i + vec2(1.0, 1.0));
+  return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
 float decodeItemId(vec2 uv) {
-  // Item ids are packed into RG8 (little-endian) by the renderer.
   vec2 rg = texture(itemIdTex, uv).rg * 255.0 + 0.5;
   return rg.r + rg.g * 256.0;
 }
@@ -65,14 +83,12 @@ float computeOutlineMask(float xPx, float yPx, bool inHex, bool inAscii, float d
   float upId = (lineIdx > 0.0) ? decodeItemId(centerUv - vec2(0.0, texel.y)) : id;
   float downId = (lineIdx < itemIdWindow.w - 1.0) ? decodeItemId(centerUv + vec2(0.0, texel.y)) : id;
 
-  // Keep border thickness visually consistent across scale factors.
-  float edgePx = 2.0 / max(dpr, 1.0);
+  float edgePx = 2.0 / dpr;
   float leftEdge = step(localX, edgePx);
   float rightEdge = step(cellW - edgePx, localX);
   float topEdge = step(localY, edgePx);
   float bottomEdge = step(lineHeightPx - edgePx, localY);
 
-  // Ownership rule: draw each shared boundary from one side only to avoid doubled seams.
   float drawLeft = (leftId < 0.5 || id < leftId) ? 1.0 : 0.0;
   float drawRight = (rightId < 0.5 || id < rightId) ? 1.0 : 0.0;
   float drawUp = (upId < 0.5 || id < upId) ? 1.0 : 0.0;
@@ -86,29 +102,102 @@ float computeOutlineMask(float xPx, float yPx, bool inHex, bool inAscii, float d
 }
 
 float computeSelectionHighlight(vec4 mask) {
-  float selected = clamp(mask.r, 0.0, 1.0);
-  float playback = clamp(mask.g, 0.0, 1.0);
-  float fadingPlayback = clamp(mask.b, 0.0, 1.0) * clamp(mask.a, 0.0, 1.0);
-  return max(selected, max(playback, fadingPlayback));
+  float sel = clamp(mask.r, 0.0, 1.0);
+  float playActiveMask = clamp(mask.g, 0.0, 1.0);
+  float playFadeMask = clamp(mask.b, 0.0, 1.0);
+  float playFadeAlpha = clamp(mask.a, 0.0, 1.0);
+  return max(sel, max(playActiveMask, playFadeMask * playFadeAlpha));
+}
+
+vec3 applyDimOutlineAndHighlight(vec3 baseRgb, float inColumns, float highlight, float outlineMask) {
+  vec3 dimmed = mix(baseRgb, vec3(0.0), overlayAndShadow.x * inColumns);
+  vec3 withOutline = mix(dimmed, outlineColor.rgb, outlineMask * outlineColor.a);
+  return mix(withOutline, baseRgb, highlight);
+}
+
+float computeShadowHalo(float selectionNorm, float selectedMask) {
+  if (overlayAndShadow.y <= 0.0) {
+    return 0.0;
+  }
+  return (1.0 - smoothstep(0.0, 1.0, selectionNorm)) * (1.0 - selectedMask);
+}
+
+float computePlaybackHalo(float activeNorm, float fadeNorm, float activeMask,
+                          float fadeMask, float fadeAlpha) {
+  float anyPlaybackMask = max(activeMask, fadeMask);
+  float activeHalo = (1.0 - smoothstep(0.0, 1.0, activeNorm)) * (1.0 - activeMask);
+  float fadeHalo = (1.0 - smoothstep(0.0, 1.0, fadeNorm)) * (1.0 - anyPlaybackMask) * fadeAlpha;
+  return max(activeHalo, fadeHalo);
+}
+
+float computeGlowTurbulence(vec2 uv, vec2 viewSize, float timeSeconds) {
+  vec2 p = uv * viewSize * 0.055;
+  float t = timeSeconds * 0.85;
+
+  float n1 = noise2(p + vec2(0.0, t * 1.2));
+  float n2 = noise2(p * 1.7 + vec2(7.4, t * 1.6));
+  float n3 = noise2(p * 2.9 + vec2(-3.1, t * 2.2));
+
+  float flicker = mix(n1, n2, 0.6);
+  float lick = mix(n2, n3, 0.5);
+  return 0.65 + 0.55 * mix(flicker, lick, 0.5);
 }
 
 void main() {
-  // Base pass result and mask channels produced by earlier render passes.
-  // mask.r = manual selection, mask.g = active playback, mask.b * mask.a = fading playback.
   vec4 base = texture(contentTex, vUv);
-  float highlight = computeSelectionHighlight(texture(maskTex, vUv));
 
-  float x = vUv.x * viewInfo.x;
-  float logicalY = mix(1.0 - vUv.y, vUv.y, viewInfo.z);
-  float y = logicalY * viewInfo.y;
-  bool inHex = (x >= columnLayout.x) && (x < columnLayout.x + columnLayout.y);
-  bool inAscii = (columnLayout.w > 0.0) && (x >= columnLayout.z) && (x < columnLayout.z + columnLayout.w);
+  float shadowStrength = overlayAndShadow.y;
+  vec2 shadowOffset = overlayAndShadow.zw;
+
+  float hexStart = columnLayout.x;
+  float hexWidth = columnLayout.y;
+  float asciiStart = columnLayout.z;
+  float asciiWidth = columnLayout.w;
+
+  vec2 viewSize = viewAndTime.xy;
+  float flipY = viewAndTime.z;
+  float dpr = max(glowHighAndDpr.a, 1.0);
+  float time = viewAndTime.w;
+  vec3 glowLow = glowLowAndStrength.rgb;
+  float glowStrength = glowLowAndStrength.a;
+  vec3 glowHigh = glowHighAndDpr.rgb;
+
+  float x = vUv.x * viewSize.x;
+  bool inHex = (x >= hexStart) && (x < hexStart + hexWidth);
+  bool inAscii = (asciiWidth > 0.0) && (x >= asciiStart) && (x < asciiStart + asciiWidth);
   float inColumns = (inHex || inAscii) ? 1.0 : 0.0;
-  float outlineMask = computeOutlineMask(x, y, inHex, inAscii, viewInfo.w);
 
-  // Composite order: dim columns, add modifier outline, then restore selected pixels.
-  vec3 dimmed = mix(base.rgb, vec3(0.0), overlayAndShadow.x * inColumns);
-  vec3 withOutline = mix(dimmed, outlineColor.rgb, outlineMask * outlineColor.a);
-  vec3 restored = mix(withOutline, base.rgb, highlight);
-  fragColor = vec4(restored, base.a);
+  vec4 mask = texture(maskTex, vUv);
+  float sel = clamp(mask.r, 0.0, 1.0);
+  float playActiveMask = clamp(mask.g, 0.0, 1.0);
+  float playFadeMask = clamp(mask.b, 0.0, 1.0);
+  float playFadeAlpha = clamp(mask.a, 0.0, 1.0);
+  float highlight = computeSelectionHighlight(mask);
+  float logicalY = mix(1.0 - vUv.y, vUv.y, flipY);
+  float y = logicalY * viewSize.y;
+  float outlineMask = computeOutlineMask(x, y, inHex, inAscii, dpr);
+
+  vec3 restored = applyDimOutlineAndHighlight(base.rgb, inColumns, highlight, outlineMask);
+
+  vec2 shadowUv = vUv + shadowOffset;
+  vec4 edgeShadow = texture(edgeTex, shadowUv);
+  float selHalo = computeShadowHalo(edgeShadow.r, sel);
+
+  float shadowAlpha = selHalo * shadowStrength * shadowColor.a;
+  vec3 withShadow = mix(restored, shadowColor.rgb, shadowAlpha);
+
+  vec4 edgeGlow = texture(edgeTex, vUv);
+  float playHalo = computePlaybackHalo(edgeGlow.g, edgeGlow.b, playActiveMask, playFadeMask,
+                                       playFadeAlpha);
+  float turbulence = computeGlowTurbulence(vUv, viewSize, time);
+
+  float flame = clamp(playHalo * glowStrength * turbulence, 0.0, 1.0);
+
+  float flameRamp = smoothstep(0.0, 1.0, flame);
+  vec3 flameColor = mix(glowLow, glowHigh, flameRamp);
+
+  vec3 withGlow = mix(withShadow, flameColor, clamp(flame, 0.0, 1.0));
+  withGlow = clamp(withGlow + flameColor * flame * 0.35, 0.0, 1.0);
+
+  fragColor = vec4(withGlow, base.a);
 }

--- a/src/ui/qt/workarea/hexview/shaders/hexedge.frag
+++ b/src/ui/qt/workarea/hexview/shaders/hexedge.frag
@@ -1,0 +1,44 @@
+#version 450
+
+layout(location = 0) in vec2 vPos;
+layout(location = 1) in vec4 vRect;
+layout(location = 2) in vec4 vColor;
+
+layout(std140, binding = 0) uniform Ubuf {
+  mat4 mvp;
+  vec4 edgeParams; // x = shadowRadius, y = glowRadius, z = shadowCurve, w = glowCurve
+};
+
+layout(location = 0) out vec4 fragColor;
+
+float sdRect(vec2 p, vec2 center, vec2 halfSize) {
+  vec2 d = abs(p - center) - halfSize;
+  vec2 dOut = max(d, vec2(0.0));
+  float outside = length(dOut);
+  float inside = min(max(d.x, d.y), 0.0);
+  return outside + inside;
+}
+
+void main() {
+  float shadowRadius = edgeParams.x;
+  float glowRadius = edgeParams.y;
+  float shadowCurve = max(edgeParams.z, 0.0001);
+  float glowCurve = max(edgeParams.w, 0.0001);
+
+  float isShadow = step(0.5, vColor.r);
+  float isGlowActive = step(0.5, vColor.g);
+  float isGlowFade = step(0.5, vColor.b);
+
+  vec2 center = vRect.xy + vRect.zw * 0.5;
+  vec2 halfSize = vRect.zw * 0.5;
+  float dist = sdRect(vPos, center, halfSize);
+  float outside = max(dist, 0.0);
+
+  float shadowNorm = shadowRadius > 0.0001 ? clamp(pow(outside / shadowRadius, shadowCurve), 0.0, 1.0) : 1.0;
+  float glowNorm = glowRadius > 0.0001 ? clamp(pow(outside / glowRadius, glowCurve), 0.0, 1.0) : 1.0;
+
+  float r = mix(1.0, shadowNorm, isShadow);
+  float g = mix(1.0, glowNorm, isGlowActive);
+  float b = mix(1.0, glowNorm, isGlowFade);
+  fragColor = vec4(r, g, b, 1.0);
+}

--- a/src/ui/qt/workarea/hexview/shaders/hexedge.vert
+++ b/src/ui/qt/workarea/hexview/shaders/hexedge.vert
@@ -1,0 +1,23 @@
+#version 450
+
+layout(location = 0) in vec2 inPos;
+layout(location = 1) in vec4 inGeomRect;
+layout(location = 2) in vec4 inRect;
+layout(location = 3) in vec4 inColor;
+
+layout(location = 0) out vec2 vPos;
+layout(location = 1) out vec4 vRect;
+layout(location = 2) out vec4 vColor;
+
+layout(std140, binding = 0) uniform Ubuf {
+  mat4 mvp;
+  vec4 edgeParams;
+};
+
+void main() {
+  vec2 pos = inGeomRect.xy + inPos * inGeomRect.zw;
+  gl_Position = mvp * vec4(pos, 0.0, 1.0);
+  vPos = pos;
+  vRect = inRect;
+  vColor = inColor;
+}

--- a/src/ui/qt/workarea/hexview/shaders/hexscreen.vert
+++ b/src/ui/qt/workarea/hexview/shaders/hexscreen.vert
@@ -5,15 +5,20 @@ layout(location = 0) out vec2 vUv;
 
 layout(std140, binding = 0) uniform Ubuf {
   mat4 mvp;
-  vec4 overlayAndShadow;   // x=overlayOpacity
+  vec4 overlayAndShadow;   // x=overlayOpacity, y=shadowStrength, z=shadowOffsetX, w=shadowOffsetY
   vec4 columnLayout;       // x=hexStart, y=hexWidth, z=asciiStart, w=asciiWidth
-  vec4 viewInfo;           // x=viewWidth, y=viewHeight, z=flipY
+  vec4 viewAndTime;        // x=viewWidth, y=viewHeight, z=flipY, w=timeSeconds
+  vec4 shadowColor;
+  vec4 glowLowAndStrength; // rgb=glowLow, a=glowStrength
+  vec4 glowHighAndDpr;     // rgb=glowHigh, a=devicePixelRatio
+  vec4 outlineColor;       // rgba
+  vec4 itemIdWindow;       // x=lineHeight, y=scrollY, z=itemIdStartLine, w=itemIdHeight
 };
 
 void main() {
   vec2 pos = inPos * 2.0 - 1.0;
   gl_Position = mvp * vec4(pos, 0.0, 1.0);
 
-  float flipY = viewInfo.z; // 0 = no flip (OpenGL), 1 = flip (Metal/D3D/Vulkan)
+  float flipY = viewAndTime.z; // 0 = no flip (OpenGL), 1 = flip (Metal/D3D/Vulkan)
   vUv = vec2(inPos.x, mix(inPos.y, 1.0 - inPos.y, flipY));
 }


### PR DESCRIPTION
## Description
This adds a HexView glow rendering pipeline. The renderer moves from a 3-pass flow to a 4-pass flow: it still renders base content into an offscreen texture, still renders selection/playback masks, and now adds a dedicated edge-field pass before final compositing. That edge-field is what enables smooth drop-shadow and playback-glow falloff without changing selection geometry itself. The final composite shader then combines contentTex (the already-rendered text/background image), maskTex (selection/playback channel mask), edgeTex (distance/falloff field), and itemIdTex (for outline boundaries).

On the data side, HexView now exports explicit glow parameters in frame data (playbackGlowLow, playbackGlowHigh, glow strength/radius, and glow edge curve), and the renderer wires those values into uniform buffers for both edge and composite passes. Shader updates include the new edge shaders (`hexedge.vert`/`hexedge.frag`), expanded fullscreen UBO layout in hexscreen.vert, and additions to `hexcomposite.frag` so that it applies dimming/outline/highlight, shadow halo, and playback glow color ramp/turbulence.

## Video
Here's the glow effect on a rest event. Note that I increased font size to make the effect larger.

https://github.com/user-attachments/assets/0dcd5568-51e9-4a1d-a041-9d6f29142aa7



## Motivation and Context
Obviously we want to make selection glow distinct from active playback glow, so selection remains a black shadow while active events get a white glow. I added an animation to the glow so that it feels alive while hopefully not distracting.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
