### PR TITLE
SuzukiSnes: Percussion support

### DIFF
--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -19,13 +19,15 @@ SuzukiSnesInstrSet::SuzukiSnesInstrSet(RawFile *file,
                                        uint16_t addrVolumeTable,
                                        uint16_t addrADSRTable,
                                        uint16_t addrTuningTable,
+                                       uint16_t addrDrumKitTable,
                                        const std::string &name) :
     VGMInstrSet(SuzukiSnesFormat::name, file, addrSRCNTable, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrSRCNTable(addrSRCNTable),
     addrVolumeTable(addrVolumeTable),
     addrADSRTable(addrADSRTable),
-    addrTuningTable(addrTuningTable) {
+    addrTuningTable(addrTuningTable),
+    addrDrumKitTable(addrDrumKitTable) {
 }
 
 SuzukiSnesInstrSet::~SuzukiSnesInstrSet() {}
@@ -90,6 +92,11 @@ bool SuzukiSnesInstrSet::parseInstrPointers() {
     return false;
   }
 
+  if (addrDrumKitTable && readShort(addrDrumKitTable) >= 0x80) {
+    SuzukiSnesDrumKit *newDrumKitInstr = new SuzukiSnesDrumKit(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrTuningTable, addrADSRTable, addrDrumKitTable, "Drum Kit");
+    aInstrs.push_back(newDrumKitInstr);
+  }
+
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
   SNESSampColl *newSampColl = new SNESSampColl(SuzukiSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
   if (!newSampColl->loadVGMFile()) {
@@ -138,55 +145,163 @@ bool SuzukiSnesInstr::loadInstr() {
 
   uint16_t addrSampStart = readShort(offDirEnt);
 
-  SuzukiSnesRgn *rgn = new SuzukiSnesRgn(this,
-                                         version,
-                                         instrNum,
-                                         spcDirAddr,
-                                         addrSRCNTable,
-                                         addrVolumeTable,
-                                         addrADSRTable,
-                                         addrTuningTable);
+  SuzukiSnesRgn *rgn = new SuzukiSnesRgn(this, version, addrSRCNTable);
   rgn->sampOffset = addrSampStart - spcDirAddr;
+  rgn->initializeNonPercussionRegion(instrNum, addrVolumeTable);
+  rgn->initializeCommonRegion(srcn, spcDirAddr, addrADSRTable, addrTuningTable);
+  rgn->loadRgn();
   addRgn(rgn);
 
   setGuessedLength();
   return true;
 }
 
+// *****************
+// SuzukiSnesDrumKit
+// *****************
+
+SuzukiSnesDrumKit::SuzukiSnesDrumKit(VGMInstrSet *instrSet,
+                                     SuzukiSnesVersion ver,
+                                     uint32_t programNum,
+                                     uint32_t spcDirAddr,
+                                     uint16_t addrTuningTable,
+                                     uint16_t addrADSRTable,
+                                     uint16_t addrDrumKitTable,
+                                     const std::string &name) :
+  VGMInstr(instrSet, addrTuningTable, 0, programNum >> 7, programNum & 0x7F, name), version(ver),
+  spcDirAddr(spcDirAddr),
+  addrTuningTable(addrTuningTable),
+  addrADSRTable(addrADSRTable),
+  addrDrumKitTable(addrDrumKitTable) {
+}
+
+SuzukiSnesDrumKit::~SuzukiSnesDrumKit() {
+}
+
+bool SuzukiSnesDrumKit::loadInstr() {
+  uint16_t addr = addrDrumKitTable;
+
+  for (uint16_t i = addr; i < 0x80; i += 5) {
+    SuzukiSnesDrumKitRgn *rgn = new SuzukiSnesDrumKitRgn(this, version, addrDrumKitTable);
+
+    if (!rgn->initializePercussionRegion(i, spcDirAddr, addrADSRTable, addrTuningTable)) {
+      delete rgn;
+      continue;
+    }
+    if (!rgn->loadRgn()) {
+      delete rgn;
+      return false;
+    }
+
+    uint32_t rgnOffDirEnt = spcDirAddr + (rgn->sampNum * 4);
+    if (rgnOffDirEnt + 4 > 0x10000) {
+      delete rgn;
+      return false;
+    }
+
+    uint16_t addrSampStart = readShort(rgnOffDirEnt);
+
+    rgn->sampOffset = addrSampStart - spcDirAddr;
+
+    addRgn(rgn);
+  }
+
+  setGuessedLength();
+  return true;
+}
+
+
 // *************
 // SuzukiSnesRgn
 // *************
 
-SuzukiSnesRgn::SuzukiSnesRgn(SuzukiSnesInstr *instr,
+SuzukiSnesRgn::SuzukiSnesRgn(VGMInstr *instr,
                              SuzukiSnesVersion ver,
-                             uint8_t instrNum,
-                             uint32_t spcDirAddr,
-                             uint16_t addrSRCNTable,
-                             uint16_t addrVolumeTable,
-                             uint16_t addrADSRTable,
-                             uint16_t addrTuningTable) :
+                             uint16_t addrSRCNTable) :
     VGMRgn(instr, addrSRCNTable, 0),
     version(ver) {
+}
+
+bool SuzukiSnesRgn::initializeNonPercussionRegion(uint8_t instrNum, uint16_t addrVolumeTable) {
+  uint16_t addrSRCNTable = offset();
   uint8_t srcn = readByte(addrSRCNTable + instrNum);
   uint8_t vol = readByte(addrVolumeTable + srcn * 2);
+  addSampNum(srcn, addrSRCNTable + instrNum, 1);
+  addVolume(vol / 256.0, addrVolumeTable + srcn * 2, 1);
+  return true;
+}
+
+bool SuzukiSnesRgn::initializeCommonRegion(uint8_t srcn,
+                                           uint32_t /*spcDirAddr*/,
+                                           uint16_t addrADSRTable,
+                                           uint16_t addrTuningTable) {
   uint8_t adsr1 = readByte(addrADSRTable + srcn * 2);
   uint8_t adsr2 = readByte(addrADSRTable + srcn * 2 + 1);
   uint8_t fine_tuning = readByte(addrTuningTable + srcn * 2);
   int8_t coarse_tuning = readByte(addrTuningTable + srcn * 2 + 1);
 
-  addSampNum(srcn, addrSRCNTable + instrNum, 1);
   addChild(addrADSRTable + srcn * 2, 1, "ADSR1");
   addChild(addrADSRTable + srcn * 2 + 1, 1, "ADSR2");
   addFineTune((int16_t) (fine_tuning / 256.0 * 100.0), addrTuningTable + srcn * 2, 1);
   addUnityKey(69 - coarse_tuning, addrTuningTable + srcn * 2 + 1, 1);
-  addVolume(vol / 256.0, addrVolumeTable + srcn * 2, 1);
   snesConvADSR<VGMRgn>(this, adsr1, adsr2, 0);
 
-  setGuessedLength();
+  return true;
 }
+
 
 SuzukiSnesRgn::~SuzukiSnesRgn() {}
 
 bool SuzukiSnesRgn::loadRgn() {
+  setGuessedLength();
+
   return true;
 }
+
+// ********************
+// SuzukiSnesDrumKitRgn
+// ********************
+
+SuzukiSnesDrumKitRgn::SuzukiSnesDrumKitRgn(SuzukiSnesDrumKit *instr,
+                                           SuzukiSnesVersion ver,
+                                           uint16_t addrDrumKitTable) :
+  SuzukiSnesRgn(instr, ver, addrDrumKitTable) {}
+
+bool SuzukiSnesDrumKitRgn::initializePercussionRegion(uint16_t noteOffset,
+                                                      uint32_t spcDirAddr,
+                                                      uint16_t addrADSRTable,
+                                                      uint16_t addrTuningTable)
+{
+  uint16_t srcnOffset = noteOffset + 1;
+  uint16_t keyOffset = noteOffset + 2;
+  uint16_t volumeOffset = noteOffset + 3;
+  uint16_t panOffset = noteOffset + 4;
+
+  uint8_t instrumentIndex = readByte(srcnOffset);
+
+  if (instrumentIndex == 0 || instrumentIndex == 0xFF) {
+    return false;
+  }
+  initializeCommonRegion(instrumentIndex, spcDirAddr, addrADSRTable, addrTuningTable);
+
+  uint8_t percussionIndex = readByte(noteOffset);
+  setName(fmt::format("Drum {}", percussionIndex));
+  keyLow = keyHigh = percussionIndex + KEY_BIAS;
+
+  // sampNum is absolute key to play
+  unityKey = (unityKey + KEY_BIAS) - readByte(keyOffset) + percussionIndex;
+
+  addSampNum(sampNum, srcnOffset);
+  addChild(keyOffset, 1, "Key");
+
+  addVolume(readByte(volumeOffset) / 256.0, volumeOffset, 1);
+
+  uint8_t panValue = readByte(panOffset);
+  if (panValue < 0x80) {
+    addPan(panValue, panOffset);
+  }
+
+  return true;
+}
+
+SuzukiSnesDrumKitRgn::~SuzukiSnesDrumKitRgn() {}

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -291,7 +291,7 @@ bool SuzukiSnesDrumKitRgn::initializePercussionRegion(uint16_t noteOffset,
   // sampNum is absolute key to play
   unityKey = (unityKey + KEY_BIAS) - readByte(keyOffset) + percussionIndex;
 
-  addSampNum(sampNum, srcnOffset);
+  addSampNum(instrumentIndex, srcnOffset);
   addChild(keyOffset, 1, "Key");
 
   addVolume(readByte(volumeOffset) / 256.0, volumeOffset, 1);

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -93,7 +93,8 @@ bool SuzukiSnesInstrSet::parseInstrPointers() {
   }
 
   if (addrDrumKitTable && readShort(addrDrumKitTable) >= 0x80) {
-    SuzukiSnesDrumKit *newDrumKitInstr = new SuzukiSnesDrumKit(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrTuningTable, addrADSRTable, addrDrumKitTable, "Drum Kit");
+    SuzukiSnesDrumKit *newDrumKitInstr = new SuzukiSnesDrumKit(this, version, DRUMKIT_PROGRAM,
+      spcDirAddr, addrSRCNTable, addrTuningTable, addrADSRTable, addrDrumKitTable, "Drum Kit");
     aInstrs.push_back(newDrumKitInstr);
   }
 
@@ -164,12 +165,14 @@ SuzukiSnesDrumKit::SuzukiSnesDrumKit(VGMInstrSet *instrSet,
                                      SuzukiSnesVersion ver,
                                      uint32_t programNum,
                                      uint32_t spcDirAddr,
+                                     uint16_t addrSRCNTable,
                                      uint16_t addrTuningTable,
                                      uint16_t addrADSRTable,
                                      uint16_t addrDrumKitTable,
                                      const std::string &name) :
   VGMInstr(instrSet, addrDrumKitTable, 0, programNum >> 7, programNum & 0x7F, name), version(ver),
   spcDirAddr(spcDirAddr),
+  addrSRCNTable(addrSRCNTable),
   addrTuningTable(addrTuningTable),
   addrADSRTable(addrADSRTable),
   addrDrumKitTable(addrDrumKitTable) {
@@ -184,7 +187,7 @@ bool SuzukiSnesDrumKit::loadInstr() {
   for (uint16_t i = addr; readByte(i) < 0x80; i += 5) {
     SuzukiSnesDrumKitRgn *rgn = new SuzukiSnesDrumKitRgn(this, version, addrDrumKitTable);
 
-    if (!rgn->initializePercussionRegion(i, spcDirAddr, addrADSRTable, addrTuningTable)) {
+    if (!rgn->initializePercussionRegion(i, spcDirAddr, addrSRCNTable, addrADSRTable, addrTuningTable)) {
       delete rgn;
       continue;
     }
@@ -269,20 +272,20 @@ SuzukiSnesDrumKitRgn::SuzukiSnesDrumKitRgn(SuzukiSnesDrumKit *instr,
 
 bool SuzukiSnesDrumKitRgn::initializePercussionRegion(uint16_t noteOffset,
                                                       uint32_t spcDirAddr,
+                                                      uint16_t addrSRCNTable,
                                                       uint16_t addrADSRTable,
                                                       uint16_t addrTuningTable)
 {
-  uint16_t srcnOffset = noteOffset + 1;
+  uint16_t instrOffset = noteOffset + 1;
   uint16_t keyOffset = noteOffset + 2;
   uint16_t volumeOffset = noteOffset + 3;
   uint16_t panOffset = noteOffset + 4;
 
-  uint8_t instrumentIndex = readByte(srcnOffset);
+  uint8_t instrNum = readByte(instrOffset);
+  addChild(instrOffset, 1, "Instrument");
 
-  if (instrumentIndex == 0 || instrumentIndex == 0xFF) {
-    return false;
-  }
-  initializeCommonRegion(instrumentIndex, spcDirAddr, addrADSRTable, addrTuningTable);
+  uint8_t srcn = readByte(addrSRCNTable + instrNum);
+  initializeCommonRegion(srcn, spcDirAddr, addrADSRTable, addrTuningTable);
 
   uint8_t percussionIndex = readByte(noteOffset);
   setName(fmt::format("Drum {}", percussionIndex));
@@ -291,7 +294,7 @@ bool SuzukiSnesDrumKitRgn::initializePercussionRegion(uint16_t noteOffset,
   // sampNum is absolute key to play
   unityKey = (unityKey + KEY_BIAS) - readByte(keyOffset) + percussionIndex;
 
-  addSampNum(instrumentIndex, srcnOffset);
+  addSampNum(srcn, addrSRCNTable + instrNum, 1);
   addChild(keyOffset, 1, "Key");
 
   addVolume(readByte(volumeOffset) / 256.0, volumeOffset, 1);

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -92,7 +92,7 @@ bool SuzukiSnesInstrSet::parseInstrPointers() {
     return false;
   }
 
-  if (addrDrumKitTable && readShort(addrDrumKitTable) >= 0x80) {
+  if (addrDrumKitTable && readByte(addrDrumKitTable) >= 0x80) {
     SuzukiSnesDrumKit *newDrumKitInstr = new SuzukiSnesDrumKit(this, version, DRUMKIT_PROGRAM,
       spcDirAddr, addrSRCNTable, addrTuningTable, addrADSRTable, addrDrumKitTable, "Drum Kit");
     aInstrs.push_back(newDrumKitInstr);

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -21,7 +21,7 @@ SuzukiSnesInstrSet::SuzukiSnesInstrSet(RawFile *file,
                                        uint16_t addrTuningTable,
                                        uint16_t addrDrumKitTable,
                                        const std::string &name) :
-    VGMInstrSet(SuzukiSnesFormat::name, file, addrSRCNTable, 0, name), version(ver),
+    VGMInstrSet(SuzukiSnesFormat::name, file, addrDrumKitTable, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrSRCNTable(addrSRCNTable),
     addrVolumeTable(addrVolumeTable),
@@ -168,7 +168,7 @@ SuzukiSnesDrumKit::SuzukiSnesDrumKit(VGMInstrSet *instrSet,
                                      uint16_t addrADSRTable,
                                      uint16_t addrDrumKitTable,
                                      const std::string &name) :
-  VGMInstr(instrSet, addrTuningTable, 0, programNum >> 7, programNum & 0x7F, name), version(ver),
+  VGMInstr(instrSet, addrDrumKitTable, 0, programNum >> 7, programNum & 0x7F, name), version(ver),
   spcDirAddr(spcDirAddr),
   addrTuningTable(addrTuningTable),
   addrADSRTable(addrADSRTable),
@@ -181,7 +181,7 @@ SuzukiSnesDrumKit::~SuzukiSnesDrumKit() {
 bool SuzukiSnesDrumKit::loadInstr() {
   uint16_t addr = addrDrumKitTable;
 
-  for (uint16_t i = addr; i < 0x80; i += 5) {
+  for (uint16_t i = addr; readByte(i) < 0x80; i += 5) {
     SuzukiSnesDrumKitRgn *rgn = new SuzukiSnesDrumKitRgn(this, version, addrDrumKitTable);
 
     if (!rgn->initializePercussionRegion(i, spcDirAddr, addrADSRTable, addrTuningTable)) {

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -92,7 +92,7 @@ bool SuzukiSnesInstrSet::parseInstrPointers() {
     return false;
   }
 
-  if (addrDrumKitTable && readByte(addrDrumKitTable) >= 0x80) {
+  if (addrDrumKitTable && readByte(addrDrumKitTable) < 0x80) {
     SuzukiSnesDrumKit *newDrumKitInstr = new SuzukiSnesDrumKit(this, version, DRUMKIT_PROGRAM,
       spcDirAddr, addrSRCNTable, addrTuningTable, addrADSRTable, addrDrumKitTable, "Drum Kit");
     aInstrs.push_back(newDrumKitInstr);

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.h
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.h
@@ -11,6 +11,8 @@
 class SuzukiSnesInstrSet:
     public VGMInstrSet {
  public:
+  static constexpr uint32_t DRUMKIT_PROGRAM = (0x7F << 7);
+
   SuzukiSnesInstrSet(RawFile *file,
                      SuzukiSnesVersion ver,
                      uint32_t spcDirAddr,
@@ -18,6 +20,7 @@ class SuzukiSnesInstrSet:
                      uint16_t addrVolumeTable,
                      uint16_t addrADSRTable,
                      uint16_t addrTuningTable,
+                     uint16_t addrDrumKitTable,
                      const std::string &name = "SuzukiSnesInstrSet");
   virtual ~SuzukiSnesInstrSet();
 
@@ -32,6 +35,7 @@ class SuzukiSnesInstrSet:
   uint16_t addrVolumeTable;
   uint16_t addrTuningTable;
   uint16_t addrADSRTable;
+  uint16_t addrDrumKitTable;
   std::vector<uint8_t> usedSRCNs;
 };
 
@@ -65,6 +69,34 @@ class SuzukiSnesInstr
   uint16_t addrADSRTable;
 };
 
+// *****************
+// SuzukiSnesDrumKit
+// *****************
+
+class SuzukiSnesDrumKit
+  : public VGMInstr {
+public:
+  SuzukiSnesDrumKit(VGMInstrSet *instrSet,
+                    SuzukiSnesVersion ver,
+                    uint32_t programNum,
+                    uint32_t spcDirAddr,
+                    uint16_t addrTuningTable,
+                    uint16_t addrADSRTable,
+                    uint16_t addrDrumKitTable,
+                  const std::string &name = "SuzukiSnesDrumKit");
+  ~SuzukiSnesDrumKit() override;
+
+  bool loadInstr() override;
+
+  SuzukiSnesVersion version;
+
+protected:
+  uint32_t spcDirAddr;
+  uint16_t addrTuningTable;
+  uint16_t addrADSRTable;
+  uint16_t addrDrumKitTable;
+};
+
 // *************
 // SuzukiSnesRgn
 // *************
@@ -72,17 +104,42 @@ class SuzukiSnesInstr
 class SuzukiSnesRgn
     : public VGMRgn {
  public:
-  SuzukiSnesRgn(SuzukiSnesInstr *instr,
+  SuzukiSnesRgn(VGMInstr *instr,
                 SuzukiSnesVersion ver,
-                uint8_t instrNum,
-                uint32_t spcDirAddr,
-                uint16_t addrSRCNTable,
-                uint16_t addrVolumeTable,
-                uint16_t addrADSRTable,
-                uint16_t addrTuningTable);
-  virtual ~SuzukiSnesRgn();
+                uint16_t addrSRCNTable);
+   virtual ~SuzukiSnesRgn();
 
+  bool initializeCommonRegion(uint8_t srcn,
+                              uint32_t spcDirAddr,
+                              uint16_t addrADSRTable,
+                              uint16_t addrTuningTable);
+  bool initializeNonPercussionRegion(uint8_t instrNum, uint16_t addrVolumeTable);
   virtual bool loadRgn();
 
   SuzukiSnesVersion version;
+};
+
+// ********************
+// SuzukiSnesDrumKitRgn
+// ********************
+
+class SuzukiSnesDrumKitRgn
+  : public SuzukiSnesRgn {
+public:
+  // We need some space to move for unityKey, since we might need it to go
+  // less than the current note, so we add this to all the percussion notes.
+  // This value can be anything from 0 to 127, but being near the middle of
+  // the range gives it a decent chance of not going out of range in either
+  // direction.
+  static constexpr uint8_t KEY_BIAS = 60;
+
+  SuzukiSnesDrumKitRgn(SuzukiSnesDrumKit *instr,
+                       SuzukiSnesVersion ver,
+                       uint16_t addrDrumKitTable);
+  ~SuzukiSnesDrumKitRgn() override;
+
+  bool initializePercussionRegion(uint16_t noteOffset,
+                                  uint32_t spcDirAddr,
+                                  uint16_t addrADSRTable,
+                                  uint16_t addrTuningTable);
 };

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.h
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.h
@@ -80,6 +80,7 @@ public:
                     SuzukiSnesVersion ver,
                     uint32_t programNum,
                     uint32_t spcDirAddr,
+                    uint16_t addrSRCNTable,
                     uint16_t addrTuningTable,
                     uint16_t addrADSRTable,
                     uint16_t addrDrumKitTable,
@@ -92,6 +93,7 @@ public:
 
 protected:
   uint32_t spcDirAddr;
+  uint16_t addrSRCNTable;
   uint16_t addrTuningTable;
   uint16_t addrADSRTable;
   uint16_t addrDrumKitTable;
@@ -140,6 +142,7 @@ public:
 
   bool initializePercussionRegion(uint16_t noteOffset,
                                   uint32_t spcDirAddr,
+                                  uint16_t addrSRCNTable,
                                   uint16_t addrADSRTable,
                                   uint16_t addrTuningTable);
 };

--- a/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
@@ -215,7 +215,6 @@ void SuzukiSnesScanner::searchForSuzukiSnesFromARAM(RawFile *file) {
     addrVolumeTable = file->readShort(ofsLoadInstr + 10);
     addrADSRTable = file->readShort(ofsLoadInstr + 18);
     addrTuningTable = file->readShort(ofsLoadInstr + 30);
-    // TODO find out where SD3 stores percussion instruments
     addrDrumKitTable = version != SUZUKISNES_SD3 ? addrSeqHeader : 0;
   } else {
     return;

--- a/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
@@ -209,17 +209,20 @@ void SuzukiSnesScanner::searchForSuzukiSnesFromARAM(RawFile *file) {
   uint16_t addrVolumeTable;
   uint16_t addrTuningTable;
   uint16_t addrADSRTable;
+  uint16_t addrDrumKitTable;
   if (file->searchBytePattern(ptnLoadInstr, ofsLoadInstr)) {
     addrSRCNTable = file->readShort(ofsLoadInstr + 5);
     addrVolumeTable = file->readShort(ofsLoadInstr + 10);
     addrADSRTable = file->readShort(ofsLoadInstr + 18);
     addrTuningTable = file->readShort(ofsLoadInstr + 30);
+    // TODO find out where SD3 stores percussion instruments
+    addrDrumKitTable = version != SUZUKISNES_SD3 ? addrSeqHeader : 0;
   } else {
     return;
   }
 
   SuzukiSnesInstrSet *newInstrSet =
-      new SuzukiSnesInstrSet(file, version, spcDirAddr, addrSRCNTable, addrVolumeTable, addrADSRTable, addrTuningTable);
+      new SuzukiSnesInstrSet(file, version, spcDirAddr, addrSRCNTable, addrVolumeTable, addrADSRTable, addrTuningTable, addrDrumKitTable);
   if (!newInstrSet->loadVGMFile()) {
     delete newInstrSet;
     return;

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
@@ -58,10 +58,12 @@ bool SuzukiSnesSeq::parseHeader() {
         curOffset++;
         break;
       }
-      else {
-        header->addChild(curOffset, 5, "Percussion");
-        curOffset += 5;
-      }
+      auto drum = header->addChild(curOffset, 5, "Percussion");
+      drum->addChild(curOffset++, 1, "Note Index");
+      drum->addChild(curOffset++, 1, "Base Instrument");
+      drum->addChild(curOffset++, 1, "Key");
+      drum->addChild(curOffset++, 1, "Volume");
+      drum->addChild(curOffset++, 1, "Pan");
     }
   }
 

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
@@ -1,5 +1,4 @@
 #include "SuzukiSnesSeq.h"
-
 #include "SuzukiSnesInstr.h"
 #include "spdlog/fmt/fmt.h"
 

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
@@ -1,4 +1,6 @@
 #include "SuzukiSnesSeq.h"
+
+#include "SuzukiSnesInstr.h"
 #include "spdlog/fmt/fmt.h"
 
 DECLARE_FORMAT(SuzukiSnes);
@@ -44,7 +46,7 @@ bool SuzukiSnesSeq::parseHeader() {
   VGMHeader *header = addHeader(offset(), 0);
   uint32_t curOffset = offset();
 
-  // skip unknown stream
+  // percussion table is actually parsed by SuzukiSnesDrumKit instead
   if (version != SUZUKISNES_SD3) {
     while (true) {
       if (curOffset + 1 >= 0x10000) {
@@ -53,12 +55,12 @@ bool SuzukiSnesSeq::parseHeader() {
 
       uint8_t firstByte = readByte(curOffset);
       if (firstByte >= 0x80) {
-        header->addChild(curOffset, 1, "Unknown Items End");
+        header->addChild(curOffset, 1, "Percussion End");
         curOffset++;
         break;
       }
       else {
-        header->addUnknownChild(curOffset, 5);
+        header->addChild(curOffset, 5, "Percussion");
         curOffset += 5;
       }
     }
@@ -212,6 +214,8 @@ void SuzukiSnesTrack::resetVars() {
   spcVolume = 100;
   loopLevel = 0;
   infiniteLoopPoint = 0;
+  percussion = false;
+  nonPercussionProgram = 0;
 }
 
 bool SuzukiSnesTrack::readEvent() {
@@ -293,9 +297,11 @@ bool SuzukiSnesTrack::readEvent() {
       if (noteIndex < 12) {
         uint8_t note = octave * 12 + noteIndex;
 
-        // TODO: percussion note
-
-        addNoteByDur(beginOffset, curOffset - beginOffset, note, NOTE_VELOCITY, dur);
+        if (percussion) {
+          addNoteByDur(beginOffset, curOffset - beginOffset, noteIndex + SuzukiSnesDrumKitRgn::KEY_BIAS - transpose, NOTE_VELOCITY, dur, "Percussion Note with Duration");
+        } else {
+          addNoteByDur(beginOffset, curOffset - beginOffset, note, NOTE_VELOCITY, dur);
+        }
         addTime(dur);
       }
       else if (noteIndex == 13) {
@@ -558,6 +564,7 @@ bool SuzukiSnesTrack::readEvent() {
     case EVENT_PROGCHANGE: {
       uint8_t newProg = readByte(curOffset++);
       addProgramChange(beginOffset, curOffset - beginOffset, newProg);
+      nonPercussionProgram = newProg;
       break;
     }
 
@@ -661,11 +668,15 @@ bool SuzukiSnesTrack::readEvent() {
 
     case EVENT_PERC_ON: {
       addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion On", desc, Type::UseDrumKit);
+      percussion = true;
+      addProgramChangeNoItem(SuzukiSnesInstrSet::DRUMKIT_PROGRAM, true);
       break;
     }
 
     case EVENT_PERC_OFF: {
       addGenericEvent(beginOffset, curOffset - beginOffset, "Percussion Off", desc, Type::UseDrumKit);
+      percussion = false;
+      addProgramChangeNoItem(nonPercussionProgram, true);
       break;
     }
 

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.h
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.h
@@ -106,6 +106,8 @@ class SuzukiSnesTrack
   uint16_t infiniteLoopPoint;
 
   uint8_t spcVolume;
+  bool percussion;
+  uint8_t nonPercussionProgram;
 
   uint8_t loopLevel;
   uint8_t loopCount[SUZUKISNES_LOOP_LEVEL_MAX];


### PR DESCRIPTION
Reads percussion data on SPC files which use the Hidenori Suzuki driver (late Square titles, e.g. Super Mario RPG).

## Description
There is already a Square driver with dedicated percussion support (the Chrono Trigger iteration of AkaoV4), so it was assumed they work similarly. As [the Lazy Shell tool](https://github.com/Yakibomb/LAZYSHELL-UPDATED) features a sound editor, the data format could be deduced from it and a solution devised with ~a blatant copy/paste job over~ AkaoSnes as a basis.

## Motivation and Context
The lack of support makes any attempted conversions not only incomplete but outright _grating_ to listen to, which made me open #178 a few years ago.

## How Has This Been Tested?
With the Super Mario RPG and Bahamut Lagoon soundtracks from snesmusic.org (Trials of Mana was also used as a sanity check to ensure things don't break, as it lacks a percussion program).

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
