### PR TITLE
Collections search utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added Flatpak builds for Linux. From now on, stable releases will be automatically available on Flathub.
 - Added Drum Kit support to the standard N-SPC driver (Nintendo's SNES SDK driver).
 - Added Drum Kit support to the SuzukiSnes driver (Seiken Densetsu 3, Super Mario RPG, etc)
+- Added a search field to the Collections panel
 
 ### Changed
 

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -51,8 +51,10 @@ target_sources(vgmtrans
     services/NotificationCenter.cpp
     util/ColorHelpers.cpp
     util/Helpers.cpp
+    util/InstructionHintLayout.cpp
     util/UIHelpers.cpp
     widgets/ItemViewDensity.cpp
+    widgets/EmptyStateWidget.cpp
     widgets/SeekBar.cpp
     widgets/MarqueeLabel.cpp
     widgets/SnappingSplitter.cpp
@@ -102,6 +104,7 @@ target_sources(vgmtrans
       util/ColorHelpers.h
       util/Colors.h
       util/Helpers.h
+      util/InstructionHintLayout.h
       util/LambdaEventFilter.h
       util/Metrics.h
       util/TintableSvgIconEngine.h
@@ -110,6 +113,7 @@ target_sources(vgmtrans
     FILE_SET headers_widgets TYPE HEADERS BASE_DIRS widgets
     FILES
       widgets/FixedHeightListDelegate.h
+      widgets/EmptyStateWidget.h
       widgets/ItemViewDensity.h
       widgets/SeekBar.h
       widgets/MarqueeLabel.h

--- a/src/ui/qt/MainWindow.cpp
+++ b/src/ui/qt/MainWindow.cpp
@@ -8,12 +8,15 @@
 #include <QDragLeaveEvent>
 #include <QDragMoveEvent>
 #include <QDropEvent>
+#include <QAction>
 #include <QFileDialog>
 #include <QDockWidget>
 #include <QApplication>
 #include <QCloseEvent>
 #include <QFileInfo>
+#include <QHBoxLayout>
 #include <QKeyEvent>
+#include <QLineEdit>
 #include <QMessageBox>
 #include <QMimeData>
 #include <QMouseEvent>
@@ -43,6 +46,7 @@
 #include "SequencePlayer.h"
 #include "services/NotificationCenter.h"
 #include "services/Settings.h"
+#include "util/UIHelpers.h"
 #include "workarea/RawFileListView.h"
 #include "workarea/VGMFileListView.h"
 #include "workarea/VGMCollListView.h"
@@ -161,9 +165,9 @@ void MainWindow::createElements() {
   setCorner(Qt::BottomLeftCorner, Qt::BottomDockWidgetArea);
   setCorner(Qt::BottomRightCorner, Qt::BottomDockWidgetArea);
 
-  const auto installTitleBar = [this](QDockWidget *dock, const QString& title,
-                                      TitleBar::Buttons buttons,
-                                      const QString& newToolTip = QString()) {
+  const auto installTitleBar = [](QDockWidget *dock, const QString& title,
+                                  TitleBar::Buttons buttons,
+                                  const QString& newToolTip = QString()) {
     auto *titleBar = new TitleBar(title, buttons, dock, newToolTip);
     connect(titleBar, &TitleBar::hideRequested, dock, &QDockWidget::hide);
     dock->setTitleBarWidget(titleBar);
@@ -211,6 +215,45 @@ void MainWindow::createElements() {
     ManualCollectionDialog dialog(this);
     dialog.exec();
   });
+
+  auto* collLeadingControls = new QWidget(collTitleBar);
+  auto* collLeadingLayout = new QHBoxLayout(collLeadingControls);
+  collLeadingLayout->setContentsMargins(0, 0, 0, 0);
+  collLeadingLayout->setSpacing(0);
+
+  auto* collSearchEdit = new QLineEdit(collLeadingControls);
+  collSearchEdit->setPlaceholderText(QStringLiteral("Search"));
+  collSearchEdit->setClearButtonEnabled(true);
+  collSearchEdit->setFixedWidth(220);
+  collSearchEdit->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+#ifdef Q_OS_MAC
+  collSearchEdit->setAttribute(Qt::WA_MacShowFocusRect, false);
+  collSearchEdit->setStyleSheet(
+      "QLineEdit {"
+      "  background-color: palette(base);"
+      "  border: 1px solid palette(mid);"
+      "  border-radius: 5px;"
+      "  padding: 0px 6px;"
+      "}"
+      "QLineEdit:focus {"
+      "  border: 1px solid palette(highlight);"
+      "}");
+#endif
+  collSearchEdit->setFixedHeight(20);
+  QAction* collSearchIconAction =
+      collSearchEdit->addAction(QIcon(), QLineEdit::LeadingPosition);
+  collLeadingLayout->addWidget(collSearchEdit);
+  collTitleBar->addLeadingWidget(collLeadingControls);
+
+  const auto refreshCollectionTitleControls =
+      [collTitleBar, collSearchIconAction]() {
+        collSearchIconAction->setIcon(stencilSvgIcon(
+            QStringLiteral(":/icons/magnify.svg"),
+            toolBarButtonIconColor(collTitleBar->palette())));
+      };
+  refreshCollectionTitleControls();
+  connect(collTitleBar, &TitleBar::appearanceChanged, this, refreshCollectionTitleControls);
+  connect(collSearchEdit, &QLineEdit::textChanged, m_coll_listview, &VGMCollListView::setFilterText);
 
   m_coll_view_dock = new QDockWidget("Collection Contents");
   m_coll_view_dock->setObjectName(QStringLiteral("collectionContentDock"));

--- a/src/ui/qt/PlaybackControls.cpp
+++ b/src/ui/qt/PlaybackControls.cpp
@@ -16,6 +16,7 @@
 #include "SequencePlayer.h"
 #include "SeekBar.h"
 #include "UIHelpers.h"
+#include "ColorHelpers.h"
 
 namespace {
 constexpr int kTransportControlHeight = 32;

--- a/src/ui/qt/util/InstructionHintLayout.cpp
+++ b/src/ui/qt/util/InstructionHintLayout.cpp
@@ -1,0 +1,79 @@
+/*
+* VGMTrans (c) 2002-2026
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+*/
+
+#include "util/InstructionHintLayout.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <QColor>
+#include <QIcon>
+#include <QPainter>
+#include <QPixmap>
+
+#include "util/UIHelpers.h"
+
+QFont prepareInstructionFont(const QFont &base, qreal scale,
+                             QFont::Weight weight,
+                             int minPointSize,
+                             const QString &fontFamily) {
+  QFont font = base;
+  if (font.pointSizeF() > 0.0) {
+    const qreal scaledPointSize = font.pointSizeF() * scale;
+    font.setPointSizeF(minPointSize > 0
+                           ? std::max<qreal>(minPointSize, scaledPointSize)
+                           : scaledPointSize);
+  } else if (font.pixelSize() > 0) {
+    const int scaledPixelSize = static_cast<int>(std::round(font.pixelSize() * scale));
+    font.setPixelSize(minPointSize > 0
+                          ? std::max(minPointSize, scaledPixelSize)
+                          : scaledPixelSize);
+  } else {
+    const int fallbackSize = scale >= 1.5 ? 18 : 14;
+    font.setPointSize(minPointSize > 0
+                          ? std::max(minPointSize, fallbackSize)
+                          : fallbackSize);
+  }
+
+  font.setWeight(weight);
+  if (!fontFamily.isEmpty()) {
+    font.setFamily(fontFamily);
+  }
+  return font;
+}
+
+InstructionMetrics computeInstructionMetrics(const InstructionHint &hint, const QFont &baseFont) {
+  QFont font = prepareInstructionFont(baseFont, hint.fontScale, hint.fontWeight,
+                                      hint.minPointSize, hint.fontFamily);
+  QFontMetrics metrics(font);
+  const int iconSide = static_cast<int>(metrics.height() * hint.iconScale);
+  const int spacing = std::max(2, static_cast<int>(metrics.height() * hint.spacingScale));
+  const int textWidth = metrics.horizontalAdvance(hint.text);
+  const int width = std::max(iconSide, textWidth);
+  const int height = iconSide + spacing + metrics.height();
+  return {hint, font, metrics, iconSide, spacing, QSize(width, height)};
+}
+
+void paintInstruction(QPainter &painter, const InstructionMetrics &metrics, const QPoint &topLeft,
+                      const QColor &accent) {
+  const QSize iconSize(metrics.iconSide, metrics.iconSide);
+  const int iconX = topLeft.x() + (metrics.size.width() - metrics.iconSide) / 2;
+  const int iconY = topLeft.y();
+  const qreal devicePixelRatio =
+      painter.device() ? painter.device()->devicePixelRatioF() : qreal(1.0);
+  const QPixmap icon = tintedIconPixmap(QIcon(metrics.hint.iconPath), iconSize, accent,
+                                        devicePixelRatio);
+  if (!icon.isNull()) {
+    painter.drawPixmap(iconX, iconY, icon);
+  }
+
+  painter.setFont(metrics.font);
+  painter.setPen(accent);
+
+  const int textTop = iconY + metrics.iconSide + metrics.spacing;
+  const QRect textRect(topLeft.x(), textTop, metrics.size.width(), metrics.metrics.height());
+  painter.drawText(textRect, Qt::AlignHCenter | Qt::AlignTop, metrics.hint.text);
+}

--- a/src/ui/qt/util/InstructionHintLayout.h
+++ b/src/ui/qt/util/InstructionHintLayout.h
@@ -1,0 +1,46 @@
+/*
+* VGMTrans (c) 2002-2026
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+*/
+
+#pragma once
+
+#include <QFont>
+#include <QFontMetrics>
+#include <QPoint>
+#include <QSize>
+#include <QString>
+
+class QColor;
+class QPainter;
+
+struct InstructionHint {
+  QString iconPath;
+  QString text;
+  qreal fontScale = 1.0;
+  qreal iconScale = 1.0;
+  qreal spacingScale = 0.3;
+  QFont::Weight fontWeight = QFont::Normal;
+  int minPointSize = 0;
+  QString fontFamily = QStringLiteral("Helvetica Neue");
+};
+
+struct InstructionMetrics {
+  InstructionHint hint;
+  QFont font;
+  QFontMetrics metrics;
+  int iconSide = 0;
+  int spacing = 0;
+  QSize size;
+};
+
+QFont prepareInstructionFont(const QFont &base, qreal scale,
+                             QFont::Weight weight = QFont::Normal,
+                             int minPointSize = 0,
+                             const QString &fontFamily = {});
+
+InstructionMetrics computeInstructionMetrics(const InstructionHint &hint, const QFont &baseFont);
+
+void paintInstruction(QPainter &painter, const InstructionMetrics &metrics, const QPoint &topLeft,
+                      const QColor &accent);

--- a/src/ui/qt/util/UIHelpers.cpp
+++ b/src/ui/qt/util/UIHelpers.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "UIHelpers.h"
+#include "ColorHelpers.h"
 #include "TintableSvgIconEngine.h"
 
 #include <QIcon>
@@ -19,6 +20,7 @@
 #include <QFileDialog>
 #include <QStandardPaths>
 #include <QApplication>
+#include <QPixmap>
 
 QScrollArea* getContainingScrollArea(const QWidget* widget) {
   QWidget* viewport = widget->parentWidget();

--- a/src/ui/qt/util/UIHelpers.h
+++ b/src/ui/qt/util/UIHelpers.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include "ColorHelpers.h"
-
 #include <filesystem>
 #include <string>
 #include <QColor>

--- a/src/ui/qt/widgets/EmptyStateWidget.cpp
+++ b/src/ui/qt/widgets/EmptyStateWidget.cpp
@@ -1,0 +1,180 @@
+/*
+* VGMTrans (c) 2002-2026
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+*/
+
+#include "EmptyStateWidget.h"
+
+#include <QColor>
+#include <QEvent>
+#include <QIcon>
+#include <QLabel>
+#include <QPalette>
+#include <QSizePolicy>
+#include <QStackedLayout>
+#include <QVBoxLayout>
+
+#include "util/UIHelpers.h"
+
+static constexpr int kEmptyStateHorizontalInset = 24;
+static constexpr int kEmptyStateVerticalInset = 24;
+static constexpr int kEmptyStateContentSpacing = 6;
+
+EmptyStateWidget::EmptyStateWidget(const InstructionHint &headingHint,
+                                   QWidget *contentWidget,
+                                   QWidget *parent)
+    : QWidget(parent),
+      m_contentWidget(contentWidget),
+      m_headingHint(headingHint) {
+  if (!m_contentWidget) {
+    m_contentWidget = new QWidget();
+  }
+
+  m_stack = new QStackedLayout(this);
+  m_stack->setContentsMargins(0, 0, 0, 0);
+  m_stack->setSpacing(0);
+  m_stack->setStackingMode(QStackedLayout::StackAll);
+
+  m_contentWidget->setParent(this);
+  m_stack->addWidget(m_contentWidget);
+
+  m_emptyView = new QWidget(this);
+  m_emptyView->setAttribute(Qt::WA_TransparentForMouseEvents, true);
+  m_emptyView->setFocusPolicy(Qt::NoFocus);
+  auto *emptyLayout = new QVBoxLayout(m_emptyView);
+  emptyLayout->setContentsMargins(kEmptyStateHorizontalInset,
+                                  kEmptyStateVerticalInset,
+                                  kEmptyStateHorizontalInset,
+                                  kEmptyStateVerticalInset);
+  emptyLayout->setSpacing(0);
+  emptyLayout->addStretch();
+
+  m_iconLabel = new QLabel(m_emptyView);
+  m_iconLabel->setAlignment(Qt::AlignHCenter | Qt::AlignBottom);
+  m_iconLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
+  m_headingLabel = new QLabel(m_emptyView);
+  m_headingLabel->setAlignment(Qt::AlignHCenter | Qt::AlignTop);
+  m_headingLabel->setWordWrap(true);
+  m_headingLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
+
+  m_bodyLabel = new QLabel(m_emptyView);
+  m_bodyLabel->setAlignment(Qt::AlignHCenter | Qt::AlignTop);
+  m_bodyLabel->setWordWrap(true);
+  m_bodyLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
+
+  emptyLayout->addWidget(m_iconLabel, 0, Qt::AlignHCenter);
+  emptyLayout->addWidget(m_headingLabel);
+  emptyLayout->addWidget(m_bodyLabel);
+  emptyLayout->addStretch();
+
+  m_stack->addWidget(m_emptyView);
+  m_emptyView->hide();
+
+  refreshEmptyStatePresentation();
+  setEmptyStateShown(false);
+}
+
+void EmptyStateWidget::setInstructionHint(const InstructionHint &headingHint) {
+  m_headingHint = headingHint;
+  refreshEmptyStatePresentation();
+}
+
+void EmptyStateWidget::setBodyText(const QString &body) {
+  m_emptyBody = body;
+  refreshEmptyStatePresentation();
+}
+
+void EmptyStateWidget::setEmptyStateContent(const QString &iconPath,
+                                            const QString &heading,
+                                            const QString &body) {
+  m_headingHint.iconPath = iconPath;
+  m_headingHint.text = heading;
+  m_emptyBody = body;
+  refreshEmptyStatePresentation();
+}
+
+void EmptyStateWidget::setEmptyStateShown(bool shown) {
+  if (m_emptyStateShown == shown) {
+    return;
+  }
+
+  m_emptyStateShown = shown;
+  m_emptyView->setVisible(m_emptyStateShown);
+  m_stack->setCurrentWidget(m_emptyStateShown ? m_emptyView : m_contentWidget);
+}
+
+void EmptyStateWidget::changeEvent(QEvent *event) {
+  QWidget::changeEvent(event);
+
+  if (!event) {
+    return;
+  }
+
+  if (event->type() == QEvent::PaletteChange ||
+      event->type() == QEvent::FontChange ||
+      event->type() == QEvent::StyleChange) {
+    refreshEmptyStatePresentation();
+  }
+}
+
+void EmptyStateWidget::refreshEmptyStatePresentation() {
+  InstructionHint headingHint = m_headingHint;
+  if (headingHint.fontFamily.isEmpty()) {
+    headingHint.fontFamily = font().family();
+  }
+
+  const InstructionMetrics headingMetrics = computeInstructionMetrics(headingHint, font());
+
+  QColor headingColor = palette().color(QPalette::WindowText);
+  QColor bodyColor = headingColor;
+  QColor iconColor = headingColor;
+  headingColor.setAlphaF(0.62);
+  bodyColor.setAlphaF(0.48);
+  iconColor.setAlphaF(0.40);
+
+  QPalette headingPalette = m_headingLabel->palette();
+  headingPalette.setColor(QPalette::WindowText, headingColor);
+  m_headingLabel->setPalette(headingPalette);
+
+  QPalette bodyPalette = m_bodyLabel->palette();
+  bodyPalette.setColor(QPalette::WindowText, bodyColor);
+  m_bodyLabel->setPalette(bodyPalette);
+
+  m_headingLabel->setFont(headingMetrics.font);
+  m_headingLabel->setText(headingHint.text);
+
+  const qreal devicePixelRatio = devicePixelRatioF();
+  const QSize iconSize(headingMetrics.iconSide, headingMetrics.iconSide);
+  const QPixmap icon = tintedIconPixmap(QIcon(headingHint.iconPath), iconSize,
+                                        iconColor, devicePixelRatio);
+
+  const bool hasIcon = !icon.isNull();
+  m_iconLabel->setVisible(hasIcon);
+  if (hasIcon) {
+    m_iconLabel->setPixmap(icon);
+  } else {
+    m_iconLabel->clear();
+  }
+
+  const bool hasHeading = !headingHint.text.isEmpty();
+  const bool hasBody = !m_emptyBody.isEmpty();
+  m_headingLabel->setVisible(hasHeading);
+  m_bodyLabel->setVisible(hasBody);
+
+  if (hasBody) {
+    const QFont bodyFont = prepareInstructionFont(font(), 1.20, QFont::Normal,
+                                                  12, font().family());
+    m_bodyLabel->setFont(bodyFont);
+    m_bodyLabel->setText(m_emptyBody);
+  } else {
+    m_bodyLabel->clear();
+  }
+
+  m_iconLabel->setContentsMargins(0, 0, 0, hasIcon ? headingMetrics.spacing : 0);
+  m_bodyLabel->setContentsMargins(0,
+                                  (hasHeading && hasBody) ? kEmptyStateContentSpacing : 0,
+                                  0,
+                                  0);
+}

--- a/src/ui/qt/widgets/EmptyStateWidget.cpp
+++ b/src/ui/qt/widgets/EmptyStateWidget.cpp
@@ -7,10 +7,12 @@
 #include "EmptyStateWidget.h"
 
 #include <QColor>
+#include <QBoxLayout>
 #include <QEvent>
 #include <QIcon>
 #include <QLabel>
 #include <QPalette>
+#include <QResizeEvent>
 #include <QSizePolicy>
 #include <QStackedLayout>
 #include <QVBoxLayout>
@@ -50,28 +52,46 @@ EmptyStateWidget::EmptyStateWidget(const InstructionHint &headingHint,
   emptyLayout->setSpacing(0);
   emptyLayout->addStretch();
 
-  m_iconLabel = new QLabel(m_emptyView);
-  m_iconLabel->setAlignment(Qt::AlignHCenter | Qt::AlignBottom);
+  m_emptyContent = new QWidget(m_emptyView);
+  m_emptyContent->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
+  m_emptyContentLayout = new QBoxLayout(QBoxLayout::TopToBottom, m_emptyContent);
+  m_emptyContentLayout->setContentsMargins(0, 0, 0, 0);
+  m_emptyContentLayout->setSpacing(kEmptyStateContentSpacing);
+  m_emptyContentLayout->setAlignment(Qt::AlignCenter);
+
+  m_iconLabel = new QLabel(m_emptyContent);
+  m_iconLabel->setAlignment(Qt::AlignCenter);
   m_iconLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
-  m_headingLabel = new QLabel(m_emptyView);
+  m_textContainer = new QWidget(m_emptyContent);
+  m_textContainer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+  auto *textLayout = new QVBoxLayout(m_textContainer);
+  textLayout->setContentsMargins(0, 0, 0, 0);
+  textLayout->setSpacing(kEmptyStateContentSpacing);
+
+  m_headingLabel = new QLabel(m_textContainer);
   m_headingLabel->setAlignment(Qt::AlignHCenter | Qt::AlignTop);
   m_headingLabel->setWordWrap(true);
   m_headingLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
 
-  m_bodyLabel = new QLabel(m_emptyView);
+  m_bodyLabel = new QLabel(m_textContainer);
   m_bodyLabel->setAlignment(Qt::AlignHCenter | Qt::AlignTop);
   m_bodyLabel->setWordWrap(true);
   m_bodyLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
 
-  emptyLayout->addWidget(m_iconLabel, 0, Qt::AlignHCenter);
-  emptyLayout->addWidget(m_headingLabel);
-  emptyLayout->addWidget(m_bodyLabel);
+  textLayout->addWidget(m_headingLabel);
+  textLayout->addWidget(m_bodyLabel);
+
+  m_emptyContentLayout->addWidget(m_iconLabel);
+  m_emptyContentLayout->addWidget(m_textContainer);
+
+  emptyLayout->addWidget(m_emptyContent);
   emptyLayout->addStretch();
 
   m_stack->addWidget(m_emptyView);
   m_emptyView->hide();
 
+  updateLayoutMode();
   refreshEmptyStatePresentation();
   setEmptyStateShown(false);
 }
@@ -92,6 +112,20 @@ void EmptyStateWidget::setEmptyStateContent(const QString &iconPath,
   m_headingHint.iconPath = iconPath;
   m_headingHint.text = heading;
   m_emptyBody = body;
+  refreshEmptyStatePresentation();
+}
+
+void EmptyStateWidget::setCompactLayoutHeightThreshold(int threshold) {
+  if (threshold < 0) {
+    threshold = 0;
+  }
+
+  if (m_compactLayoutHeightThreshold == threshold) {
+    return;
+  }
+
+  m_compactLayoutHeightThreshold = threshold;
+  updateLayoutMode();
   refreshEmptyStatePresentation();
 }
 
@@ -117,6 +151,50 @@ void EmptyStateWidget::changeEvent(QEvent *event) {
       event->type() == QEvent::StyleChange) {
     refreshEmptyStatePresentation();
   }
+}
+
+void EmptyStateWidget::resizeEvent(QResizeEvent *event) {
+  QWidget::resizeEvent(event);
+  updateLayoutMode();
+}
+
+void EmptyStateWidget::updateLayoutMode() {
+  if (!m_emptyContentLayout || !m_headingLabel || !m_bodyLabel || !m_textContainer) {
+    return;
+  }
+
+  const bool compact = m_compactLayoutHeightThreshold > 0
+      && height() < m_compactLayoutHeightThreshold;
+  if (m_compactLayoutActive == compact) {
+    return;
+  }
+
+  m_compactLayoutActive = compact;
+  m_emptyContentLayout->setDirection(compact ? QBoxLayout::LeftToRight
+                                             : QBoxLayout::TopToBottom);
+
+  if (compact) {
+    m_textContainer->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
+    m_headingLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
+    m_bodyLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
+
+    m_headingLabel->setAlignment(Qt::AlignCenter);
+    m_bodyLabel->setAlignment(Qt::AlignCenter);
+    m_headingLabel->setWordWrap(false);
+  } else {
+    m_textContainer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+    m_headingLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
+    m_bodyLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
+
+    m_headingLabel->setAlignment(Qt::AlignHCenter | Qt::AlignTop);
+    m_bodyLabel->setAlignment(Qt::AlignHCenter | Qt::AlignTop);
+    m_headingLabel->setWordWrap(true);
+  }
+
+  m_textContainer->updateGeometry();
+  m_headingLabel->updateGeometry();
+  m_bodyLabel->updateGeometry();
+  m_emptyContent->updateGeometry();
 }
 
 void EmptyStateWidget::refreshEmptyStatePresentation() {
@@ -171,10 +249,4 @@ void EmptyStateWidget::refreshEmptyStatePresentation() {
   } else {
     m_bodyLabel->clear();
   }
-
-  m_iconLabel->setContentsMargins(0, 0, 0, hasIcon ? headingMetrics.spacing : 0);
-  m_bodyLabel->setContentsMargins(0,
-                                  (hasHeading && hasBody) ? kEmptyStateContentSpacing : 0,
-                                  0,
-                                  0);
 }

--- a/src/ui/qt/widgets/EmptyStateWidget.h
+++ b/src/ui/qt/widgets/EmptyStateWidget.h
@@ -14,7 +14,9 @@
 #include "util/InstructionHintLayout.h"
 
 class QEvent;
+class QBoxLayout;
 class QLabel;
+class QResizeEvent;
 class QStackedLayout;
 
 namespace emptystate_detail {
@@ -51,6 +53,7 @@ public:
   void setBodyText(const QString &body);
   void setEmptyStateContent(const QString &iconPath, const QString &heading,
                             const QString &body = {});
+  void setCompactLayoutHeightThreshold(int threshold);
   void setEmptyStateShown(bool shown);
 
   template <EmptyStateSource T>
@@ -65,20 +68,30 @@ public:
   }
 
   [[nodiscard]] bool emptyStateShown() const { return m_emptyStateShown; }
+  [[nodiscard]] int compactLayoutHeightThreshold() const {
+    return m_compactLayoutHeightThreshold;
+  }
 
 protected:
   void changeEvent(QEvent *event) override;
+  void resizeEvent(QResizeEvent *event) override;
 
 private:
   void refreshEmptyStatePresentation();
+  void updateLayoutMode();
 
   QWidget *m_contentWidget = nullptr;
   QWidget *m_emptyView = nullptr;
+  QWidget *m_emptyContent = nullptr;
+  QWidget *m_textContainer = nullptr;
   QStackedLayout *m_stack = nullptr;
+  QBoxLayout *m_emptyContentLayout = nullptr;
   QLabel *m_iconLabel = nullptr;
   QLabel *m_headingLabel = nullptr;
   QLabel *m_bodyLabel = nullptr;
   InstructionHint m_headingHint;
   QString m_emptyBody;
+  int m_compactLayoutHeightThreshold = 0;
+  bool m_compactLayoutActive = false;
   bool m_emptyStateShown = false;
 };

--- a/src/ui/qt/widgets/EmptyStateWidget.h
+++ b/src/ui/qt/widgets/EmptyStateWidget.h
@@ -1,0 +1,84 @@
+/*
+* VGMTrans (c) 2002-2026
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+*/
+
+#pragma once
+
+#include <concepts>
+
+#include <QString>
+#include <QWidget>
+
+#include "util/InstructionHintLayout.h"
+
+class QEvent;
+class QLabel;
+class QStackedLayout;
+
+namespace emptystate_detail {
+template <typename T>
+concept HasEmptyMethod = requires(const T &value) {
+  { value.empty() } -> std::convertible_to<bool>;
+};
+
+template <typename T>
+concept HasCountMethod = requires(const T &value) {
+  { value.count() } -> std::integral;
+};
+
+template <typename T>
+concept HasRowCountMethod = requires(const T &value) {
+  { value.rowCount() } -> std::integral;
+};
+}
+
+template <typename T>
+concept EmptyStateSource = emptystate_detail::HasEmptyMethod<T>
+                        || emptystate_detail::HasCountMethod<T>
+                        || emptystate_detail::HasRowCountMethod<T>;
+
+class EmptyStateWidget final : public QWidget {
+public:
+  explicit EmptyStateWidget(const InstructionHint &headingHint,
+                            QWidget *contentWidget = new QWidget(),
+                            QWidget *parent = nullptr);
+
+  [[nodiscard]] QWidget *contentWidget() const { return m_contentWidget; }
+
+  void setInstructionHint(const InstructionHint &headingHint);
+  void setBodyText(const QString &body);
+  void setEmptyStateContent(const QString &iconPath, const QString &heading,
+                            const QString &body = {});
+  void setEmptyStateShown(bool shown);
+
+  template <EmptyStateSource T>
+  void setEmptyStateFrom(const T &source) {
+    if constexpr (emptystate_detail::HasEmptyMethod<T>) {
+      setEmptyStateShown(source.empty());
+    } else if constexpr (emptystate_detail::HasCountMethod<T>) {
+      setEmptyStateShown(source.count() == 0);
+    } else {
+      setEmptyStateShown(source.rowCount() == 0);
+    }
+  }
+
+  [[nodiscard]] bool emptyStateShown() const { return m_emptyStateShown; }
+
+protected:
+  void changeEvent(QEvent *event) override;
+
+private:
+  void refreshEmptyStatePresentation();
+
+  QWidget *m_contentWidget = nullptr;
+  QWidget *m_emptyView = nullptr;
+  QStackedLayout *m_stack = nullptr;
+  QLabel *m_iconLabel = nullptr;
+  QLabel *m_headingLabel = nullptr;
+  QLabel *m_bodyLabel = nullptr;
+  InstructionHint m_headingHint;
+  QString m_emptyBody;
+  bool m_emptyStateShown = false;
+};

--- a/src/ui/qt/widgets/TitleBar.cpp
+++ b/src/ui/qt/widgets/TitleBar.cpp
@@ -50,7 +50,8 @@ TitleBar::TitleBar(const QString& title, Buttons buttons, QWidget *parent, const
 
   m_leadingContainer = new QWidget(this);
   m_leadingLayout = new QHBoxLayout(m_leadingContainer);
-  m_leadingLayout->setContentsMargins(kTitleToLeadingControlsGap, 0, 0, 0);
+  const int leadingLeftMargin = buttons.testFlag(NewButton) ? 2 : kTitleToLeadingControlsGap;
+  m_leadingLayout->setContentsMargins(leadingLeftMargin, 0, 0, 0);
   m_leadingLayout->setSpacing(1);
   m_leadingContainer->hide();
   titleLayout->addWidget(m_leadingContainer);

--- a/src/ui/qt/widgets/WindowBar.cpp
+++ b/src/ui/qt/widgets/WindowBar.cpp
@@ -14,6 +14,7 @@
 #include <QShowEvent>
 #include <QStyle>
 #include <QToolButton>
+#include "ColorHelpers.h"
 #include "UIHelpers.h"
 
 namespace {

--- a/src/ui/qt/widgets/Windows11ProxyStyle.cpp
+++ b/src/ui/qt/widgets/Windows11ProxyStyle.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "Windows11ProxyStyle.h"
+#include "ColorHelpers.h"
 #include "UIHelpers.h"
 
 #include <QGraphicsDropShadowEffect>

--- a/src/ui/qt/workarea/MdiArea.cpp
+++ b/src/ui/qt/workarea/MdiArea.cpp
@@ -27,29 +27,13 @@
 #include <VGMColl.h>
 
 #include "VGMFileView.h"
+#include "InstructionHintLayout.h"
 #include "Metrics.h"
 #include "QtVGMRoot.h"
 #include "UIHelpers.h"
 #include "services/NotificationCenter.h"
 
 namespace {
-
-struct InstructionHint {
-  QString iconPath;
-  QString text;
-  qreal fontScale;
-  qreal iconScale;
-  qreal spacingScale;
-};
-
-struct InstructionMetrics {
-  InstructionHint hint;
-  QFont font;
-  QFontMetrics metrics;
-  int iconSide;
-  int spacing;
-  QSize size;
-};
 
 struct DetailedInstruction {
   QString iconPath;
@@ -80,57 +64,12 @@ struct DetailedInstructionLayout {
         subMetrics(this->subFont) {}
 };
 
-QFont prepareFont(const QFont &base, qreal scale) {
-  QFont font = base;
-  if (font.pointSizeF() > 0) {
-    font.setPointSizeF(font.pointSizeF() * scale);
-  } else if (font.pixelSize() > 0) {
-    font.setPixelSize(static_cast<int>(font.pixelSize() * scale));
-  } else {
-    font.setPointSize(scale >= 1.5 ? 18 : 14);
-  }
-  font.setBold(false);
-  font.setWeight(QFont::Normal);
-  font.setFamily(QStringLiteral("Helvetica Neue"));
-  return font;
-}
-
-InstructionMetrics computeInstructionMetrics(const InstructionHint &hint, const QFont &baseFont) {
-  QFont font = prepareFont(baseFont, hint.fontScale);
-  QFontMetrics metrics(font);
-  const int iconSide = static_cast<int>(metrics.height() * hint.iconScale);
-  const int spacing = std::max(2, static_cast<int>(metrics.height() * hint.spacingScale));
-  const int textWidth = metrics.horizontalAdvance(hint.text);
-  const int width = std::max(iconSide, textWidth);
-  const int height = iconSide + spacing + metrics.height();
-  return {hint, font, metrics, iconSide, spacing, QSize(width, height)};
-}
-
-void paintInstruction(QPainter &painter, const InstructionMetrics &metrics, const QPoint &topLeft,
-                      const QColor &accent) {
-  const QSize iconSize(metrics.iconSide, metrics.iconSide);
-  const int iconX = topLeft.x() + (metrics.size.width() - metrics.iconSide) / 2;
-  const int iconY = topLeft.y();
-  const qreal devicePixelRatio =
-      painter.device() ? painter.device()->devicePixelRatioF() : qreal(1.0);
-  const QPixmap icon =
-      tintedIconPixmap(QIcon(metrics.hint.iconPath), iconSize, accent, devicePixelRatio);
-  if (!icon.isNull()) {
-    painter.drawPixmap(iconX, iconY, icon);
-  }
-
-  painter.setFont(metrics.font);
-  painter.setPen(accent);
-
-  const int textTop = iconY + metrics.iconSide + metrics.spacing;
-  const QRect textRect(topLeft.x(), textTop, metrics.size.width(), metrics.metrics.height());
-  painter.drawText(textRect, Qt::AlignHCenter | Qt::AlignTop, metrics.hint.text);
-}
-
 DetailedInstructionLayout computeDetailedInstructionLayout(const DetailedInstruction &instruction,
                                                            const QFont &baseFont) {
-  QFont headingFont = prepareFont(baseFont, 1.8);
-  QFont subFont = prepareFont(baseFont, 1.25);
+  QFont headingFont = prepareInstructionFont(baseFont, 1.8, QFont::Normal, 0,
+                                             QStringLiteral("Helvetica Neue"));
+  QFont subFont = prepareInstructionFont(baseFont, 1.25, QFont::Normal, 0,
+                                         QStringLiteral("Helvetica Neue"));
   DetailedInstructionLayout layout(instruction, headingFont, subFont);
 
   layout.iconSide = std::max(layout.headingMetrics.height(),

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -7,16 +7,33 @@
 #include "VGMCollListView.h"
 
 #include <algorithm>
+#include <QStringView>
 #include <QLineEdit>
+#include <QResizeEvent>
 #include <VGMColl.h>
 #include <VGMExport.h>
 #include <VGMSeq.h>
 #include "SequencePlayer.h"
+#include "widgets/EmptyStateWidget.h"
 #include "widgets/ItemViewDensity.h"
 #include "workarea/MdiArea.h"
 #include "QtVGMRoot.h"
 #include "services/MenuManager.h"
 #include "services/NotificationCenter.h"
+#include "util/UIHelpers.h"
+
+static constexpr int kSearchEmptyCompactHeightThreshold = 170;
+
+static InstructionHint SearchEmptyStateHeadingHint() {
+  InstructionHint hint;
+  hint.iconPath = QStringLiteral(":/icons/magnify.svg");
+  hint.text = QStringLiteral("No matching collections");
+  hint.fontScale = 1.30;
+  hint.iconScale = 2.0;
+  hint.fontWeight = QFont::DemiBold;
+  hint.minPointSize = 12;
+  return hint;
+}
 
 static const QIcon &VGMCollIcon() {
   static QIcon icon(":/icons/collection.svg");
@@ -135,22 +152,158 @@ VGMCollListView::VGMCollListView(QWidget *parent) : QListView(parent) {
   }
 #endif
 
+  m_searchEmptyState = new EmptyStateWidget(SearchEmptyStateHeadingHint(), nullptr, viewport());
+  m_searchEmptyState->setAttribute(Qt::WA_TransparentForMouseEvents, true);
+  m_searchEmptyState->setFocusPolicy(Qt::NoFocus);
+  m_searchEmptyState->setBodyText(QString());
+  m_searchEmptyState->setCompactLayoutHeightThreshold(kSearchEmptyCompactHeightThreshold);
+  m_searchEmptyState->setGeometry(viewport()->rect());
+  m_searchEmptyState->hide();
+
   connect(this, &QListView::doubleClicked, this,
           &VGMCollListView::handlePlaybackRequest);
   connect(this, &QAbstractItemView::customContextMenuRequested, this,
           &VGMCollListView::collectionMenu);
   connect(model, &VGMCollListViewModel::dataChanged, [this]() {
+    applyFilter();
     if (!selectedIndexes().empty()) {
       selectionModel()->currentChanged(selectedIndexes().front(), {});
     } else {
       selectionModel()->currentChanged({}, {});
     }
   });
+  connect(model, &QAbstractItemModel::rowsInserted, this, [this]() { applyFilter(); });
+  connect(model, &QAbstractItemModel::rowsRemoved, this, [this]() { applyFilter(); });
+  connect(model, &QAbstractItemModel::modelReset, this, [this]() { applyFilter(); });
   connect(selectionModel(), &QItemSelectionModel::selectionChanged, this, &VGMCollListView::onSelectionChanged);
   connect(selectionModel(), &QItemSelectionModel::currentChanged, this,
           [this](const QModelIndex&, const QModelIndex&) { updateSelectedCollection(); });
   connect(NotificationCenter::the(), &NotificationCenter::vgmFileSelected, this,
           &VGMCollListView::onVGMFileSelected);
+
+  applyFilter();
+}
+
+int VGMCollListView::visibleCollectionCount() const {
+  if (!model()) {
+    return 0;
+  }
+
+  int visibleCount = 0;
+  const int totalRows = model()->rowCount();
+  for (int row = 0; row < totalRows; ++row) {
+    if (!isRowHidden(row)) {
+      ++visibleCount;
+    }
+  }
+  return visibleCount;
+}
+
+void VGMCollListView::setFilterText(const QString& text) {
+  const QString trimmed = text.trimmed();
+  if (m_filterText == trimmed) {
+    return;
+  }
+  m_filterText = trimmed;
+  applyFilter();
+}
+
+void VGMCollListView::clearFilter() {
+  setFilterText(QString());
+}
+
+void VGMCollListView::applyFilter() {
+  const auto& allColls = qtVGMRoot.vgmColls();
+  int visibleCount = 0;
+  const bool hasFilter = !m_filterText.isEmpty();
+  bool currentHidden = false;
+  QModelIndex firstVisibleIndex;
+  const QModelIndex current = selectionModel()->currentIndex();
+
+  for (int row = 0; row < static_cast<int>(allColls.size()); ++row) {
+    const bool visible = matchesFilter(allColls[static_cast<size_t>(row)]);
+    setRowHidden(row, !visible);
+    if (visible) {
+      ++visibleCount;
+    }
+
+    const QModelIndex index = model()->index(row, 0);
+    if (visible && !firstVisibleIndex.isValid() && index.isValid()) {
+      firstVisibleIndex = index;
+    }
+    if (index.isValid() && selectionModel()->isSelected(index) && !visible) {
+      selectionModel()->select(index, QItemSelectionModel::Deselect);
+      if (current == index) {
+        currentHidden = true;
+      }
+    }
+  }
+
+  if (currentHidden) {
+    QModelIndex replacementCurrent;
+    const QModelIndexList selected = selectionModel()->selectedRows();
+    if (!selected.isEmpty()) {
+      replacementCurrent = selected.front();
+    } else if (firstVisibleIndex.isValid()) {
+      replacementCurrent = firstVisibleIndex;
+    }
+    selectionModel()->setCurrentIndex(replacementCurrent, QItemSelectionModel::NoUpdate);
+  }
+
+  updateContextualMenus();
+  updateSelectedCollection();
+  updateSearchEmptyState(visibleCount, hasFilter);
+  emit filterVisibilityChanged(visibleCount, hasFilter);
+}
+
+void VGMCollListView::updateSearchEmptyState(int visibleCount, bool hasFilter) {
+  if (!m_searchEmptyState) {
+    return;
+  }
+
+  const bool show = hasFilter && visibleCount == 0;
+  m_searchEmptyState->setEmptyStateShown(show);
+  m_searchEmptyState->setVisible(show);
+  if (show) {
+    m_searchEmptyState->setGeometry(viewport()->rect());
+    m_searchEmptyState->raise();
+  }
+}
+
+void VGMCollListView::resizeEvent(QResizeEvent *event) {
+  QListView::resizeEvent(event);
+  if (m_searchEmptyState) {
+    m_searchEmptyState->setGeometry(viewport()->rect());
+  }
+}
+
+bool VGMCollListView::matchesFilter(const VGMColl* coll) const {
+  if (!coll) {
+    return false;
+  }
+
+  if (m_filterText.isEmpty()) {
+    return true;
+  }
+
+  const QStringView needle = QStringView(m_filterText);
+  const QString collName = QString::fromStdString(coll->name());
+  if (collName.contains(needle, Qt::CaseInsensitive)) {
+    return true;
+  }
+
+  if (const VGMSeq* seq = coll->seq()) {
+    const QString seqName = QString::fromStdString(seq->name());
+    if (seqName.contains(needle, Qt::CaseInsensitive)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool VGMCollListView::indexIsVisible(const QModelIndex& index) const {
+  return index.isValid() && !isRowHidden(index.row());
 }
 
 void VGMCollListView::collectionMenu(const QPoint &pos) const {
@@ -167,10 +320,14 @@ void VGMCollListView::collectionMenu(const QPoint &pos) const {
   auto selectedColls = std::make_shared<std::vector<VGMColl*>>();
   selectedColls->reserve(list.size());
   for (const auto &index : list) {
-    if (index.isValid()) {
+    if (indexIsVisible(index)) {
       selectedColls->push_back(qtVGMRoot.vgmColls()[index.row()]);
     }
   }
+  if (selectedColls->empty()) {
+    return;
+  }
+
   auto menu = MenuManager::the()->createMenuForItems<VGMColl>(selectedColls);
   menu->exec(mapToGlobal(pos));
   menu->deleteLater();
@@ -192,7 +349,7 @@ void VGMCollListView::keyPressEvent(QKeyEvent *e) {
 
 void VGMCollListView::handlePlaybackRequest() {
   QModelIndexList list = this->selectionModel()->selectedIndexes();
-  if (list.empty() || list[0].row() >= model()->rowCount()) {
+  if (list.empty() || !indexIsVisible(list[0]) || list[0].row() >= model()->rowCount()) {
     if (SequencePlayer::the().activeCollection() != nullptr) {
       SequencePlayer::the().toggle();
       return;
@@ -239,7 +396,11 @@ void VGMCollListView::onVGMFileSelected(VGMFile* file, const QWidget* caller) {
 
   const int row = static_cast<int>(std::distance(colls.begin(), it));
   const auto index = model()->index(row, 0);
-  if (!index.isValid()) {
+  if (!index.isValid() || !indexIsVisible(index)) {
+    clearSelection();
+    selectionModel()->setCurrentIndex({}, QItemSelectionModel::NoUpdate);
+    updateContextualMenus();
+    updateSelectedCollection();
     return;
   }
 
@@ -255,17 +416,19 @@ void VGMCollListView::updateSelectedCollection() const {
     return;
   }
 
+  const QModelIndexList selected = selectionModel()->selectedRows();
+  if (selected.isEmpty()) {
+    NotificationCenter::the()->selectVGMColl(nullptr, const_cast<VGMCollListView*>(this));
+    return;
+  }
+
   QModelIndex index = selectionModel()->currentIndex();
-  if (!index.isValid()) {
-    const QModelIndexList selected = selectionModel()->selectedRows();
-    if (selected.isEmpty()) {
-      NotificationCenter::the()->selectVGMColl(nullptr, const_cast<VGMCollListView*>(this));
-      return;
-    }
+  if (!index.isValid() || !selectionModel()->isSelected(index)) {
     index = selected.front();
   }
 
-  if (!index.isValid() || static_cast<size_t>(index.row()) >= qtVGMRoot.vgmColls().size()) {
+  if (!indexIsVisible(index) ||
+      static_cast<size_t>(index.row()) >= qtVGMRoot.vgmColls().size()) {
     NotificationCenter::the()->selectVGMColl(nullptr, const_cast<VGMCollListView*>(this));
     return;
   }
@@ -275,17 +438,12 @@ void VGMCollListView::updateSelectedCollection() const {
 }
 
 void VGMCollListView::updateContextualMenus() const {
-  if (!selectionModel()) {
-    NotificationCenter::the()->updateContextualMenusForVGMColls({});
-    return;
-  }
-
   QModelIndexList list = selectionModel()->selectedRows();
   QList<VGMColl*> colls;
   colls.reserve(list.size());
 
   for (const auto& index : list) {
-    if (index.isValid()) {
+    if (indexIsVisible(index)) {
       colls.append(qtVGMRoot.vgmColls()[index.row()]);
     }
   }

--- a/src/ui/qt/workarea/VGMCollListView.h
+++ b/src/ui/qt/workarea/VGMCollListView.h
@@ -8,12 +8,16 @@
 #include <QAbstractListModel>
 #include <QListView>
 #include <QKeyEvent>
+#include <QString>
 #include "widgets/FixedHeightListDelegate.h"
 
 class VGMColl;
 class VGMFile;
 class VGMCollListView;
 class QItemSelection;
+class QResizeEvent;
+class QWidget;
+class EmptyStateWidget;
 
 class VGMCollListViewModel : public QAbstractListModel {
 public:
@@ -42,19 +46,32 @@ class VGMCollListView : public QListView {
   Q_OBJECT
 public:
   explicit VGMCollListView(QWidget *parent = nullptr);
+  [[nodiscard]] int visibleCollectionCount() const;
+  void setFilterText(const QString& text);
+  [[nodiscard]] QString filterText() const { return m_filterText; }
+  void clearFilter();
 
 signals:
   void nothingToPlay();
+  void filterVisibilityChanged(int visibleCount, bool hasFilter);
 
 public slots:
   void handlePlaybackRequest();
   static void handleStopRequest();
 
 private:
+  void resizeEvent(QResizeEvent *event) override;
+  void applyFilter();
+  void updateSearchEmptyState(int visibleCount, bool hasFilter);
+  [[nodiscard]] bool matchesFilter(const VGMColl* coll) const;
+  [[nodiscard]] bool indexIsVisible(const QModelIndex& index) const;
   void collectionMenu(const QPoint &pos) const;
   void keyPressEvent(QKeyEvent *e) override;
   void onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
   void onVGMFileSelected(VGMFile* file, const QWidget* caller);
   void updateSelectedCollection() const;
   void updateContextualMenus() const;
+
+  QString m_filterText;
+  EmptyStateWidget *m_searchEmptyState = nullptr;
 };


### PR DESCRIPTION
## Description
- Added a search field in the **Collections** title bar.
- Implemented filtering in `VGMCollListView`
- Added reusable empty-state infrastructure and extracted CTA from MdiArea
  - `EmptyStateWidget` switches to painting instructions when "empty state" is tripped

## Motivation and Context
The Collections view needed in-place search to quickly find items.
Certain games can have thousands of collections. Filtering by `BGM_` for example makes for a much nicer experience in browsing certain Pokemon games!

This also centralizes empty-state rendering so other widgets can adopt consistent “no data / no results” states with less duplication.

I have another PR coming up for a "stitch mode" export and having the search bar is really useful for that.

## How Has This Been Tested?
Searching for things, playback

## Screenshots (if appropriate):
<img width="1312" height="891" alt="image" src="https://github.com/user-attachments/assets/2dcbdda4-2f36-4e7b-9d87-79ec0ce73982" />
<img width="1312" height="891" alt="image" src="https://github.com/user-attachments/assets/ef6a8e0a-6b7b-42d5-943a-3f535cae3fcb" />
<img width="1312" height="891" alt="image" src="https://github.com/user-attachments/assets/f276f60f-14c7-482c-aba2-f7e6f76df0ab" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
