### PR TITLE
add hooks for enabling/disabling Commands and update Stitch Commands

### DIFF
--- a/src/ui/qt/services/MenuManager.cpp
+++ b/src/ui/qt/services/MenuManager.cpp
@@ -24,8 +24,9 @@ MenuManager::MenuManager() {
       std::make_shared<OpenCommand>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<SaveAsMidiCommand>(),
-      std::make_shared<StitchSequencesCommand>(),
       std::make_shared<SaveAsOriginalFormatCommand<VGMFile>>(),
+      std::make_shared<CommandSeparator>(),
+      std::make_shared<StitchSequencesCommand>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<CloseVGMFileCommand>(),
   });
@@ -64,10 +65,11 @@ MenuManager::MenuManager() {
       std::make_shared<PlayCommand>(),
       std::make_shared<CommandSeparator>(),
       std::make_shared<SaveCollCommand<conversion::Target::MIDI | conversion::Target::SF2>>(),
-      std::make_shared<StitchCollectionsCommand>(),
       std::make_shared<SaveCollCommand<conversion::Target::MIDI | conversion::Target::DLS>>(),
       std::make_shared<SaveCollCommand<conversion::Target::MIDI | conversion::Target::SF2
                        | conversion::Target::DLS>>(),
+      std::make_shared<CommandSeparator>(),
+      std::make_shared<StitchCollectionsCommand>(),
   });
 }
 

--- a/src/ui/qt/services/MenuManager.h
+++ b/src/ui/qt/services/MenuManager.h
@@ -191,6 +191,14 @@ public:
         continue;
       }
       auto propSpecs = contextFactory->propertySpecifications();
+      PropertyMap initialPropMap;
+      for (const auto& propSpec : propSpecs) {
+        if (propSpec.valueType == PropertySpecValueType::ItemList) {
+          initialPropMap.insert({propSpec.key, items});
+        } else {
+          initialPropMap.insert({propSpec.key, propSpec.defaultValue});
+        }
+      }
 
       auto action = menu->addAction(command->name().c_str(), [command, items, propSpecs, contextFactory] {
         PropertyMap propMap;
@@ -234,6 +242,7 @@ public:
         }
         command->execute(*context);
       });
+      action->setEnabled(command->isEnabled(initialPropMap));
       if (const auto& keySequences = command->shortcutKeySequences(); !keySequences.empty()) {
         action->setShortcuts(keySequences);
         action->setShortcutVisibleInContextMenu(true);

--- a/src/ui/qt/services/commands/Command.h
+++ b/src/ui/qt/services/commands/Command.h
@@ -128,6 +128,12 @@ public:
   [[nodiscard]] virtual std::shared_ptr<CommandContextFactory> contextFactory() const = 0;
 
   /**
+   * Determines whether the command should be enabled for the provided known properties.
+   * Properties that require user input may still contain their default values at this stage.
+   */
+  [[nodiscard]] virtual bool isEnabled(const PropertyMap& properties) const { return true; }
+
+  /**
    * Defines a key sequence that will be displayed in the menu as a shortcut for the command
    * @return the keyboard shortcut
    */

--- a/src/ui/qt/services/commands/GeneralCommands.h
+++ b/src/ui/qt/services/commands/GeneralCommands.h
@@ -80,7 +80,18 @@ public:
     return m_contextFactory;
   }
 
+  [[nodiscard]] bool isEnabled(const PropertyMap& properties) const override {
+    auto context = m_contextFactory->createContext(properties);
+    if (!context) {
+      return false;
+    }
+
+    const auto& items = dynamic_cast<ItemListCommandContext<T>&>(*context).items();
+    return isEnabledForItems(items);
+  }
+
   virtual void executeItems(std::vector<T*> items) const = 0;
+  [[nodiscard]] virtual bool isEnabledForItems(const std::vector<T*>& items) const { return !items.empty(); }
 
 private:
   std::shared_ptr<ItemListContextFactory<T>> m_contextFactory;

