### PR TITLE
New Layout - Part 1: Windows platform plugin and helper methods

### DIFF
--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(vgmtrans
     services/NotificationCenter.cpp
     util/Helpers.cpp
     util/UIHelpers.cpp
+    widgets/ItemViewDensity.cpp
     widgets/SeekBar.cpp
     widgets/MarqueeLabel.cpp
     widgets/SnappingSplitter.cpp
@@ -91,6 +92,7 @@ target_sources(vgmtrans
   PRIVATE
     FILE_SET headers_widgets TYPE HEADERS BASE_DIRS widgets
     FILES
+      widgets/ItemViewDensity.h
       widgets/SeekBar.h
       widgets/MarqueeLabel.h
       widgets/SnappingSplitter.h

--- a/src/ui/qt/main_ui.cpp
+++ b/src/ui/qt/main_ui.cpp
@@ -43,9 +43,16 @@ int main(int argc, char *argv[]) {
 
   VGMTransApplication app(argc, argv);
 
-#ifdef _WIN32
-  app.setStyle(QStyleFactory::create("fusion"));
+#ifdef Q_OS_WIN
+  QFont font = app.font();
+  if (font.pointSizeF() > 0.0) {
+    font.setPointSizeF(font.pointSizeF() + 1.0);
+  } else if (font.pixelSize() > 0) {
+    font.setPixelSize(font.pixelSize() + 1);
+  }
+  app.setFont(font);
 #endif
+
   qtVGMRoot.init();
 
   QFontDatabase::addApplicationFont(":/fonts/Roboto_Mono/RobotoMono-VariableFont_wght.ttf");

--- a/src/ui/qt/resources/icons/file-outline.svg
+++ b/src/ui/qt/resources/icons/file-outline.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#cecece"><path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" /></svg>

--- a/src/ui/qt/resources/resources.qrc
+++ b/src/ui/qt/resources/resources.qrc
@@ -12,6 +12,7 @@
   <file>icons/sample-collection.svg</file>
   <file>icons/sample.svg</file>
   <file>icons/file.svg</file>
+  <file>icons/file-outline.svg</file>
   <file>icons/collection.svg</file>
   <file>icons/instrument-set.svg</file>
   <file>icons/instr.svg</file>

--- a/src/ui/qt/util/Helpers.cpp
+++ b/src/ui/qt/util/Helpers.cpp
@@ -345,7 +345,7 @@ const QIcon &iconForItemType(VGMItem::Type type) {
       break;
   }
 
-  static auto i_gen = QIcon(":/icons/file.svg");
+  static auto i_gen = QIcon(":/icons/binary.svg");
   return i_gen;
 }
 

--- a/src/ui/qt/util/TintableSvgIconEngine.h
+++ b/src/ui/qt/util/TintableSvgIconEngine.h
@@ -1,17 +1,27 @@
 #pragma once
 
-#include <QGraphicsPixmapItem>
+#include <cmath>
 #include <QIconEngine>
+#include <QLinearGradient>
 #include <QPainter>
 #include <QSvgRenderer>
 #include <QHash>
 #include <qguiapplication.h>
+#include <QtMath>
 
 class TintableSvgIconEngine : public QIconEngine
 {
 public:
   TintableSvgIconEngine(QString svgPath, QColor tint)
-      : m_path(std::move(svgPath)), m_tint(std::move(tint)) {
+      : m_path(std::move(svgPath)), m_startColor(std::move(tint)) {
+  }
+
+  TintableSvgIconEngine(QString svgPath, QColor startColor, QColor endColor, int angleDegrees = 90)
+      : m_path(std::move(svgPath)),
+        m_startColor(std::move(startColor)),
+        m_endColor(std::move(endColor)),
+        m_angleDegrees(angleDegrees),
+        m_useGradient(true) {
   }
 
   QIconEngine *clone() const override {
@@ -28,6 +38,19 @@ public:
   }
 
 private:
+  QLinearGradient gradientForRect(const QRectF &rect) const {
+    const qreal radians = qDegreesToRadians(qreal(m_angleDegrees));
+    const QPointF direction(std::cos(radians), std::sin(radians));
+    const QPointF center = rect.center();
+    const qreal halfLength = std::hypot(rect.width(), rect.height()) * 0.5;
+
+    QLinearGradient gradient(center - direction * halfLength, center + direction * halfLength);
+    gradient.setSpread(QGradient::PadSpread);
+    gradient.setColorAt(0.0, m_startColor);
+    gradient.setColorAt(1.0, m_endColor);
+    return gradient;
+  }
+
   QPixmap renderCached(const QSize &logicalSize, qreal dpr) const {
     const QSize phys = logicalSize * dpr;
     const quint64 key = (quint64(phys.width()) << 32) | phys.height();
@@ -43,7 +66,8 @@ private:
     renderer.render(&p, QRectF(QPointF(0, 0), QSizeF(phys)));
 
     p.setCompositionMode(QPainter::CompositionMode_SourceIn);
-    p.fillRect(img.rect(), m_tint);                             // apply tint
+    p.fillRect(img.rect(), m_useGradient ? QBrush(gradientForRect(QRectF(QPointF(0, 0), QSizeF(phys))))
+                                         : QBrush(m_startColor));
     p.end();
 
     QPixmap pm = QPixmap::fromImage(img);
@@ -54,6 +78,9 @@ private:
 
 
   QString                m_path;
-  QColor                 m_tint;
+  QColor                 m_startColor;
+  QColor                 m_endColor;
+  int                    m_angleDegrees = 90;
+  bool                   m_useGradient = false;
   mutable QHash<quint64, QPixmap> m_cache;
 };

--- a/src/ui/qt/util/UIHelpers.cpp
+++ b/src/ui/qt/util/UIHelpers.cpp
@@ -5,8 +5,13 @@
 */
 
 #include "UIHelpers.h"
+#include "TintableSvgIconEngine.h"
+#include <QIcon>
 #include <QWidget>
 #include <QScrollArea>
+#include <QScrollBar>
+#include <QToolButton>
+#include <QStyle>
 #include <QGraphicsScene>
 #include <QGraphicsPixmapItem>
 #include <QPainter>
@@ -25,6 +30,19 @@ QScrollArea* getContainingScrollArea(const QWidget* widget) {
   return nullptr;
 }
 
+int horizontalScrollBarReservedHeight(const QAbstractScrollArea* area) {
+  const QScrollBar* hbar = area->horizontalScrollBar();
+
+  const int extent = hbar->sizeHint().height();
+  const int overlap = hbar->style()->pixelMetric(
+      QStyle::PM_ScrollView_ScrollBarOverlap,
+      nullptr,
+      hbar
+  );
+
+  return std::max(0, extent - overlap);
+}
+
 void applyEffectToPixmap(QPixmap &src, QPixmap &tgt, QGraphicsEffect *effect, int extent)
 {
   if(src.isNull()) return;  // Check if src is valid
@@ -39,6 +57,127 @@ void applyEffectToPixmap(QPixmap &src, QPixmap &tgt, QGraphicsEffect *effect, in
   tgt.fill(Qt::transparent);
   QPainter ptr(&tgt);
   scene.render(&ptr, QRectF(), QRectF(-extent, -extent, src.width() + extent*2, src.height() + extent*2));
+}
+
+QIcon stencilSvgIcon(const QString &iconPath, const QColor &color) {
+  return QIcon(new TintableSvgIconEngine(iconPath, color));
+}
+
+QIcon gradientStencilSvgIcon(const QString &iconPath, const QColor &startColor, const QColor &endColor,
+                             int angleDegrees) {
+  return QIcon(new TintableSvgIconEngine(iconPath, startColor, endColor, angleDegrees));
+}
+
+QPixmap tintedIconPixmap(const QIcon &icon, const QSize &size, const QColor &color, qreal devicePixelRatio) {
+  if (size.isEmpty()) {
+    return {};
+  }
+
+  QPixmap pixmap = icon.pixmap(size, std::max(devicePixelRatio, qreal(1.0)));
+  if (pixmap.isNull()) {
+    return pixmap;
+  }
+
+  QPainter painter(&pixmap);
+  painter.setCompositionMode(QPainter::CompositionMode_SourceIn);
+  painter.fillRect(pixmap.rect(), color);
+  return pixmap;
+}
+
+QString cssColor(const QColor &color) {
+  return QStringLiteral("rgba(%1, %2, %3, %4)")
+      .arg(color.red())
+      .arg(color.green())
+      .arg(color.blue())
+      .arg(color.alpha());
+}
+
+QColor blendColors(const QColor &foreground, const QColor &background, qreal foregroundWeight) {
+  const qreal backgroundWeight = 1.0 - foregroundWeight;
+  return QColor::fromRgbF(foreground.redF() * foregroundWeight + background.redF() * backgroundWeight,
+                          foreground.greenF() * foregroundWeight + background.greenF() * backgroundWeight,
+                          foreground.blueF() * foregroundWeight + background.blueF() * backgroundWeight,
+                          foreground.alphaF() * foregroundWeight + background.alphaF() * backgroundWeight);
+}
+
+bool isDarkPalette(const QPalette &palette) {
+  return palette.color(QPalette::Window).lightnessF() < 0.5;
+}
+
+void configureToolButton(QToolButton *button, const QString &toolTip, const QSize &buttonSize,
+                         const QSize &iconSize, bool textOnly) {
+  if (!button) {
+    return;
+  }
+
+  button->setAutoRaise(true);
+  button->setFocusPolicy(Qt::NoFocus);
+  button->setToolTip(toolTip);
+  button->setCursor(Qt::ArrowCursor);
+  button->setToolButtonStyle(textOnly ? Qt::ToolButtonTextOnly : Qt::ToolButtonIconOnly);
+
+  if (buttonSize.isValid()) {
+    button->setFixedSize(buttonSize);
+  }
+
+  if (iconSize.isValid()) {
+    button->setIconSize(iconSize);
+  }
+}
+
+QString toolBarButtonStyle(const QPalette &palette, bool checkable) {
+  const bool darkPalette = isDarkPalette(palette);
+  QColor hoverFill = palette.color(QPalette::Text);
+  hoverFill.setAlpha(darkPalette ? 18 : 12);
+  QColor pressedFill = palette.color(QPalette::Text);
+  pressedFill.setAlpha(darkPalette ? 28 : 20);
+
+  QString style = QStringLiteral(
+      "QToolButton {"
+      " border: none;"
+      " background: transparent;"
+      " border-radius: 6px;"
+      " padding: 0px;"
+      " margin: 0px;"
+      "}"
+      "QToolButton:hover { background: %1; }"
+      "QToolButton:pressed { background: %2; }")
+                      .arg(cssColor(hoverFill))
+                      .arg(cssColor(pressedFill));
+
+  if (checkable) {
+    QColor checkedFill = palette.color(QPalette::Text);
+    checkedFill.setAlpha(darkPalette ? 38 : 33);
+    style += QStringLiteral("QToolButton:checked { background: %1; }").arg(cssColor(checkedFill));
+  }
+
+  return style;
+}
+
+QColor toolBarButtonIconColor(const QPalette &palette, bool enabled) {
+  const QColor windowColor = palette.color(QPalette::Window);
+  const bool darkPalette = isDarkPalette(palette);
+  const QColor textColor =
+      enabled ? palette.color(QPalette::Text) : palette.color(QPalette::Disabled, QPalette::Text);
+  return blendColors(textColor, windowColor, enabled ? (darkPalette ? 0.72 : 0.56) : (darkPalette ? 0.6 : 0.46));
+}
+
+void refreshStencilToolButton(QToolButton *button, const QString &iconPath, const QPalette &palette,
+                              bool checkable) {
+  if (!button) {
+    return;
+  }
+
+  button->setStyleSheet(toolBarButtonStyle(palette, checkable));
+  button->setIcon(stencilSvgIcon(iconPath, toolBarButtonIconColor(palette, button->isEnabled())));
+}
+
+QString toolBarTextButtonStyle(const QPalette &palette, int leftMargin) {
+  return QStringLiteral(
+      "QToolButton { border: none; background: transparent; padding: 0px; margin: 0px 0px 0px %1px; color: %2; }"
+      "QToolButton::menu-indicator { image: none; width: 0px; }")
+      .arg(leftMargin)
+      .arg(cssColor(toolBarButtonIconColor(palette)));
 }
 
 std::filesystem::path openSaveDirDialog() {

--- a/src/ui/qt/util/UIHelpers.h
+++ b/src/ui/qt/util/UIHelpers.h
@@ -8,15 +8,37 @@
 
 #include <filesystem>
 #include <string>
+#include <QColor>
+#include <QIcon>
+#include <QPalette>
+#include <QSize>
+#include <QString>
 
 class QScrollArea;
+class QAbstractScrollArea;
+class QToolButton;
 class QWidget;
 class QPixmap;
 class QGraphicsEffect;
 class VGMItem;
 
 QScrollArea* getContainingScrollArea(const QWidget* widget);
+int horizontalScrollBarReservedHeight(const QAbstractScrollArea* area);
 void applyEffectToPixmap(QPixmap& src, QPixmap& tgt, QGraphicsEffect* effect, int extent = 0);
+QIcon stencilSvgIcon(const QString &iconPath, const QColor &color);
+QIcon gradientStencilSvgIcon(const QString &iconPath, const QColor &startColor, const QColor &endColor,
+                             int angleDegrees = 90);
+QPixmap tintedIconPixmap(const QIcon &icon, const QSize &size, const QColor &color, qreal devicePixelRatio);
+QString cssColor(const QColor &color);
+QColor blendColors(const QColor &foreground, const QColor &background, qreal foregroundWeight);
+bool isDarkPalette(const QPalette &palette);
+void configureToolButton(QToolButton *button, const QString &toolTip, const QSize &buttonSize = QSize(),
+                         const QSize &iconSize = QSize(), bool textOnly = false);
+QString toolBarButtonStyle(const QPalette &palette, bool checkable = false);
+QColor toolBarButtonIconColor(const QPalette &palette, bool enabled = true);
+void refreshStencilToolButton(QToolButton *button, const QString &iconPath, const QPalette &palette,
+                              bool checkable = false);
+QString toolBarTextButtonStyle(const QPalette &palette, int leftMargin = 0);
 
 std::filesystem::path openSaveDirDialog();
 std::filesystem::path openSaveFileDialog(const std::filesystem::path& suggested_filename, const std::string& extension);

--- a/src/ui/qt/widgets/ItemViewDensity.cpp
+++ b/src/ui/qt/widgets/ItemViewDensity.cpp
@@ -1,0 +1,79 @@
+/*
+* VGMTrans (c) 2002-2026
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+*/
+
+#include "ItemViewDensity.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <QAbstractItemView>
+#include <QHeaderView>
+#include <QListView>
+#include <QTableView>
+
+namespace {
+constexpr double kTablePaddingRatio = 0.78;
+constexpr int kTablePaddingMin = 4;
+constexpr double kListPaddingRatio = 0.22;
+constexpr int kListPaddingMin = 2;
+constexpr double kListSpacingRatio = 0.03;
+
+int scaledPadding(int textHeight, double ratio, int minimum) {
+  return std::max(minimum, static_cast<int>(std::lround(textHeight * ratio)));
+}
+}
+
+namespace ItemViewDensity {
+int textHeight(const QAbstractItemView* view) {
+  return view ? view->fontMetrics().lineSpacing() : 0;
+}
+
+int contentHeight(const QAbstractItemView* view) {
+  if (!view) {
+    return 0;
+  }
+
+  const QSize iconSize = view->iconSize();
+  const int iconHeight = iconSize.isValid() ? iconSize.height() : 0;
+  return std::max(textHeight(view), iconHeight);
+}
+
+int tableRowHeight(const QTableView* view) {
+  return contentHeight(view) + scaledPadding(textHeight(view), kTablePaddingRatio, kTablePaddingMin);
+}
+
+int listItemHeight(const QListView* view) {
+  return contentHeight(view) + scaledPadding(textHeight(view), kListPaddingRatio, kListPaddingMin);
+}
+
+int listSpacing(const QListView* view) {
+  if (!view) {
+    return 0;
+  }
+
+  return std::max(0, static_cast<int>(std::lround(textHeight(view) * kListSpacingRatio)));
+}
+
+int listItemStride(const QListView* view) {
+  return listItemHeight(view) + listSpacing(view);
+}
+
+void apply(QTableView* view) {
+  if (!view) {
+    return;
+  }
+
+  view->verticalHeader()->setDefaultSectionSize(tableRowHeight(view));
+}
+
+void apply(QListView* view) {
+  if (!view) {
+    return;
+  }
+
+  view->setSpacing(listSpacing(view));
+}
+}

--- a/src/ui/qt/widgets/ItemViewDensity.h
+++ b/src/ui/qt/widgets/ItemViewDensity.h
@@ -1,0 +1,22 @@
+/*
+* VGMTrans (c) 2002-2026
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+*/
+
+#pragma once
+
+class QAbstractItemView;
+class QListView;
+class QTableView;
+
+namespace ItemViewDensity {
+int textHeight(const QAbstractItemView* view);
+int contentHeight(const QAbstractItemView* view);
+int tableRowHeight(const QTableView* view);
+int listItemHeight(const QListView* view);
+int listSpacing(const QListView* view);
+int listItemStride(const QListView* view);
+void apply(QTableView* view);
+void apply(QListView* view);
+}

--- a/src/ui/qt/widgets/SeekBar.cpp
+++ b/src/ui/qt/widgets/SeekBar.cpp
@@ -71,7 +71,7 @@ void SeekBar::setValue(int value) {
 }
 
 QSize SeekBar::sizeHint() const {
-  return QSize(160, 26);
+  return QSize(220, 26);
 }
 
 void SeekBar::changeEvent(QEvent* event) {

--- a/src/ui/qt/widgets/TableView.cpp
+++ b/src/ui/qt/widgets/TableView.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "TableView.h"
+#include "ItemViewDensity.h"
 #include <QHeaderView>
 
 TableView::TableView(QWidget *parent) : QTableView(parent) {
@@ -15,6 +16,7 @@ TableView::TableView(QWidget *parent) : QTableView(parent) {
   setWordWrap(false);
 
   verticalHeader()->hide();
+  ItemViewDensity::apply(this);
 
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
@@ -44,6 +46,11 @@ void TableView::setModel(QAbstractItemModel *model) {
     int columnWidth = std::max(90, textWidth + 15);
     setColumnWidth(lastSectionIdx, columnWidth);
   }
+}
+
+void TableView::setIconSize(const QSize &size) {
+  QTableView::setIconSize(size);
+  ItemViewDensity::apply(this);
 }
 
 void TableView::onHeaderSectionResized(int index, int oldSize, int newSize) {

--- a/src/ui/qt/widgets/TableView.h
+++ b/src/ui/qt/widgets/TableView.h
@@ -16,6 +16,7 @@ public:
   ~TableView() override = default;
 
   void setModel(QAbstractItemModel *model) override;
+  void setIconSize(const QSize &size);
 
 protected:
   void scrollContentsBy(int dx, int dy) override;

--- a/src/ui/qt/widgets/Toast.cpp
+++ b/src/ui/qt/widgets/Toast.cpp
@@ -12,13 +12,13 @@
 #include <QGraphicsOpacityEffect>
 #include <QIcon>
 #include <QLabel>
-#include <QPainter>
-#include <QPixmap>
 #include <QPushButton>
 #include <QScreen>
 #include <QSizePolicy>
 #include <QVariantAnimation>
 #include <QVBoxLayout>
+
+#include "UIHelpers.h"
 
 static constexpr const char* kInfoIcon    = ":/icons/toast_info.svg";
 static constexpr const char* kWarnIcon    = ":/icons/toast_warning.svg";
@@ -32,19 +32,6 @@ static const ToastTheme kThemes[] = {
   { QColor(230,201,197), QColor(155, 64, 68), QColor(173,151,151), kErrorIcon   }, // Error
   { QColor(226,242,216), QColor( 98,114, 88), QColor(198,209,188), kSuccessIcon }, // Success
 };
-
-static inline QPixmap tintedIcon(const QIcon& base, const QSize& pxSize, const QColor& color) {
-  QPixmap pm = base.pixmap(pxSize);
-  if (!pm.isNull()) {
-    const qreal dpr = pm.devicePixelRatio();
-    QPainter p(&pm);
-    p.setCompositionMode(QPainter::CompositionMode_SourceIn);
-    p.fillRect(pm.rect(), color);
-    p.end();
-    pm.setDevicePixelRatio(dpr);
-  }
-  return pm;
-}
 
 const ToastTheme& Toast::themeFor(ToastType type) noexcept {
   const int idx = static_cast<int>(type);
@@ -147,8 +134,9 @@ void Toast::applyTheme(const ToastTheme& th) {
   ).arg(th.bg.name(), th.border.name(), th.text.name()));
 
   // tint close icon
-  m_close->setIcon(QIcon(tintedIcon(QIcon(QString(kCloseIcon)),
-                                    QSize(kCloseIconPx, kCloseIconPx), th.text)));
+  m_close->setIcon(QIcon(tintedIconPixmap(QIcon(QString(kCloseIcon)),
+                                          QSize(kCloseIconPx, kCloseIconPx), th.text,
+                                          m_close->devicePixelRatioF())));
 }
 
 void Toast::setTextHtml(const QString& message) {
@@ -200,8 +188,9 @@ void Toast::showMessage(const QString& message, ToastType type, int duration_ms)
   setTextHtml(message);
 
   // main icon (tinted to theme text color)
-  m_icon->setPixmap(tintedIcon(QIcon(QString::fromUtf8(th.icon)),
-                               QSize(kIconPx, kIconPx), th.text));
+  m_icon->setPixmap(tintedIconPixmap(QIcon(QString::fromUtf8(th.icon)),
+                                     QSize(kIconPx, kIconPx), th.text,
+                                     m_icon->devicePixelRatioF()));
 
   adjustSize();
 

--- a/src/ui/qt/workarea/MdiArea.cpp
+++ b/src/ui/qt/workarea/MdiArea.cpp
@@ -29,6 +29,7 @@
 #include "VGMFileView.h"
 #include "Metrics.h"
 #include "QtVGMRoot.h"
+#include "UIHelpers.h"
 #include "services/NotificationCenter.h"
 
 namespace {
@@ -105,35 +106,15 @@ InstructionMetrics computeInstructionMetrics(const InstructionHint &hint, const 
   return {hint, font, metrics, iconSide, spacing, QSize(width, height)};
 }
 
-QPixmap tintedPixmap(const QString &iconPath, const QSize &size, const QColor &accent) {
-  if (size.isEmpty()) {
-    return {};
-  }
-
-  const QIcon icon(iconPath);
-  const QPixmap pixmap = icon.pixmap(size);
-  if (pixmap.isNull()) {
-    return pixmap;
-  }
-
-  QPixmap tinted(size);
-  tinted.fill(Qt::transparent);
-
-  QPainter iconPainter(&tinted);
-  iconPainter.setRenderHint(QPainter::Antialiasing, true);
-  iconPainter.setRenderHint(QPainter::SmoothPixmapTransform, true);
-  iconPainter.drawPixmap(0, 0, pixmap);
-  iconPainter.setCompositionMode(QPainter::CompositionMode_SourceIn);
-  iconPainter.fillRect(tinted.rect(), accent);
-  return tinted;
-}
-
 void paintInstruction(QPainter &painter, const InstructionMetrics &metrics, const QPoint &topLeft,
                       const QColor &accent) {
   const QSize iconSize(metrics.iconSide, metrics.iconSide);
   const int iconX = topLeft.x() + (metrics.size.width() - metrics.iconSide) / 2;
   const int iconY = topLeft.y();
-  const QPixmap icon = tintedPixmap(metrics.hint.iconPath, iconSize, accent);
+  const qreal devicePixelRatio =
+      painter.device() ? painter.device()->devicePixelRatioF() : qreal(1.0);
+  const QPixmap icon =
+      tintedIconPixmap(QIcon(metrics.hint.iconPath), iconSize, accent, devicePixelRatio);
   if (!icon.isNull()) {
     painter.drawPixmap(iconX, iconY, icon);
   }
@@ -174,7 +155,10 @@ void paintDetailedInstruction(QPainter &painter, const DetailedInstructionLayout
   const int rowLeft = origin.x();
   const int headingTop = origin.y();
   const QSize iconSize(layout.iconSide, layout.iconSide);
-  const QPixmap icon = tintedPixmap(layout.instruction.iconPath, iconSize, accent);
+  const qreal devicePixelRatio =
+      painter.device() ? painter.device()->devicePixelRatioF() : qreal(1.0);
+  const QPixmap icon = tintedIconPixmap(QIcon(layout.instruction.iconPath), iconSize, accent,
+                                        devicePixelRatio);
   if (!icon.isNull()) {
     const int iconY = headingTop + (layout.headingMetrics.height() - layout.iconSide) / 2;
     painter.drawPixmap(rowLeft, iconY, icon);

--- a/src/ui/qt/workarea/RawFileListView.cpp
+++ b/src/ui/qt/workarea/RawFileListView.cpp
@@ -17,7 +17,7 @@
 #include "VGMExport.h"
 
 static const QIcon& fileIcon() {
-  static QIcon fileIcon(":/icons/file.svg");
+  static QIcon fileIcon(":/icons/file-outline.svg");
   return fileIcon;
 }
 

--- a/src/ui/qt/workarea/VGMFileListView.cpp
+++ b/src/ui/qt/workarea/VGMFileListView.cpp
@@ -123,6 +123,7 @@ int VGMFileListModel::columnCount(const QModelIndex &parent) const {
 VGMFileListView::VGMFileListView(QWidget *parent) : TableView(parent) {
   view_model = new VGMFileListModel(this);
   VGMFileListView::setModel(view_model);
+  setIconSize(QSize(16, 16));
 
   setSelectionMode(QAbstractItemView::ExtendedSelection);
   setSelectionBehavior(QAbstractItemView::SelectRows);

--- a/src/ui/qt/workarea/hexview/HexView.cpp
+++ b/src/ui/qt/workarea/hexview/HexView.cpp
@@ -380,8 +380,8 @@ HexView::HexView(VGMFile* vgmfile, QWidget* parent)
   m_rhiHost->show();
 
   const double appFontPointSize = QApplication::font().pointSizeF();
-  QFont font("Roboto Mono", appFontPointSize + 1.0);
-  font.setPointSizeF(appFontPointSize + 1.0);
+  QFont font("Roboto Mono", appFontPointSize);
+  font.setPointSizeF(appFontPointSize);
   setShadowStrength(SHADOW_STRENGTH);
   m_playbackGlowLow = PLAYBACK_GLOW_LOW;
   m_playbackGlowHigh = PLAYBACK_GLOW_HIGH;


### PR DESCRIPTION
This is the first in a series of PRs to improve the app layout. As I did with the RHI HexView rewrite, I have implemented my changes into a single branch (`new-layout`) but split up the result into multiple incremental branches (4) for the sake of creating more digestible PRs.


## The big picture
Here's what the final product looks like:

Mac:
<img width="1061" height="799" alt="image" src="https://github.com/user-attachments/assets/945841c6-329b-4b95-a3d0-cbb64ba69d60" />

Windows 11:

<img width="794" height="561" alt="image" src="https://github.com/user-attachments/assets/0930ecba-4e36-4923-9ff4-865b4372150d" />


Ubuntu 25.10

<img width="2564" height="1798" alt="image" src="https://github.com/user-attachments/assets/1d2856a8-9281-47c5-9f3b-c38ef2f09302" />

(logger isn't enabled by default)

- I am using [QWindowKit](https://github.com/stdware/qwindowkit) to create a custom window bar that contains our playback controls, toggle buttons for the dock views,and the OS chrome - the close/min/max buttons and the app menu on Windows and Linux. This frees up vertical space and decouples the playback controls from the bottom dock. The controls hide in a prioritized way as width shrinks.

- VGMCollView and VGMCollListView are made into separate docks. There is special behavior for VGMCollView when it is docked in the lower left corner so that it resizes vertically and horizontally in sync with both dock areas (left and bottom) and seamlessly transfers to and from the left and bottom docking areas as needed when other docks are closed.

- VGMCollView uses lines and indent to show the relationship of the selected collection to its files.

- VGMCollListView and Logger have their controls integrated into their dock title bar. 

- Docks can be closed via a Hide button that appears on the right end of the title bar when the view is focused or hovered over, visible in "Detected Files" in the screenshot.

- Docks persist their enabled/disabled state and their position and size between app runs, including floating docks. A new "Reset Dock Layout" action is added to the View menu.

- Windows no longer uses the  fusion platform plugin. Windows app font size is increased to make the app visually consistent with other Windows apps. Windows menus are given more spacing for the same reason.

- QListViews and QTableViews are given spacing rules instead of relying on each platform's defaults. This makes appearance more consistent across platforms, and fixes the awful Windows 11 plugin spacing.


## This PR:

- Changes the Windows platform plugin to the Windows native default
- Increases the Windows app font size
- Decreases the HexView app font size (to default) because it felt too big
- Adds gradient parameters to TintableSvgIconEngine (used for Play and Stop buttons)
- Adds helper methods, especially related to colors and ToolBar buttons
- Adds ItemViewDensity.h/.cpp, which defines constants and functions for sizing and spacing the elements of QListViews and QTableViews
- Updates MdiArea and Toast to use the helper methods for generating PixMaps from our svg icons (and also fixes the CTA and Toast blurriness for hidpi displays)
- Updates the RawFile icon to an outlined version for better icon visual consistency

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
