### PR TITLE
HexView Refactor 4: improve resource upload scheduling

### DIFF
--- a/src/ui/qt/workarea/hexview/HexViewRhiRenderer.cpp
+++ b/src/ui/qt/workarea/hexview/HexViewRhiRenderer.cpp
@@ -408,8 +408,14 @@ void HexViewRhiRenderer::renderFrame(QRhiCommandBuffer* cb, const RenderTargetIn
     cb->drawIndexed(6, 1, 0, 0, 0);
   };
 
+  // Submit uploads before the first pass so render-pass startup does not also
+  // carry resource-update work on backends that are sensitive to it.
+  if (u) {
+    cb->resourceUpdate(u);
+  }
+
   // Pass 1: base content (background spans + glyphs) into an offscreen texture.
-  cb->beginPass(m_contentRt, clearColor, {1.0f, 0}, u);
+  cb->beginPass(m_contentRt, clearColor, {1.0f, 0}, nullptr);
   cb->setViewport(viewport);
   drawInstanced(m_rectPso,
                 m_rectSrb,


### PR DESCRIPTION
This PR makes one small scheduling change in the HexView RHI renderer. Instead of passing the resource update batch into `beginPass()` for the content pass, it submits the update batch explicitly before the first render pass begins.

If memory serves, I found that this alone provides a significant performance gain.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
