### PR TITLE
Bump actions, improve download experience for binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       HOMEBREW_PREFIX: ${{ (matrix.target == 'intel' && '/usr/local') || '/opt/homebrew' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           show-progress: false
@@ -64,11 +64,12 @@ jobs:
           cmake --build --preset "macos-${{ matrix.target }}-release" --target install
 
       - name: "Checkout create-dmg"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: create-dmg/create-dmg
           path: "./build/macos-${{ matrix.target }}/create-dmg"
           ref: master
+          show-progress: false
 
       - name: Build macOS DMG
         shell: bash
@@ -92,7 +93,7 @@ jobs:
             "dist/usr/local/"
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         if: ${{ github.event_name != 'pull_request' }}
         with:
           subject-name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-${{ matrix.target }}-${{ runner.os }}
@@ -114,7 +115,7 @@ jobs:
       contents: read
       attestations: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           show-progress: false
@@ -152,7 +153,7 @@ jobs:
         shell: bash
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         if: ${{ github.event_name != 'pull_request' }}
         with:
           subject-name: VGMTrans-${{ github.sha }}-${{ env.BRANCH }}-x86_64-${{ runner.os }}
@@ -174,7 +175,7 @@ jobs:
       contents: read
       attestations: write
     steps:
-       - uses: actions/checkout@v4
+       - uses: actions/checkout@v6
          with:
           submodules: recursive
           show-progress: false
@@ -232,7 +233,7 @@ jobs:
             --target package
 
        - name: Generate artifact attestation
-         uses: actions/attest-build-provenance@v3
+         uses: actions/attest@v4
          if: ${{ github.event_name != 'pull_request' }}
          with:
            subject-path: "build/win-${{ matrix.target }}/${{ env.PACKAGE_FILE_NAME }}.zip"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- actions/checkout: v4 -> v6
- actions/upload-artifact: v4 -> v7, with archive: false to upload files directly without re-zipping. Artifact names are now derived from the filename itself
- actions/attest-build-provenance: replaced with actions/attest@v4

## Motivation and Context
Routine dependency updates.
`archive: false` removes a the redundant zip layer for builds.
This is helpful because:
- having to unzip a dmg is annoying
- every single format is already compressed and doesn't benefit from zipping
- attestation now tracks the hash of the very archive we produce instead of github's wrapper. mostly relevant to DMG and Flatpak

## How Has This Been Tested?
CI
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
