### PR TITLE
SeqTrack volume bug fixes and small cleanup

### DIFF
--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -11,6 +11,17 @@
 #include "VGMSeqNoTrks.h"
 #include "helper.h"
 #include <algorithm>
+#include <cmath>
+
+namespace {
+constexpr uint16_t maxLevelForResolution(Resolution res) {
+  return res == Resolution::FourteenBit ? 16383 : 127;
+}
+
+double normalizedLevelFromRaw(uint16_t rawLevel, Resolution res) {
+  return rawLevel / static_cast<double>(maxLevelForResolution(res));
+}
+}  // namespace
 
 SeqTrack::SeqTrack(VGMSeq *parentFile, uint32_t offset, uint32_t length, std::string name)
     : VGMItem(parentFile, offset, length, std::move(name), Type::Track),
@@ -31,8 +42,11 @@ void SeqTrack::resetVars() {
   totalTicks = -1;
   deltaTime = 0;
   vol = 100;
+  volResolution = Resolution::SevenBit;
   expression = 127;
+  expressionResolution = Resolution::SevenBit;
   mastVol = 127;
+  masterVolResolution = Resolution::SevenBit;
   prevPan = 64;
   prevReverb = 40;
   channelGroup = 0;
@@ -791,29 +805,34 @@ double SeqTrack::applyLevelCorrection(double level, LevelController controller) 
     if (parentSeq->panVolumeCorrectionMode == relevantCorrectionMode)
       level *= panVolumeCorrectionRate;
   }
