### PR TITLE
CPS3 fixes - volume and region ADSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,5 +31,6 @@
 - Fixed an issue where Nintendo DS (SDAT) PSG instruments were exported too quiet (-4.6dB attenuated).
 - Fixed an issues where samples from Nintendo DS (SDAT) data were being read with the wrong sample rate,
   resulting in instruments playing at the wrong pitch or seemingly be absent.
+- Fixed CPS3 volume and ADSR bugs.
 - Fixed various memory leaks, most notably one which occurred on collection playback.
 - Fixed loading of older SPC files that do not have ID666 tags.

--- a/src/main/formats/CPS/CPS2Instr.cpp
+++ b/src/main/formats/CPS/CPS2Instr.cpp
@@ -294,11 +294,19 @@ CPS2Instr::CPS2Instr(VGMInstrSet *instrSet,
 }
 
 bool CPS2Instr::loadInstr() {
-  std::vector<VGMRgn*> rgns;
+  struct CPSRgnInfo {
+    VGMRgn* rgn;
+    uint8_t attack_rate;
+    uint8_t decay_rate;
+    uint8_t sustain_level;
+    uint8_t sustain_rate;
+    uint8_t release_rate;
+  };
+
+  std::vector<CPSRgnInfo> rgns;
   const CPS2FormatVer formatVer = formatVersion();
   if (formatVer < CPS2_V103) {
     VGMRgn* rgn = new VGMRgn(this, offset(), length());
-    rgns.push_back(rgn);
     rgn->addChild(this->offset(),     1, "Sample Info Index");
     rgn->addChild(this->offset() + 1, 1, "Unknown / Ignored");
     rgn->addChild(this->offset() + 2, 1, "Attack Rate");
@@ -311,15 +319,15 @@ bool CPS2Instr::loadInstr() {
     qs_prog_info_ver_101 progInfo;
     readBytes(offset(), sizeof(qs_prog_info_ver_101), &progInfo);
     rgn->sampNum = progInfo.sample_index;
-    this->attack_rate = progInfo.attack_rate;
-    this->decay_rate = progInfo.decay_rate;
-    this->sustain_level = progInfo.sustain_level;
-    this->sustain_rate = progInfo.sustain_rate;
-    this->release_rate = progInfo.release_rate;
+    rgns.push_back({rgn,
+                    progInfo.attack_rate,
+                    progInfo.decay_rate,
+                    progInfo.sustain_level,
+                    progInfo.sustain_rate,
+                    progInfo.release_rate});
   }
   else if (formatVer < CPS2_V130 || formatVer == CPS2_V200 || formatVer == CPS2_V201B) {
     VGMRgn* rgn = new VGMRgn(this, offset(), length());
-    rgns.push_back(rgn);
     qs_prog_info_ver_103 progInfo;
     readBytes(offset(), sizeof(qs_prog_info_ver_103), &progInfo);
 
@@ -331,11 +339,12 @@ bool CPS2Instr::loadInstr() {
     rgn->addChild(this->offset() + 6, 1, "Sustain Rate");
     rgn->addChild(this->offset() + 7, 1, "Release Rate");
 
-    this->attack_rate = progInfo.attack_rate;
-    this->decay_rate = progInfo.decay_rate;
-    this->sustain_level = progInfo.sustain_level;
-    this->sustain_rate = progInfo.sustain_rate;
-    this->release_rate = progInfo.release_rate;
+    rgns.push_back({rgn,
+                    progInfo.attack_rate,
+                    progInfo.decay_rate,
+                    progInfo.sustain_level,
+                    progInfo.sustain_rate,
+                    progInfo.release_rate});
   }
   else if (formatVer == CPS3) {
     uint8_t prevKeyHigh = 0;
@@ -345,12 +354,10 @@ bool CPS2Instr::loadInstr() {
         break;
 
       VGMRgn* rgn = new VGMRgn(this, off, 12);
-      rgns.push_back(rgn);
 
       qs_prog_info_ver_cps3 progInfo;
       readBytes(off, sizeof(qs_prog_info_ver_cps3), &progInfo);
 
-      //    rgn->AddFineTune( (int16_t)((progInfo.fine_tune / 256.0) * 100), this->offset() + 2, 1);
       rgn->addKeyHigh(progInfo.key_high, off + 0, 1);
       rgn->keyLow = prevKeyHigh + 1;
       prevKeyHigh = progInfo.key_high;
@@ -360,7 +367,10 @@ bool CPS2Instr::loadInstr() {
       uint8_t pan = progInfo.pan_override == -1 ? 64 : progInfo.pan_override;
       rgn->addPan(pan, off+1, 1, "Pan Override");
 
-      auto volume_percent = ((64 + progInfo.volume_adjustment) & 0x7F) / 64.0;
+      double volume_percent = ((64 + progInfo.volume_adjustment) & 0x7F) / 64.0;
+      // CPS3 instrument regions can (almost) double volume, but SF2 only allows attenuation. To compensate, we set a
+      // default (neutral) attenuation of half volume. Doubled CPS3 instruent volume translates to no attenuation.
+      volume_percent /= 2.0;
       rgn->addVolume(volume_percent, off+2, 1);
       rgn->addUnknown(off+3, 1);
       rgn->addSampNum((progInfo.sample_index_hi << 8) + progInfo.sample_index_lo, off+4, 2);
@@ -374,18 +384,17 @@ bool CPS2Instr::loadInstr() {
       rgn->addChild(off + 10, 1, "Sustain Rate");
       rgn->addChild(off + 11, 1, "Release Rate");
 
-
-      this->attack_rate = progInfo.attack_rate;
-      this->decay_rate = progInfo.decay_rate;
-      this->sustain_level = progInfo.sustain_level;
-      this->sustain_rate = progInfo.sustain_rate;
-      this->release_rate = progInfo.release_rate;
+      rgns.push_back({rgn,
+                      progInfo.attack_rate,
+                      progInfo.decay_rate,
+                      progInfo.sustain_level,
+                      progInfo.sustain_rate,
+                      progInfo.release_rate});
     }
     setLength(off - offset());
   }
   else {
     VGMRgn* rgn = new VGMRgn(this, offset(), length(), "Region");
-    rgns.push_back(rgn);
     qs_prog_info_ver_130 progInfo;
     readBytes(offset(), sizeof(qs_prog_info_ver_130), &progInfo);
 
@@ -396,14 +405,17 @@ bool CPS2Instr::loadInstr() {
     const CPSArticTable* articTable = static_cast<CPS2InstrSet*>(this->parInstrSet)->articTable;
     const qs_artic_info* artic = &articTable->artics[progInfo.artic_index];
     rgn->sampNum = progInfo.sample_index;
-    this->attack_rate = artic->attack_rate;
-    this->decay_rate = artic->decay_rate;
-    this->sustain_level = artic->sustain_level;
-    this->sustain_rate = artic->sustain_rate;
-    this->release_rate = artic->release_rate;
+    rgns.push_back({rgn,
+                    artic->attack_rate,
+                    artic->decay_rate,
+                    artic->sustain_level,
+                    artic->sustain_rate,
+                    artic->release_rate});
   }
 
-  for (auto rgn : rgns) {
+  for (const auto& rgnInfo : rgns) {
+    VGMRgn* rgn = rgnInfo.rgn;
+
     // Fix for Dungeons and Dragons Shadow Over Mystara
     if (rgn->sampNum >= 0x8000)
       rgn->sampNum -= 0x8000;
@@ -412,11 +424,11 @@ bool CPS2Instr::loadInstr() {
     if (rgn->sampNum >= static_cast<CPS2InstrSet*>(parInstrSet)->sampInfoTable->numSamples)
       rgn->sampNum = 0;
 
-    uint16_t Ar = attack_rate_table[std::min<u8>(attack_rate, 63)];
-    uint16_t Dr = decay_rate_table[std::min<u8>(decay_rate, 63)];
-    uint16_t Sl = sustain_level_table[std::min<u8>(sustain_level, 127)];
-    uint16_t Sr = decay_rate_table[std::min<u8>(sustain_rate, 63)];
-    uint16_t Rr = decay_rate_table[std::min<u8>(release_rate, 63)];
+    uint16_t Ar = attack_rate_table[std::min<u8>(rgnInfo.attack_rate, 63)];
+    uint16_t Dr = decay_rate_table[std::min<u8>(rgnInfo.decay_rate, 63)];
+    uint16_t Sl = sustain_level_table[std::min<u8>(rgnInfo.sustain_level, 127)];
+    uint16_t Sr = decay_rate_table[std::min<u8>(rgnInfo.sustain_rate, 63)];
+    uint16_t Rr = decay_rate_table[std::min<u8>(rgnInfo.release_rate, 63)];
 
     const double UPDATE_RATE_IN_HZ = formatVer == CPS3 ? CPS3_DRIVER_RATE_HZ : CPS2_DRIVER_RATE_HZ;
     // The rate values are all measured from max to min, as the SF2 and DLS specs call for.
@@ -432,7 +444,7 @@ bool CPS2Instr::loadInstr() {
     //  super short - then let's set the sustain level to 0 and substitute the sustain
     //  rate into the decay rate,  achieving the same effect as sustain rate.
 
-    if (this->sustain_level >= 0x7E && this->sustain_rate > 0 && this->decay_rate > 1) {
+    if (rgnInfo.sustain_level >= 0x7E && rgnInfo.sustain_rate > 0 && rgnInfo.decay_rate > 1) {
       //for a better approximation, we count the ticks to get from original Dr to original Sl
       ticks = static_cast<long>(ceil((0xFFFF - Sl)) / static_cast<double>(Dr));
       ticks += static_cast<long>(ceil(Sl / static_cast<double>(Sr)));

--- a/src/main/formats/CPS/CPS2Instr.h
+++ b/src/main/formats/CPS/CPS2Instr.h
@@ -238,12 +238,6 @@ protected:
   CPS2FormatVer formatVersion() const { return (static_cast<CPS2InstrSet*>(parInstrSet))->fmt_version; }
 
 protected:
-  uint8_t attack_rate{};
-  uint8_t decay_rate{};
-  uint8_t sustain_level{};
-  uint8_t sustain_rate{};
-  uint8_t release_rate{};
-
   int info_ptr{};        //pointer to start of instrument set block
   int nNumRegions{};
 };

--- a/src/main/formats/CPS/CPS2TrackV2.cpp
+++ b/src/main/formats/CPS/CPS2TrackV2.cpp
@@ -13,8 +13,8 @@ CPS2TrackV2::CPS2TrackV2(CPS2Seq *parentSeq, uint32_t offset, uint32_t length)
 }
 
 void CPS2TrackV2::resetVars() {
-  m_master_volume = 0;
-  m_secondary_volume = 0x40;
+  m_volume = 0;
+  m_expression = 0x40;
   memset(loopCounter, 0, sizeof(loopCounter));
   memset(loopOffset, 0, sizeof(loopOffset));
   SeqTrack::resetVars();
@@ -120,10 +120,12 @@ bool CPS2TrackV2::readEvent() {
       break;
     }
 
-    case C6_TRACK_MASTER_VOLUME: {
-      m_master_volume = readByte(curOffset++);
-      double volPercent = (m_master_volume * m_secondary_volume) / (127.0 * 127.0);
-      addVol(beginOffset, curOffset - beginOffset, volPercent, Resolution::FourteenBit, "Track Master Volume");
+    case C6_VOLUME: {
+      m_volume = readByte(curOffset++);
+      // We fold expression into volume to not interfere with our tremolo implementation
+      double expression = m_expression > 0 ? m_expression + 1 : 0;
+      double volPercent = (m_volume * expression) / (128.0 * 128.0);
+      addVol(beginOffset, curOffset - beginOffset, volPercent, Resolution::FourteenBit);
       break;
     }
 
@@ -133,10 +135,12 @@ bool CPS2TrackV2::readEvent() {
       break;
     }
 
-    case EVENT_C8: {
-      m_secondary_volume = readByte(curOffset++);
-      double volPercent = (m_master_volume * m_secondary_volume) / (127.0 * 127.0);
-      addVol(beginOffset, curOffset - beginOffset, volPercent, Resolution::FourteenBit);
+    case C8_EXPRESSION: {
+      m_expression = readByte(curOffset++);
+      double expression = m_expression > 0 ? m_expression + 1 : 0;
+      double volPercent = (m_volume * expression) / (128.0 * 128.0);
+      // We fold expression into volume to not interfere with our tremolo implementation
+      addVol(beginOffset, curOffset - beginOffset, volPercent, Resolution::FourteenBit, "Expression");
       break;
     }
 
@@ -154,7 +158,7 @@ bool CPS2TrackV2::readEvent() {
       break;
 
     case EVENT_CC:
-      //      curOffset++; //REALLY DOES ONE THING THEN JUMPS TO EVENT CE
+      // need to check if it's different in CPS2 usage vs CPS3
       curOffset += 3;
       addUnknown(beginOffset, curOffset-beginOffset);
       break;

--- a/src/main/formats/CPS/CPS2TrackV2.h
+++ b/src/main/formats/CPS/CPS2TrackV2.h
@@ -13,9 +13,9 @@ enum CPSv2SeqEventType {
   C3_PITCHBEND,
   C4_PROGCHANGE,
   C5_VIBRATO,
-  C6_TRACK_MASTER_VOLUME,
+  C6_VOLUME,
   C7_PAN,
-  EVENT_C8,
+  C8_EXPRESSION,
   C9_PORTAMENTO,
   EVENT_CA,
   EVENT_CB,
@@ -65,8 +65,8 @@ private:
   CPS2FormatVer version() const { return static_cast<CPS2Seq*>(this->parentSeq)->fmt_version; }
   uint32_t readVarLength();
 
-  uint8_t m_master_volume{0};
-  uint8_t m_secondary_volume{0x40};
+  uint8_t m_volume{0};
+  uint8_t m_expression{0x40};
   int8_t loopCounter[4];
   uint32_t loopOffset[4];    //used for detecting infinite loops
 };


### PR DESCRIPTION
- fix CPS3 using last region ADSR for all regions of an instrument - we were saving ADSR data to instrument class members, not the region, so we kept overwriting it as we iterated over regions 🍷
- fix region volume only applying for negative values (attenuation). SF2 is incapable of having a region increase volume; it can only attenuate. Since the max CPS3 region volume value (nearly) doubles the volume, we set the new neutral value to half volume on the SF2-side to allow for the full range. That means a max CPS3 region volume value will result in (nearly) no attenuation in the SF2 region.
- small tweak to volume / expression calculation - divide by 128 instead of 127, 7-bit expression value gets +1 unless 0. This is what the driver does.
- renamed event C6: Master Track Vol -> Volume and event C8: Volume -> Expression. I think it's cleaner this way - who's to say what the original events were labelled? Both are still using volume controller to not interfere with the tremolo handler, which uses expression controller. This is explained in comments.

## Motivation and Context
This was bugging me.

## How Has This Been Tested?
A number of problem tracks sound correct, now. CPS2 sounds the same.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
