### PR TITLE
CI: add CLI and shell Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,6 +250,8 @@ jobs:
           # Windows users get frightened at the sight of GNU directories.
           cmake --preset win-${{ matrix.target }} `
             -DINSTALL_CHANGELOG=ON `
+            -DINSTALL_CLI=ON `
+            -DINSTALL_SHELL=ON `
             -DQT_DEBUG_FIND_PACKAGE=${{runner.debug == '1' && 'ON' || 'OFF' }} `
             -DCMAKE_VERBOSE_MAKEFILE=${{runner.debug == '1' && 'ON' || 'OFF' }} `
             -DCMAKE_FIND_DEBUG_MODE=${{runner.debug == '1' && 'ON' || 'OFF' }} `
@@ -262,7 +264,7 @@ jobs:
          run: |
            cmake --build `
             --preset win-${{ matrix.target }}-release `
-            --target vgmtrans vgmtrans-shell
+            --target vgmtrans vgmtrans-cli vgmtrans-shell
 
        - name: "Package project"
          run: |

--- a/src/ui/cli/CMakeLists.txt
+++ b/src/ui/cli/CMakeLists.txt
@@ -6,6 +6,11 @@ target_sources(vgmtrans-cli
 )
 
 target_include_directories(vgmtrans-cli PUBLIC "${PROJECT_BINARY_DIR}/src")
-
 target_link_libraries(vgmtrans-cli PRIVATE vgmtranscore)
 target_compile_features(vgmtrans-cli PRIVATE cxx_std_20)
+
+if(INSTALL_CLI)
+  install(TARGETS vgmtrans-cli
+          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  )
+endif()


### PR DESCRIPTION
Added cli and shell builds on CI

## Description
The only easily accessible windows build is the GUI one, I updated the CI to also build the shell and CLI versions to make them easier to get online

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I needed a Windows CLI build and couldn't find one without having to build it myself

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the pipeline in my fork and it the build stage worked and I got the 3 .exe in the artifact's zip

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
