### PR TITLE
our toast got roast; fix the host!

### DIFF
--- a/src/ui/qt/MainWindow.cpp
+++ b/src/ui/qt/MainWindow.cpp
@@ -367,7 +367,7 @@ void MainWindow::createElements() {
       {m_logger->toggleViewAction(), QStringLiteral(":/icons/book-open-variant-outline.svg")},
   });
   createStatusBar();
-  m_toastHost = new ToastHost(this, MdiArea::the());
+  m_toastHost = new ToastHost(this, MdiArea::the(), ToastHost::Mode::ToolWindow);
 }
 
 void MainWindow::configureWindowAgent() {

--- a/src/ui/qt/MainWindow.cpp
+++ b/src/ui/qt/MainWindow.cpp
@@ -367,7 +367,13 @@ void MainWindow::createElements() {
       {m_logger->toggleViewAction(), QStringLiteral(":/icons/book-open-variant-outline.svg")},
   });
   createStatusBar();
-  m_toastHost = new ToastHost(this, MdiArea::the(), ToastHost::Mode::ToolWindow);
+
+#if defined(Q_OS_LINUX)
+  const auto toastMode = ToastHost::Mode::ChildWidget;
+#else
+  const auto toastMode = ToastHost::Mode::ToolWindow;
+#endif
+  m_toastHost = new ToastHost(this, MdiArea::the(), toastMode);
 }
 
 void MainWindow::configureWindowAgent() {

--- a/src/ui/qt/MainWindow.cpp
+++ b/src/ui/qt/MainWindow.cpp
@@ -367,13 +367,7 @@ void MainWindow::createElements() {
       {m_logger->toggleViewAction(), QStringLiteral(":/icons/book-open-variant-outline.svg")},
   });
   createStatusBar();
-
-#if defined(Q_OS_LINUX)
-  const auto toastMode = ToastHost::Mode::ChildWidget;
-#else
-  const auto toastMode = ToastHost::Mode::ToolWindow;
-#endif
-  m_toastHost = new ToastHost(this, MdiArea::the(), toastMode);
+  m_toastHost = new ToastHost(this, MdiArea::the(), ToastHost::defaultMode());
 }
 
 void MainWindow::configureWindowAgent() {

--- a/src/ui/qt/MainWindow.cpp
+++ b/src/ui/qt/MainWindow.cpp
@@ -367,7 +367,7 @@ void MainWindow::createElements() {
       {m_logger->toggleViewAction(), QStringLiteral(":/icons/book-open-variant-outline.svg")},
   });
   createStatusBar();
-  m_toastHost = new ToastHost(this);
+  m_toastHost = new ToastHost(this, MdiArea::the());
 }
 
 void MainWindow::configureWindowAgent() {

--- a/src/ui/qt/util/Helpers.cpp
+++ b/src/ui/qt/util/Helpers.cpp
@@ -445,3 +445,8 @@ void qtOpenUrl(const QUrl& url) {
   QDesktopServices::openUrl(QUrl::fromEncoded(encoded));
 #endif
 }
+
+#ifndef __APPLE__
+void qtSetMacWindowChildOf(QWidget*, QWidget*) {
+}
+#endif

--- a/src/ui/qt/util/Helpers.h
+++ b/src/ui/qt/util/Helpers.h
@@ -11,6 +11,7 @@
 #include <VGMItem.h>
 
 class QUrl;
+class QWidget;
 
 const QIcon &iconForFile(VGMFileVariant file);
 const QIcon &iconForItemType(VGMItem::Type type);
@@ -21,6 +22,7 @@ QColor textColorForItemType(VGMItem::Type type);
 QString getFullDescriptionForTooltip(VGMItem* item);
 
 void qtOpenUrl(const QUrl& url);
+void qtSetMacWindowChildOf(QWidget* child, QWidget* parent);
 
 template<typename ... Base>
 struct Visitor : Base ... {

--- a/src/ui/qt/util/Helpers_mac.mm
+++ b/src/ui/qt/util/Helpers_mac.mm
@@ -1,5 +1,6 @@
 #import <CoreFoundation/CoreFoundation.h>
 #import <AppKit/AppKit.h>
+#include <QWidget>
 #include <QUrl>
 
 #include "LogManager.h"
@@ -21,5 +22,29 @@ void qtOpenUrlNative(const QByteArray& encodedUrl) {
     } else {
       L_ERROR("Could not open bug URL: {}", encodedUrl.constData());
     }
+  }
+}
+
+void qtSetMacWindowChildOf(QWidget* child, QWidget* parent) {
+  @autoreleasepool {
+    if (!child)
+      return;
+
+    NSView* childView = reinterpret_cast<NSView*>(child->winId());
+    NSWindow* childWindow = childView ? childView.window : nil;
+    NSWindow* parentWindow = nil;
+    if (parent) {
+      NSView* parentView = reinterpret_cast<NSView*>(parent->winId());
+      parentWindow = parentView ? parentView.window : nil;
+    }
+
+    if (!childWindow)
+      return;
+
+    if (NSWindow* existingParent = childWindow.parentWindow; existingParent && existingParent != parentWindow)
+      [existingParent removeChildWindow:childWindow];
+
+    if (parentWindow && childWindow.parentWindow != parentWindow)
+      [parentWindow addChildWindow:childWindow ordered:NSWindowAbove];
   }
 }

