### PR TITLE
HexView Refactor 3: optimize selection mask generation

### DIFF
--- a/src/ui/qt/util/NonTransientScrollBarStyle.h
+++ b/src/ui/qt/util/NonTransientScrollBarStyle.h
@@ -1,0 +1,60 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#pragma once
+
+#include <QProxyStyle>
+#include <QScrollBar>
+#include <QStyleFactory>
+
+namespace QtUi {
+
+#ifdef Q_OS_MAC
+
+class NonTransientScrollBarStyle final : public QProxyStyle {
+public:
+  using QProxyStyle::QProxyStyle;
+
+  int styleHint(StyleHint hint,
+                const QStyleOption* option = nullptr,
+                const QWidget* widget = nullptr,
+                QStyleHintReturn* returnData = nullptr) const override {
+    if (hint == QStyle::SH_ScrollBar_Transient) {
+      return 0;
+    }
+    return QProxyStyle::styleHint(hint, option, widget, returnData);
+  }
+};
+
+inline void applyNonTransientScrollBarStyle(QScrollBar* scrollBar) {
+  if (!scrollBar) {
+    return;
+  }
+
+  QStyle* baseStyle = QStyleFactory::create(QStringLiteral("macos"));
+  if (!baseStyle) {
+    baseStyle = QStyleFactory::create(QStringLiteral("macintosh"));
+  }
+  if (!baseStyle) {
+    baseStyle = QStyleFactory::create(QStringLiteral("Fusion"));
+  }
+
+  auto* style = baseStyle ? new NonTransientScrollBarStyle(baseStyle)
+                          : new NonTransientScrollBarStyle();
+  scrollBar->setStyle(style);
+  if (!style->parent()) {
+    style->setParent(scrollBar);
+  }
+}
+
+#else
+
+inline void applyNonTransientScrollBarStyle(QScrollBar*) {
+}
+
+#endif
+
+}  // namespace QtUi

--- a/src/ui/qt/workarea/hexview/HexView.cpp
+++ b/src/ui/qt/workarea/hexview/HexView.cpp
@@ -8,6 +8,7 @@
 #include "Helpers.h"
 #include "HexViewInput.h"
 #include "HexViewRhiHost.h"
+#include "util/NonTransientScrollBarStyle.h"
 #include "services/NotificationCenter.h"
 #include "VGMFile.h"
 
@@ -21,9 +22,7 @@
 #include <QKeyEvent>
 #include <QMouseEvent>
 #include <QPixmap>
-#include <QProxyStyle>
 #include <QRawFont>
-#include <QStyleFactory>
 #include <QPainter>
 #include <QParallelAnimationGroup>
 #include <QPropertyAnimation>
@@ -98,22 +97,6 @@ WidgetLayoutMetrics computeWidgetLayoutMetrics(const QWidget* widget, int charWi
   layout.asciiEndPx = layout.asciiStartPx + (BYTES_PER_LINE * layout.charWidthPx);
   return layout;
 }
