### PR TITLE
Fix SuzukiSnes drumkit handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Added an in-app dialog to help with reporting bugs.
 - Added Flatpak builds for Linux. From now on, stable releases will be automatically available on Flathub.
+- Added Drum Kit support to the SuzukiSnes driver (Seiken Densetsu 3, Super Mario RPG, etc)
 
 ### Changed
 

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -5,7 +5,10 @@
  */
 
 #include "SuzukiSnesInstr.h"
+#include "SuzukiSnesSeq.h"
 #include "SNESDSP.h"
+#include "VGMColl.h"
+#include <algorithm>
 #include <spdlog/fmt/fmt.h>
 
 // ******************
@@ -19,15 +22,13 @@ SuzukiSnesInstrSet::SuzukiSnesInstrSet(RawFile *file,
                                        uint16_t addrVolumeTable,
                                        uint16_t addrADSRTable,
                                        uint16_t addrTuningTable,
-                                       uint16_t addrDrumKitTable,
                                        const std::string &name) :
-    VGMInstrSet(SuzukiSnesFormat::name, file, addrDrumKitTable, 0, name), version(ver),
+    VGMInstrSet(SuzukiSnesFormat::name, file, addrSRCNTable, 0, name), version(ver),
     spcDirAddr(spcDirAddr),
     addrSRCNTable(addrSRCNTable),
     addrVolumeTable(addrVolumeTable),
     addrADSRTable(addrADSRTable),