--- a/src/ui/qt/util/Helpers_mac.mm
+++ b/src/ui/qt/util/Helpers_mac.mm
@@ -25,6 +25,8 @@ void qtOpenUrlNative(const QByteArray& encodedUrl) {
   }
 }
 
+// On macOS, attaching the toast panel as an NSWindow child makes it track the main
+// window during live drags instead of waiting for delayed Qt move notifications.
 void qtSetMacWindowChildOf(QWidget* child, QWidget* parent) {
   @autoreleasepool {
     if (!child)

--- a/src/ui/qt/widgets/Toast.cpp
+++ b/src/ui/qt/widgets/Toast.cpp
@@ -6,14 +6,11 @@
 
 #include "Toast.h"
 
-#include <QApplication>
 #include <QColor>
-#include <QEvent>
 #include <QGraphicsOpacityEffect>
 #include <QIcon>
 #include <QLabel>
 #include <QPushButton>
-#include <QScreen>
 #include <QSizePolicy>
 #include <QVariantAnimation>
 #include <QVBoxLayout>
@@ -25,7 +22,7 @@ static constexpr const char* kWarnIcon    = ":/icons/toast_warning.svg";
 static constexpr const char* kErrorIcon   = ":/icons/toast_error.svg";
 static constexpr const char* kSuccessIcon = ":/icons/toast_success.svg";
 static constexpr const char* kCloseIcon   = ":/icons/toast_close.svg";
-static constexpr Qt::WindowFlags kToastWindowFlags =
+static constexpr Qt::WindowFlags kToastToolWindowFlags =
     Qt::Tool | Qt::FramelessWindowHint | Qt::WindowDoesNotAcceptFocus;
 
 static const ToastTheme kThemes[] = {
@@ -43,22 +40,21 @@ const ToastTheme& Toast::themeFor(ToastType type) noexcept {
   return fallback;
 }
 
-Toast::Toast(QWidget* parent, QWidget* anchorWidget)
-  : QWidget(parent, kToastWindowFlags),
+Toast::Toast(QWidget* parent, bool useToolWindow)
+  : QWidget(parent),
     m_bubble(new QFrame(this)),
     m_icon(new QLabel(m_bubble)),
     m_text(new QLabel(m_bubble)),
     m_close(new QPushButton(m_bubble)),
     m_opacity_effect(new QGraphicsOpacityEffect(this)),
-    m_opacity_anim(new QVariantAnimation(this)) {
+    m_opacity_anim(new QVariantAnimation(this)),
+    m_useToolWindow(useToolWindow) {
 
   setAttribute(Qt::WA_TranslucentBackground);
   setAttribute(Qt::WA_ShowWithoutActivating);
-  setFocusPolicy(Qt::NoFocus);
-
-  if (parent)
-    parent->installEventFilter(this);
-  setAnchorWidget(anchorWidget);
+  setWindowFlags(m_useToolWindow ? kToastToolWindowFlags : Qt::FramelessWindowHint);
+  if (m_useToolWindow)
+    setFocusPolicy(Qt::NoFocus);
 
   auto* outer = new QVBoxLayout(this);
   outer->setContentsMargins(0,0,0,0);
@@ -111,13 +107,7 @@ Toast::Toast(QWidget* parent, QWidget* anchorWidget)
     if (qFuzzyCompare(m_opacity_effect->opacity(), 1.0)) {
       m_timer.start(m_duration_ms);
     } else {
-      // fade-out complete
-      if (!m_emittedDismissed) {
-        m_emittedDismissed = true;
-        emit dismissed(this);
-      }
-      hide();
-      deleteLater();
+      dismiss();
     }
   });
 
@@ -181,39 +171,25 @@ void Toast::cancelAnimations() noexcept {
   m_opacity_effect->setOpacity(0.0);
 }
 
-void Toast::setAnchorWidget(QWidget* anchorWidget) {
-  QWidget* normalizedAnchor = anchorWidget ? anchorWidget : parentWidget();
-  if (m_anchorWidget == normalizedAnchor) {
-    return;
+void Toast::dismiss() noexcept {
+  if (!m_emittedDismissed) {
+    m_emittedDismissed = true;
+    emit dismissed(this);
   }
-
-  if (m_anchorWidget && m_anchorWidget != parentWidget()) {
-    m_anchorWidget->removeEventFilter(this);
-  }
-
-  m_anchorWidget = normalizedAnchor;
-
-  if (m_anchorWidget && m_anchorWidget != parentWidget()) {
-    m_anchorWidget->installEventFilter(this);
-  }
+  hide();
+  deleteLater();
 }
 
-void Toast::updatePlacement() {
-  QWidget* anchor = m_anchorWidget ? m_anchorWidget.data() : parentWidget();
-  if (anchor) {
-    const QPoint topLeft =
-        anchor->mapToGlobal(QPoint(anchor->width() - width() - m_marginX, m_marginY + m_stackOffsetY));
-    move(topLeft);
+void Toast::updatePlacement(QWidget* anchorWidget) {
+  QWidget* anchor = anchorWidget ? anchorWidget : parentWidget();
+  if (!anchor)
     return;
-  }
 
-  if (QScreen* screen = QGuiApplication::primaryScreen()) {
-    const QRect geom = screen->availableGeometry();
-    move(geom.right() - width() - m_marginX, geom.top() + m_marginY + m_stackOffsetY);
-  }
+  const QPoint pos(anchor->width() - width() - m_marginX, m_marginY + m_stackOffsetY);
+  move(m_useToolWindow ? anchor->mapToGlobal(pos) : pos);
 }
 
-void Toast::showMessage(const QString& message, ToastType type, int duration_ms) {
+void Toast::showMessage(const QString& message, ToastType type, QWidget* anchorWidget, int duration_ms) {
   m_duration_ms = duration_ms;
   m_emittedDismissed = false;
   cancelAnimations();
@@ -228,7 +204,7 @@ void Toast::showMessage(const QString& message, ToastType type, int duration_ms)
                                      m_icon->devicePixelRatioF()));
 
   adjustSize();
-  updatePlacement();
+  updatePlacement(anchorWidget);
 
   show();
   raise();
@@ -236,23 +212,6 @@ void Toast::showMessage(const QString& message, ToastType type, int duration_ms)
 }
 
 void Toast::onCloseClicked() noexcept {
-  if (!m_emittedDismissed) {
-    m_emittedDismissed = true;
-    emit dismissed(this);
-  }
   cancelAnimations();
-  hide();
-  deleteLater();
-}
-
-bool Toast::eventFilter(QObject* watched, QEvent* event) {
-  QWidget* owner = parentWidget();
-  QWidget* anchor = m_anchorWidget ? m_anchorWidget.data() : owner;
-  if ((watched == owner || watched == anchor) &&
-      (event->type() == QEvent::Move || event->type() == QEvent::Resize)) {
-    if (isVisible()) {
-      updatePlacement();
-    }
-  }
-  return QWidget::eventFilter(watched, event);
+  dismiss();
 }

--- a/src/ui/qt/widgets/Toast.cpp
+++ b/src/ui/qt/widgets/Toast.cpp
@@ -43,7 +43,7 @@ const ToastTheme& Toast::themeFor(ToastType type) noexcept {
   return fallback;
 }
 
-Toast::Toast(QWidget* parent)
+Toast::Toast(QWidget* parent, QWidget* anchorWidget)
   : QWidget(parent, kToastWindowFlags),
     m_bubble(new QFrame(this)),
     m_icon(new QLabel(m_bubble)),
@@ -58,6 +58,7 @@ Toast::Toast(QWidget* parent)
 
   if (parent)
     parent->installEventFilter(this);
+  setAnchorWidget(anchorWidget);
 
   auto* outer = new QVBoxLayout(this);
   outer->setContentsMargins(0,0,0,0);
@@ -180,10 +181,28 @@ void Toast::cancelAnimations() noexcept {
   m_opacity_effect->setOpacity(0.0);
 }
 
+void Toast::setAnchorWidget(QWidget* anchorWidget) {
+  QWidget* normalizedAnchor = anchorWidget ? anchorWidget : parentWidget();
+  if (m_anchorWidget == normalizedAnchor) {
+    return;
+  }
+
+  if (m_anchorWidget && m_anchorWidget != parentWidget()) {
+    m_anchorWidget->removeEventFilter(this);
+  }
+
+  m_anchorWidget = normalizedAnchor;
+
+  if (m_anchorWidget && m_anchorWidget != parentWidget()) {
+    m_anchorWidget->installEventFilter(this);
+  }
+}
+
 void Toast::updatePlacement() {
-  if (QWidget* p = parentWidget()) {
+  QWidget* anchor = m_anchorWidget ? m_anchorWidget.data() : parentWidget();
+  if (anchor) {
     const QPoint topLeft =
-        p->mapToGlobal(QPoint(p->width() - width() - m_marginX, m_marginY + m_stackOffsetY));
+        anchor->mapToGlobal(QPoint(anchor->width() - width() - m_marginX, m_marginY + m_stackOffsetY));
     move(topLeft);
     return;
   }
@@ -227,9 +246,11 @@ void Toast::onCloseClicked() noexcept {
 }
 
 bool Toast::eventFilter(QObject* watched, QEvent* event) {
-  QWidget* p = parentWidget();
-  if (watched == p && (event->type() == QEvent::Move || event->type() == QEvent::Resize)) {
-    if (isVisible() && p) {
+  QWidget* owner = parentWidget();
+  QWidget* anchor = m_anchorWidget ? m_anchorWidget.data() : owner;
+  if ((watched == owner || watched == anchor) &&
+      (event->type() == QEvent::Move || event->type() == QEvent::Resize)) {
+    if (isVisible()) {
       updatePlacement();
     }
   }

--- a/src/ui/qt/widgets/Toast.cpp
+++ b/src/ui/qt/widgets/Toast.cpp
@@ -25,6 +25,8 @@ static constexpr const char* kWarnIcon    = ":/icons/toast_warning.svg";
 static constexpr const char* kErrorIcon   = ":/icons/toast_error.svg";
 static constexpr const char* kSuccessIcon = ":/icons/toast_success.svg";
 static constexpr const char* kCloseIcon   = ":/icons/toast_close.svg";
+static constexpr Qt::WindowFlags kToastWindowFlags =
+    Qt::Tool | Qt::FramelessWindowHint | Qt::WindowDoesNotAcceptFocus;
 
 static const ToastTheme kThemes[] = {
   { QColor(209,231,243), QColor( 82,123,167), QColor(171,194,202), kInfoIcon    }, // Info
@@ -42,7 +44,7 @@ const ToastTheme& Toast::themeFor(ToastType type) noexcept {
 }
 
 Toast::Toast(QWidget* parent)
-  : QWidget(parent),
+  : QWidget(parent, kToastWindowFlags),
     m_bubble(new QFrame(this)),
     m_icon(new QLabel(m_bubble)),
     m_text(new QLabel(m_bubble)),
@@ -52,7 +54,7 @@ Toast::Toast(QWidget* parent)
 
   setAttribute(Qt::WA_TranslucentBackground);
   setAttribute(Qt::WA_ShowWithoutActivating);
-  setWindowFlags(Qt::FramelessWindowHint);
+  setFocusPolicy(Qt::NoFocus);
 
   if (parent)
     parent->installEventFilter(this);
@@ -178,6 +180,20 @@ void Toast::cancelAnimations() noexcept {
   m_opacity_effect->setOpacity(0.0);
 }
 
+void Toast::updatePlacement() {
+  if (QWidget* p = parentWidget()) {
+    const QPoint topLeft =
+        p->mapToGlobal(QPoint(p->width() - width() - m_marginX, m_marginY + m_stackOffsetY));
+    move(topLeft);
+    return;
+  }
+
+  if (QScreen* screen = QGuiApplication::primaryScreen()) {
+    const QRect geom = screen->availableGeometry();
+    move(geom.right() - width() - m_marginX, geom.top() + m_marginY + m_stackOffsetY);
+  }
+}
+
 void Toast::showMessage(const QString& message, ToastType type, int duration_ms) {
   m_duration_ms = duration_ms;
   m_emittedDismissed = false;
@@ -193,14 +209,7 @@ void Toast::showMessage(const QString& message, ToastType type, int duration_ms)
                                      m_icon->devicePixelRatioF()));
 
   adjustSize();
-
-  // Initial placement; host will keep it updated via setStackOffset + margins
-  if (QWidget* pw = parentWidget()) {
-    move(pw->width() - width() - m_marginX, m_marginY + m_stackOffsetY);
-  } else if (QScreen* screen = QGuiApplication::primaryScreen()) {
-    const QRect geom = screen->availableGeometry();
-    move(geom.right() - width() - m_marginX, geom.top() + m_marginY + m_stackOffsetY);
-  }
+  updatePlacement();
 
   show();
   raise();
@@ -221,7 +230,7 @@ bool Toast::eventFilter(QObject* watched, QEvent* event) {
   QWidget* p = parentWidget();
   if (watched == p && (event->type() == QEvent::Move || event->type() == QEvent::Resize)) {
     if (isVisible() && p) {
-      move(p->width() - width() - m_marginX, m_marginY + m_stackOffsetY);
+      updatePlacement();
     }
   }
   return QWidget::eventFilter(watched, event);

--- a/src/ui/qt/widgets/Toast.cpp
+++ b/src/ui/qt/widgets/Toast.cpp
@@ -15,6 +15,7 @@
 #include <QVariantAnimation>
 #include <QVBoxLayout>
 
+#include "Helpers.h"
 #include "UIHelpers.h"
 
 static constexpr const char* kInfoIcon    = ":/icons/toast_info.svg";
@@ -172,6 +173,8 @@ void Toast::cancelAnimations() noexcept {
 }
 
 void Toast::dismiss() noexcept {
+  if (m_useToolWindow)
+    qtSetMacWindowChildOf(this, nullptr);
   if (!m_emittedDismissed) {
     m_emittedDismissed = true;
     emit dismissed(this);
@@ -207,6 +210,8 @@ void Toast::showMessage(const QString& message, ToastType type, QWidget* anchorW
   updatePlacement(anchorWidget);
 
   show();
+  if (m_useToolWindow)
+    qtSetMacWindowChildOf(this, parentWidget());
   raise();
   startFadeIn();
 }

--- a/src/ui/qt/widgets/Toast.h
+++ b/src/ui/qt/widgets/Toast.h
@@ -25,6 +25,7 @@ class Toast : public QWidget {
 public:
   explicit Toast(QWidget* parent = nullptr);
   void showMessage(const QString& message, ToastType type, int duration_ms = 3000);
+  void updatePlacement();
 
   // host-controlled placement knobs
   void setMargins(int marginX, int marginY) noexcept { m_marginX = marginX; m_marginY = marginY; }

--- a/src/ui/qt/widgets/Toast.h
+++ b/src/ui/qt/widgets/Toast.h
@@ -5,7 +5,6 @@
  */
 
 #pragma once
-#include <QPointer>
 #include <QWidget>
 #include <QTimer>
 
@@ -24,21 +23,18 @@ struct ToastTheme {
 class Toast : public QWidget {
   Q_OBJECT
 public:
-  explicit Toast(QWidget* parent = nullptr, QWidget* anchorWidget = nullptr);
-  void showMessage(const QString& message, ToastType type, int duration_ms = 3000);
-  void updatePlacement();
-  void setAnchorWidget(QWidget* anchorWidget);
+  explicit Toast(QWidget* parent = nullptr, bool useToolWindow = false);
+  void showMessage(const QString& message, ToastType type, QWidget* anchorWidget,
+                   int duration_ms = 3000);
+  void updatePlacement(QWidget* anchorWidget);
 
   // host-controlled placement knobs
   void setMargins(int marginX, int marginY) noexcept { m_marginX = marginX; m_marginY = marginY; }
   void setStackOffset(int offsetY) noexcept { m_stackOffsetY = offsetY; }
 
-  signals:
-    // emitted exactly once when the toast is dismissed (fadeout or close)
-    void dismissed(Toast* self);
-
-protected:
-  bool eventFilter(QObject* watched, QEvent* event) override;
+signals:
+  // emitted exactly once when the toast is dismissed (fadeout or close)
+  void dismissed(Toast* self);
 
 private slots:
   void onCloseClicked() noexcept;
@@ -50,6 +46,7 @@ private:
   void startFadeIn();
   void startFadeOut();
   void cancelAnimations() noexcept;
+  void dismiss() noexcept;
 
 private:
   QFrame* m_bubble{nullptr};
@@ -75,7 +72,7 @@ private:
   int m_marginX{10};
   int m_marginY{10};
   int m_stackOffsetY{0};
-  QPointer<QWidget> m_anchorWidget;
+  bool m_useToolWindow{false};
 
   // internal: to ensure dismissed() is sent once
   bool m_emittedDismissed{false};

--- a/src/ui/qt/widgets/Toast.h
+++ b/src/ui/qt/widgets/Toast.h
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+#include <QPointer>
 #include <QWidget>
 #include <QTimer>
 
@@ -23,9 +24,10 @@ struct ToastTheme {
 class Toast : public QWidget {
   Q_OBJECT
 public:
-  explicit Toast(QWidget* parent = nullptr);
+  explicit Toast(QWidget* parent = nullptr, QWidget* anchorWidget = nullptr);
   void showMessage(const QString& message, ToastType type, int duration_ms = 3000);
   void updatePlacement();
+  void setAnchorWidget(QWidget* anchorWidget);
 
   // host-controlled placement knobs
   void setMargins(int marginX, int marginY) noexcept { m_marginX = marginX; m_marginY = marginY; }
@@ -73,6 +75,7 @@ private:
   int m_marginX{10};
   int m_marginY{10};
   int m_stackOffsetY{0};
+  QPointer<QWidget> m_anchorWidget;
 
   // internal: to ensure dismissed() is sent once
   bool m_emittedDismissed{false};

--- a/src/ui/qt/widgets/ToastHost.cpp
+++ b/src/ui/qt/widgets/ToastHost.cpp
@@ -8,13 +8,15 @@
 #include "Toast.h"
 
 #include <QEvent>
+#include <QMoveEvent>
 #include <QWidget>
 
 ToastHost::ToastHost(QWidget* ownerWidget, QWidget* anchorWidget, Mode mode)
   : QObject(ownerWidget),
     m_owner(ownerWidget),
     m_anchor(anchorWidget ? anchorWidget : ownerWidget),
-    m_mode(mode) {
+    m_mode(mode),
+    m_ownerPos(ownerWidget ? ownerWidget->pos() : QPoint()) {
   if (m_anchor)
     m_anchor->installEventFilter(this);
   if (m_mode == Mode::ToolWindow && m_owner && m_owner != m_anchor)
@@ -39,8 +41,20 @@ void ToastHost::onToastDismissed(Toast* t) {
 }
 
 bool ToastHost::eventFilter(QObject* watched, QEvent* event) {
+#if !defined(Q_OS_MACOS) && !defined(Q_OS_MAC)
+  if (watched == m_owner && event->type() == QEvent::Move) {
+    const QPoint delta = static_cast<QMoveEvent*>(event)->pos() - m_ownerPos;
+    m_ownerPos = static_cast<QMoveEvent*>(event)->pos();
+    if (m_mode == Mode::ToolWindow && !delta.isNull()) {
+      for (Toast* t : m_toasts)
+        t->move(t->pos() + delta);
+      return QObject::eventFilter(watched, event);
+    }
+  }
+#endif
+
   if ((watched == m_owner || watched == m_anchor) &&
-      (event->type() == QEvent::Move || event->type() == QEvent::Resize)) {
+      (event->type() == QEvent::Resize || (watched == m_anchor && event->type() == QEvent::Move))) {
     reflow();
   }
   return QObject::eventFilter(watched, event);

--- a/src/ui/qt/widgets/ToastHost.cpp
+++ b/src/ui/qt/widgets/ToastHost.cpp
@@ -57,8 +57,7 @@ void ToastHost::reflow() {
       continue;
     t->setMargins(m_marginX, m_marginY);
     t->setStackOffset(y);
-    // X/Y are applied by Toast's eventFilter as well; set once here:
-    t->move(m_parent->width() - t->width() - m_marginX, m_marginY + y);
+    t->updatePlacement();
     t->raise();
     y += t->height() + m_spacing;
   }

--- a/src/ui/qt/widgets/ToastHost.cpp
+++ b/src/ui/qt/widgets/ToastHost.cpp
@@ -10,18 +10,20 @@
 #include <QEvent>
 #include <QWidget>
 
-ToastHost::ToastHost(QWidget* parentWidget)
-  : QObject(parentWidget), m_parent(parentWidget) {
-  if (m_parent)
-    m_parent->installEventFilter(this);
+ToastHost::ToastHost(QWidget* ownerWidget, QWidget* anchorWidget)
+  : QObject(ownerWidget), m_owner(ownerWidget), m_anchor(anchorWidget ? anchorWidget : ownerWidget) {
+  if (m_owner)
+    m_owner->installEventFilter(this);
+  if (m_anchor && m_anchor != m_owner)
+    m_anchor->installEventFilter(this);
 }
 
 Toast* ToastHost::showToast(const QString& message, ToastType type, int duration_ms) {
-  if (!m_parent)
+  if (!m_owner)
     return nullptr;
 
   // Newest toast goes at index 0 (top)
-  auto* t = new Toast(m_parent);
+  auto* t = new Toast(m_owner, m_anchor);
   t->setMargins(m_marginX, m_marginY);
   t->showMessage(message, type, duration_ms);
 
@@ -41,14 +43,15 @@ void ToastHost::onToastDismissed(Toast* t) {
 }
 
 bool ToastHost::eventFilter(QObject* watched, QEvent* event) {
-  if (watched == m_parent && (event->type() == QEvent::Move || event->type() == QEvent::Resize)) {
+  if ((watched == m_owner || watched == m_anchor) &&
+      (event->type() == QEvent::Move || event->type() == QEvent::Resize)) {
     reflow();
   }
   return QObject::eventFilter(watched, event);
 }
 
 void ToastHost::reflow() {
-  if (!m_parent)
+  if (!m_owner)
     return;
 
   int y = 0; // stack offset from top, grows downward

--- a/src/ui/qt/widgets/ToastHost.cpp
+++ b/src/ui/qt/widgets/ToastHost.cpp
@@ -8,15 +8,13 @@
 #include "Toast.h"
 
 #include <QEvent>
-#include <QMoveEvent>
 #include <QWidget>
 
 ToastHost::ToastHost(QWidget* ownerWidget, QWidget* anchorWidget, Mode mode)
   : QObject(ownerWidget),
     m_owner(ownerWidget),
     m_anchor(anchorWidget ? anchorWidget : ownerWidget),
-    m_mode(mode),
-    m_ownerPos(ownerWidget ? ownerWidget->pos() : QPoint()) {
+    m_mode(mode) {
   if (m_anchor)
     m_anchor->installEventFilter(this);
   if (m_mode == Mode::ToolWindow && m_owner && m_owner != m_anchor)
@@ -41,20 +39,8 @@ void ToastHost::onToastDismissed(Toast* t) {
 }
 
 bool ToastHost::eventFilter(QObject* watched, QEvent* event) {
-#if !defined(Q_OS_MACOS) && !defined(Q_OS_MAC)
-  if (watched == m_owner && event->type() == QEvent::Move) {
-    const QPoint delta = static_cast<QMoveEvent*>(event)->pos() - m_ownerPos;
-    m_ownerPos = static_cast<QMoveEvent*>(event)->pos();
-    if (m_mode == Mode::ToolWindow && !delta.isNull()) {
-      for (Toast* t : m_toasts)
-        t->move(t->pos() + delta);
-      return QObject::eventFilter(watched, event);
-    }
-  }
-#endif
-
   if ((watched == m_owner || watched == m_anchor) &&
-      (event->type() == QEvent::Resize || (watched == m_anchor && event->type() == QEvent::Move))) {
+      (event->type() == QEvent::Move || event->type() == QEvent::Resize)) {
     reflow();
   }
   return QObject::eventFilter(watched, event);

--- a/src/ui/qt/widgets/ToastHost.cpp
+++ b/src/ui/qt/widgets/ToastHost.cpp
@@ -10,35 +10,31 @@
 #include <QEvent>
 #include <QWidget>
 
-ToastHost::ToastHost(QWidget* ownerWidget, QWidget* anchorWidget)
-  : QObject(ownerWidget), m_owner(ownerWidget), m_anchor(anchorWidget ? anchorWidget : ownerWidget) {
-  if (m_owner)
-    m_owner->installEventFilter(this);
-  if (m_anchor && m_anchor != m_owner)
+ToastHost::ToastHost(QWidget* ownerWidget, QWidget* anchorWidget, Mode mode)
+  : QObject(ownerWidget),
+    m_owner(ownerWidget),
+    m_anchor(anchorWidget ? anchorWidget : ownerWidget),
+    m_mode(mode) {
+  if (m_anchor)
     m_anchor->installEventFilter(this);
+  if (m_mode == Mode::ToolWindow && m_owner && m_owner != m_anchor)
+    m_owner->installEventFilter(this);
 }
 
 Toast* ToastHost::showToast(const QString& message, ToastType type, int duration_ms) {
-  if (!m_owner)
-    return nullptr;
-
   // Newest toast goes at index 0 (top)
-  auto* t = new Toast(m_owner, m_anchor);
-  t->setMargins(m_marginX, m_marginY);
-  t->showMessage(message, type, duration_ms);
-
-  connect(t, &Toast::dismissed, this, &ToastHost::onToastDismissed);
-
+  auto* t = new Toast(m_mode == Mode::ToolWindow ? m_owner : m_anchor,
+                      m_mode == Mode::ToolWindow);
   m_toasts.prepend(t);
+  t->setMargins(m_marginX, m_marginY);
+  connect(t, &Toast::dismissed, this, &ToastHost::onToastDismissed);
+  t->showMessage(message, type, m_anchor, duration_ms);
   reflow();
   return t;
 }
 
 void ToastHost::onToastDismissed(Toast* t) {
-  const int idx = m_toasts.indexOf(t);
-  if (idx >= 0)
-    m_toasts.removeAt(idx);
-  // Toast deletes itself; just reflow others
+  m_toasts.removeOne(t);
   reflow();
 }
 
@@ -51,16 +47,11 @@ bool ToastHost::eventFilter(QObject* watched, QEvent* event) {
 }
 
 void ToastHost::reflow() {
-  if (!m_owner)
-    return;
-
   int y = 0; // stack offset from top, grows downward
   for (Toast* t : m_toasts) {
-    if (!t)
-      continue;
     t->setMargins(m_marginX, m_marginY);
     t->setStackOffset(y);
-    t->updatePlacement();
+    t->updatePlacement(m_anchor);
     t->raise();
     y += t->height() + m_spacing;
   }

--- a/src/ui/qt/widgets/ToastHost.h
+++ b/src/ui/qt/widgets/ToastHost.h
@@ -6,6 +6,7 @@
 
 #pragma once
 #include <QObject>
+#include <QPoint>
 #include <QVector>
 
 class QWidget;
@@ -42,6 +43,7 @@ private:
   QWidget* m_owner{nullptr};
   QWidget* m_anchor{nullptr};
   Mode m_mode{Mode::ChildWidget};
+  QPoint m_ownerPos;
   QVector<Toast*> m_toasts;  // index 0 == newest (top)
   int m_marginX{10};
   int m_marginY{10};

--- a/src/ui/qt/widgets/ToastHost.h
+++ b/src/ui/qt/widgets/ToastHost.h
@@ -6,7 +6,6 @@
 
 #pragma once
 #include <QObject>
-#include <QPoint>
 #include <QVector>
 
 class QWidget;
@@ -43,7 +42,6 @@ private:
   QWidget* m_owner{nullptr};
   QWidget* m_anchor{nullptr};
   Mode m_mode{Mode::ChildWidget};
-  QPoint m_ownerPos;
   QVector<Toast*> m_toasts;  // index 0 == newest (top)
   int m_marginX{10};
   int m_marginY{10};

--- a/src/ui/qt/widgets/ToastHost.h
+++ b/src/ui/qt/widgets/ToastHost.h
@@ -15,7 +15,13 @@ enum class ToastType;
 class ToastHost : public QObject {
   Q_OBJECT
 public:
-  explicit ToastHost(QWidget* ownerWidget, QWidget* anchorWidget = nullptr);
+  enum class Mode {
+    ChildWidget,
+    ToolWindow,
+  };
+
+  explicit ToastHost(QWidget* ownerWidget, QWidget* anchorWidget = nullptr,
+                     Mode mode = Mode::ChildWidget);
   ~ToastHost() override = default;
 
   // Create + show a toast (newest appears at the top)
@@ -35,6 +41,7 @@ private:
 private:
   QWidget* m_owner{nullptr};
   QWidget* m_anchor{nullptr};
+  Mode m_mode{Mode::ChildWidget};
   QVector<Toast*> m_toasts;  // index 0 == newest (top)
   int m_marginX{10};
   int m_marginY{10};

--- a/src/ui/qt/widgets/ToastHost.h
+++ b/src/ui/qt/widgets/ToastHost.h
@@ -15,7 +15,7 @@ enum class ToastType;
 class ToastHost : public QObject {
   Q_OBJECT
 public:
-  explicit ToastHost(QWidget* parentWidget);
+  explicit ToastHost(QWidget* ownerWidget, QWidget* anchorWidget = nullptr);
   ~ToastHost() override = default;
 
   // Create + show a toast (newest appears at the top)
@@ -33,7 +33,8 @@ private:
   void onToastDismissed(Toast* t);
 
 private:
-  QWidget* m_parent{nullptr};
+  QWidget* m_owner{nullptr};
+  QWidget* m_anchor{nullptr};
   QVector<Toast*> m_toasts;  // index 0 == newest (top)
   int m_marginX{10};
   int m_marginY{10};

--- a/src/ui/qt/widgets/ToastHost.h
+++ b/src/ui/qt/widgets/ToastHost.h
@@ -20,6 +20,14 @@ public:
     ToolWindow,
   };
 
+  static constexpr Mode defaultMode() noexcept {
+#if defined(Q_OS_LINUX)
+    return Mode::ChildWidget;
+#else
+    return Mode::ToolWindow;
+#endif
+  }
+
   explicit ToastHost(QWidget* ownerWidget, QWidget* anchorWidget = nullptr,
                      Mode mode = Mode::ChildWidget);
   ~ToastHost() override = default;


### PR DESCRIPTION
This PR fixes toast notification behavior when RHI-backed views are present, while keeping the original simpler logic for Linux where the workaround is not needed.

### The Problem

Toasts are drawn behind Rhi windows. This affects macOS and Windows, but not Linux where we use the `QRhiWidget` class.

Also, toasts were being drawn on top of WindowBar. We want them anchored to the the MdiArea.

### The Fix

We create two modes for ToastHost: ChildWidget and ToolWindow. We use ToolWindow mode on Mac and Windows os that  toast notifications are made Qt::Tool Windows instead of child widgets. On Mac, we go a step further and make them native NSWindows child to the main app window, which fixes a visual latency issue. Linux uses ChildWidget mode, and retains the original logic.

Also, we assign MdiArea as the "anchor" widget. Both modes position toasts to this anchor.

The only apparent downside to the ToolWindow workaround is that the toast stack is no longer bounded by the app window.

### Changes

- Anchor toast placement to `MdiArea` instead of the main window so notifications no longer overlap the `WindowBar`.
- Add explicit toast host modes:
  - `ChildWidget` for the original embedded-widget behavior
  - `ToolWindow` for platforms where toasts must render above native/RHI-backed content
- Make `ToastHost::defaultMode()` choose the platform default:
  - Linux: `ChildWidget`
  - other platforms: `ToolWindow`
- Refactor toast positioning so the host owns anchoring/reflow and `Toast` only handles mode-specific placement.
- In `ToolWindow` mode on macOS, attach toast windows as native child `NSWindow`s of the main app window so they move with the app during live drags. Without this fix, dragging the app window results in visible delay while the toast windows catch up.

## How Has This Been Tested?
Tested on all three platforms.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
