### PR TITLE
Aligned format configurations with contribution guidelines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,13 +15,15 @@ AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: "Yes"
 BasedOnStyle: Google
-ColumnLimit:     100
+BreakBeforeBraces: Attach
+ColumnLimit:     120
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
+InsertBraces:    true
 KeepEmptyLinesAtTheStartOfBlocks: false
 Language:        Cpp
 MaxEmptyLinesToKeep: 1

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ trim_trailing_whitespace = true
 [*.{c,cpp,h}]
 indent_style = space
 insert_final_newline = true
-max_line_length = 100
+max_line_length = 120
 
 [{CMakeLists.txt,*.cmake}]
 indent_style = tab


### PR DESCRIPTION
## Description
This changes `.clang-format` and `.editorconfig` to be more in line with the guidelines described by `CONTRIBUTING.md`

## Motivation and Context
As my editor is set to autorun `clang-format`, a couple contradictions with the coding guidelines emerged:
- Lines should contain no more than 120 characters _(the limit is set to 100)_
- Conditional body must always be wrapped by brackets _(the base Google style allows a few exceptions)_

Plus one rule that might've already been covered, but I added it for *"the docs are already open so why not"* reasons:
- Opening brackets always go on the same line


## How Has This Been Tested?
This was tested by VSCode's automatic `clang-format` runner.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
