### PR TITLE
CPS2/CPS3: fix vibrato and tremelo

### DIFF
--- a/src/main/formats/CPS/CPS2Seq.cpp
+++ b/src/main/formats/CPS/CPS2Seq.cpp
@@ -85,10 +85,6 @@ bool CPS2Seq::postLoad() {
   if (readMode != READMODE_CONVERT_TO_MIDI)
     return true;
 
-  if (fmt_version <= CPS1_V502) {
-    return true;
-  }
-
   const double UPDATE_RATE_IN_HZ = (fmt_version == CPS3) ? CPS3_DRIVER_RATE_HZ : CPS2_DRIVER_RATE_HZ;
 
   // We need to add pitch bend events for vibrato, which is controlled by a software LFO


### PR DESCRIPTION
At some point before V1.3, I pushed a change that always skips the vibrato and tremelo effect pipeline in the CPS2/3 driver. It's an unnecessary version check, but also compares an enum type against the value of a different enum type - so it's nonsensical as written.

## How Has This Been Tested?
Verified vibrato is working again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