-    addrTuningTable(addrTuningTable),
-    addrDrumKitTable(addrDrumKitTable) {
+    addrTuningTable(addrTuningTable) {
 }
 
 bool SuzukiSnesInstrSet::parseHeader() {
@@ -104,6 +105,60 @@ bool SuzukiSnesInstrSet::parseInstrPointers() {
   }
 
   return true;
+}
+
+void SuzukiSnesInstrSet::useColl(const VGMColl* coll) {
+  if (coll == nullptr || version == SUZUKISNES_SD3 || coll->seq() == nullptr) {
+    return;
+  }
+
+  const auto* seq = dynamic_cast<const SuzukiSnesSeq*>(coll->seq());
+  if (seq == nullptr || seq->rawFile() != rawFile() || seq->version != version) {
+    return;
+  }
+
+  auto* drumKit = new SuzukiSnesDrumKit(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrSRCNTable,
+                                        addrTuningTable, addrADSRTable,
+                                        static_cast<uint16_t>(seq->offset()), "Drum Kit");
+  if (!drumKit->loadInstr()) {
+    delete drumKit;
+    return;
+  }
+
+  std::vector<uint8_t> extraSRCNs;
+  extraSRCNs.reserve(drumKit->regions().size());
+  for (auto* vgmRgn : drumKit->regions()) {
+    auto* rgn = dynamic_cast<SuzukiSnesRgn*>(vgmRgn);
+    if (rgn == nullptr) {
+      continue;
+    }
+
+    const auto srcn = static_cast<uint8_t>(rgn->sampNum);
+    if (std::binary_search(usedSRCNs.begin(), usedSRCNs.end(), srcn) ||
+        std::find(extraSRCNs.begin(), extraSRCNs.end(), srcn) != extraSRCNs.end()) {
+      continue;
+    }
+
+    extraSRCNs.push_back(srcn);
+  }
+
+  if (!extraSRCNs.empty()) {
+    auto* tempSampColl = new SNESSampColl(SuzukiSnesFormat::name, this, spcDirAddr, extraSRCNs);
+    if (!addTempSampColl(tempSampColl)) {
+      delete drumKit;
+      return;
+    }
+
+    for (auto* vgmRgn : drumKit->regions()) {
+      auto* rgn = dynamic_cast<SuzukiSnesRgn*>(vgmRgn);
+      if (rgn != nullptr &&
+          std::find(extraSRCNs.begin(), extraSRCNs.end(), static_cast<uint8_t>(rgn->sampNum)) != extraSRCNs.end()) {
+        rgn->sampCollPtr = tempSampColl;
+      }
+    }
+  }
+
+  addTempInstr(drumKit);
 }
 
 // ***************

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -8,8 +8,12 @@
 #include "SuzukiSnesSeq.h"
 #include "SNESDSP.h"
 #include "VGMColl.h"
-#include <algorithm>
 #include <spdlog/fmt/fmt.h>
+
+namespace {
+constexpr uint8_t kSuzukiSnesSrcnCount = 0x40;
+constexpr uint16_t kSuzukiSnesSd3DrumKitOffset = 16;
+}
 
 // ******************
 // SuzukiSnesInstrSet
@@ -36,14 +40,13 @@ bool SuzukiSnesInstrSet::parseHeader() {
 }
 
 bool SuzukiSnesInstrSet::parseInstrPointers() {
-  usedSRCNs.clear();
   for (uint8_t instrNum = 0; instrNum <= 0x7f; instrNum++) {
     uint32_t ofsSRCNEntry = addrSRCNTable + instrNum;
     if (ofsSRCNEntry + 1 > 0x10000) {
       continue;
     }
     uint8_t srcn = readByte(ofsSRCNEntry);
-    if (srcn >= 0x40) {
+    if (srcn >= kSuzukiSnesSrcnCount) {
       continue;
     }
 
@@ -80,8 +83,6 @@ bool SuzukiSnesInstrSet::parseInstrPointers() {
       continue;
     }
 
-    usedSRCNs.push_back(srcn);
-
     SuzukiSnesInstr *newInstr = new SuzukiSnesInstr(
       this, version, instrNum, spcDirAddr, addrSRCNTable, addrVolumeTable, addrADSRTable,
       addrTuningTable, fmt::format("Instrument: {:#x}", srcn));
@@ -91,14 +92,9 @@ bool SuzukiSnesInstrSet::parseInstrPointers() {
     return false;
   }
 
-  if (addrDrumKitTable && readByte(addrDrumKitTable) < 0x80) {
-    SuzukiSnesDrumKit *newDrumKitInstr = new SuzukiSnesDrumKit(this, version, DRUMKIT_PROGRAM,
-      spcDirAddr, addrSRCNTable, addrTuningTable, addrADSRTable, addrDrumKitTable, "Drum Kit");
-    aInstrs.push_back(newDrumKitInstr);
-  }
-
-  std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(SuzukiSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
+  // Load all valid Suzuki sample slots so conversion-time drumkits can reuse the base sample collection.
+  SNESSampColl *newSampColl = new SNESSampColl(
+      SuzukiSnesFormat::name, this->rawFile(), spcDirAddr, kSuzukiSnesSrcnCount);
   if (!newSampColl->loadVGMFile()) {
     delete newSampColl;
     return false;
@@ -108,7 +104,7 @@ bool SuzukiSnesInstrSet::parseInstrPointers() {
 }
 
 void SuzukiSnesInstrSet::useColl(const VGMColl* coll) {
-  if (coll == nullptr || version == SUZUKISNES_SD3 || coll->seq() == nullptr) {
+  if (coll == nullptr || coll->seq() == nullptr) {
     return;
   }
 
@@ -117,45 +113,19 @@ void SuzukiSnesInstrSet::useColl(const VGMColl* coll) {
     return;
   }
 
-  auto* drumKit = new SuzukiSnesDrumKit(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrSRCNTable,
-                                        addrTuningTable, addrADSRTable,
-                                        static_cast<uint16_t>(seq->offset()), "Drum Kit");
-  if (!drumKit->loadInstr()) {
-    delete drumKit;
+  uint16_t addrDrumKitTable = static_cast<uint16_t>(seq->offset());
+  if (version == SUZUKISNES_SD3) {
+    addrDrumKitTable += kSuzukiSnesSd3DrumKitOffset;
+  }
+  if (readByte(addrDrumKitTable) >= 0x80) {
     return;
   }
 
-  std::vector<uint8_t> extraSRCNs;
-  extraSRCNs.reserve(drumKit->regions().size());
-  for (auto* vgmRgn : drumKit->regions()) {
-    auto* rgn = dynamic_cast<SuzukiSnesRgn*>(vgmRgn);
-    if (rgn == nullptr) {
-      continue;
-    }
-
-    const auto srcn = static_cast<uint8_t>(rgn->sampNum);
-    if (std::binary_search(usedSRCNs.begin(), usedSRCNs.end(), srcn) ||
-        std::find(extraSRCNs.begin(), extraSRCNs.end(), srcn) != extraSRCNs.end()) {
-      continue;
-    }
-
-    extraSRCNs.push_back(srcn);
-  }
-
-  if (!extraSRCNs.empty()) {
-    auto* tempSampColl = new SNESSampColl(SuzukiSnesFormat::name, this, spcDirAddr, extraSRCNs);
-    if (!addTempSampColl(tempSampColl)) {
-      delete drumKit;
-      return;
-    }
-
-    for (auto* vgmRgn : drumKit->regions()) {
-      auto* rgn = dynamic_cast<SuzukiSnesRgn*>(vgmRgn);
-      if (rgn != nullptr &&
-          std::find(extraSRCNs.begin(), extraSRCNs.end(), static_cast<uint8_t>(rgn->sampNum)) != extraSRCNs.end()) {
-        rgn->sampCollPtr = tempSampColl;
-      }
-    }
+  auto* drumKit = new SuzukiSnesDrumKit(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrSRCNTable,
+                                        addrTuningTable, addrADSRTable, addrDrumKitTable, "Drum Kit");
+  if (!drumKit->loadInstr() || drumKit->regions().empty()) {
+    delete drumKit;
+    return;
   }
 
   addTempInstr(drumKit);

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -30,8 +30,6 @@ SuzukiSnesInstrSet::SuzukiSnesInstrSet(RawFile *file,
     addrDrumKitTable(addrDrumKitTable) {
 }
 
-SuzukiSnesInstrSet::~SuzukiSnesInstrSet() {}
-
 bool SuzukiSnesInstrSet::parseHeader() {
   return true;
 }
@@ -176,9 +174,6 @@ SuzukiSnesDrumKit::SuzukiSnesDrumKit(VGMInstrSet *instrSet,
   addrTuningTable(addrTuningTable),
   addrADSRTable(addrADSRTable),
   addrDrumKitTable(addrDrumKitTable) {
-}
-
-SuzukiSnesDrumKit::~SuzukiSnesDrumKit() {
 }
 
 bool SuzukiSnesDrumKit::loadInstr() {

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.h
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.h
@@ -20,12 +20,12 @@ class SuzukiSnesInstrSet:
                      uint16_t addrVolumeTable,
                      uint16_t addrADSRTable,
                      uint16_t addrTuningTable,
-                     uint16_t addrDrumKitTable,
                      const std::string &name = "SuzukiSnesInstrSet");
   ~SuzukiSnesInstrSet() override = default;
 
   virtual bool parseHeader();
   virtual bool parseInstrPointers();
+  void useColl(const VGMColl* coll) override;
 
   SuzukiSnesVersion version;
 
@@ -35,7 +35,6 @@ class SuzukiSnesInstrSet:
   uint16_t addrVolumeTable;
   uint16_t addrTuningTable;
   uint16_t addrADSRTable;
-  uint16_t addrDrumKitTable;
   std::vector<uint8_t> usedSRCNs;
 };
 

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.h
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.h
@@ -22,7 +22,7 @@ class SuzukiSnesInstrSet:
                      uint16_t addrTuningTable,
                      uint16_t addrDrumKitTable,
                      const std::string &name = "SuzukiSnesInstrSet");
-  virtual ~SuzukiSnesInstrSet();
+  ~SuzukiSnesInstrSet() override = default;
 
   virtual bool parseHeader();
   virtual bool parseInstrPointers();
@@ -85,7 +85,7 @@ public:
                     uint16_t addrADSRTable,
                     uint16_t addrDrumKitTable,
                   const std::string &name = "SuzukiSnesDrumKit");
-  ~SuzukiSnesDrumKit() override;
+  ~SuzukiSnesDrumKit() override = default;
 
   bool loadInstr() override;
 

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.h
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.h
@@ -23,8 +23,8 @@ class SuzukiSnesInstrSet:
                      const std::string &name = "SuzukiSnesInstrSet");
   ~SuzukiSnesInstrSet() override = default;
 
-  virtual bool parseHeader();
-  virtual bool parseInstrPointers();
+  bool parseHeader() override;
+  bool parseInstrPointers() override;
   void useColl(const VGMColl* coll) override;
 
   SuzukiSnesVersion version;
@@ -35,7 +35,6 @@ class SuzukiSnesInstrSet:
   uint16_t addrVolumeTable;
   uint16_t addrTuningTable;
   uint16_t addrADSRTable;
-  std::vector<uint8_t> usedSRCNs;
 };
 
 // *************

--- a/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
@@ -215,7 +215,7 @@ void SuzukiSnesScanner::searchForSuzukiSnesFromARAM(RawFile *file) {
     addrVolumeTable = file->readShort(ofsLoadInstr + 10);
     addrADSRTable = file->readShort(ofsLoadInstr + 18);
     addrTuningTable = file->readShort(ofsLoadInstr + 30);
-    addrDrumKitTable = version != SUZUKISNES_SD3 ? addrSeqHeader : 0;
+    addrDrumKitTable = addrSeqHeader + (version == SUZUKISNES_SD3 ? 16 : 0);
   } else {
     return;
   }

--- a/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
@@ -209,19 +209,18 @@ void SuzukiSnesScanner::searchForSuzukiSnesFromARAM(RawFile *file) {
   uint16_t addrVolumeTable;
   uint16_t addrTuningTable;
   uint16_t addrADSRTable;
-  uint16_t addrDrumKitTable;
   if (file->searchBytePattern(ptnLoadInstr, ofsLoadInstr)) {
     addrSRCNTable = file->readShort(ofsLoadInstr + 5);
     addrVolumeTable = file->readShort(ofsLoadInstr + 10);
     addrADSRTable = file->readShort(ofsLoadInstr + 18);
     addrTuningTable = file->readShort(ofsLoadInstr + 30);
-    addrDrumKitTable = addrSeqHeader + (version == SUZUKISNES_SD3 ? 16 : 0);
   } else {
     return;
   }
 
   SuzukiSnesInstrSet *newInstrSet =
-      new SuzukiSnesInstrSet(file, version, spcDirAddr, addrSRCNTable, addrVolumeTable, addrADSRTable, addrTuningTable, addrDrumKitTable);
+      new SuzukiSnesInstrSet(file, version, spcDirAddr, addrSRCNTable, addrVolumeTable,
+                             addrADSRTable, addrTuningTable);
   if (!newInstrSet->loadVGMFile()) {
     delete newInstrSet;
     return;

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
@@ -61,7 +61,7 @@ bool SuzukiSnesSeq::parseHeader() {
       auto drum = header->addChild(curOffset, 5, "Percussion");
       drum->addChild(curOffset++, 1, "Note Index");
       drum->addChild(curOffset++, 1, "Base Instrument");
-      drum->addChild(curOffset++, 1, "Key");
+      drum->addChild(curOffset++, 1, "Unity Key");
       drum->addChild(curOffset++, 1, "Volume");
       drum->addChild(curOffset++, 1, "Pan");
     }

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
@@ -43,10 +43,7 @@ bool SuzukiSnesSeq::parseHeader() {
   setPPQN(SEQ_PPQN);
 
   VGMHeader *header = addHeader(offset(), 0);
-  uint32_t curOffset = offset();
-
-  // percussion table is actually parsed by SuzukiSnesDrumKit instead
-  if (version != SUZUKISNES_SD3) {
+  auto addDrumKitChildren = [this, header](uint32_t &curOffset) -> bool {
     while (true) {
       if (curOffset + 1 >= 0x10000) {
         return false;
@@ -54,35 +51,53 @@ bool SuzukiSnesSeq::parseHeader() {
 
       uint8_t firstByte = readByte(curOffset);
       if (firstByte >= 0x80) {
-        header->addChild(curOffset, 1, "Percussion End");
+        header->addChild(curOffset, 1, "Drum Kit End");
         curOffset++;
         break;
       }
-      auto drum = header->addChild(curOffset, 5, "Percussion");
+      auto drum = header->addChild(curOffset, 5, "Drum Instrument");
       drum->addChild(curOffset++, 1, "Note Index");
       drum->addChild(curOffset++, 1, "Base Instrument");
       drum->addChild(curOffset++, 1, "Unity Key");
       drum->addChild(curOffset++, 1, "Volume");
       drum->addChild(curOffset++, 1, "Pan");
     }
+
+    return true;
+  };
+
+  auto addTrackPointerChildren = [this, header](uint32_t curOffset) {
+    for (int trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
+      uint16_t addrTrackStart = readShort(curOffset);
+
+      if (addrTrackStart != 0) {
+        auto trackName = fmt::format("Track Pointer {:d}", trackIndex + 1);
+        header->addChild(curOffset, 2, trackName);
+
+        aTracks.push_back(new SuzukiSnesTrack(this, addrTrackStart));
+      }
+      else {
+        // example: Super Mario RPG - Where Am I Going?
+        header->addChild(curOffset, 2, "NULL");
+      }
+
+      curOffset += 2;
+    }
+  };
+
+  if (version == SUZUKISNES_SD3) {
+    addTrackPointerChildren(offset());
+    uint32_t curOffset = offset() + MAX_TRACKS * 2;
+    if (!addDrumKitChildren(curOffset)) {
+      return false;
+    }
   }
-
-  // create tracks
-  for (int trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
-    uint16_t addrTrackStart = readShort(curOffset);
-
-    if (addrTrackStart != 0) {
-      auto trackName = fmt::format("Track Pointer {:d}", trackIndex + 1);
-      header->addChild(curOffset, 2, trackName);
-
-      aTracks.push_back(new SuzukiSnesTrack(this, addrTrackStart));
+  else {
+    uint32_t curOffset = offset();
+    if (!addDrumKitChildren(curOffset)) {
+      return false;
     }
-    else {
-      // example: Super Mario RPG - Where Am I Going?
-      header->addChild(curOffset, 2, "NULL");
-    }
-
-    curOffset += 2;
+    addTrackPointerChildren(curOffset);
   }
 
   header->setGuessedLength();


### PR DESCRIPTION
This updates the SuzukiSnes driver so that it:
- uses the new `VGMInstrSet::useColl()` functionality introduced in PR #814 and thereby decouples instrument sets from sequences
- adds support for Seiken Densetsu 3 drum kits
- addresses some minor feedback in the original PR (default deconstructors, different naming for UI items)

I've updated SuzukiInstrSet to load every sample (SRCN) rather than the samples referenced by instruments. This is because the sequence-side drumkit data can refer to sample indices that are otherwise unused.

## How Has This Been Tested?
Tested against every SuzukiSnes game I'm aware of.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
