### PR TITLE
Add support for NinSnes drum kits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Added an in-app dialog to help with reporting bugs.
 - Added Flatpak builds for Linux. From now on, stable releases will be automatically available on Flathub.
+- Added Drum Kit support to the more standard versions of the N-SPC driver (Nintendo's SNES SDK driver).
 - Added Drum Kit support to the SuzukiSnes driver (Seiken Densetsu 3, Super Mario RPG, etc)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 - Added an in-app dialog to help with reporting bugs.
 - Added Flatpak builds for Linux. From now on, stable releases will be automatically available on Flathub.
-- Added Drum Kit support to the more standard versions of the N-SPC driver (Nintendo's SNES SDK driver).
+- Added Drum Kit support to the standard N-SPC driver (Nintendo's SNES SDK driver).
 - Added Drum Kit support to the SuzukiSnes driver (Seiken Densetsu 3, Super Mario RPG, etc)
 
 ### Changed
@@ -17,6 +17,7 @@
 - Improved accuracy of Nintendo DS (SDAT) instrument ADSR.
 - Improved Wayland support (drag and drop, sandbox).
 - The space-bar hotkey to toggle playback no longer requires clicking on a collection first.
+- Improved detection of N-SPC driver instrument data.
 
 ### Fixed
 

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -108,6 +108,9 @@ void VGMInstrSet::prepareForExport(const VGMColl* coll) {
   cleanupAfterExport();
   m_exportInstrs = aInstrs;
   if (coll != nullptr) {
+    if (coll->seq() == nullptr) {
+      L_DEBUG("Collection is missing a sequence. This is unusual.");
+    }
     useColl(coll);
   }
 }

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -302,8 +302,8 @@ NinSnesRgn::NinSnesRgn(NinSnesInstr *instr,
   double coarse_tuning;
 
   // Very large NinSnes pitch multipliers can wrap the SNES DSP's 14-bit pitch instead of acting
-  // like a normal transposition. We have only observed this on percussion instruments (ex. F-Zero
-  // Big Blue), which the driver plays at fixed note 0x24 (base pitch 0x0217). When that happens,
+  // like a normal transposition. We have only observed this on percussion instruments (ex. SimCity
+  // Metropolis), which the driver plays at fixed note 0x24 (base pitch 0x0217). When that happens,
   // assume percussion usage and replace the raw multiplier with the wrapped pitch actually heard at
   // 0x24, expressed again as an equivalent scale factor for SF2/DLS unity key / fine-tune calculation.
   bool wrapsPercussion = (((uint32_t)0x0217 * pitch_scale) >> 8) > 0x3FFF;

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -4,8 +4,35 @@
  * refer to the included LICENSE.txt file
  */
 #include "NinSnesInstr.h"
+#include "NinSnesSeq.h"
 #include "SNESDSP.h"
+#include "VGMColl.h"
 #include <spdlog/fmt/fmt.h>
+
+namespace {
+
+VGMRgn* cloneRgnForDrumKit(VGMInstr* instr, VGMRgn* sourceRgn, uint8_t noteIndex, int8_t globalTranspose) {
+  auto* newRgn = new VGMRgn(instr,
+                            sourceRgn->offset(),
+                            sourceRgn->length(),
+                            noteIndex,
+                            noteIndex,
+                            sourceRgn->velLow,
+                            sourceRgn->velHigh,
+                            sourceRgn->sampNum);
+
+  newRgn->sampOffset = sourceRgn->sampOffset;
+  newRgn->unityKey = sourceRgn->unityKey + (noteIndex - 0x3C) - globalTranspose;
+  newRgn->fineTune = sourceRgn->fineTune;
+  newRgn->attack_time = sourceRgn->attack_time;
+  newRgn->decay_time = sourceRgn->decay_time;
+  newRgn->sustain_level = sourceRgn->sustain_level;
+  newRgn->sustain_time = sourceRgn->sustain_time;
+  newRgn->release_time = sourceRgn->release_time;
+  return newRgn;
+}
+
+}  // namespace
 
 // ****************
 // NinSnesInstrSet
@@ -117,6 +144,49 @@ bool NinSnesInstrSet::parseInstrPointers() {
   return true;
 }
 
+void NinSnesInstrSet::useColl(const VGMColl* coll) {
+  if (coll == nullptr || coll->seq() == nullptr) {
+    return;
+  }
+
+  const auto* seq = dynamic_cast<const NinSnesSeq*>(coll->seq());
+  if (seq == nullptr || seq->rawFile() != rawFile() || seq->version != version) {
+    return;
+  }
+
+  const auto& percussionInstrNoteMap = seq->percussionInstrNoteMap();
+  if (percussionInstrNoteMap.empty()) {
+    return;
+  }
+
+  // Create the drumkit instrument for percussion note events
+  auto* drumKit = new VGMInstr(this, 0, 0, 127, 0, "Drum Kit");
+  for (const auto& [instrIndex, percussionDef] : percussionInstrNoteMap) {
+    // Get the referenced instrument by checking its instrument number
+    VGMInstr* sourceInstr = nullptr;
+    for (auto* instr : aInstrs) {
+      if (instr->instrNum == instrIndex) {
+        sourceInstr = instr;
+        break;
+      }
+    }
+    if (sourceInstr == nullptr) {
+      continue;
+    }
+
+    for (auto* sourceRgn : sourceInstr->regions()) {
+      drumKit->addRgn(cloneRgnForDrumKit(drumKit, sourceRgn, percussionDef.noteIndex, percussionDef.globalTranspose));
+    }
+  }
+
+  if (drumKit->regions().empty()) {
+    delete drumKit;
+    return;
+  }
+
+  addTempInstr(drumKit);
+}
+
 // *************
 // NinSnesInstr
 // *************
@@ -219,7 +289,7 @@ NinSnesRgn::NinSnesRgn(NinSnesInstr *instr,
   uint8_t adsr1 = readByte(offset + 1);
   uint8_t adsr2 = readByte(offset + 2);
   uint8_t gain = readByte(offset + 3);
-  int16_t pitch_scale;
+  uint16_t pitch_scale;
   if (version == NINSNES_EARLIER) {
     pitch_scale = (int8_t) readByte(offset + 4) * 256;
   }
@@ -230,6 +300,17 @@ NinSnesRgn::NinSnesRgn(NinSnesInstr *instr,
   const double pitch_fixer = 4286.0 / 4096.0;
   double fine_tuning;
   double coarse_tuning;
+
+  // Very large NinSnes pitch multipliers can wrap the SNES DSP's 14-bit pitch instead of acting
+  // like a normal transposition. We have only observed this on percussion instruments (ex. F-Zero
+  // Big Blue), which the driver plays at fixed note 0x24 (base pitch 0x0217). When that happens,
+  // assume percussion usage and replace the raw multiplier with the wrapped pitch actually heard at
+  // 0x24, expressed again as an equivalent scale factor for SF2/DLS unity key / fine-tune calculation.
+  bool wrapsPercussion = (((uint32_t)0x0217 * pitch_scale) >> 8) > 0x3FFF;
+  if (wrapsPercussion) {
+    pitch_scale = ((((uint32_t)0x0217 * pitch_scale) >> 8) & 0x3FFF) * 256.0 / 0x0217;
+  }
+
   fine_tuning = modf((log(pitch_scale * pitch_fixer / 256.0) / log(2.0)) * 12.0, &coarse_tuning);
 
   // normalize

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -145,7 +145,7 @@ bool NinSnesInstrSet::parseInstrPointers() {
 }
 
 void NinSnesInstrSet::useColl(const VGMColl* coll) {
-  if (coll == nullptr || coll->seq() == nullptr) {
+  if (coll->seq() == nullptr) {
     return;
   }
 

--- a/src/main/formats/NinSnes/NinSnesInstr.h
+++ b/src/main/formats/NinSnes/NinSnesInstr.h
@@ -18,8 +18,9 @@ class NinSnesInstrSet:
                   const std::string &name = "NinSnesInstrSet");
   virtual ~NinSnesInstrSet();
 
-  virtual bool parseHeader();
-  virtual bool parseInstrPointers();
+  bool parseHeader() override;
+  bool parseInstrPointers() override;
+  void useColl(const VGMColl* coll) override;
 
   NinSnesVersion version;
 

--- a/src/main/formats/NinSnes/NinSnesScanner.cpp
+++ b/src/main/formats/NinSnes/NinSnesScanner.cpp
@@ -1611,6 +1611,11 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile *file) {
   if (file->searchBytePattern(ptnLoadInstrTableAddress, ofsLoadInstrTableAddressASM)) {
     addrInstrTable =
         file->readByte(ofsLoadInstrTableAddressASM + 7) | (file->readByte(ofsLoadInstrTableAddressASM + 10) << 8);
+    // Fix for HyperZone
+    u32 firstWord = file->readWord(addrInstrTable);
+    if (firstWord == 0 || firstWord == 0xFFFFFFFF) {
+      addrInstrTable += 4;
+    }
   }
   else if (file->searchBytePattern(ptnLoadInstrTableAddressSMW, ofsLoadInstrTableAddressASM)) {
     addrInstrTable =

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -46,6 +46,8 @@ void NinSnesSeq::resetVars() {
 
   spcPercussionBase = spcPercussionBaseInit;
   sectionRepeatCount = 0;
+  globalTranspose = 0;
+  m_percussionInstrNoteMap.clear();
 
   // Intelligent Systems:
   intelliUseCustomNoteParam = false;
@@ -512,7 +514,6 @@ void NinSnesSeq::loadEventMap() {
       break;
 
     case NINSNES_HAL:
-      EventMap[0xfa] = EVENT_NOP1;
       break;
 
     case NINSNES_KONAMI:
@@ -592,7 +593,7 @@ void NinSnesSeq::loadStandardVcmdMap(uint8_t statusByte) {
   EventMap[statusByte + 0x17] = EVENT_ECHO_PARAM;
   EventMap[statusByte + 0x18] = EVENT_ECHO_VOLUME_FADE;
   EventMap[statusByte + 0x19] = EVENT_PITCH_SLIDE;
-  EventMap[statusByte + 0x1a] = EVENT_PERCCUSION_PATCH_BASE;
+  EventMap[statusByte + 0x1a] = EVENT_PERCUSSION_PATCH_BASE;
 }
 
 double NinSnesSeq::getTempoInBPM(uint8_t tempo) {
@@ -719,7 +720,9 @@ NinSnesTrack::NinSnesTrack(NinSnesSection *parentSection, uint32_t offset, uint3
     : SeqTrack(parentSection->parentSeq, offset, length, theName),
       parentSection(parentSection),
       shared(NULL),
-      available(true) {
+      available(true),
+      m_lastNoteWasPercussion(false),
+      nonPercussionProgram(0) {
   resetVars();
   bDetermineTrackLengthEventByEvent = true;
 }
@@ -730,6 +733,47 @@ void NinSnesTrack::resetVars(void) {
   cKeyCorrection = SEQ_KEYOFS;
   if (shared != NULL) {
     transpose = shared->spcTranspose;
+  }
+  m_lastNoteWasPercussion = false;
+  nonPercussionProgram = 0;
+}
+
+void NinSnesTrack::restoreNonPercussionProgramIfNeeded() {
+  if (!m_lastNoteWasPercussion) {
+    return;
+  }
+
+  addBankSelectNoItem(0);
+  addProgramChangeNoItem(nonPercussionProgram, false);
+  m_lastNoteWasPercussion = false;
+}
+
+void NinSnesTrack::switchToPercussionProgramIfNeeded() {
+  if (m_lastNoteWasPercussion) {
+    return;
+  }
+
+  addBankSelectNoItem(127);
+  addProgramChangeNoItem(0, false);
+  m_lastNoteWasPercussion = true;
+}
+
+void NinSnesTrack::addProgramChangeEvent(uint32_t offset,
+                                         uint32_t length,
+                                         uint32_t progNum,
+                                         bool requireBank,
+                                         const std::string &eventName) {
+  nonPercussionProgram = progNum;
+
+  bool isNewOffset = onEvent(offset, length);
+  recordSeqEvent<ProgChangeSeqEvent>(isNewOffset, getTime(), progNum, offset, length, eventName);
+
+  if (readMode == READMODE_ADD_TO_UI) {
+    parentSeq->addInstrumentRef(progNum);
+  }
+
+  if (!m_lastNoteWasPercussion) {
+    addProgramChangeNoItem(progNum, requireBank);
   }
 }
 
@@ -882,8 +926,11 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t duration = (shared->spcNoteDuration * shared->spcNoteDurRate) >> 8;
       duration = std::min(std::max(duration, (uint8_t) 1), (uint8_t) (shared->spcNoteDuration - 2));
 
+      restoreNonPercussionProgramIfNeeded();
+
       // Note: Konami engine can have volume=0
       addNoteByDur(beginOffset, curOffset - beginOffset, noteNumber, shared->spcNoteVolume / 2, duration, "Note");
+      m_lastNoteWasPercussion = false;
       addTime(shared->spcNoteDuration);
       break;
     }
@@ -904,27 +951,43 @@ bool NinSnesTrack::readEvent(void) {
     }
 
     case EVENT_PERCUSSION_NOTE: {
-      uint8_t noteNumber = statusByte - parentSeq->STATUS_PERCUSSION_NOTE_MIN;
+      // Like standard MIDI drum channels, percussion notes swap the ability to denote pitch (key)
+      // for the ability to indicate which instrument to play per note. The EVENT_PERCUSSION_PATCH_BASE
+      // event sets the base instr index to use (spcPercussionBase). The instrument to use is then
+      // spcPercussionBase + the percussion note opcode index. So, if spcPercussionBase is 5
+      // and the percussion note opcode is CB when STATUS_PERCUSSION_NOTE_MIN is CA, it would use
+      // instrument 6.
+      uint8_t instrIndex = statusByte - parentSeq->STATUS_PERCUSSION_NOTE_MIN;
 
-      noteNumber += parentSeq->spcPercussionBase;
+      instrIndex += parentSeq->spcPercussionBase;
 
       if (parentSeq->version == NINSNES_QUINTET_ACTR) {
-        noteNumber += parentSeq->quintetBGMInstrBase;
+        instrIndex += parentSeq->quintetBGMInstrBase;
       }
       else if (NinSnesFormat::isQuintetVersion(parentSeq->version)) {
-        noteNumber = readByte(parentSeq->quintetAddrBGMInstrLookup + noteNumber);
+        instrIndex = readByte(parentSeq->quintetAddrBGMInstrLookup + instrIndex);
       }
+
+      // Pitches are fixed, but we assign each drum to a unique note. The note value is 0x24
+      // plus the instrument index (relative to the base percussion instrument).
+      // We maintain a table of these mappings which NinSnesInstrSet uses at conversion time to
+      // create the drum kit. We also indicate the global transpose, since that should affect
+      // percussion note pitch. We do that by factoring it into the instrument region unity key.
+      uint8_t noteIndex = 0x24 + instrIndex - parentSeq->spcPercussionBase;
+      parentSeq->addPercussionInstrNoteMapping(instrIndex, noteIndex, parentSeq->globalTranspose);
 
       uint8_t duration = (shared->spcNoteDuration * shared->spcNoteDurRate) >> 8;
       duration = std::min(std::max(duration, (uint8_t) 1), (uint8_t) (shared->spcNoteDuration - 2));
 
       // Note: Konami engine can have volume=0
+      switchToPercussionProgramIfNeeded();
       addPercNoteByDur(beginOffset,
                        curOffset - beginOffset,
-                       noteNumber,
+                       static_cast<int8_t>(noteIndex - cKeyCorrection - parentSeq->globalTranspose),
                        shared->spcNoteVolume / 2,
                        duration,
                        "Percussion Note");
+      m_lastNoteWasPercussion = true;
       addTime(shared->spcNoteDuration);
       break;
     }
@@ -946,7 +1009,7 @@ bool NinSnesTrack::readEvent(void) {
         newProgNum = readByte(parentSeq->quintetAddrBGMInstrLookup + newProgNum);
       }
 
-      addProgramChange(beginOffset, curOffset - beginOffset, newProgNum, true);
+      addProgramChangeEvent(beginOffset, curOffset - beginOffset, newProgNum, true);
       break;
     }
 
@@ -1037,6 +1100,7 @@ bool NinSnesTrack::readEvent(void) {
 
     case EVENT_GLOBAL_TRANSPOSE: {
       int8_t semitones = readByte(curOffset++);
+      parentSeq->globalTranspose = semitones;
       addGlobalTranspose(beginOffset, curOffset - beginOffset, semitones);
       break;
     }
@@ -1250,7 +1314,7 @@ bool NinSnesTrack::readEvent(void) {
       break;
     }
 
-    case EVENT_PERCCUSION_PATCH_BASE: {
+    case EVENT_PERCUSSION_PATCH_BASE: {
       uint8_t percussionBase = readByte(curOffset++);
       parentSeq->spcPercussionBase = percussionBase;
 
@@ -1267,7 +1331,8 @@ bool NinSnesTrack::readEvent(void) {
       uint8_t newProgNum = readByte(curOffset++);
       uint8_t adsr1 = readByte(curOffset++);
       uint8_t adsr2 = readByte(curOffset++);
-      addProgramChange(beginOffset, curOffset - beginOffset, newProgNum, true, "Program Change & ADSR");
+      addProgramChangeEvent(beginOffset, curOffset - beginOffset, newProgNum, true,
+                            "Program Change & ADSR");
       break;
     }
 
@@ -1509,7 +1574,10 @@ bool NinSnesTrack::readEvent(void) {
           newProgNum &= 0x1f;
         }
 
-        addProgramChangeNoItem(newProgNum, true);
+        nonPercussionProgram = newProgNum;
+        if (!m_lastNoteWasPercussion) {
+          addProgramChangeNoItem(newProgNum, true);
+        }
 
         addVolNoItem(newVol / 2);
 

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -717,17 +717,12 @@ void NinSnesTrackSharedData::resetVars(void) {
 //  ************
 
 NinSnesTrack::NinSnesTrack(NinSnesSection *parentSection, uint32_t offset, uint32_t length, const std::string &theName)
-    : SeqTrack(parentSection->parentSeq, offset, length, theName),
-      parentSection(parentSection),
-      shared(NULL),
-      available(true),
-      m_lastNoteWasPercussion(false),
-      nonPercussionProgram(0) {
+    : SeqTrack(parentSection->parentSeq, offset, length, theName), parentSection(parentSection) {
   resetVars();
   bDetermineTrackLengthEventByEvent = true;
 }
 
-void NinSnesTrack::resetVars(void) {
+void NinSnesTrack::resetVars() {
   SeqTrack::resetVars();
 
   cKeyCorrection = SEQ_KEYOFS;
@@ -777,7 +772,7 @@ void NinSnesTrack::addProgramChangeEvent(uint32_t offset,
   }
 }
 
-bool NinSnesTrack::readEvent(void) {
+bool NinSnesTrack::readEvent() {
   if (!available) {
     return false;
   }

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -211,8 +211,8 @@ class NinSnesTrack
   int8_t calculatePanValue(uint8_t pan, double &volumeScale, bool &reverseLeft, bool &reverseRight);
 
   NinSnesSection *parentSection;
-  NinSnesTrackSharedData *shared;
-  bool available;
+  NinSnesTrackSharedData *shared = nullptr;
+  bool available = true;
 
  private:
   void restoreNonPercussionProgramIfNeeded();
@@ -223,6 +223,6 @@ class NinSnesTrack
                              bool requireBank,
                              const std::string &eventName = "Program Change");
 
-  bool m_lastNoteWasPercussion;
-  uint32_t nonPercussionProgram;
+  bool m_lastNoteWasPercussion = false;
+  uint32_t nonPercussionProgram = 0;
 };

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -45,7 +45,7 @@ enum NinSnesSeqEventType {
   EVENT_ECHO_PARAM,
   EVENT_ECHO_VOLUME_FADE,
   EVENT_PITCH_SLIDE,
-  EVENT_PERCCUSION_PATCH_BASE,
+  EVENT_PERCUSSION_PATCH_BASE,
 
   // Nintendo RD2:
       EVENT_RD2_PROGCHANGE_AND_ADSR,
@@ -104,6 +104,11 @@ class NinSnesTrackSharedData {
   uint8_t konamiLoopCount;
 };
 
+struct NinSnesPercussionDef {
+  uint8_t noteIndex;
+  int8_t globalTranspose;
+};
+
 class NinSnesSeq:
     public VGMMultiSectionSeq {
  public:
@@ -142,6 +147,7 @@ class NinSnesSeq:
 
   uint8_t spcPercussionBase;
   uint8_t sectionRepeatCount;
+  int8_t globalTranspose;
 
   // Konami:
   uint16_t konamiBaseAddress;
@@ -160,6 +166,13 @@ class NinSnesSeq:
   // Falcom:
   uint16_t falcomBaseOffset;
 
+  void addPercussionInstrNoteMapping(uint8_t instrIndex, uint8_t noteIndex, int8_t globalTranspose) {
+    m_percussionInstrNoteMap[instrIndex] = {noteIndex, globalTranspose};
+  }
+  const std::map<uint8_t, NinSnesPercussionDef>& percussionInstrNoteMap() const {
+    return m_percussionInstrNoteMap;
+  }
+
 protected:
   VGMHeader *header;
 
@@ -168,6 +181,7 @@ protected:
   void loadStandardVcmdMap(uint8_t statusByte);
 
   uint8_t spcPercussionBaseInit;
+  std::map<uint8_t, NinSnesPercussionDef> m_percussionInstrNoteMap;
 };
 
 class NinSnesSection
@@ -199,4 +213,16 @@ class NinSnesTrack
   NinSnesSection *parentSection;
   NinSnesTrackSharedData *shared;
   bool available;
+
+ private:
+  void restoreNonPercussionProgramIfNeeded();
+  void switchToPercussionProgramIfNeeded();
+  void addProgramChangeEvent(uint32_t offset,
+                             uint32_t length,
+                             uint32_t progNum,
+                             bool requireBank,
+                             const std::string &eventName = "Program Change");
+
+  bool m_lastNoteWasPercussion;
+  uint32_t nonPercussionProgram;
 };

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -104,7 +104,7 @@ bool SuzukiSnesInstrSet::parseInstrPointers() {
 }
 
 void SuzukiSnesInstrSet::useColl(const VGMColl* coll) {
-  if (coll == nullptr || coll->seq() == nullptr) {
+  if (coll->seq() == nullptr) {
     return;
   }
 


### PR DESCRIPTION
## High level

This updates both NinSnesInstrSet and NinSnesSeq so that the converted instrument set contains a drum kit used by percussion note events. Previously, percussion note events were just generating noise by playing arbitrary notes without a program change.

Similar to Suzuki and PS1 Akao, crucial data for the drum kit is stored in the sequence itself, so we utilize `VGMInstrSet::useColl()` and `VGMInstrSet::addTempInstr()` to allow the instrument set to access sequence data and create the drum kit at conversion time. 

## Low level 

In NinSnes sequence data, the `EVENT_PERCUSSION_PATCH_BASE` event indicates the base instrument index to use for drums. The opcode of a drum note event indicates which instrument index offset to add to this base. The driver has a lot of versions, but for most, percussion note events start with opcode 0xCA. A percussion note with opcode 0xCB would therefore use the base instrument index + 1. We assign notes for these events at base offset 0x24 (arbitrary) plus the relative instrument index. So in this example, 0xCB would use note value 0x25.

We track the assignment of drum instruments to notes in NinSnesSeq::m_percussionInstrNoteMap. We also save the global transposition value when the note was first encountered, as this affects its pitch (but track transpose does not). Using pitch bend would be messy, so we instead subtract the global transposition from the drum kit region's unity key.

With that data stored, at conversion time the NinSnesInstrSet creates a new temporary drum kit instrument and iterates over all of the instr indexes in the map to create a new region for each using the given note index, which also factors into the unity key alongside global transposition. The rest of the data for that instrument (sample number, ADSR, Gain, etc) was already parsed on load, so we just copy it over.

## Other things

I found a case of an instrument using an insane pitch scale value, which was not handled properly by VGMTrans and resulted in a very wrong unity key. Specifically, in SimCity, one of the drum instruments had a pitch scale value of 0x8000 (we call these bytes "unity key" and "fine tune", but it's a slight misnomer). This value was causing the DSP 14-bit pitch scale register to wrap. I added some logic to handle values like this. Since calculating accurate pitch in this case requires knowing the note ahead of time, the code assumes it's a percussion note (which uses the fixed pitch for note index 0x24).

Another thing: for some reason, @loveemu reassigned what would normally be the EVENT_PERCUSSION_PATCH_BASE opcode to NOP for the HAL version of the driver. I tested many HAL games and couldn't determine why he did this (it breaks drum kit conversion) so I took it out.

## Motivation and Context
This fixes percussion on a good chunk of classic (and not-so-classic) SNES games.

## How Has This Been Tested?
Tested a large number of NinSnes games, including the Quintet versions of the driver which use special logic in the EVENT_PERCUSSION_NOTE handler.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
