### PR TITLE
add BytePattern for detecting Vegas Stakes DIR

### DIFF
--- a/src/main/formats/NinSnes/NinSnesScanner.cpp
+++ b/src/main/formats/NinSnes/NinSnesScanner.cpp
@@ -196,6 +196,17 @@ BytePattern NinSnesScanner::ptnSetDIRYI(
 	,
 	7);
 
+//; Vegas Stakes SPC
+//0817: e5 fe 07     mov   a,$07FE           ; reads $5d from $7FE
+//042e: 8d 5d        mov   y,#$5d
+//0430: 3f de 09     call  $09de             ; source dir = $5d00
+BytePattern NinSnesScanner::ptnSetDIRVS(
+  "\xe5\xfe\x07\x8d\x5d\x3f\xde\x09"
+  ,
+  "x??xxx??"
+  ,
+  8);
+
 //; Super Mario World SPC
 //; default values for DSP regs
 //1295: db $7f,$7f,$00,$00,$2f,$60,$00,$00,$00,$80,$60,$02
@@ -1641,6 +1652,10 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile *file) {
     }
     else if (file->searchBytePattern(ptnSetDIRYI, ofsSetDIR)) {
       spcDirAddr = file->readByte(ofsSetDIR + 1) << 8;
+    }
+    else if (file->searchBytePattern(ptnSetDIRVS, ofsSetDIR)) {
+      u16 spcDirAddrPtr = file->readShort(ofsSetDIR + 1);
+      spcDirAddr = file->readByte(spcDirAddrPtr) << 8;
     }
     else if (file->searchBytePattern(ptnSetDIRSMW, ofsSetDIR)) {
       spcDirAddr = file->readByte(ofsSetDIR + 9) << 8;

--- a/src/main/formats/NinSnes/NinSnesScanner.h
+++ b/src/main/formats/NinSnes/NinSnesScanner.h
@@ -26,6 +26,7 @@ class NinSnesScanner : public VGMScanner {
   static BytePattern ptnLoadInstrTableAddressSMW;
   static BytePattern ptnSetDIR;
   static BytePattern ptnSetDIRYI;
+  static BytePattern ptnSetDIRVS;
   static BytePattern ptnSetDIRSMW;
 
   // PATTERNS FOR DERIVED VERSIONS


### PR DESCRIPTION
## Description
This adds DIR detection for the 1993 HAL game Vegas Stakes. The DIR is the list of sample pointers and lengths, so this unlocks sample collection conversion. It might help other games that use a similar version of the driver. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
