### PR TITLE
Fix dimming overlay not disappearing after file dragged into HexView

### DIFF
--- a/src/ui/qt/MainWindow.cpp
+++ b/src/ui/qt/MainWindow.cpp
@@ -300,6 +300,8 @@ void MainWindow::hideDragOverlay() {
 }
 
 void MainWindow::handleDroppedUrls(const QList<QUrl>& urls) {
+  hideDragOverlay();
+
   if (urls.isEmpty()) {
     return;
   }


### PR DESCRIPTION
There was a small regression introduced when adding the FlatPak drag & drop permissions workaround. When a file is dropped into the HexView, the dimming overlay doesn't disappear. This fixes that.

## How Has This Been Tested?
Dragged files into the HexView.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
