### PR TITLE
RhiHexView 10: add Linux QRhiWidget primer in MainWindow

### DIFF
--- a/src/ui/qt/main_ui.cpp
+++ b/src/ui/qt/main_ui.cpp
@@ -52,18 +52,19 @@ int main(int argc, char *argv[]) {
   QFontDatabase::addApplicationFont(":/fonts/Roboto_Mono/RobotoMono-VariableFont_wght.ttf");
 
   MainWindow window;
+
 #if defined(Q_OS_LINUX) && QT_CONFIG(opengl)
+  // Prime QRhiWidget once at startup to avoid first-use window re-creation. Not necessary for other platforms
+  // where we use a QWindow instead of QRhiWidget.
   auto* rhiPrimer = new QRhiWidget(&window);
   rhiPrimer->setApi(QRhiWidget::Api::OpenGL);
-  rhiPrimer->setAttribute(Qt::WA_TransparentForMouseEvents);
-  rhiPrimer->setFocusPolicy(Qt::NoFocus);
   rhiPrimer->hide();
 #endif
+
   window.show();
+
 #if defined(Q_OS_LINUX) && QT_CONFIG(opengl)
-  QTimer::singleShot(0, &window, [rhiPrimer]() {
-    rhiPrimer->deleteLater();
-  });
+  QTimer::singleShot(0, rhiPrimer, &QObject::deleteLater);
 #endif
 
   const QStringList args = app.arguments();


### PR DESCRIPTION
## Description
This is the final planned PR for the RHI HexView rewrite 🎉. I should have put this one earlier, but didn't want to rearrange these iterative branches.

This PR fixes a problem on Linux, which uses HexViewRhiWidget instead of the HexViewRhiWindow class. When HexViewRhiWidget is first displayed, Qt (or the OS?) swaps the app window, presumably with one that can utilize the GPU more directly. This swap isn't hidden, it's visible and jarring - the app window closes and a new window pops up at a different screen position.

To fix this, we add a "primer" QRhiWidget in MainWindow, which lets us initialize the app in an already GPU-capable window so there's never any swap. During `createElements()`, the app creates this widget, pins it to the OpenGL API (`setApi(QRhiWidget::Api::OpenGL)`), marks it non-interactive (`WA_TransparentForMouseEvents`, `NoFocus`), and keeps it hidden. Thus, the primer widget only affects initialization and doesn't interfere in any way with the UI.

## Testing
This PR marks the code state where I did extensive testing across Windows, macOS, and Linux and tested for issues with just about every format we support.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