--- a/src/ui/qt/services/commands/StitchCommands.cpp
+++ b/src/ui/qt/services/commands/StitchCommands.cpp
@@ -33,19 +33,9 @@ void StitchSequencesCommand::executeItems(std::vector<VGMFile*> vgmfiles) const 
     collections.push_back(const_cast<VGMColl*>(coll));
   }
 
-  if (collections.size() < 2) {
-    pRoot->UI_toast("Select at least two sequence chunks to stitch.", ToastType::Info);
-    return;
-  }
-
   stitchui::openCollectionStitchBalloon(collections, QApplication::activeWindow());
 }
 
 void StitchCollectionsCommand::executeItems(std::vector<VGMColl*> vgmcolls) const {
-  if (vgmcolls.size() < 2) {
-    pRoot->UI_toast("Select at least two collections to stitch.", ToastType::Info);
-    return;
-  }
-
   stitchui::openCollectionStitchBalloon(vgmcolls, QApplication::activeWindow());
 }

--- a/src/ui/qt/services/commands/StitchCommands.h
+++ b/src/ui/qt/services/commands/StitchCommands.h
@@ -19,13 +19,13 @@ class QAbstractButton;
 class StitchSequencesCommand : public ItemListCommand<VGMFile> {
 public:
   void executeItems(std::vector<VGMFile*> vgmfiles) const override;
-  [[nodiscard]] std::string name() const override { return "Stitch as MIDI + SF2"; }
+  [[nodiscard]] std::string name() const override { return "Stitch"; }
   [[nodiscard]] std::optional<MenuPath> menuPath() const override { return MenuPaths::Convert; }
 };
 
 class StitchCollectionsCommand : public ItemListCommand<VGMColl> {
 public:
   void executeItems(std::vector<VGMColl*> vgmcolls) const override;
-  [[nodiscard]] std::string name() const override { return "Stitch as MIDI + SF2"; }
+  [[nodiscard]] std::string name() const override { return "Stitch"; }
   [[nodiscard]] std::optional<MenuPath> menuPath() const override { return MenuPaths::Convert; }
 };

--- a/src/ui/qt/services/commands/StitchCommands.h
+++ b/src/ui/qt/services/commands/StitchCommands.h
@@ -19,6 +19,9 @@ class QAbstractButton;
 class StitchSequencesCommand : public ItemListCommand<VGMFile> {
 public:
   void executeItems(std::vector<VGMFile*> vgmfiles) const override;
+  [[nodiscard]] bool isEnabledForItems(const std::vector<VGMFile*>& vgmfiles) const override {
+    return vgmfiles.size() >= 2;
+  }
   [[nodiscard]] std::string name() const override { return "Stitch"; }
   [[nodiscard]] std::optional<MenuPath> menuPath() const override { return MenuPaths::Convert; }
 };
@@ -26,6 +29,9 @@ public:
 class StitchCollectionsCommand : public ItemListCommand<VGMColl> {
 public:
   void executeItems(std::vector<VGMColl*> vgmcolls) const override;
+  [[nodiscard]] bool isEnabledForItems(const std::vector<VGMColl*>& vgmcolls) const override {
+    return vgmcolls.size() >= 2;
+  }
   [[nodiscard]] std::string name() const override { return "Stitch"; }
   [[nodiscard]] std::optional<MenuPath> menuPath() const override { return MenuPaths::Convert; }
 };


### PR DESCRIPTION
This adds a lightweight hook for `Command`s to determine if they should be enabled.

`Command` now exposes `isEnabled(const PropertyMap&)`, and `ItemListCommand` adds the simpler typed hook `isEnabledForItems(const std::vector<T*>&)` . `MenuManager` now builds the initial property map during action creation and uses `isEnabled(...)` to set each `QAction`'s enabled state up front.

With that in place, the Stitch commands now override `isEnabledForItems(...)` so they are disabled unless at least two relevant items are selected. I've also renamed the commands to simply "Stitch" and moved them into a separate grouping apart from the "Save as" commands. The commands' `executeItems(...)` hooks no longer test for item count to show a toast notification.

## Motivation and Context
Better to not enable menu actions that can't be used.

## How Has This Been Tested?
Tested context menus for sequences and collections.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
