### PR TITLE
update qt cmake script to use the freetype font engine on Windows

### DIFF
--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -278,6 +278,26 @@ if (NOT FLATPAK)
       DEPLOY_TOOL_OPTIONS ${DEPLOY_EXTRA_OPTIONS}
   )
   install(SCRIPT ${deploy_script})
+
+  # On Windows, ensure qt.conf sets WindowsArguments = fontengine=freetype after deployment.
+  if(WIN32)
+    file(GENERATE
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/patch-qtconf-$<CONFIG>.cmake"
+            CONTENT [==[
+set(_qtconf "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/qt.conf")
+
+if(NOT EXISTS "${_qtconf}")
+  message(FATAL_ERROR "Expected qt.conf was not generated: ${_qtconf}")
+endif()
+
+file(READ "${_qtconf}" _qtconf_contents)
+if(NOT _qtconf_contents MATCHES "WindowsArguments[ \t]*=[ \t]*fontengine=freetype")
+  file(APPEND "${_qtconf}" "\n[Platforms]\nWindowsArguments = fontengine=freetype\n")
+endif()
+]==]
+    )
+    install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/patch-qtconf-$<CONFIG>.cmake")
+  endif()
 endif()
 
 # ~~~


### PR DESCRIPTION
This adds an install-time patch to qt.conf on Windows to ensure we add

```
[Platforms]
WindowsArguments = fontengine=freetype
```

On my Windows 10 machine, using the default fontengine (directwrite) results in obvious aliasing within HexView when the DPR is fractional (specifically when display scale is set to 150% or 175%). This occurs regardless of the fact we round the "high dpi scale factor" via `setHighDpiScaleFactorRoundingPolicy()`, though I intend to remove this line in a separate PR anyway.

@sykhro when you're available (no rush), I'd like to get info from you about your experience with freetype rendering on Windows, since what you previously wrote about this conflicts with what I'm seeing.

My experience is that rendering at fractional DPRs is working well on every platform except for Windows. On the Linux side, I'm testing with Ubuntu, which uses Wayland.

## How Has This Been Tested?
I built and installed locally with CMake and verified the qt.conf file was amended. It reads as follows:

```
[Paths]
Prefix = .
Libraries = .
Binaries = .

[Platforms]
WindowsArguments = fontengine=freetype
```

## Screenshots
Here's an example of aliasing at 150% scaling when directwrite is used.
<img width="231" height="86" alt="image" src="https://github.com/user-attachments/assets/d019f478-b7b6-4224-9b61-58b48c23d5d7" />

Here's how it renders at 150% scaling with freetype:
<img width="234" height="100" alt="image" src="https://github.com/user-attachments/assets/1c39bda1-664b-40c3-949a-cc0dbd14be09" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
