### PR TITLE
Fix crash in NDSScanner when ASAN is enabled

### DIFF
--- a/src/main/formats/NDS/NDSScanner.cpp
+++ b/src/main/formats/NDS/NDSScanner.cpp
@@ -4,13 +4,24 @@
  * refer to the included LICENSE.txt file
  */
 
+#include "NDSScanner.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "ScannerManager.h"
 #include "NDSSeq.h"
 #include "NDSInstrSet.h"
-#include "ScannerManager.h"
 
 namespace vgmtrans::scanners {
-ScannerRegistration<NDSScanner> s_nds("NDS", {"nds", "sdat", "mini2sf", "2sf", "2sflib"});
+  ScannerRegistration<NDSScanner> s_nds("NDS", {"nds", "sdat", "mini2sf", "2sf", "2sflib"});
 }
+
+/* Observed from multiple samples, the maximum length of standard archives is 127 + null terminator */
+constexpr auto MAX_NAME_LEN = 128;
 
 void NDSScanner::scan(RawFile* file, void* /*info*/) {
   searchForSDAT(file);
@@ -74,38 +85,30 @@ uint32_t NDSScanner::loadFromSDAT(RawFile *file, uint32_t baseOff) {
   }
 
   for (uint32_t i = 0; i < nSeqs; i++) {
-    char temp[32];        //that 32 is totally arbitrary, i should change it
     if (hasSYMB) {
-      file->readBytes(file->readWord(pSeqNamePtrList + 4 + i * 4) + SYMBoff, 32, temp);
+      seqNames.push_back(file->readNullTerminatedString(file->readWord(pSeqNamePtrList + 4 + i * 4) + SYMBoff, MAX_NAME_LEN));
     }
     else {
-      snprintf(temp, 32, "SSEQ_%04d", i);
+      seqNames.push_back(fmt::format("SSEQ_{:04d}", i));
     }
-    seqNames.push_back(temp);
   }
 
   for (uint32_t i = 0; i < nBnks; i++) {
-    char temp[32];        //that 32 is totally arbitrary, i should change it
-
     if (hasSYMB) {
-      file->readBytes(file->readWord(pBnkNamePtrList + 4 + i * 4) + SYMBoff, 32, temp);
+      bnkNames.push_back(file->readNullTerminatedString(file->readWord(pBnkNamePtrList + 4 + i * 4) + SYMBoff, MAX_NAME_LEN));
     }
     else {
-      snprintf(temp, 32, "SBNK_%04d", i);
+      bnkNames.push_back(fmt::format("SBNK_{:04d}", i));
     }
-    bnkNames.push_back(temp);
   }
 
   for (uint32_t i = 0; i < nWAs; i++) {
-    char temp[32];        //that 32 is totally arbitrary, i should change it
-
     if (hasSYMB) {
-      file->readBytes(file->readWord(pWANamePtrList + 4 + i * 4) + SYMBoff, 32, temp);
+      waNames.push_back(file->readNullTerminatedString(file->readWord(pWANamePtrList + 4 + i * 4) + SYMBoff, MAX_NAME_LEN));
     }
     else {
-      snprintf(temp, 32, "SWAR_%04d", i);
+      waNames.push_back(fmt::format("SWAR_{:04d}", i));
     }
-    waNames.push_back(temp);
   }
 
   uint32_t pSeqInfoPtrList = file->readWord(INFOoff + 8) + INFOoff;

--- a/src/main/formats/NDS/NDSScanner.h
+++ b/src/main/formats/NDS/NDSScanner.h
@@ -4,7 +4,10 @@
  * refer to the included LICENSE.txt file
  */
 #pragma once
+
 #include "Scanner.h"
+
+#include <cstdint>
 
 class NDSScanner : public VGMScanner {
  public:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Current code is reading strings into fixed-size buffers without ensuring null termination. I've switched it to `RawFile::readNullTerminatedString`.
Also added `NDSScanner.h` to ensure it compiles.

## Motivation and Context
32 was arbitrary, various game decompilation projects show that the maximum filename for filesystem functions in the NDS SDK is 127 + 1 for the null-terminator.
While it's possible this doesn't apply to SYMB entries, the worst that can happen is we end up with a cut filename.
I will clean up this whole function and refactor a few things about how these are read with a PR related to DSE support.

Fixes an issue where scanning "Sonic & Sega All Star Racing" would result in a crash with ASAN enabled.

## How Has This Been Tested?
Opening various NDS roms and music dumps.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