-
-#ifdef Q_OS_MAC
-class NonTransientScrollBarStyle final : public QProxyStyle {
-public:
-  using QProxyStyle::QProxyStyle;
-
-  int styleHint(StyleHint hint, const QStyleOption* option = nullptr,
-                const QWidget* widget = nullptr,
-                QStyleHintReturn* returnData = nullptr) const override {
-    if (hint == QStyle::SH_ScrollBar_Transient) {
-      return 0;
-    }
-    return QProxyStyle::styleHint(hint, option, widget, returnData);
-  }
-};
-#endif
 
 QString tooltipIconDataUrl(VGMItem::Type type) {
   static QHash<int, QString> cache;
@@ -353,6 +336,13 @@ uint64_t HexView::selectionKey(const FadePlaybackSelection& selection) {
 // Trivial destructor; QObject ownership handles child cleanup.
 HexView::~HexView() = default;
 
+QFont HexView::defaultViewFont() {
+  const double appFontPointSize = QApplication::font().pointSizeF();
+  QFont font("Roboto Mono", appFontPointSize + 1.0);
+  font.setPointSizeF(appFontPointSize + 1.0);
+  return font;
+}
+
 // Initialize HexView UI state, RHI host, typography, animations, and signal wiring.
 HexView::HexView(VGMFile* vgmfile, QWidget* parent)
     : QAbstractScrollArea(parent), m_vgmfile(vgmfile) {
@@ -363,25 +353,14 @@ HexView::HexView(VGMFile* vgmfile, QWidget* parent)
 #ifdef Q_OS_MAC
   // With AA_DontCreateNativeWidgetSiblings, the RHI QWindow can cover transient (overlay)
   // scrollbars, so keep HexView's scrollbars non-transient on macOS.
-  QStyle* baseStyle = QStyleFactory::create(QStringLiteral("macos"));
-  if (!baseStyle)
-    baseStyle = QStyleFactory::create(QStringLiteral("macintosh"));
-  if (!baseStyle)
-    baseStyle = QStyleFactory::create(QStringLiteral("Fusion"));
-  auto* scrollStyle = baseStyle ? new NonTransientScrollBarStyle(baseStyle)
-                                : new NonTransientScrollBarStyle();
-  verticalScrollBar()->setStyle(scrollStyle);
-  if (!scrollStyle->parent())
-    scrollStyle->setParent(verticalScrollBar());
+  QtUi::applyNonTransientScrollBarStyle(verticalScrollBar());
 #endif
 
   m_rhiHost = new HexViewRhiHost(this, viewport());
   m_rhiHost->setGeometry(viewport()->rect());
   m_rhiHost->show();
 
-  const double appFontPointSize = QApplication::font().pointSizeF();
-  QFont font("Roboto Mono", appFontPointSize);
-  font.setPointSizeF(appFontPointSize);
+  QFont font = defaultViewFont();
   setShadowStrength(SHADOW_STRENGTH);
   m_playbackGlowLow = PLAYBACK_GLOW_LOW;
   m_playbackGlowHigh = PLAYBACK_GLOW_HIGH;
@@ -415,6 +394,11 @@ HexView::HexView(VGMFile* vgmfile, QWidget* parent)
               return;
             }
             m_seekModifierActive = active;
+            if (!isVisible()) {
+              hideTooltip();
+              requestRhiUpdate();
+              return;
+            }
             m_outlineFadeClock.restart();
             if (!m_outlineFadeTimer.isActive()) {
               m_outlineFadeTimer.start(16, this);
@@ -1610,6 +1594,9 @@ void HexView::showTooltip(VGMItem* item, const QPoint& pos) {
 
 // Hide active tooltip and clear tracked tooltip item.
 void HexView::hideTooltip() {
+  if (m_tooltipItem == nullptr) {
+    return;
+  }
   QToolTip::hideText();
   m_tooltipItem = nullptr;
 }

--- a/src/ui/qt/workarea/hexview/HexView.h
+++ b/src/ui/qt/workarea/hexview/HexView.h
@@ -40,6 +40,7 @@ class HexView final : public QAbstractScrollArea {
 public:
   explicit HexView(VGMFile* vgmfile, QWidget* parent = nullptr);
   ~HexView() override;
+  [[nodiscard]] static QFont defaultViewFont();
   void setSelectedItem(VGMItem* item);
   void setPlaybackSelectionsForItems(const std::vector<const VGMItem*>& items);
   void clearPlaybackSelections(bool fade = true);

--- a/src/ui/qt/workarea/hexview/HexViewRhiEventForwarder.h
+++ b/src/ui/qt/workarea/hexview/HexViewRhiEventForwarder.h
@@ -35,6 +35,10 @@ public:
 
     switch (event->type()) {
       case QEvent::MouseButtonPress: {
+        auto* me = static_cast<QMouseEvent*>(event);
+        if (me->button() == Qt::RightButton) {
+          return false;
+        }
         m_view->setFocus(Qt::MouseFocusReason);
         dragging = true;
         QCoreApplication::sendEvent(m_view->viewport(), event);
@@ -45,6 +49,9 @@ public:
       case QEvent::MouseButtonDblClick: {
         // Ensure the second click still behaves like a press for quick select/deselect.
         auto* me = static_cast<QMouseEvent*>(event);
+        if (me->button() == Qt::RightButton) {
+          return false;
+        }
         if (!dragging && me->button() == Qt::LeftButton) {
           QMouseEvent pressEvent(QEvent::MouseButtonPress,
                                  me->position(),
@@ -73,11 +80,16 @@ public:
         return true;
       }
 
-      case QEvent::MouseButtonRelease:
+      case QEvent::MouseButtonRelease: {
+        auto* me = static_cast<QMouseEvent*>(event);
+        if (me->button() == Qt::RightButton) {
+          return false;
+        }
         QCoreApplication::sendEvent(m_view->viewport(), event);
         dragging = false;
         requestUpdate();
         return true;
+      }
 
       case QEvent::Wheel:
         m_input.queueWheel(static_cast<QWheelEvent*>(event));

--- a/src/ui/qt/workarea/hexview/HexViewRhiHost.cpp
+++ b/src/ui/qt/workarea/hexview/HexViewRhiHost.cpp
@@ -8,15 +8,14 @@
 
 #include "HexView.h"
 #include "HexViewRhiRenderer.h"
+#include "workarea/rhi/RhiWindowMainWindowLocator.h"
 
 #if defined(Q_OS_LINUX)
 #include "HexViewRhiWidget.h"
 #else
 #include "HexViewRhiWindow.h"
-#include "MainWindow.h"
 #endif
 
-#include <QApplication>
 #include <QWindow>
 #include <QResizeEvent>
 
@@ -36,22 +35,7 @@ HexViewRhiHost::HexViewRhiHost(HexView* view, QWidget* parent)
 
   auto* rhiWindow = qobject_cast<HexViewRhiWindow*>(m_window);
   if (rhiWindow) {
-    MainWindow* mainWindow = nullptr;
-    for (QWidget* widget = this; widget; widget = widget->parentWidget()) {
-      mainWindow = qobject_cast<MainWindow*>(widget);
-      if (mainWindow) {
-        break;
-      }
-    }
-    if (!mainWindow) {
-      const auto topLevelWidgets = QApplication::topLevelWidgets();
-      for (QWidget* widget : topLevelWidgets) {
-        mainWindow = qobject_cast<MainWindow*>(widget);
-        if (mainWindow) {
-          break;
-        }
-      }
-    }
+    MainWindow* mainWindow = QtUi::findMainWindowForWidget(this);
     if (mainWindow) {
       connect(rhiWindow, &HexViewRhiWindow::dragOverlayShowRequested,
               mainWindow, &MainWindow::showDragOverlay);

--- a/src/ui/qt/workarea/hexview/HexViewRhiRenderer.cpp
+++ b/src/ui/qt/workarea/hexview/HexViewRhiRenderer.cpp
@@ -1231,12 +1231,51 @@ void HexViewRhiRenderer::buildBaseInstances(const HexViewFrame::Data& frame,
   }
 }
 
-// Convert byte-range selections into per-visible-line byte-column intervals.
-void HexViewRhiRenderer::collectIntervalsForSelections(
+// Build mask and edge geometry for a selection set across the visible range.
+void HexViewRhiRenderer::appendMaskForSelections(
     const std::vector<HexViewFrame::SelectionRange>& selections,
-    const SelectionBuildContext& ctx,
-    std::vector<std::vector<Interval>>& perLine) const {
-  perLine.assign(static_cast<size_t>(ctx.visibleCount), {});
+                                                 const SelectionBuildContext& ctx,
+                                                 float padX,
+                                                 float padY,
+                                                 float edgePad,
+                                                 const QVector4D& maskColor,
+                                                 const QVector4D& edgeColor) {
+  if (selections.empty() || ctx.visibleCount <= 0) {
+    return;
+  }
+
+  struct EdgeRun {
+    int startCol = 0;
+    int endCol = 0;
+    int startLine = 0;
+    int endLine = 0;
+  };
+  constexpr int kIntervalCoordCount = kBytesPerLine + 1;
+  constexpr int kIntervalKeyCount = kIntervalCoordCount * kIntervalCoordCount;
+
+  std::vector<uint8_t> lineBytes(static_cast<size_t>(ctx.visibleCount), 0);
+  std::vector<uint16_t> lineMasks(static_cast<size_t>(ctx.visibleCount), 0);
+
+  for (int line = ctx.startLine; line <= ctx.endLine; ++line) {
+    const CachedLine* entry = cachedLineFor(line);
+    if (entry && entry->bytes > 0) {
+      lineBytes[static_cast<size_t>(line - ctx.startLine)] =
+          static_cast<uint8_t>(std::min(entry->bytes, kBytesPerLine));
+    }
+  }
+
+  auto spanMaskBits = [](int startCol, int endCol) -> uint16_t {
+    const int start = std::clamp(startCol, 0, kBytesPerLine);
+    const int end = std::clamp(endCol, 0, kBytesPerLine);
+    if (end <= start) {
+      return 0;
+    }
+    const uint32_t lowMask = (start > 0) ? ((uint32_t(1) << start) - 1u) : 0u;
+    const uint32_t highMask = (end >= kBytesPerLine)
+                                  ? 0xFFFFu
+                                  : ((uint32_t(1) << end) - 1u);
+    return static_cast<uint16_t>(highMask & ~lowMask);
+  };
 
   for (const auto& selection : selections) {
     if (selection.length == 0) {
@@ -1260,143 +1299,136 @@ void HexViewRhiRenderer::collectIntervalsForSelections(
     const int lineEnd = std::min(ctx.endLine, selEndLine);
 
     for (int line = lineStart; line <= lineEnd; ++line) {
-      const CachedLine* entry = cachedLineFor(line);
-      if (!entry || entry->bytes <= 0) {
+      const size_t lineIndex = static_cast<size_t>(line - ctx.startLine);
+      const int lineByteCount = static_cast<int>(lineBytes[lineIndex]);
+      if (lineByteCount <= 0) {
         continue;
       }
 
       const int lineOffset = line * kBytesPerLine;
       const int startCol = (line == selStartLine) ? (selectionStart - lineOffset) : 0;
-      const int endCol = (line == selEndLine) ? (selectionEnd - lineOffset) : entry->bytes;
-
-      const int clampedStart = std::clamp(startCol, 0, entry->bytes);
-      const int clampedEnd = std::clamp(endCol, 0, entry->bytes);
+      const int endCol = (line == selEndLine) ? (selectionEnd - lineOffset) : lineByteCount;
+      const int clampedStart = std::clamp(startCol, 0, lineByteCount);
+      const int clampedEnd = std::clamp(endCol, 0, lineByteCount);
       if (clampedEnd <= clampedStart) {
         continue;
       }
-
-      perLine[static_cast<size_t>(line - ctx.startLine)].push_back({clampedStart, clampedEnd});
+      lineMasks[lineIndex] |= spanMaskBits(clampedStart, clampedEnd);
     }
   }
-}
 
-// Sort and merge overlapping/adjacent intervals on a single line.
-std::vector<HexViewRhiRenderer::Interval> HexViewRhiRenderer::mergeIntervals(
-    std::vector<Interval>& intervals) {
-  if (intervals.empty()) {
-    return {};
-  }
-  std::sort(intervals.begin(), intervals.end(),
-            [](const Interval& a, const Interval& b) { return a.start < b.start; });
-
-  std::vector<Interval> merged;
-  merged.reserve(intervals.size());
-  for (const auto& interval : intervals) {
-    if (merged.empty() || interval.start > merged.back().end) {
-      merged.push_back(interval);
-    } else {
-      merged.back().end = std::max(merged.back().end, interval.end);
+  auto appendMaskSpan = [&](int line, int startCol, int endCol) {
+    const int spanLen = endCol - startCol;
+    if (spanLen <= 0) {
+      return;
     }
-  }
-  return merged;
-}
-
-// Emit mask quads for merged selection intervals on one visible line.
-void HexViewRhiRenderer::appendMaskRectsForIntervals(const std::vector<Interval>& intervals,
-                                                     int line,
-                                                     const SelectionBuildContext& ctx,
-                                                     float padX,
-                                                     float padY,
-                                                     const QVector4D& maskColor) {
-  const float y = line * ctx.lineHeight;
-  for (const auto& interval : intervals) {
-    const int length = interval.end - interval.start;
-    if (length <= 0) {
-      continue;
-    }
-
-    const float hexX = ctx.hexStartX + interval.start * 3.0f * ctx.charWidth - padX;
-    appendRect(m_maskRectInstances, hexX, y - padY,
-               length * 3.0f * ctx.charWidth + padX * 2.0f,
-               ctx.lineHeight + padY * 2.0f, maskColor);
+    const float y = line * ctx.lineHeight;
+    const float hexX = ctx.hexStartX + startCol * 3.0f * ctx.charWidth - padX;
+    appendRect(m_maskRectInstances,
+               hexX,
+               y - padY,
+               spanLen * 3.0f * ctx.charWidth + padX * 2.0f,
+               ctx.lineHeight + padY * 2.0f,
+               maskColor);
     if (ctx.shouldDrawAscii) {
-      const float asciiX = ctx.asciiStartX + interval.start * ctx.charWidth - padX;
-      appendRect(m_maskRectInstances, asciiX, y - padY,
-                 length * ctx.charWidth + padX * 2.0f,
-                 ctx.lineHeight + padY * 2.0f, maskColor);
+      const float asciiX = ctx.asciiStartX + startCol * ctx.charWidth - padX;
+      appendRect(m_maskRectInstances,
+                 asciiX,
+                 y - padY,
+                 spanLen * ctx.charWidth + padX * 2.0f,
+                 ctx.lineHeight + padY * 2.0f,
+                 maskColor);
     }
-  }
-}
+  };
 
-// Emit edge instances for finalized vertical runs of identical intervals.
-void HexViewRhiRenderer::emitEdgeRuns(const std::unordered_map<uint32_t, EdgeRun>& runs,
-                                      const SelectionBuildContext& ctx,
-                                      float edgePad,
-                                      const QVector4D& edgeColor) {
-  for (const auto& [ignoredKey, run] : runs) {
-    (void) ignoredKey;
-    const int length = run.endCol - run.startCol;
-    if (length <= 0) {
-      continue;
+  auto emitEdgeRun = [&](const EdgeRun& run) {
+    const int spanLen = run.endCol - run.startCol;
+    if (spanLen <= 0) {
+      return;
     }
-
     const float runY = run.startLine * ctx.lineHeight;
     const float runH = (run.endLine - run.startLine + 1) * ctx.lineHeight;
     const float hexX = ctx.hexStartX + run.startCol * 3.0f * ctx.charWidth;
-    appendEdgeRect(m_edgeRectInstances, hexX, runY, length * 3.0f * ctx.charWidth, runH,
-                   edgePad, edgeColor);
+    appendEdgeRect(m_edgeRectInstances,
+                   hexX,
+                   runY,
+                   spanLen * 3.0f * ctx.charWidth,
+                   runH,
+                   edgePad,
+                   edgeColor);
     if (ctx.shouldDrawAscii) {
       const float asciiX = ctx.asciiStartX + run.startCol * ctx.charWidth;
-      appendEdgeRect(m_edgeRectInstances, asciiX, runY, length * ctx.charWidth, runH,
-                     edgePad, edgeColor);
+      appendEdgeRect(m_edgeRectInstances,
+                     asciiX,
+                     runY,
+                     spanLen * ctx.charWidth,
+                     runH,
+                     edgePad,
+                     edgeColor);
     }
-  }
-}
+  };
 
-// Build mask and edge geometry for a selection set across the visible range.
-void HexViewRhiRenderer::appendMaskForSelections(
-    const std::vector<HexViewFrame::SelectionRange>& selections,
-                                                 const SelectionBuildContext& ctx,
-                                                 float padX,
-                                                 float padY,
-                                                 float edgePad,
-                                                 const QVector4D& maskColor,
-                                                 const QVector4D& edgeColor) {
-  std::vector<std::vector<Interval>> perLine;
-  collectIntervalsForSelections(selections, ctx, perLine);
+  auto intervalKey = [&](int startCol, int endCol) -> int {
+    return (startCol * kIntervalCoordCount) + endCol;
+  };
 
-  std::unordered_map<uint32_t, EdgeRun> activeRuns;
+  std::array<EdgeRun, kIntervalKeyCount> activeRuns{};
+  std::array<uint8_t, kIntervalKeyCount> activeRunMask{};
+
   for (int line = ctx.startLine; line <= ctx.endLine; ++line) {
-    auto& intervals = perLine[static_cast<size_t>(line - ctx.startLine)];
-    const std::vector<Interval> merged = mergeIntervals(intervals);
-    appendMaskRectsForIntervals(merged, line, ctx, padX, padY, maskColor);
+    const size_t lineIndex = static_cast<size_t>(line - ctx.startLine);
+    const uint16_t maskBits = lineMasks[lineIndex];
+    std::array<uint8_t, kIntervalKeyCount> lineRunMask{};
+
+    int col = 0;
+    while (col < kBytesPerLine) {
+      while (col < kBytesPerLine &&
+             (maskBits & static_cast<uint16_t>(1u << col)) == 0u) {
+        ++col;
+      }
+      if (col >= kBytesPerLine) {
+        break;
+      }
+      const int startCol = col;
+      while (col < kBytesPerLine &&
+             (maskBits & static_cast<uint16_t>(1u << col)) != 0u) {
+        ++col;
+      }
+      const int endCol = col;
+      appendMaskSpan(line, startCol, endCol);
+
+      if (edgePad > 0.0f) {
+        const int key = intervalKey(startCol, endCol);
+        lineRunMask[static_cast<size_t>(key)] = 1;
+        if (activeRunMask[static_cast<size_t>(key)] != 0) {
+          activeRuns[static_cast<size_t>(key)].endLine = line;
+        } else {
+          activeRunMask[static_cast<size_t>(key)] = 1;
+          activeRuns[static_cast<size_t>(key)] = EdgeRun{startCol, endCol, line, line};
+        }
+      }
+    }
 
     if (edgePad <= 0.0f) {
       continue;
     }
 
-    std::unordered_map<uint32_t, EdgeRun> nextRuns;
-    // Coalesce identical intervals across adjacent lines into vertical runs.
-    // This keeps edge geometry compact when selections span many rows.
-    for (const auto& interval : merged) {
-      const uint32_t key = (static_cast<uint32_t>(interval.start) << 16) | static_cast<uint32_t>(interval.end);
-      auto it = activeRuns.find(key);
-      if (it != activeRuns.end()) {
-        EdgeRun run = it->second;
-        run.endLine = line;
-        nextRuns.emplace(key, run);
-        activeRuns.erase(it);
-      } else {
-        nextRuns.emplace(key, EdgeRun{interval.start, interval.end, line, line});
+    for (int key = 0; key < kIntervalKeyCount; ++key) {
+      const size_t keyIndex = static_cast<size_t>(key);
+      if (activeRunMask[keyIndex] != 0 && lineRunMask[keyIndex] == 0) {
+        emitEdgeRun(activeRuns[keyIndex]);
+        activeRunMask[keyIndex] = 0;
       }
     }
-
-    emitEdgeRuns(activeRuns, ctx, edgePad, edgeColor);
-    activeRuns = std::move(nextRuns);
   }
 
   if (edgePad > 0.0f) {
-    emitEdgeRuns(activeRuns, ctx, edgePad, edgeColor);
+    for (int key = 0; key < kIntervalKeyCount; ++key) {
+      const size_t keyIndex = static_cast<size_t>(key);
+      if (activeRunMask[keyIndex] != 0) {
+        emitEdgeRun(activeRuns[keyIndex]);
+      }
+    }
   }
 }
 
@@ -1442,6 +1474,61 @@ void HexViewRhiRenderer::buildSelectionInstances(int startLine, int endLine,
   const float glowBase = std::max(0.0f, static_cast<float>(frame.playbackGlowRadius)) *
                          std::max(1.0f, std::min(charWidth, lineHeight));
   const float glowPad = glowBase * 1.35f;
+  auto appendMaskForRangeNoEdge =
+      [&](const HexViewFrame::SelectionRange& range, const QVector4D& maskColor) {
+        if (range.length == 0) {
+          return;
+        }
+        int selectionStart = static_cast<int>(range.offset - ctx.fileBaseOffset);
+        int selectionEnd = selectionStart + static_cast<int>(range.length);
+        if (selectionEnd <= 0 || selectionStart >= static_cast<int>(ctx.fileLength)) {
+          return;
+        }
+        selectionStart = std::max(selectionStart, 0);
+        selectionEnd = std::min(selectionEnd, static_cast<int>(ctx.fileLength));
+        if (selectionEnd <= selectionStart) {
+          return;
+        }
+
+        const int selStartLine = selectionStart / kBytesPerLine;
+        const int selEndLine = (selectionEnd - 1) / kBytesPerLine;
+        const int lineStart = std::max(ctx.startLine, selStartLine);
+        const int lineEnd = std::min(ctx.endLine, selEndLine);
+
+        for (int line = lineStart; line <= lineEnd; ++line) {
+          const CachedLine* entry = cachedLineFor(line);
+          if (!entry || entry->bytes <= 0) {
+            continue;
+          }
+          const int lineOffset = line * kBytesPerLine;
+          const int startCol = (line == selStartLine) ? (selectionStart - lineOffset) : 0;
+          const int endCol = (line == selEndLine) ? (selectionEnd - lineOffset) : entry->bytes;
+          const int clampedStart = std::clamp(startCol, 0, entry->bytes);
+          const int clampedEnd = std::clamp(endCol, 0, entry->bytes);
+          const int spanLen = clampedEnd - clampedStart;
+          if (spanLen <= 0) {
+            continue;
+          }
+
+          const float y = line * ctx.lineHeight;
+          const float hexX = ctx.hexStartX + clampedStart * 3.0f * ctx.charWidth;
+          appendRect(m_maskRectInstances,
+                     hexX,
+                     y,
+                     spanLen * 3.0f * ctx.charWidth,
+                     ctx.lineHeight,
+                     maskColor);
+          if (ctx.shouldDrawAscii) {
+            const float asciiX = ctx.asciiStartX + clampedStart * ctx.charWidth;
+            appendRect(m_maskRectInstances,
+                       asciiX,
+                       y,
+                       spanLen * ctx.charWidth,
+                       ctx.lineHeight,
+                       maskColor);
+          }
+        }
+      };
 
   if (hasSelection) {
     const std::vector<HexViewFrame::SelectionRange>& selections =
@@ -1470,14 +1557,12 @@ void HexViewRhiRenderer::buildSelectionInstances(int startLine, int endLine,
     const QVector4D playbackEdgeColor(0.0f, 0.0f, 1.0f, 0.0f);
     appendMaskForSelections(fadeRanges, ctx, 0.0f, 0.0f, glowPad, playbackMaskColor,
                             playbackEdgeColor);
-    const QVector4D fadeEdgeColor(0.0f, 0.0f, 0.0f, 0.0f);
     for (const auto& selection : frame.fadePlaybackSelections) {
       if (selection.alpha <= 0.0f) {
         continue;
       }
       const QVector4D fadeMaskColor(0.0f, 0.0f, 1.0f, selection.alpha);
-      const std::vector<HexViewFrame::SelectionRange> one{selection.range};
-      appendMaskForSelections(one, ctx, 0.0f, 0.0f, 0.0f, fadeMaskColor, fadeEdgeColor);
+      appendMaskForRangeNoEdge(selection.range, fadeMaskColor);
     }
   }
 }

--- a/src/ui/qt/workarea/hexview/HexViewRhiRenderer.cpp
+++ b/src/ui/qt/workarea/hexview/HexViewRhiRenderer.cpp
@@ -370,43 +370,94 @@ void HexViewRhiRenderer::renderFrame(QRhiCommandBuffer* cb, const RenderTargetIn
   }
 
   const QColor clearColor = frame.windowColor;
+  const QRhiViewport viewport(0, 0, target.pixelSize.width(), target.pixelSize.height());
+
+  auto drawInstanced = [&](QRhiGraphicsPipeline* pso,
+                           QRhiShaderResourceBindings* srb,
+                           QRhiBuffer* instanceBuffer,
+                           int count,
+                           int firstInstance,
+                           int instanceStride) {
+    if (!pso || !srb || !instanceBuffer || count <= 0) {
+      return;
+    }
+    quint32 instanceOffset = 0;
+    int drawFirstInstance = firstInstance;
+    if (!m_supportsBaseInstance && firstInstance > 0) {
+      instanceOffset = static_cast<quint32>(firstInstance * instanceStride);
+      drawFirstInstance = 0;
+    }
+    cb->setGraphicsPipeline(pso);
+    cb->setShaderResources(srb);
+    const QRhiCommandBuffer::VertexInput bindings[] = {
+        {m_vbuf, 0},
+        {instanceBuffer, instanceOffset},
+    };
+    cb->setVertexInput(0, 2, bindings, m_ibuf, 0, QRhiCommandBuffer::IndexUInt16);
+    cb->drawIndexed(6, count, 0, 0, drawFirstInstance);
+  };
+
+  auto drawFullscreen = [&](QRhiGraphicsPipeline* pso, QRhiShaderResourceBindings* srb) {
+    if (!pso || !srb) {
+      return;
+    }
+    cb->setGraphicsPipeline(pso);
+    cb->setShaderResources(srb);
+    const QRhiCommandBuffer::VertexInput bindings[] = {{m_vbuf, 0}};
+    cb->setVertexInput(0, 1, bindings, m_ibuf, 0, QRhiCommandBuffer::IndexUInt16);
+    cb->drawIndexed(6, 1, 0, 0, 0);
+  };
 
   // Pass 1: base content (background spans + glyphs) into an offscreen texture.
   cb->beginPass(m_contentRt, clearColor, {1.0f, 0}, u);
-  cb->setViewport(QRhiViewport(0, 0, target.pixelSize.width(), target.pixelSize.height()));
-  drawRectBuffer(cb, m_baseRectBuf, baseRectCount, baseRectFirst);
-  drawGlyphBuffer(cb, m_baseGlyphBuf, baseGlyphCount, baseGlyphFirst);
+  cb->setViewport(viewport);
+  drawInstanced(m_rectPso,
+                m_rectSrb,
+                m_baseRectBuf,
+                baseRectCount,
+                baseRectFirst,
+                static_cast<int>(sizeof(RectInstance)));
+  drawInstanced(m_glyphPso,
+                m_glyphSrb,
+                m_baseGlyphBuf,
+                baseGlyphCount,
+                baseGlyphFirst,
+                static_cast<int>(sizeof(GlyphInstance)));
   cb->endPass();
 
   // Pass 2: selection/playback mask into an offscreen texture.
   // Channel encoding:
   // R=selection mask, G=active playback, B=fading playback, A=fade alpha.
   cb->beginPass(m_maskRt, QColor(0, 0, 0, 0), {1.0f, 0}, nullptr);
-  cb->setViewport(QRhiViewport(0, 0, target.pixelSize.width(), target.pixelSize.height()));
-  drawRectBuffer(cb, m_maskRectBuf, static_cast<int>(m_maskRectInstances.size()), 0, nullptr,
-                 m_maskPso);
+  cb->setViewport(viewport);
+  drawInstanced(m_maskPso,
+                m_rectSrb,
+                m_maskRectBuf,
+                static_cast<int>(m_maskRectInstances.size()),
+                0,
+                static_cast<int>(sizeof(RectInstance)));
   cb->endPass();
 
   // Pass 3: edge field for drop shadow and playback glow falloff.
   const bool edgeEnabled = !m_edgeRectInstances.empty() &&
       ((frame.shadowBlur > 0.0 && frame.shadowStrength > 0.0) ||
        (frame.playbackGlowRadius > 0.0f && frame.playbackGlowStrength > 0.0f));
+  cb->beginPass(m_edgeRt, QColor(255, 255, 255, 255), {1.0f, 0}, nullptr);
+  cb->setViewport(viewport);
   if (edgeEnabled) {
-    cb->beginPass(m_edgeRt, QColor(255, 255, 255, 255), {1.0f, 0}, nullptr);
-    cb->setViewport(QRhiViewport(0, 0, target.pixelSize.width(), target.pixelSize.height()));
-    drawEdgeBuffer(cb, m_edgeRectBuf, static_cast<int>(m_edgeRectInstances.size()), 0,
-                   m_edgeSrb, m_edgePso);
-    cb->endPass();
-  } else {
-    cb->beginPass(m_edgeRt, QColor(255, 255, 255, 255), {1.0f, 0}, nullptr);
-    cb->setViewport(QRhiViewport(0, 0, target.pixelSize.width(), target.pixelSize.height()));
-    cb->endPass();
+    drawInstanced(m_edgePso,
+                  m_edgeSrb,
+                  m_edgeRectBuf,
+                  static_cast<int>(m_edgeRectInstances.size()),
+                  0,
+                  static_cast<int>(sizeof(EdgeInstance)));
   }
+  cb->endPass();
 
   // Pass 4: fullscreen composite combines content + mask + edge + item-id textures.
   cb->beginPass(target.renderTarget, clearColor, {1.0f, 0}, nullptr);
-  cb->setViewport(QRhiViewport(0, 0, target.pixelSize.width(), target.pixelSize.height()));
-  drawFullscreen(cb, m_compositePso, m_compositeSrb);
+  cb->setViewport(viewport);
+  drawFullscreen(m_compositePso, m_compositeSrb);
   cb->endPass();
 }
 
@@ -482,50 +533,54 @@ void HexViewRhiRenderer::ensurePipelines(QRhiRenderPassDescriptor* outputRp,
   m_sampleCount = outputSampleCount;
   m_pipelinesDirty = false;
 
-  delete m_rectPso;
-  delete m_glyphPso;
-  delete m_maskPso;
-  delete m_edgePso;
-  delete m_compositePso;
-  delete m_rectSrb;
-  delete m_glyphSrb;
-  delete m_edgeSrb;
-  delete m_compositeSrb;
+  auto resetOwned = [](auto*& ptr) {
+    delete ptr;
+    ptr = nullptr;
+  };
+  resetOwned(m_rectPso);
+  resetOwned(m_glyphPso);
+  resetOwned(m_maskPso);
+  resetOwned(m_edgePso);
+  resetOwned(m_compositePso);
+  resetOwned(m_rectSrb);
+  resetOwned(m_glyphSrb);
+  resetOwned(m_edgeSrb);
+  resetOwned(m_compositeSrb);
 
-  m_rectSrb = m_rhi->newShaderResourceBindings();
-  m_rectSrb->setBindings({
-    QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::VertexStage, m_ubuf)
+  auto createSrb = [&](QRhiShaderResourceBindings*& srb,
+                       std::initializer_list<QRhiShaderResourceBinding> bindings) {
+    srb = m_rhi->newShaderResourceBindings();
+    srb->setBindings(bindings);
+    srb->create();
+  };
+  createSrb(m_rectSrb, {
+      QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::VertexStage, m_ubuf),
   });
-  m_rectSrb->create();
-
-  m_glyphSrb = m_rhi->newShaderResourceBindings();
-  m_glyphSrb->setBindings({
-    QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::VertexStage, m_ubuf),
-    QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage,
-                                              m_glyphTex, m_glyphSampler)
+  createSrb(m_glyphSrb, {
+      QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::VertexStage, m_ubuf),
+      QRhiShaderResourceBinding::sampledTexture(1,
+                                                QRhiShaderResourceBinding::FragmentStage,
+                                                m_glyphTex,
+                                                m_glyphSampler),
   });
-  m_glyphSrb->create();
-
-  m_edgeSrb = m_rhi->newShaderResourceBindings();
-  m_edgeSrb->setBindings({
-    QRhiShaderResourceBinding::uniformBuffer(0,
-                                             QRhiShaderResourceBinding::VertexStage |
-                                             QRhiShaderResourceBinding::FragmentStage,
-                                             m_edgeUbuf)
+  createSrb(m_edgeSrb, {
+      QRhiShaderResourceBinding::uniformBuffer(
+          0,
+          QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage,
+          m_edgeUbuf),
   });
-  m_edgeSrb->create();
-
   m_compositeSrb = m_rhi->newShaderResourceBindings();
   updateCompositeSrb();
+  m_compositeSrbDirty = false;
 
-  QShader rectVert = loadShader(":/shaders/hexquad.vert.qsb");
-  QShader rectFrag = loadShader(":/shaders/hexquad.frag.qsb");
-  QShader glyphVert = loadShader(":/shaders/hexglyph.vert.qsb");
-  QShader glyphFrag = loadShader(":/shaders/hexglyph.frag.qsb");
-  QShader screenVert = loadShader(":/shaders/hexscreen.vert.qsb");
-  QShader edgeVert = loadShader(":/shaders/hexedge.vert.qsb");
-  QShader edgeFrag = loadShader(":/shaders/hexedge.frag.qsb");
-  QShader compositeFrag = loadShader(":/shaders/hexcomposite.frag.qsb");
+  const QShader rectVert = loadShader(":/shaders/hexquad.vert.qsb");
+  const QShader rectFrag = loadShader(":/shaders/hexquad.frag.qsb");
+  const QShader glyphVert = loadShader(":/shaders/hexglyph.vert.qsb");
+  const QShader glyphFrag = loadShader(":/shaders/hexglyph.frag.qsb");
+  const QShader screenVert = loadShader(":/shaders/hexscreen.vert.qsb");
+  const QShader edgeVert = loadShader(":/shaders/hexedge.vert.qsb");
+  const QShader edgeFrag = loadShader(":/shaders/hexedge.frag.qsb");
+  const QShader compositeFrag = loadShader(":/shaders/hexcomposite.frag.qsb");
 
   QRhiVertexInputLayout rectInputLayout;
   rectInputLayout.setBindings({
@@ -595,59 +650,67 @@ void HexViewRhiRenderer::ensurePipelines(QRhiRenderPassDescriptor* outputRp,
   edgeBlend.dstAlpha = QRhiGraphicsPipeline::One;
   edgeBlend.opAlpha = QRhiGraphicsPipeline::Min;
 
-  m_rectPso = m_rhi->newGraphicsPipeline();
-  m_rectPso->setShaderStages({{QRhiShaderStage::Vertex, rectVert},
-                              {QRhiShaderStage::Fragment, rectFrag}});
-  m_rectPso->setVertexInputLayout(rectInputLayout);
-  m_rectPso->setShaderResourceBindings(m_rectSrb);
-  m_rectPso->setCullMode(QRhiGraphicsPipeline::None);
-  m_rectPso->setTargetBlends({blend});
-  m_rectPso->setSampleCount(1);
-  m_rectPso->setRenderPassDescriptor(m_contentRp);
-  m_rectPso->create();
+  auto createPipeline = [&](QRhiGraphicsPipeline*& pso,
+                            const QShader& vs,
+                            const QShader& fs,
+                            const QRhiVertexInputLayout& inputLayout,
+                            QRhiShaderResourceBindings* srb,
+                            const QRhiGraphicsPipeline::TargetBlend* targetBlend,
+                            int sampleCount,
+                            QRhiRenderPassDescriptor* rp) {
+    pso = m_rhi->newGraphicsPipeline();
+    pso->setShaderStages({{QRhiShaderStage::Vertex, vs}, {QRhiShaderStage::Fragment, fs}});
+    pso->setVertexInputLayout(inputLayout);
+    pso->setShaderResourceBindings(srb);
+    pso->setCullMode(QRhiGraphicsPipeline::None);
+    if (targetBlend) {
+      pso->setTargetBlends({*targetBlend});
+    }
+    pso->setSampleCount(sampleCount);
+    pso->setRenderPassDescriptor(rp);
+    pso->create();
+  };
 
-  m_glyphPso = m_rhi->newGraphicsPipeline();
-  m_glyphPso->setShaderStages({{QRhiShaderStage::Vertex, glyphVert},
-                               {QRhiShaderStage::Fragment, glyphFrag}});
-  m_glyphPso->setVertexInputLayout(glyphInputLayout);
-  m_glyphPso->setShaderResourceBindings(m_glyphSrb);
-  m_glyphPso->setCullMode(QRhiGraphicsPipeline::None);
-  m_glyphPso->setTargetBlends({blend});
-  m_glyphPso->setSampleCount(1);
-  m_glyphPso->setRenderPassDescriptor(m_contentRp);
-  m_glyphPso->create();
-
-  m_maskPso = m_rhi->newGraphicsPipeline();
-  m_maskPso->setShaderStages({{QRhiShaderStage::Vertex, rectVert},
-                              {QRhiShaderStage::Fragment, rectFrag}});
-  m_maskPso->setVertexInputLayout(rectInputLayout);
-  m_maskPso->setShaderResourceBindings(m_rectSrb);
-  m_maskPso->setCullMode(QRhiGraphicsPipeline::None);
-  m_maskPso->setTargetBlends({maskBlend});
-  m_maskPso->setSampleCount(1);
-  m_maskPso->setRenderPassDescriptor(m_maskRp);
-  m_maskPso->create();
-
-  m_edgePso = m_rhi->newGraphicsPipeline();
-  m_edgePso->setShaderStages({{QRhiShaderStage::Vertex, edgeVert},
-                              {QRhiShaderStage::Fragment, edgeFrag}});
-  m_edgePso->setVertexInputLayout(edgeInputLayout);
-  m_edgePso->setShaderResourceBindings(m_edgeSrb);
-  m_edgePso->setCullMode(QRhiGraphicsPipeline::None);
-  m_edgePso->setTargetBlends({edgeBlend});
-  m_edgePso->setSampleCount(1);
-  m_edgePso->setRenderPassDescriptor(m_edgeRp);
-  m_edgePso->create();
-
-  m_compositePso = m_rhi->newGraphicsPipeline();
-  m_compositePso->setShaderStages({{QRhiShaderStage::Vertex, screenVert},
-                                   {QRhiShaderStage::Fragment, compositeFrag}});
-  m_compositePso->setVertexInputLayout(screenInputLayout);
-  m_compositePso->setShaderResourceBindings(m_compositeSrb);
-  m_compositePso->setCullMode(QRhiGraphicsPipeline::None);
-  m_compositePso->setSampleCount(m_sampleCount);
-  m_compositePso->setRenderPassDescriptor(m_outputRp);
-  m_compositePso->create();
+  createPipeline(m_rectPso,
+                 rectVert,
+                 rectFrag,
+                 rectInputLayout,
+                 m_rectSrb,
+                 &blend,
+                 1,
+                 m_contentRp);
+  createPipeline(m_glyphPso,
+                 glyphVert,
+                 glyphFrag,
+                 glyphInputLayout,
+                 m_glyphSrb,
+                 &blend,
+                 1,
+                 m_contentRp);
+  createPipeline(m_maskPso,
+                 rectVert,
+                 rectFrag,
+                 rectInputLayout,
+                 m_rectSrb,
+                 &maskBlend,
+                 1,
+                 m_maskRp);
+  createPipeline(m_edgePso,
+                 edgeVert,
+                 edgeFrag,
+                 edgeInputLayout,
+                 m_edgeSrb,
+                 &edgeBlend,
+                 1,
+                 m_edgeRp);
+  createPipeline(m_compositePso,
+                 screenVert,
+                 compositeFrag,
+                 screenInputLayout,
+                 m_compositeSrb,
+                 nullptr,
+                 m_sampleCount,
+                 m_outputRp);
 }
 
 // Upload the glyph atlas texture when the source atlas version changes.
@@ -880,151 +943,47 @@ void HexViewRhiRenderer::updateUniforms(QRhiResourceUpdateBatch* u, float scroll
                          &itemIdWindow);
 }
 
-// Ensure dynamic instance buffer exists and is large enough for current upload size.
+// Ensure dynamic instance buffer exists and can hold current data; grow geometrically.
 bool HexViewRhiRenderer::ensureInstanceBuffer(QRhiBuffer*& buffer, int bytes) {
-  if (bytes <= 0) {
-    bytes = 1;
+  const int requiredBytes = std::max(1, bytes);
+  if (buffer && buffer->size() >= static_cast<quint32>(requiredBytes)) {
+    return false;
   }
-  if (!buffer || buffer->size() < static_cast<quint32>(bytes)) {
-    delete buffer;
-    buffer = m_rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::VertexBuffer, bytes);
-    buffer->create();
-    return true;
+
+  int allocBytes = requiredBytes;
+  if (buffer) {
+    allocBytes = std::max(requiredBytes, static_cast<int>(buffer->size()) * 2);
+  } else {
+    allocBytes = std::max(requiredBytes, 1024);
   }
-  return false;
+
+  delete buffer;
+  buffer = m_rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::VertexBuffer, allocBytes);
+  buffer->create();
+  return true;
 }
 
 // Upload dirty base/mask/edge instance arrays to their corresponding dynamic buffers.
 void HexViewRhiRenderer::updateInstanceBuffers(QRhiResourceUpdateBatch* u) {
-  bool baseRectResized = ensureInstanceBuffer(
-      m_baseRectBuf, static_cast<int>(m_baseRectInstances.size() * sizeof(RectInstance)));
-  if ((m_baseBufferDirty || baseRectResized) && !m_baseRectInstances.empty()) {
-    u->updateDynamicBuffer(m_baseRectBuf, 0,
-                           static_cast<int>(m_baseRectInstances.size() * sizeof(RectInstance)),
-                           m_baseRectInstances.data());
-  }
+  auto uploadIfDirty = [&](QRhiBuffer*& buffer, const void* data, int bytes, bool dirty) {
+    const bool resized = ensureInstanceBuffer(buffer, bytes);
+    if ((dirty || resized) && bytes > 0 && data) {
+      u->updateDynamicBuffer(buffer, 0, bytes, data);
+    }
+  };
 
-  bool baseGlyphResized = ensureInstanceBuffer(
-      m_baseGlyphBuf, static_cast<int>(m_baseGlyphInstances.size() * sizeof(GlyphInstance)));
-  if ((m_baseBufferDirty || baseGlyphResized) && !m_baseGlyphInstances.empty()) {
-    u->updateDynamicBuffer(m_baseGlyphBuf, 0,
-                           static_cast<int>(m_baseGlyphInstances.size() * sizeof(GlyphInstance)),
-                           m_baseGlyphInstances.data());
-  }
+  const int baseRectBytes = static_cast<int>(m_baseRectInstances.size() * sizeof(RectInstance));
+  const int baseGlyphBytes = static_cast<int>(m_baseGlyphInstances.size() * sizeof(GlyphInstance));
+  const int maskRectBytes = static_cast<int>(m_maskRectInstances.size() * sizeof(RectInstance));
+  const int edgeRectBytes = static_cast<int>(m_edgeRectInstances.size() * sizeof(EdgeInstance));
 
-  bool maskRectResized = ensureInstanceBuffer(
-      m_maskRectBuf, static_cast<int>(m_maskRectInstances.size() * sizeof(RectInstance)));
-  if ((m_selectionBufferDirty || maskRectResized) && !m_maskRectInstances.empty()) {
-    u->updateDynamicBuffer(m_maskRectBuf, 0,
-                           static_cast<int>(m_maskRectInstances.size() * sizeof(RectInstance)),
-                           m_maskRectInstances.data());
-  }
-
-  bool edgeRectResized = ensureInstanceBuffer(
-      m_edgeRectBuf, static_cast<int>(m_edgeRectInstances.size() * sizeof(EdgeInstance)));
-  if ((m_selectionBufferDirty || edgeRectResized) && !m_edgeRectInstances.empty()) {
-    u->updateDynamicBuffer(m_edgeRectBuf, 0,
-                           static_cast<int>(m_edgeRectInstances.size() * sizeof(EdgeInstance)),
-                           m_edgeRectInstances.data());
-  }
+  uploadIfDirty(m_baseRectBuf, m_baseRectInstances.data(), baseRectBytes, m_baseBufferDirty);
+  uploadIfDirty(m_baseGlyphBuf, m_baseGlyphInstances.data(), baseGlyphBytes, m_baseBufferDirty);
+  uploadIfDirty(m_maskRectBuf, m_maskRectInstances.data(), maskRectBytes, m_selectionBufferDirty);
+  uploadIfDirty(m_edgeRectBuf, m_edgeRectInstances.data(), edgeRectBytes, m_selectionBufferDirty);
 
   m_baseBufferDirty = false;
   m_selectionBufferDirty = false;
-}
-
-// Draw instanced rectangle geometry for base content or mask pass.
-void HexViewRhiRenderer::drawRectBuffer(QRhiCommandBuffer* cb, QRhiBuffer* buffer, int count,
-                                       int firstInstance, QRhiShaderResourceBindings* srb,
-                                       QRhiGraphicsPipeline* pso) {
-  if (!buffer || count <= 0) {
-    return;
-  }
-  if (!srb) {
-    srb = m_rectSrb;
-  }
-  if (!pso) {
-    pso = m_rectPso;
-  }
-  quint32 instanceOffset = 0;
-  int drawFirstInstance = firstInstance;
-  if (!m_supportsBaseInstance && firstInstance > 0) {
-    instanceOffset = static_cast<quint32>(firstInstance * sizeof(RectInstance));
-    drawFirstInstance = 0;
-  }
-  cb->setGraphicsPipeline(pso);
-  cb->setShaderResources(srb);
-  const QRhiCommandBuffer::VertexInput vbufBindings[] = {
-    {m_vbuf, 0},
-    {buffer, instanceOffset}
-  };
-  cb->setVertexInput(0, 2, vbufBindings, m_ibuf, 0, QRhiCommandBuffer::IndexUInt16);
-  cb->drawIndexed(6, count, 0, 0, drawFirstInstance);
-}
-
-// Draw instanced edge geometry used to produce shadow/glow distance fields.
-void HexViewRhiRenderer::drawEdgeBuffer(QRhiCommandBuffer* cb, QRhiBuffer* buffer, int count,
-                                       int firstInstance, QRhiShaderResourceBindings* srb,
-                                       QRhiGraphicsPipeline* pso) {
-  if (!buffer || count <= 0) {
-    return;
-  }
-  if (!srb) {
-    srb = m_edgeSrb;
-  }
-  if (!pso) {
-    pso = m_edgePso;
-  }
-  quint32 instanceOffset = 0;
-  int drawFirstInstance = firstInstance;
-  if (!m_supportsBaseInstance && firstInstance > 0) {
-    instanceOffset = static_cast<quint32>(firstInstance * sizeof(EdgeInstance));
-    drawFirstInstance = 0;
-  }
-  cb->setGraphicsPipeline(pso);
-  cb->setShaderResources(srb);
-  const QRhiCommandBuffer::VertexInput vbufBindings[] = {
-    {m_vbuf, 0},
-    {buffer, instanceOffset}
-  };
-  cb->setVertexInput(0, 2, vbufBindings, m_ibuf, 0, QRhiCommandBuffer::IndexUInt16);
-  cb->drawIndexed(6, count, 0, 0, drawFirstInstance);
-}
-
-// Draw instanced glyph quads sampling from the glyph atlas texture.
-void HexViewRhiRenderer::drawGlyphBuffer(QRhiCommandBuffer* cb, QRhiBuffer* buffer, int count,
-                                        int firstInstance) {
-  if (!buffer || count <= 0) {
-    return;
-  }
-  quint32 instanceOffset = 0;
-  int drawFirstInstance = firstInstance;
-  if (!m_supportsBaseInstance && firstInstance > 0) {
-    instanceOffset = static_cast<quint32>(firstInstance * sizeof(GlyphInstance));
-    drawFirstInstance = 0;
-  }
-  cb->setGraphicsPipeline(m_glyphPso);
-  cb->setShaderResources(m_glyphSrb);
-  const QRhiCommandBuffer::VertexInput vbufBindings[] = {
-    {m_vbuf, 0},
-    {buffer, instanceOffset}
-  };
-  cb->setVertexInput(0, 2, vbufBindings, m_ibuf, 0, QRhiCommandBuffer::IndexUInt16);
-  cb->drawIndexed(6, count, 0, 0, drawFirstInstance);
-}
-
-// Draw a single fullscreen quad for the composite post-process pass.
-void HexViewRhiRenderer::drawFullscreen(QRhiCommandBuffer* cb, QRhiGraphicsPipeline* pso,
-                                        QRhiShaderResourceBindings* srb) {
-  if (!pso || !srb) {
-    return;
-  }
-  cb->setGraphicsPipeline(pso);
-  cb->setShaderResources(srb);
-  const QRhiCommandBuffer::VertexInput vbufBindings[] = {
-    {m_vbuf, 0}
-  };
-  cb->setVertexInput(0, 1, vbufBindings, m_ibuf, 0, QRhiCommandBuffer::IndexUInt16);
-  cb->drawIndexed(6, 1, 0, 0, 0);
 }
 
 // Resolve atlas UVs for a character, with '.' as a fallback glyph.
@@ -1178,6 +1137,14 @@ void HexViewRhiRenderer::buildBaseInstances(const HexViewFrame::Data& frame,
     hexUvs[i] = glyphUv(QLatin1Char(kHexDigits[i]), frame);
   }
   const QRectF spaceUv = glyphUv(QLatin1Char(' '), frame);
+  std::array<QRectF, 256> asciiUvs{};
+  if (frame.shouldDrawAscii) {
+    const QRectF fallbackUv = glyphUv(QLatin1Char('.'), frame);
+    asciiUvs.fill(fallbackUv);
+    for (int c = 0x20; c <= 0x7E; ++c) {
+      asciiUvs[static_cast<size_t>(c)] = glyphUv(QLatin1Char(static_cast<char>(c)), frame);
+    }
+  }
 
   for (const auto& entry : m_cachedLines) {
     LineRange range{};
@@ -1246,10 +1213,15 @@ void HexViewRhiRenderer::buildBaseInstances(const HexViewFrame::Data& frame,
                   spaceUv, textColor);
 
       if (frame.shouldDrawAscii) {
-        const char asciiChar = isPrintable(value) ? static_cast<char>(value) : '.';
+        const uint8_t asciiChar = isPrintable(value) ? value : static_cast<uint8_t>('.');
         const float asciiX = asciiStartX + i * charWidth;
-        appendGlyph(m_baseGlyphInstances, asciiX, y, charWidth, lineHeight,
-                    glyphUv(QLatin1Char(asciiChar), frame), textColor);
+        appendGlyph(m_baseGlyphInstances,
+                    asciiX,
+                    y,
+                    charWidth,
+                    lineHeight,
+                    asciiUvs[static_cast<size_t>(asciiChar)],
+                    textColor);
       }
     }
 

--- a/src/ui/qt/workarea/hexview/HexViewRhiRenderer.h
+++ b/src/ui/qt/workarea/hexview/HexViewRhiRenderer.h
@@ -166,15 +166,6 @@ private:
                       const HexViewFrame::Data& frame, const LayoutMetrics& layout);
   bool ensureInstanceBuffer(QRhiBuffer*& buffer, int bytes);
   void updateInstanceBuffers(QRhiResourceUpdateBatch* u);
-  void drawRectBuffer(QRhiCommandBuffer* cb, QRhiBuffer* buffer, int count,
-                      int firstInstance = 0, QRhiShaderResourceBindings* srb = nullptr,
-                      QRhiGraphicsPipeline* pso = nullptr);
-  void drawEdgeBuffer(QRhiCommandBuffer* cb, QRhiBuffer* buffer, int count,
-                      int firstInstance = 0, QRhiShaderResourceBindings* srb = nullptr,
-                      QRhiGraphicsPipeline* pso = nullptr);
-  void drawGlyphBuffer(QRhiCommandBuffer* cb, QRhiBuffer* buffer, int count, int firstInstance = 0);
-  void drawFullscreen(QRhiCommandBuffer* cb, QRhiGraphicsPipeline* pso,
-                      QRhiShaderResourceBindings* srb);
 
   QRectF glyphUv(const QChar& ch, const HexViewFrame::Data& frame) const;
   void appendRect(std::vector<RectInstance>& rects, float x, float y, float w, float h,

--- a/src/ui/qt/workarea/hexview/HexViewRhiRenderer.h
+++ b/src/ui/qt/workarea/hexview/HexViewRhiRenderer.h
@@ -10,7 +10,6 @@
 #include <QSize>
 #include <array>
 #include <cstdint>
-#include <unordered_map>
 #include <vector>
 
 #include "HexViewFrameData.h"
@@ -117,16 +116,6 @@ private:
     uint32_t glyphStart = 0;
     uint32_t glyphCount = 0;
   };
-  struct Interval {
-    int start = 0;
-    int end = 0;
-  };
-  struct EdgeRun {
-    int startCol = 0;
-    int endCol = 0;
-    int startLine = 0;
-    int endLine = 0;
-  };
   struct SelectionBuildContext {
     // Visible range and geometry needed when converting byte selections into
     // GPU rect instances for both hex and ASCII columns.
@@ -179,20 +168,6 @@ private:
                          const HexViewFrame::Data& frame);
   void rebuildCacheWindow(const HexViewFrame::Data& frame);
   const CachedLine* cachedLineFor(int line) const;
-  void collectIntervalsForSelections(const std::vector<HexViewFrame::SelectionRange>& selections,
-                                     const SelectionBuildContext& ctx,
-                                     std::vector<std::vector<Interval>>& perLine) const;
-  static std::vector<Interval> mergeIntervals(std::vector<Interval>& intervals);
-  void appendMaskRectsForIntervals(const std::vector<Interval>& intervals,
-                                   int line,
-                                   const SelectionBuildContext& ctx,
-                                   float padX,
-                                   float padY,
-                                   const QVector4D& maskColor);
-  void emitEdgeRuns(const std::unordered_map<uint32_t, EdgeRun>& runs,
-                    const SelectionBuildContext& ctx,
-                    float edgePad,
-                    const QVector4D& edgeColor);
   void appendMaskForSelections(const std::vector<HexViewFrame::SelectionRange>& selections,
                                const SelectionBuildContext& ctx,
                                float padX,

--- a/src/ui/qt/workarea/hexview/HexViewRhiWindow.cpp
+++ b/src/ui/qt/workarea/hexview/HexViewRhiWindow.cpp
@@ -9,17 +9,13 @@
 #include "HexView.h"
 #include "HexViewRhiRenderer.h"
 #include "LogManager.h"
+#include "workarea/rhi/RhiWindowDragDropEvents.h"
 
 #include <rhi/qrhi.h>
 #include <rhi/qrhi_platform.h>
 
-#include <QDragEnterEvent>
-#include <QDragLeaveEvent>
-#include <QDragMoveEvent>
-#include <QDropEvent>
 #include <QEvent>
 #include <QExposeEvent>
-#include <QMimeData>
 #include <QResizeEvent>
 #include <QScrollBar>
 
@@ -148,46 +144,12 @@ bool HexViewRhiWindow::event(QEvent* e) {
     return true;
   }
 
-  if (!m_view || !m_view->viewport()) {
-    return QWindow::event(e);
-  }
-
-  switch (e->type()) {
-    case QEvent::DragEnter:
-    case QEvent::DragMove:
-    case QEvent::DragLeave:
-    case QEvent::Drop: {
-      switch (e->type()) {
-        case QEvent::DragEnter: {
-          auto* dragEvent = static_cast<QDragEnterEvent*>(e);
-          emit dragOverlayShowRequested();
-          dragEvent->acceptProposedAction();
-          break;
-        }
-        case QEvent::DragMove: {
-          auto* dragEvent = static_cast<QDragMoveEvent*>(e);
-          emit dragOverlayShowRequested();
-          dragEvent->acceptProposedAction();
-          break;
-        }
-        case QEvent::DragLeave:
-          emit dragOverlayHideRequested();
-          e->accept();
-          break;
-        case QEvent::Drop: {
-          auto* dropEvent = static_cast<QDropEvent*>(e);
-          emit dropUrlsRequested(dropEvent->mimeData()->urls());
-          dropEvent->acceptProposedAction();
-          break;
-        }
-        default:
-          break;
-      }
-      return true;
-    }
-
-    default:
-      break;
+  if (QtUi::handleRhiWindowDragDropEvent(
+          e,
+          [this]() { emit dragOverlayShowRequested(); },
+          [this]() { emit dragOverlayHideRequested(); },
+          [this](const QList<QUrl>& urls) { emit dropUrlsRequested(urls); })) {
+    return true;
   }
 
   return QWindow::event(e);
@@ -298,13 +260,7 @@ void HexViewRhiWindow::resizeSwapChain() {
     return;
   }
 
-  if (!m_ds || m_ds->pixelSize() != pixelSize) {
-    delete m_ds;
-    m_ds = m_rhi->newRenderBuffer(QRhiRenderBuffer::DepthStencil, pixelSize, m_sc->sampleCount(),
-                                  QRhiRenderBuffer::UsedWithSwapChainOnly);
-    m_ds->create();
-    m_sc->setDepthStencil(m_ds);
-  }
+  m_sc->setDepthStencil(nullptr);
 
   m_hasSwapChain = m_sc->createOrResize();
   L_DEBUG("HexViewRhiWindow swapchain resized pixelSize={}x{} sampleCount={}",
@@ -366,8 +322,6 @@ void HexViewRhiWindow::releaseResources() {
 
   delete m_rp;
   m_rp = nullptr;
-  delete m_ds;
-  m_ds = nullptr;
 
   releaseSwapChain();
   delete m_sc;

--- a/src/ui/qt/workarea/hexview/HexViewRhiWindow.h
+++ b/src/ui/qt/workarea/hexview/HexViewRhiWindow.h
@@ -19,7 +19,6 @@ class QExposeEvent;
 class QResizeEvent;
 class QRhi;
 class QRhiCommandBuffer;
-class QRhiRenderBuffer;
 class QRhiRenderPassDescriptor;
 class QRhiSwapChain;
 class HexView;
@@ -58,7 +57,6 @@ private:
 
   QRhi* m_rhi = nullptr;
   QRhiSwapChain* m_sc = nullptr;
-  QRhiRenderBuffer* m_ds = nullptr;
   QRhiRenderPassDescriptor* m_rp = nullptr;
   QRhiCommandBuffer* m_cb = nullptr;
 

--- a/src/ui/qt/workarea/hexview/shaders/hexcomposite.frag
+++ b/src/ui/qt/workarea/hexview/shaders/hexcomposite.frag
@@ -70,6 +70,16 @@ float computeOutlineMask(float xPx, float yPx, bool inHex, bool inAscii, float d
   }
   localX -= byteIdx * cellW;
 
+  float edgePx = 2.0 / dpr;
+  float leftEdge = step(localX, edgePx);
+  float rightEdge = step(cellW - edgePx, localX);
+  float topEdge = step(localY, edgePx);
+  float bottomEdge = step(lineHeightPx - edgePx, localY);
+  // Interior pixels can skip all item-id texture sampling.
+  if (leftEdge + rightEdge + topEdge + bottomEdge <= 0.0) {
+    return 0.0;
+  }
+
   vec2 texSize = vec2(bytesPerLine, itemIdWindow.w);
   vec2 texel = vec2(1.0) / texSize;
   vec2 centerUv = vec2(byteIdx + 0.5, lineIdx + 0.5) / texSize;
@@ -78,16 +88,22 @@ float computeOutlineMask(float xPx, float yPx, bool inHex, bool inAscii, float d
     return 0.0;
   }
 
-  float leftId = (byteIdx > 0.0) ? decodeItemId(centerUv - vec2(texel.x, 0.0)) : id;
-  float rightId = (byteIdx < bytesPerLine - 1.0) ? decodeItemId(centerUv + vec2(texel.x, 0.0)) : id;
-  float upId = (lineIdx > 0.0) ? decodeItemId(centerUv - vec2(0.0, texel.y)) : id;
-  float downId = (lineIdx < itemIdWindow.w - 1.0) ? decodeItemId(centerUv + vec2(0.0, texel.y)) : id;
-
-  float edgePx = 2.0 / dpr;
-  float leftEdge = step(localX, edgePx);
-  float rightEdge = step(cellW - edgePx, localX);
-  float topEdge = step(localY, edgePx);
-  float bottomEdge = step(lineHeightPx - edgePx, localY);
+  float leftId = id;
+  if (leftEdge > 0.0 && byteIdx > 0.0) {
+    leftId = decodeItemId(centerUv - vec2(texel.x, 0.0));
+  }
+  float rightId = id;
+  if (rightEdge > 0.0 && byteIdx < bytesPerLine - 1.0) {
+    rightId = decodeItemId(centerUv + vec2(texel.x, 0.0));
+  }
+  float upId = id;
+  if (topEdge > 0.0 && lineIdx > 0.0) {
+    upId = decodeItemId(centerUv - vec2(0.0, texel.y));
+  }
+  float downId = id;
+  if (bottomEdge > 0.0 && lineIdx < itemIdWindow.w - 1.0) {
+    downId = decodeItemId(centerUv + vec2(0.0, texel.y));
+  }
 
   float drawLeft = (leftId < 0.5 || id < leftId) ? 1.0 : 0.0;
   float drawRight = (rightId < 0.5 || id < rightId) ? 1.0 : 0.0;
@@ -99,14 +115,6 @@ float computeOutlineMask(float xPx, float yPx, bool inHex, bool inAscii, float d
                topEdge * drawUp * step(0.5, abs(id - upId)) +
                bottomEdge * drawDown * step(0.5, abs(id - downId));
   return clamp(edge, 0.0, 1.0);
-}
-
-float computeSelectionHighlight(vec4 mask) {
-  float sel = clamp(mask.r, 0.0, 1.0);
-  float playActiveMask = clamp(mask.g, 0.0, 1.0);
-  float playFadeMask = clamp(mask.b, 0.0, 1.0);
-  float playFadeAlpha = clamp(mask.a, 0.0, 1.0);
-  return max(sel, max(playActiveMask, playFadeMask * playFadeAlpha));
 }
 
 vec3 applyDimOutlineAndHighlight(vec3 baseRgb, float inColumns, float highlight, float outlineMask) {
@@ -172,7 +180,7 @@ void main() {
   float playActiveMask = clamp(mask.g, 0.0, 1.0);
   float playFadeMask = clamp(mask.b, 0.0, 1.0);
   float playFadeAlpha = clamp(mask.a, 0.0, 1.0);
-  float highlight = computeSelectionHighlight(mask);
+  float highlight = max(sel, max(playActiveMask, playFadeMask * playFadeAlpha));
   float logicalY = mix(1.0 - vUv.y, vUv.y, flipY);
   float y = logicalY * viewSize.y;
   float outlineMask = computeOutlineMask(x, y, inHex, inAscii, dpr);

--- a/src/ui/qt/workarea/rhi/RhiWindowDragDropEvents.h
+++ b/src/ui/qt/workarea/rhi/RhiWindowDragDropEvents.h
@@ -1,0 +1,66 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#pragma once
+
+#include <QDragEnterEvent>
+#include <QDragLeaveEvent>
+#include <QDragMoveEvent>
+#include <QDropEvent>
+#include <QEvent>
+#include <QMimeData>
+#include <QUrl>
+
+#include <functional>
+
+namespace QtUi {
+
+inline bool handleRhiWindowDragDropEvent(
+    QEvent* event,
+    const std::function<void()>& showOverlay,
+    const std::function<void()>& hideOverlay,
+    const std::function<void(const QList<QUrl>&)>& dropUrls) {
+  if (!event) {
+    return false;
+  }
+
+  switch (event->type()) {
+    case QEvent::DragEnter: {
+      auto* dragEvent = static_cast<QDragEnterEvent*>(event);
+      if (showOverlay) {
+        showOverlay();
+      }
+      dragEvent->acceptProposedAction();
+      return true;
+    }
+    case QEvent::DragMove: {
+      auto* dragEvent = static_cast<QDragMoveEvent*>(event);
+      if (showOverlay) {
+        showOverlay();
+      }
+      dragEvent->acceptProposedAction();
+      return true;
+    }
+    case QEvent::DragLeave:
+      if (hideOverlay) {
+        hideOverlay();
+      }
+      event->accept();
+      return true;
+    case QEvent::Drop: {
+      auto* dropEvent = static_cast<QDropEvent*>(event);
+      if (dropUrls) {
+        dropUrls(dropEvent->mimeData()->urls());
+      }
+      dropEvent->acceptProposedAction();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+}  // namespace QtUi

--- a/src/ui/qt/workarea/rhi/RhiWindowMainWindowLocator.h
+++ b/src/ui/qt/workarea/rhi/RhiWindowMainWindowLocator.h
@@ -1,0 +1,33 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#pragma once
+
+#include "MainWindow.h"
+
+#include <QApplication>
+#include <QWidget>
+
+namespace QtUi {
+
+inline MainWindow* findMainWindowForWidget(QWidget* origin) {
+  for (QWidget* widget = origin; widget; widget = widget->parentWidget()) {
+    if (auto* mainWindow = qobject_cast<MainWindow*>(widget)) {
+      return mainWindow;
+    }
+  }
+
+  const auto topLevelWidgets = QApplication::topLevelWidgets();
+  for (QWidget* widget : topLevelWidgets) {
+    if (auto* mainWindow = qobject_cast<MainWindow*>(widget)) {
+      return mainWindow;
+    }
+  }
+
+  return nullptr;
+}
+
+}  // namespace QtUi


### PR DESCRIPTION
## Description

This PR rewrites HexView’s selection and playback mask builder inside `HexViewRhiRenderer`. The older logic first collected per-line intervals for each range, then sorted and merged those intervals, then emitted mask rectangles from the merged intervals, and finally tracked matching intervals across lines to coalesce edge geometry. This branch replaces that with a single bitmask-based builder in `appendMaskForSelections()`. Each visible line is represented as a compact `uint16_t` byte mask, mask rectangles are emitted directly from those masks, and edge runs are tracked with fixed-size arrays keyed by `(startCol, endCol)` instead of dynamic maps and intermediate interval vectors.

The same change also simplifies a couple of related hot paths. Fade playback alpha overlays no longer go through the full edge-building path when they only need plain mask rectangles, and the now-unused interval and edge-run helper declarations are removed from `HexViewRhiRenderer.h`. The intent here is to reduce per-frame allocation, sorting, and bookkeeping in the selection/playback builder while keeping the existing renderer structure intact.

Future PRs will change the rendering pipeline more fundamentally while using this new mask paradigm.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
