### PR TITLE
HexView Refactor 7 - note-preview hooks

### DIFF
--- a/src/ui/qt/workarea/hexview/HexView.cpp
+++ b/src/ui/qt/workarea/hexview/HexView.cpp
@@ -1303,7 +1303,11 @@ void HexView::handleSelectionPress(int offset, VGMItem* item) {
     stopNotePreview();
   } else {
     selectionChanged(item);
-    notePreviewRequested(item, false);
+    if (item) {
+      notePreviewRequested(item, false);
+    } else {
+      stopNotePreview();
+    }
   }
   hideTooltip();
 }
@@ -1343,7 +1347,11 @@ void HexView::handleSelectionDrag(int offset) {
   auto* item = m_vgmfile->getItemAtOffset(offset, false);
   if (item != m_selectedItem) {
     selectionChanged(item);
-    notePreviewRequested(item, false);
+    if (item) {
+      notePreviewRequested(item, false);
+    } else {
+      stopNotePreview();
+    }
   }
   hideTooltip();
 }

--- a/src/ui/qt/workarea/hexview/HexView.cpp
+++ b/src/ui/qt/workarea/hexview/HexView.cpp
@@ -1281,9 +1281,11 @@ void HexView::handleSeekPress(VGMItem* item, const QPoint& pos) {
     if (item != m_lastSeekItem) {
       m_lastSeekItem = item;
       seekToEventRequested(item);
+      notePreviewRequested(item, true);
     }
     showTooltip(item, pos);
   } else {
+    stopNotePreview();
     hideTooltip();
   }
 }
@@ -1291,14 +1293,17 @@ void HexView::handleSeekPress(VGMItem* item, const QPoint& pos) {
 void HexView::handleSelectionPress(int offset, VGMItem* item) {
   if (offset == -1) {
     selectionChanged(nullptr);
+    stopNotePreview();
     return;
   }
 
   m_selectedOffset = offset;
   if (item == m_selectedItem) {
     selectionChanged(nullptr);
+    stopNotePreview();
   } else {
     selectionChanged(item);
+    notePreviewRequested(item, false);
   }
   hideTooltip();
 }
@@ -1309,8 +1314,13 @@ void HexView::handleSeekScrubDrag(int offset) {
       if (item != m_lastSeekItem) {
         m_lastSeekItem = item;
         seekToEventRequested(item);
+        notePreviewRequested(item, true);
       }
+    } else {
+      stopNotePreview();
     }
+  } else {
+    stopNotePreview();
   }
   hideTooltip();
 }
@@ -1318,6 +1328,7 @@ void HexView::handleSeekScrubDrag(int offset) {
 void HexView::handleSelectionDrag(int offset) {
   if (offset == -1) {
     selectionChanged(nullptr);
+    stopNotePreview();
     hideTooltip();
     return;
   }
@@ -1332,6 +1343,7 @@ void HexView::handleSelectionDrag(int offset) {
   auto* item = m_vgmfile->getItemAtOffset(offset, false);
   if (item != m_selectedItem) {
     selectionChanged(item);
+    notePreviewRequested(item, false);
   }
   hideTooltip();
 }
@@ -1362,7 +1374,7 @@ void HexView::mousePressEvent(QMouseEvent* event) {
 void HexView::mouseReleaseEvent(QMouseEvent* event) {
   if (event->button() == Qt::LeftButton) {
     m_isDragging = false;
-    m_lastSeekItem = nullptr;
+    stopNotePreview();
     const QPoint vp = viewport()->mapFromGlobal(QCursor::pos());
     handleTooltipHoverMove(vp, QApplication::keyboardModifiers());
   }
@@ -1671,6 +1683,11 @@ void HexView::updateHighlightState(bool animateSelection) {
   setOverlayOpacity(OVERLAY_ALPHA_F);
   setShadowBlur(SHADOW_BLUR_RADIUS);
   setShadowOffset(QPointF(SHADOW_OFFSET_X, SHADOW_OFFSET_Y));
+}
+
+void HexView::stopNotePreview() {
+  emit notePreviewStopped();
+  m_lastSeekItem = nullptr;
 }
 
 // Show rich HTML tooltip for a hovered item, avoiding redundant re-show for same item.

--- a/src/ui/qt/workarea/hexview/HexView.h
+++ b/src/ui/qt/workarea/hexview/HexView.h
@@ -69,6 +69,8 @@ public:
 signals:
   void selectionChanged(VGMItem* item);
   void seekToEventRequested(VGMItem* item);
+  void notePreviewRequested(VGMItem* item, bool includeActiveNotesAtTick);
+  void notePreviewStopped();
 
 protected:
   bool viewportEvent(QEvent* event) override;
@@ -148,6 +150,7 @@ private:
   void updateHighlightState(bool animateSelection);
   void showTooltip(VGMItem* item, const QPoint& pos);
   void hideTooltip();
+  void stopNotePreview();
 
   VGMFile* m_vgmfile = nullptr;
   // Interaction state.


### PR DESCRIPTION
This PR adds note-preview hooks to `HexView` so higher-level UI code can trigger and stop note previews directly from hex-view interactions.

Given that note-preview functionality is planned a few PRs down the line, I regret adding this functionality here and not later. Removing this from each cumulative branch would be a headache.

## Changes

- add `notePreviewRequested(VGMItem* item, bool includeActiveNotesAtTick)` and `notePreviewStopped()` signals to `HexView`
- emit note preview requests from both selection interactions and modifier-based seek scrubbing
- distinguish scrub previews from normal selection previews via the `includeActiveNotesAtTick` flag
- stop active note previews when selection is cleared, the pointer moves off a valid item, or the drag interaction ends
- centralize note-preview teardown in `stopNotePreview()`, which also resets the cached seek item state

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
