### PR TITLE
Remove CloseVGMCollCommand

### DIFF
--- a/src/ui/qt/services/MenuManager.cpp
+++ b/src/ui/qt/services/MenuManager.cpp
@@ -68,8 +68,6 @@ MenuManager::MenuManager() {
       std::make_shared<SaveCollCommand<conversion::Target::MIDI | conversion::Target::DLS>>(),
       std::make_shared<SaveCollCommand<conversion::Target::MIDI | conversion::Target::SF2
                        | conversion::Target::DLS>>(),
-      std::make_shared<CommandSeparator>(),
-      std::make_shared<CloseVGMCollCommand>(),
   });
 }
 

--- a/src/ui/qt/services/commands/GeneralCommands.h
+++ b/src/ui/qt/services/commands/GeneralCommands.h
@@ -145,23 +145,6 @@ public:
 };
 
 /**
- * A command for closing a VGMColl
- */
-class CloseVGMCollCommand : public ItemListCommand<VGMColl> {
-public:
-  void executeItems(std::vector<VGMColl*> vgmcolls) const override {
-    pRoot->pushRemoveVGMColls();
-    for (auto coll : vgmcolls) {
-      pRoot->removeVGMColl(coll);
-    }
-    pRoot->popRemoveVGMColls();
-  }
-  [[nodiscard]] QList<QKeySequence> shortcutKeySequences() const override { return {Qt::Key_Backspace, Qt::Key_Delete}; };
-  [[nodiscard]] std::string name() const override { return "Remove"; }
-  [[nodiscard]] std::optional<MenuPath> menuPath() const override { return MenuPaths::File; }
-};
-
-/**
  * A command for opening a VGMFile in the MdiArea
  */
 class OpenCommand : public ItemListCommand<VGMFile> {


### PR DESCRIPTION
This removes the "Remove" action for collections, as this is likely causing more accidental grief than utility.