-  if (usesLinearAmplitudeScale())
-    level = sqrt(level);
-  return level;
+  return std::clamp(level, 0.0, 1.0);
 }
 
 void SeqTrack::addLevelNoItem(double level, LevelController controller, Resolution res, int absTime) {
-  u16 origLevel = static_cast<u16>(level * (res == Resolution::FourteenBit ? 16383.0 : 127.0));
+  level = std::clamp(level, 0.0, 1.0);
+  const uint16_t maxLevel = maxLevelForResolution(res);
+  const u16 origLevel = static_cast<u16>(std::lround(level * maxLevel));
   switch (controller) {
     case LevelController::Volume:
       vol = origLevel;
+      volResolution = res;
       break;
     case LevelController::Expression:
       expression = origLevel;
+      expressionResolution = res;
       break;
     case LevelController::MasterVolume:
       mastVol = origLevel;
+      masterVolResolution = res;
       break;
   }
 
   level = applyLevelCorrection(level, controller);
   switch (res) {
     case Resolution::SevenBit: {
-      u8 midiLevel = static_cast<uint8_t>(std::min(level * 127.0, 127.0));
+      const u8 midiLevel = usesLinearAmplitudeScale()
+        ? convertPercentAmpToStdMidiVal(level)
+        : static_cast<u8>(std::lround(level * maxLevel));
       switch (controller) {
         case LevelController::Volume:
           if (readMode == READMODE_CONVERT_TO_MIDI) {
@@ -846,9 +865,11 @@ void SeqTrack::addLevelNoItem(double level, LevelController controller, Resoluti
       break;
     }
     case Resolution::FourteenBit: {
-      u16 midiLevel = static_cast<uint16_t>(std::min(level * 16383.0, 16383.0));
-      u8 levelHi = static_cast<uint8_t>((midiLevel >> 7) & 0x7F);
-      u8 levelLo = static_cast<uint8_t>(midiLevel & 0x7F);
+      const u16 midiLevel = usesLinearAmplitudeScale()
+        ? convertPercentAmpToStd14BitMidiVal(level)
+        : static_cast<u16>(std::lround(level * maxLevel));
+      const u8 levelHi = static_cast<uint8_t>((midiLevel >> 7) & 0x7F);
+      const u8 levelLo = static_cast<uint8_t>(midiLevel & 0x7F);
       switch (controller) {
         case LevelController::Volume:
           if (readMode == READMODE_CONVERT_TO_MIDI) {
@@ -868,7 +889,7 @@ void SeqTrack::addLevelNoItem(double level, LevelController controller, Resoluti
               pMidiTrack->addExpression(channel, levelHi);
             } else {
               pMidiTrack->insertExpressionFine(channel, levelLo, absTime);
-              pMidiTrack->insertVol(channel, levelHi, absTime);
+              pMidiTrack->insertExpression(channel, levelHi, absTime);
             }
           }
           break;
@@ -885,6 +906,27 @@ void SeqTrack::addLevelNoItem(double level, LevelController controller, Resoluti
       break;
     }
   }
+}
+
+void SeqTrack::reapplyStoredLevelNoItem(LevelController controller, int absTime) {
+  uint16_t rawLevel;
+  Resolution resolution;
+  switch (controller) {
+    case LevelController::Volume:
+      rawLevel = vol;
+      resolution = volResolution;
+      break;
+    case LevelController::Expression:
+      rawLevel = expression;
+      resolution = expressionResolution;
+      break;
+    case LevelController::MasterVolume:
+      rawLevel = mastVol;
+      resolution = masterVolResolution;
+      break;
+  }
+
+  addLevelNoItem(normalizedLevelFromRaw(rawLevel, resolution), controller, resolution, absTime);
 }
 
 void SeqTrack::addVol(u32 offset, u32 length, double volPercent, Resolution res, const std::string &sEventName) {
@@ -930,7 +972,7 @@ void SeqTrack::insertVol(uint32_t offset,
   bool isNewOffset = onEvent(offset, length);
 
   recordSeqEvent<VolSeqEvent>(isNewOffset, absTime, newVol, offset, length, sEventName);
-  addLevelNoItem(newVol / 127.0, LevelController::Volume, Resolution::SevenBit);
+  addLevelNoItem(newVol / 127.0, LevelController::Volume, Resolution::SevenBit, absTime);
 }
 
 void SeqTrack::addExpression(u32 offset, u32 length, double levelPercent, Resolution res, const std::string &sEventName) {
@@ -1029,11 +1071,11 @@ void SeqTrack::addPanNoItem(uint8_t pan) {
 
     switch (parentSeq->panVolumeCorrectionMode) {
     case PanVolumeCorrectionMode::kAdjustVolumeController:
-      addVolNoItem(vol);
+      reapplyStoredLevelNoItem(LevelController::Volume);
       break;
 
     case PanVolumeCorrectionMode::kAdjustExpressionController:
-      addExpressionNoItem(expression);
+      reapplyStoredLevelNoItem(LevelController::Expression);
       break;
 
     default:
@@ -1075,11 +1117,11 @@ void SeqTrack::insertPan(uint32_t offset,
     // TODO: (bugfix) Pan volume compensation does not work properly when using pan slider and volume slider at the same time
     switch (parentSeq->panVolumeCorrectionMode) {
     case PanVolumeCorrectionMode::kAdjustVolumeController:
-      insertVol(offset, length, vol, absTime);
+      reapplyStoredLevelNoItem(LevelController::Volume, absTime);
       break;
 
     case PanVolumeCorrectionMode::kAdjustExpressionController:
-      insertExpression(offset, length, expression, absTime);
+      reapplyStoredLevelNoItem(LevelController::Expression, absTime);
       break;
 
     default:

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -797,7 +797,7 @@ void SeqTrack::clearPrevDurEvents() {
   prevDurEventIndices.clear();
 }
 
-double SeqTrack::applyLevelCorrection(double level, LevelController controller) const {
+double SeqTrack::applyPanVolumeCorrection(double level, LevelController controller) const {
   if (controller != LevelController::MasterVolume) {
     PanVolumeCorrectionMode relevantCorrectionMode = controller == LevelController::Volume ?
       PanVolumeCorrectionMode::kAdjustVolumeController :
@@ -805,7 +805,7 @@ double SeqTrack::applyLevelCorrection(double level, LevelController controller) 
     if (parentSeq->panVolumeCorrectionMode == relevantCorrectionMode)
       level *= panVolumeCorrectionRate;
   }
-  return std::clamp(level, 0.0, 1.0);
+  return level;
 }
 
 void SeqTrack::addLevelNoItem(double level, LevelController controller, Resolution res, int absTime) {
@@ -827,7 +827,8 @@ void SeqTrack::addLevelNoItem(double level, LevelController controller, Resoluti
       break;
   }
 
-  level = applyLevelCorrection(level, controller);
+  level = applyPanVolumeCorrection(level, controller);
+  level = std::clamp(level, 0.0, 1.0);
   switch (res) {
     case Resolution::SevenBit: {
       const u8 midiLevel = usesLinearAmplitudeScale()

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -957,12 +957,14 @@ void SeqTrack::addVolSlide(uint32_t offset,
 
   recordDurSeqEvent<VolSlideSeqEvent>(isNewOffset, getTime(), dur, targVol, dur, offset, length, sEventName);
 
-  if (readMode == READMODE_CONVERT_TO_MIDI)
+  if (readMode == READMODE_CONVERT_TO_MIDI) {
     addControllerSlide(dur,
                        vol,
                        targVol,
                        usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
                        &MidiTrack::insertVol);
+    volResolution = Resolution::SevenBit;
+  }
 }
 
 void SeqTrack::insertVol(uint32_t offset,
@@ -1005,12 +1007,14 @@ void SeqTrack::addExpressionSlide(uint32_t offset,
 
   recordDurSeqEvent<ExpressionSlideSeqEvent>(isNewOffset, getTime(), dur, targExpr, dur, offset, length, sEventName);
 
-  if (readMode == READMODE_CONVERT_TO_MIDI)
+  if (readMode == READMODE_CONVERT_TO_MIDI) {
     addControllerSlide(dur,
                        expression,
                        targExpr,
                        usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
                        &MidiTrack::insertExpression);
+    expressionResolution = Resolution::SevenBit;
+  }
 }
 
 void SeqTrack::insertExpression(uint32_t offset,
@@ -1048,12 +1052,14 @@ void SeqTrack::addMastVolSlide(uint32_t offset,
 
   recordDurSeqEvent<MastVolSlideSeqEvent>(isNewOffset, getTime(), dur, targVol, dur, offset, length, sEventName);
 
-  if (readMode == READMODE_CONVERT_TO_MIDI)
+  if (readMode == READMODE_CONVERT_TO_MIDI) {
     addControllerSlide(dur,
                        mastVol,
                        targVol,
                        usesLinearAmplitudeScale() ? convert7bitPercentAmpToStdMidiVal : nullptr,
                        &MidiTrack::insertMasterVol);
+    masterVolResolution = Resolution::SevenBit;
+  }
 }
 
 void SeqTrack::addPan(uint32_t offset, uint32_t length, uint8_t pan, const std::string &sEventName) {

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -140,7 +140,7 @@ protected:
 
 private:
   void addControllerSlide(u32 dur, u16 &prevVal, u16 targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t)) const;
-  double applyLevelCorrection(double level, LevelController controller) const;
+  double applyPanVolumeCorrection(double level, LevelController controller) const;
   void addLevelNoItem(double level, LevelController controller, Resolution res, int absTime = -1);
   void reapplyStoredLevelNoItem(LevelController controller, int absTime = -1);
   void purgePrevDurEvents(uint32_t absTime);

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -142,6 +142,7 @@ private:
   void addControllerSlide(u32 dur, u16 &prevVal, u16 targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t)) const;
   double applyLevelCorrection(double level, LevelController controller) const;
   void addLevelNoItem(double level, LevelController controller, Resolution res, int absTime = -1);
+  void reapplyStoredLevelNoItem(LevelController controller, int absTime = -1);
   void purgePrevDurEvents(uint32_t absTime);
   void clearPrevDurEvents();
   void trackActiveNoteIndex(int8_t key, SeqEventTimeIndex::Index idx);
@@ -295,8 +296,11 @@ private:
   uint8_t prevVel;
   uint8_t octave;
   u16 vol;
+  Resolution volResolution;
   u16 expression;
+  Resolution expressionResolution;
   u16 mastVol;
+  Resolution masterVolResolution;
   double panVolumeCorrectionRate; // as percentage of original volume (default: 1.0)
   u16 prevPan;
   uint8_t prevReverb;


### PR DESCRIPTION
Fixes some bugs related to volume. Also cleans up some volume-related code.

- fix inserting 14-bit expression actually inserting a coarse volume event 👍
- fix insert volume, not passing absTime and thereby adding volume at current time 👍👍
- preserve controller resolution when reapplying volume/expression after pan compensation, instead of silently replaying 14-bit state through 7-bit helpers
- move linear amplitude correction out of `applyLevelCorrection()` and renamed that method to `applyPanVolumeCorrection()`
- add maxLevelForResolution() and normalizedLevelFromRaw() helpers

To my surprise, those first two bugs weren't affecting any actual usage, so I'm not adding an entry to the changelog.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
