### PR TITLE
HexView Refactor 6: Multi-selection and SplitterSnapProvider

### DIFF
--- a/src/ui/qt/workarea/SplitterSnapProvider.h
+++ b/src/ui/qt/workarea/SplitterSnapProvider.h
@@ -1,0 +1,20 @@
+/*
+* VGMTrans (c) 2002-2026
+* Licensed under the zlib license,
+* refer to the included LICENSE.txt file
+*/
+
+#pragma once
+
+#include <vector>
+
+struct SplitterSnapRange {
+  int lowerBound = 0;
+  int upperBound = 0;
+};
+
+class SplitterSnapProvider {
+public:
+  virtual ~SplitterSnapProvider() = default;
+  [[nodiscard]] virtual std::vector<SplitterSnapRange> splitterSnapRanges() const = 0;
+};

--- a/src/ui/qt/workarea/hexview/HexView.cpp
+++ b/src/ui/qt/workarea/hexview/HexView.cpp
@@ -514,6 +514,13 @@ int HexView::getViewportWidthSansAsciiAndAddress() const {
   return getVirtualWidthSansAsciiAndAddress() + VIEWPORT_PADDING;
 }
 
+std::vector<SplitterSnapRange> HexView::splitterSnapRanges() const {
+  return {
+      {getViewportWidthSansAsciiAndAddress(), getViewportWidthSansAscii()},
+      {getViewportWidthSansAscii(), getViewportFullWidth()},
+  };
+}
+
 // Sync vertical scrollbar range/steps with current content and viewport dimensions.
 void HexView::updateScrollBars() {
   const int totalHeight = getVirtualHeight();
@@ -610,6 +617,91 @@ void HexView::setSelectedItem(VGMItem* item) {
   }
 
   selectCurrentItem(true);
+
+  if (!m_lineHeight) {
+    return;
+  }
+
+  const int itemBaseOffset = static_cast<int>(m_selectedItem->offset() - m_vgmfile->offset());
+  const int line = itemBaseOffset / BYTES_PER_LINE;
+  const int endLine = (itemBaseOffset + static_cast<int>(m_selectedItem->length())) / BYTES_PER_LINE;
+
+  const int viewStartLine = verticalScrollBar()->value() / m_lineHeight;
+  const int viewEndLine = viewStartLine + (viewport()->height() / m_lineHeight);
+
+  if (line <= viewEndLine && endLine > viewStartLine) {
+    return;
+  }
+
+  if (line < viewStartLine) {
+    verticalScrollBar()->setValue(line * m_lineHeight);
+  } else if (endLine > viewEndLine) {
+    if ((endLine - line) > (viewport()->height() / m_lineHeight)) {
+      verticalScrollBar()->setValue(line * m_lineHeight);
+    } else {
+      const int y = ((endLine + 1) * m_lineHeight) + 1 - viewport()->height();
+      verticalScrollBar()->setValue(y);
+    }
+  }
+}
+
+void HexView::setSelectedItems(const std::vector<const VGMItem*>& items,
+                               const VGMItem* primaryItem) {
+  if (items.empty()) {
+    setSelectedItem(nullptr);
+    return;
+  }
+
+  VGMItem* resolvedPrimary = const_cast<VGMItem*>(primaryItem);
+  if (!resolvedPrimary) {
+    for (const auto* item : items) {
+      if (item) {
+        resolvedPrimary = const_cast<VGMItem*>(item);
+        break;
+      }
+    }
+  }
+
+  if (!resolvedPrimary) {
+    setSelectedItem(nullptr);
+    return;
+  }
+
+  m_selectedItem = resolvedPrimary;
+  m_selectedOffset = m_selectedItem->offset();
+
+  std::vector<SelectionRange> selections;
+  selections.reserve(items.size());
+  std::unordered_set<uint64_t> keys;
+  keys.reserve(items.size() * 2 + 1);
+
+  for (const auto* item : items) {
+    if (!item) {
+      continue;
+    }
+    const uint32_t length = item->length() > 0 ? item->length() : 1u;
+    const SelectionRange range{item->offset(), length};
+    if (keys.insert(selectionKey(range)).second) {
+      selections.push_back(range);
+    }
+  }
+
+  if (selections.empty()) {
+    setSelectedItem(nullptr);
+    return;
+  }
+
+  std::sort(selections.begin(), selections.end(), [](const SelectionRange& a, const SelectionRange& b) {
+    if (a.offset != b.offset) {
+      return a.offset < b.offset;
+    }
+    return a.length < b.length;
+  });
+
+  m_selections = std::move(selections);
+  m_fadeSelections.clear();
+  updateHighlightState(true);
+  requestRhiUpdate(false, true);
 
   if (!m_lineHeight) {
     return;

--- a/src/ui/qt/workarea/hexview/HexView.cpp
+++ b/src/ui/qt/workarea/hexview/HexView.cpp
@@ -645,6 +645,7 @@ void HexView::setSelectedItem(VGMItem* item) {
   }
 }
 
+// Select multiple items, using the primary item as the anchor for keyboard focus and scroll-to-visible behavior.
 void HexView::setSelectedItems(const std::vector<const VGMItem*>& items,
                                const VGMItem* primaryItem) {
   if (items.empty()) {
@@ -652,6 +653,8 @@ void HexView::setSelectedItems(const std::vector<const VGMItem*>& items,
     return;
   }
 
+  // If the caller did not provide an explicit primary item, fall back to the first non-null entry so we still have
+  // a stable anchor for the selection.
   VGMItem* resolvedPrimary = const_cast<VGMItem*>(primaryItem);
   if (!resolvedPrimary) {
     for (const auto* item : items) {
@@ -679,8 +682,10 @@ void HexView::setSelectedItems(const std::vector<const VGMItem*>& items,
     if (!item) {
       continue;
     }
+    // Zero-length items still need a visible caret-width highlight in the hex view, so normalize them to a one-byte range.
     const uint32_t length = item->length() > 0 ? item->length() : 1u;
     const SelectionRange range{item->offset(), length};
+    // Ignore duplicate ranges so the renderer and highlight animation only see one entry per distinct byte span.
     if (keys.insert(selectionKey(range)).second) {
       selections.push_back(range);
     }
@@ -691,6 +696,7 @@ void HexView::setSelectedItems(const std::vector<const VGMItem*>& items,
     return;
   }
 
+  // Keep the stored ranges ordered for deterministic rendering and hit-testing.
   std::sort(selections.begin(), selections.end(), [](const SelectionRange& a, const SelectionRange& b) {
     if (a.offset != b.offset) {
       return a.offset < b.offset;
@@ -703,6 +709,7 @@ void HexView::setSelectedItems(const std::vector<const VGMItem*>& items,
   updateHighlightState(true);
   requestRhiUpdate(false, true);
 
+  // Reuse the single-item visibility logic and anchor it to the primary item.
   if (!m_lineHeight) {
     return;
   }

--- a/src/ui/qt/workarea/hexview/HexView.h
+++ b/src/ui/qt/workarea/hexview/HexView.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <vector>
 #include "HexViewFrameData.h"
+#include "workarea/SplitterSnapProvider.h"
 
 class QParallelAnimationGroup;
 class QWidget;
@@ -30,7 +31,7 @@ class HexViewRhiHost;
 
 static constexpr int OUTLINE_FADE_DURATION_MS = 150;
 
-class HexView final : public QAbstractScrollArea {
+class HexView final : public QAbstractScrollArea, public SplitterSnapProvider {
   Q_OBJECT
   Q_PROPERTY(qreal overlayOpacity READ overlayOpacity WRITE setOverlayOpacity)
   Q_PROPERTY(qreal shadowBlur READ shadowBlur WRITE setShadowBlur)
@@ -42,6 +43,8 @@ public:
   ~HexView() override;
   [[nodiscard]] static QFont defaultViewFont();
   void setSelectedItem(VGMItem* item);
+  void setSelectedItems(const std::vector<const VGMItem*>& items,
+                        const VGMItem* primaryItem = nullptr);
   void setPlaybackSelectionsForItems(const std::vector<const VGMItem*>& items);
   void clearPlaybackSelections(bool fade = true);
   void setPlaybackActive(bool active);
@@ -55,6 +58,7 @@ public:
   [[nodiscard]] int getViewportFullWidth() const;
   [[nodiscard]] int getViewportWidthSansAscii() const;
   [[nodiscard]] int getViewportWidthSansAsciiAndAddress() const;
+  [[nodiscard]] std::vector<SplitterSnapRange> splitterSnapRanges() const override;
   HexViewFrame::Data captureRhiFrameData(float dpr);
 
   void handleCoalescedMouseMove(const QPoint& pos,


### PR DESCRIPTION
This PR adds multi-item selection to the HexView and reintroduces the snapping splitter logic as an interface class.

`HexView::setSelectedItems(...)` provides multi-selection while still maintaining a primary item for focus and scrolling behavior.

Making the snapping logic an interface allows HexView to define its own snapping regions rather than MdiArea having to reconstruct HexView's layout thresholds.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
