### PR TITLE
Add global modulator and generator support for instruments

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -117,6 +117,7 @@ target_sources(vgmtranscore
     components/VGMMultiSectionSeq.cpp
     components/VGMSampColl.cpp
     components/VGMTag.cpp
+    components/instr/InstrumentModulation.cpp
     components/instr/VGMInstrSet.cpp
     components/instr/VGMRgn.cpp
     components/instr/VGMSamp.cpp

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -487,6 +487,7 @@ target_sources(vgmtranscore
       components/VGMTag.h
     FILE_SET headers_components_instr TYPE HEADERS BASE_DIRS components/instr
     FILES
+      components/instr/InstrumentModulation.h
       components/instr/VGMInstrSet.h
       components/instr/VGMRgn.h
       components/instr/VGMSamp.h

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -117,7 +117,7 @@ target_sources(vgmtranscore
     components/VGMMultiSectionSeq.cpp
     components/VGMSampColl.cpp
     components/VGMTag.cpp
-    components/instr/InstrumentModulation.cpp
+        components/instr/Modulation.cpp
     components/instr/VGMInstrSet.cpp
     components/instr/VGMRgn.cpp
     components/instr/VGMSamp.cpp
@@ -488,7 +488,7 @@ target_sources(vgmtranscore
       components/VGMTag.h
     FILE_SET headers_components_instr TYPE HEADERS BASE_DIRS components/instr
     FILES
-      components/instr/InstrumentModulation.h
+        components/instr/Modulation.h
       components/instr/VGMInstrSet.h
       components/instr/VGMRgn.h
       components/instr/VGMSamp.h

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -44,6 +44,7 @@ public:
     NoteOn,
     Octave,
     Pan,
+    ChannelPressure,
     PanLfo,
     PanSlide,
     PanEnvelope,

--- a/src/main/components/instr/InstrumentModulation.cpp
+++ b/src/main/components/instr/InstrumentModulation.cpp
@@ -1,0 +1,75 @@
+/*
+ * VGMTrans (c) 2002-2024
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#include "InstrumentModulation.h"
+#include <cmath>
+#include "ScaleConversion.h"
+
+namespace {
+
+constexpr double kSf2LfoReferenceHz = 8.176;
+
+bool isValidFiniteNumber(double value) {
+  return std::isfinite(value);
+}
+
+int32_t hertzToInstrumentCents(double hertz) {
+  return static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / kSf2LfoReferenceHz)));
+}
+
+}  // namespace
+
+ParamAmount ParamAmount::raw(int32_t amount) {
+  return ParamAmount(amount, true);
+}
+
+ParamAmount ParamAmount::cents(double cents) {
+  if (!isValidFiniteNumber(cents)) {
+    return ParamAmount(0, false);
+  }
+
+  return ParamAmount(static_cast<int32_t>(std::lround(cents)), true);
+}
+
+ParamAmount ParamAmount::hertz(double hertz) {
+  if (hertz <= 0.0 || !isValidFiniteNumber(hertz)) {
+    return ParamAmount(0, false);
+  }
+
+  return ParamAmount(hertzToInstrumentCents(hertz), true);
+}
+
+ParamAmount ParamAmount::hertzRange(double minHertz, double maxHertz) {
+  if (minHertz <= 0.0 || maxHertz <= 0.0 ||
+      !isValidFiniteNumber(minHertz) || !isValidFiniteNumber(maxHertz)) {
+    return ParamAmount(0, false);
+  }
+
+  const double minCents = static_cast<double>(hertzToInstrumentCents(minHertz));
+  const double maxCents = static_cast<double>(hertzToInstrumentCents(maxHertz));
+  const double fullScaleRange = (maxCents - minCents) * 128.0 / 127.0;
+  return ParamAmount(static_cast<int32_t>(std::lround(fullScaleRange)), true);
+}
+
+ParamAmount ParamAmount::seconds(double seconds) {
+  return ParamAmount(secondsToSf2Timecents(seconds), true);
+}
+
+ParamAmount ParamAmount::centibels(double centibels) {
+  if (!isValidFiniteNumber(centibels)) {
+    return ParamAmount(0, false);
+  }
+
+  return ParamAmount(static_cast<int32_t>(std::lround(centibels)), true);
+}
+
+ParamAmount ParamAmount::attenuationDb(double decibels) {
+  if (!isValidFiniteNumber(decibels)) {
+    return ParamAmount(0, false);
+  }
+
+  return ParamAmount(static_cast<int32_t>(std::lround(decibels * 10.0)), true);
+}

--- a/src/main/components/instr/InstrumentModulation.cpp
+++ b/src/main/components/instr/InstrumentModulation.cpp
@@ -1,5 +1,5 @@
 /*
- * VGMTrans (c) 2002-2024
+ * VGMTrans (c) 2002-2026
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
  */
@@ -12,10 +12,6 @@ namespace {
 
 constexpr double kSf2LfoReferenceHz = 8.176;
 
-bool isValidFiniteNumber(double value) {
-  return std::isfinite(value);
-}
-
 int32_t hertzToInstrumentCents(double hertz) {
   return static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / kSf2LfoReferenceHz)));
 }
@@ -27,7 +23,7 @@ ParamAmount ParamAmount::raw(int32_t amount) {
 }
 
 ParamAmount ParamAmount::cents(double cents) {
-  if (!isValidFiniteNumber(cents)) {
+  if (!std::isfinite(cents)) {
     return ParamAmount(0, false);
   }
 
@@ -35,7 +31,7 @@ ParamAmount ParamAmount::cents(double cents) {
 }
 
 ParamAmount ParamAmount::hertz(double hertz) {
-  if (hertz <= 0.0 || !isValidFiniteNumber(hertz)) {
+  if (hertz <= 0.0 || !std::isfinite(hertz)) {
     return ParamAmount(0, false);
   }
 
@@ -44,7 +40,7 @@ ParamAmount ParamAmount::hertz(double hertz) {
 
 ParamAmount ParamAmount::hertzRange(double minHertz, double maxHertz) {
   if (minHertz <= 0.0 || maxHertz <= 0.0 ||
-      !isValidFiniteNumber(minHertz) || !isValidFiniteNumber(maxHertz)) {
+      !std::isfinite(minHertz) || !std::isfinite(maxHertz)) {
     return ParamAmount(0, false);
   }
 
@@ -59,7 +55,7 @@ ParamAmount ParamAmount::seconds(double seconds) {
 }
 
 ParamAmount ParamAmount::centibels(double centibels) {
-  if (!isValidFiniteNumber(centibels)) {
+  if (!std::isfinite(centibels)) {
     return ParamAmount(0, false);
   }
 
@@ -67,7 +63,7 @@ ParamAmount ParamAmount::centibels(double centibels) {
 }
 
 ParamAmount ParamAmount::attenuationDb(double decibels) {
-  if (!isValidFiniteNumber(decibels)) {
+  if (!std::isfinite(decibels)) {
     return ParamAmount(0, false);
   }
 

--- a/src/main/components/instr/InstrumentModulation.cpp
+++ b/src/main/components/instr/InstrumentModulation.cpp
@@ -18,54 +18,54 @@ int32_t hertzToInstrumentCents(double hertz) {
 
 }  // namespace
 
-ParamAmount ParamAmount::raw(int32_t amount) {
-  return ParamAmount(amount, true);
+ModAmount ModAmount::raw(int32_t amount) {
+  return ModAmount(amount, true);
 }
 
-ParamAmount ParamAmount::cents(double cents) {
+ModAmount ModAmount::fromCents(double cents) {
   if (!std::isfinite(cents)) {
-    return ParamAmount(0, false);
+    return ModAmount(0, false);
   }
 
-  return ParamAmount(static_cast<int32_t>(std::lround(cents)), true);
+  return ModAmount(static_cast<int32_t>(std::lround(cents)), true);
 }
 
-ParamAmount ParamAmount::hertz(double hertz) {
+ModAmount ModAmount::fromHertz(double hertz) {
   if (hertz <= 0.0 || !std::isfinite(hertz)) {
-    return ParamAmount(0, false);
+    return ModAmount(0, false);
   }
 
-  return ParamAmount(hertzToInstrumentCents(hertz), true);
+  return ModAmount(hertzToInstrumentCents(hertz), true);
 }
 
-ParamAmount ParamAmount::hertzRange(double minHertz, double maxHertz) {
+ModAmount ModAmount::fromHertzRange(double minHertz, double maxHertz) {
   if (minHertz <= 0.0 || maxHertz <= 0.0 ||
       !std::isfinite(minHertz) || !std::isfinite(maxHertz)) {
-    return ParamAmount(0, false);
+    return ModAmount(0, false);
   }
 
   const double minCents = static_cast<double>(hertzToInstrumentCents(minHertz));
   const double maxCents = static_cast<double>(hertzToInstrumentCents(maxHertz));
   const double fullScaleRange = (maxCents - minCents) * 128.0 / 127.0;
-  return ParamAmount(static_cast<int32_t>(std::lround(fullScaleRange)), true);
+  return ModAmount(static_cast<int32_t>(std::lround(fullScaleRange)), true);
 }
 
-ParamAmount ParamAmount::seconds(double seconds) {
-  return ParamAmount(secondsToSf2Timecents(seconds), true);
+ModAmount ModAmount::fromSeconds(double seconds) {
+  return ModAmount(secondsToSf2Timecents(seconds), true);
 }
 
-ParamAmount ParamAmount::centibels(double centibels) {
+ModAmount ModAmount::fromCentibels(double centibels) {
   if (!std::isfinite(centibels)) {
-    return ParamAmount(0, false);
+    return ModAmount(0, false);
   }
 
-  return ParamAmount(static_cast<int32_t>(std::lround(centibels)), true);
+  return ModAmount(static_cast<int32_t>(std::lround(centibels)), true);
 }
 
-ParamAmount ParamAmount::attenuationDb(double decibels) {
+ModAmount ModAmount::fromDecibels(double decibels) {
   if (!std::isfinite(decibels)) {
-    return ParamAmount(0, false);
+    return ModAmount(0, false);
   }
 
-  return ParamAmount(static_cast<int32_t>(std::lround(decibels * 10.0)), true);
+  return ModAmount(static_cast<int32_t>(std::lround(decibels * 10.0)), true);
 }

--- a/src/main/components/instr/InstrumentModulation.h
+++ b/src/main/components/instr/InstrumentModulation.h
@@ -1,3 +1,9 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/src/main/components/instr/InstrumentModulation.h
+++ b/src/main/components/instr/InstrumentModulation.h
@@ -31,26 +31,23 @@ enum class ModDest : uint8_t {
   InitialAtten,
 };
 
-class ParamAmount {
+class ModAmount {
 public:
-  static ParamAmount raw(int32_t amount);
-  static ParamAmount cents(double cents);
-
+  static ModAmount raw(int32_t amount);
+  static ModAmount fromCents(double cents);
   // Absolute SF2/DLS LFO frequency units, measured as cents relative to 8.176 Hz.
-  static ParamAmount hertz(double hertz);
-
+  static ModAmount fromHertz(double hertz);
   // A 7-bit unipolar controller range in Hz, scaled so MIDI value 127 reaches maxHertz.
-  static ParamAmount hertzRange(double minHertz, double maxHertz);
-
-  static ParamAmount seconds(double seconds);
-  static ParamAmount centibels(double centibels);
-  static ParamAmount attenuationDb(double decibels);
+  static ModAmount fromHertzRange(double minHertz, double maxHertz);
+  static ModAmount fromSeconds(double seconds);
+  static ModAmount fromCentibels(double centibels);
+  static ModAmount fromDecibels(double decibels);
 
   [[nodiscard]] bool valid() const { return m_valid; }
   [[nodiscard]] int32_t value() const { return m_value; }
 
 private:
-  constexpr ParamAmount(int32_t value, bool valid) : m_value(value), m_valid(valid) {}
+  constexpr ModAmount(int32_t value, bool valid) : m_value(value), m_valid(valid) {}
 
   int32_t m_value;
   bool m_valid;
@@ -62,7 +59,7 @@ struct InstrumentModulator {
 
   // Amount units are the shared SF2/DLS semantic units for the destination:
   // cents for pitch/frequency, timecents for delay, and centibels for volume/attenuation.
-  // Use ParamAmount helpers at call sites when you want more readable units.
+  // Use ModAmount helpers at call sites when you want more readable units.
   int32_t amount;
 };
 
@@ -71,6 +68,6 @@ struct InstrumentGenerator {
 
   // Absolute generator amount in shared SF2/DLS semantic units:
   // cents for pitch/frequency, timecents for delay, and centibels for volume/attenuation.
-  // Use ParamAmount helpers at call sites when you want more readable units.
+  // Use ModAmount helpers at call sites when you want more readable units.
   int32_t amount;
 };

--- a/src/main/components/instr/InstrumentModulation.h
+++ b/src/main/components/instr/InstrumentModulation.h
@@ -22,6 +22,7 @@ enum class InstrumentModDestination : uint8_t {
   ModLfoToVolume,
   ModLfoFrequency,
   ModLfoStartDelay,
+  InitialAttenuation,
 };
 
 struct InstrumentModulator {
@@ -29,7 +30,7 @@ struct InstrumentModulator {
   InstrumentModDestination destination;
 
   // Amount units are the shared SF2/DLS semantic units for the destination:
-  // cents for pitch/frequency, timecents for delay, and centibels for volume.
+  // cents for pitch/frequency, timecents for delay, and centibels for volume/attenuation.
   int32_t amount;
 };
 
@@ -37,6 +38,6 @@ struct InstrumentGenerator {
   InstrumentModDestination destination;
 
   // Absolute generator amount in shared SF2/DLS semantic units:
-  // cents for pitch/frequency, timecents for delay, and centibels for volume.
+  // cents for pitch/frequency, timecents for delay, and centibels for volume/attenuation.
   int32_t amount;
 };

--- a/src/main/components/instr/InstrumentModulation.h
+++ b/src/main/components/instr/InstrumentModulation.h
@@ -4,10 +4,15 @@
 
 enum class InstrumentModSource : uint8_t {
   // Keep this list to controllers expressible by both SF2 and DLS2.
-  ModWheel = 1,
-  Volume = 7,
-  Pan = 10,
-  Expression = 11,
+  ModWheel,
+  ChannelPressure,
+  PolyPressure,
+  PitchWheel,
+  Volume,
+  Pan,
+  Expression,
+  ReverbSend,
+  ChorusSend,
 };
 
 enum class InstrumentModDestination : uint8_t {

--- a/src/main/components/instr/InstrumentModulation.h
+++ b/src/main/components/instr/InstrumentModulation.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+
+enum class InstrumentModSource : uint8_t {
+  // Keep this list to controllers expressible by both SF2 and DLS2.
+  ModWheel = 1,
+  Volume = 7,
+  Pan = 10,
+  Expression = 11,
+};
+
+enum class InstrumentModDestination : uint8_t {
+  VibLfoToPitch,
+  VibLfoFrequency,
+  VibLfoStartDelay,
+  ModLfoToVolume,
+  ModLfoFrequency,
+  ModLfoStartDelay,
+};
+
+struct InstrumentModulator {
+  InstrumentModSource source;
+  InstrumentModDestination destination;
+
+  // Amount units are the shared SF2/DLS semantic units for the destination:
+  // cents for pitch/frequency, timecents for delay, and centibels for volume.
+  int32_t amount;
+};

--- a/src/main/components/instr/InstrumentModulation.h
+++ b/src/main/components/instr/InstrumentModulation.h
@@ -53,7 +53,7 @@ private:
   bool m_valid;
 };
 
-struct InstrumentModulator {
+struct SynthModulator {
   ModSource source;
   ModDest destination;
 
@@ -63,7 +63,7 @@ struct InstrumentModulator {
   int32_t amount;
 };
 
-struct InstrumentGenerator {
+struct SynthGenerator {
   ModDest destination;
 
   // Absolute generator amount in shared SF2/DLS semantic units:

--- a/src/main/components/instr/InstrumentModulation.h
+++ b/src/main/components/instr/InstrumentModulation.h
@@ -25,12 +25,38 @@ enum class InstrumentModDestination : uint8_t {
   InitialAttenuation,
 };
 
+class InstrumentParamAmount {
+public:
+  static InstrumentParamAmount raw(int32_t amount);
+  static InstrumentParamAmount cents(double cents);
+
+  // Absolute SF2/DLS LFO frequency units, measured as cents relative to 8.176 Hz.
+  static InstrumentParamAmount hertz(double hertz);
+
+  // A 7-bit unipolar controller range in Hz, scaled so MIDI value 127 reaches maxHertz.
+  static InstrumentParamAmount hertzRange(double minHertz, double maxHertz);
+
+  static InstrumentParamAmount seconds(double seconds);
+  static InstrumentParamAmount centibels(double centibels);
+  static InstrumentParamAmount attenuationDb(double decibels);
+
+  [[nodiscard]] bool valid() const { return m_valid; }
+  [[nodiscard]] int32_t value() const { return m_value; }
+
+private:
+  constexpr InstrumentParamAmount(int32_t value, bool valid) : m_value(value), m_valid(valid) {}
+
+  int32_t m_value;
+  bool m_valid;
+};
+
 struct InstrumentModulator {
   InstrumentModSource source;
   InstrumentModDestination destination;
 
   // Amount units are the shared SF2/DLS semantic units for the destination:
   // cents for pitch/frequency, timecents for delay, and centibels for volume/attenuation.
+  // Use InstrumentParamAmount helpers at call sites when you want more readable units.
   int32_t amount;
 };
 
@@ -39,5 +65,6 @@ struct InstrumentGenerator {
 
   // Absolute generator amount in shared SF2/DLS semantic units:
   // cents for pitch/frequency, timecents for delay, and centibels for volume/attenuation.
+  // Use InstrumentParamAmount helpers at call sites when you want more readable units.
   int32_t amount;
 };

--- a/src/main/components/instr/InstrumentModulation.h
+++ b/src/main/components/instr/InstrumentModulation.h
@@ -32,3 +32,11 @@ struct InstrumentModulator {
   // cents for pitch/frequency, timecents for delay, and centibels for volume.
   int32_t amount;
 };
+
+struct InstrumentGenerator {
+  InstrumentModDestination destination;
+
+  // Absolute generator amount in shared SF2/DLS semantic units:
+  // cents for pitch/frequency, timecents for delay, and centibels for volume.
+  int32_t amount;
+};

--- a/src/main/components/instr/InstrumentModulation.h
+++ b/src/main/components/instr/InstrumentModulation.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-enum class InstrumentModSource : uint8_t {
+enum class ModSource : uint8_t {
   // Keep this list to controllers expressible by both SF2 and DLS2.
   ModWheel,
   ChannelPressure,
@@ -15,56 +15,56 @@ enum class InstrumentModSource : uint8_t {
   ChorusSend,
 };
 
-enum class InstrumentModDestination : uint8_t {
+enum class ModDest : uint8_t {
   VibLfoToPitch,
-  VibLfoFrequency,
-  VibLfoStartDelay,
-  ModLfoToVolume,
-  ModLfoFrequency,
-  ModLfoStartDelay,
-  InitialAttenuation,
+  VibLfoFreq,
+  VibLfoDelay,
+  ModLfoToVol,
+  ModLfoFreq,
+  ModLfoDelay,
+  InitialAtten,
 };
 
-class InstrumentParamAmount {
+class ParamAmount {
 public:
-  static InstrumentParamAmount raw(int32_t amount);
-  static InstrumentParamAmount cents(double cents);
+  static ParamAmount raw(int32_t amount);
+  static ParamAmount cents(double cents);
 
   // Absolute SF2/DLS LFO frequency units, measured as cents relative to 8.176 Hz.
-  static InstrumentParamAmount hertz(double hertz);
+  static ParamAmount hertz(double hertz);
 
   // A 7-bit unipolar controller range in Hz, scaled so MIDI value 127 reaches maxHertz.
-  static InstrumentParamAmount hertzRange(double minHertz, double maxHertz);
+  static ParamAmount hertzRange(double minHertz, double maxHertz);
 
-  static InstrumentParamAmount seconds(double seconds);
-  static InstrumentParamAmount centibels(double centibels);
-  static InstrumentParamAmount attenuationDb(double decibels);
+  static ParamAmount seconds(double seconds);
+  static ParamAmount centibels(double centibels);
+  static ParamAmount attenuationDb(double decibels);
 
   [[nodiscard]] bool valid() const { return m_valid; }
   [[nodiscard]] int32_t value() const { return m_value; }
 
 private:
-  constexpr InstrumentParamAmount(int32_t value, bool valid) : m_value(value), m_valid(valid) {}
+  constexpr ParamAmount(int32_t value, bool valid) : m_value(value), m_valid(valid) {}
 
   int32_t m_value;
   bool m_valid;
 };
 
 struct InstrumentModulator {
-  InstrumentModSource source;
-  InstrumentModDestination destination;
+  ModSource source;
+  ModDest destination;
 
   // Amount units are the shared SF2/DLS semantic units for the destination:
   // cents for pitch/frequency, timecents for delay, and centibels for volume/attenuation.
-  // Use InstrumentParamAmount helpers at call sites when you want more readable units.
+  // Use ParamAmount helpers at call sites when you want more readable units.
   int32_t amount;
 };
 
 struct InstrumentGenerator {
-  InstrumentModDestination destination;
+  ModDest destination;
 
   // Absolute generator amount in shared SF2/DLS semantic units:
   // cents for pitch/frequency, timecents for delay, and centibels for volume/attenuation.
-  // Use InstrumentParamAmount helpers at call sites when you want more readable units.
+  // Use ParamAmount helpers at call sites when you want more readable units.
   int32_t amount;
 };

--- a/src/main/components/instr/Modulation.cpp
+++ b/src/main/components/instr/Modulation.cpp
@@ -4,7 +4,7 @@
  * refer to the included LICENSE.txt file
  */
 
-#include "InstrumentModulation.h"
+#include "Modulation.h"
 #include <cmath>
 #include "ScaleConversion.h"
 

--- a/src/main/components/instr/Modulation.h
+++ b/src/main/components/instr/Modulation.h
@@ -53,7 +53,7 @@ private:
   bool m_valid;
 };
 
-struct SynthModulator {
+struct Modulator {
   ModSource source;
   ModDest destination;
 
@@ -63,7 +63,7 @@ struct SynthModulator {
   int32_t amount;
 };
 
-struct SynthGenerator {
+struct Generator {
   ModDest destination;
 
   // Absolute generator amount in shared SF2/DLS semantic units:

--- a/src/main/components/instr/Modulation.h
+++ b/src/main/components/instr/Modulation.h
@@ -53,7 +53,7 @@ private:
   bool m_valid;
 };
 
-struct Modulator {
+struct SynthModulator {
   ModSource source;
   ModDest destination;
 
@@ -63,7 +63,7 @@ struct Modulator {
   int32_t amount;
 };
 
-struct Generator {
+struct SynthGenerator {
   ModDest destination;
 
   // Absolute generator amount in shared SF2/DLS semantic units:

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -175,7 +175,7 @@ void VGMInstr::addModulator(ModSource source, ModDest destination, int32_t amoun
   m_modulators.push_back({source, destination, amount});
 }
 
-void VGMInstr::addModulator(ModSource source, ModDest destination, ParamAmount amount) {
+void VGMInstr::addModulator(ModSource source, ModDest destination, ModAmount amount) {
   if (!amount.valid()) {
     return;
   }
@@ -184,19 +184,19 @@ void VGMInstr::addModulator(ModSource source, ModDest destination, ParamAmount a
 }
 
 void VGMInstr::addPitchModulator(ModSource source, ModDest destination, double cents) {
-  addModulator(source, destination, ParamAmount::cents(cents));
+  addModulator(source, destination, ModAmount::fromCents(cents));
 }
 
 void VGMInstr::addFrequencyRangeModulator(ModSource source, ModDest destination, double minHertz, double maxHertz) {
-  addModulator(source, destination, ParamAmount::hertzRange(minHertz, maxHertz));
+  addModulator(source, destination, ModAmount::fromHertzRange(minHertz, maxHertz));
 }
 
 void VGMInstr::addDelayModulator(ModSource source, ModDest destination, double seconds) {
-  addModulator(source, destination, ParamAmount::seconds(seconds));
+  addModulator(source, destination, ModAmount::fromSeconds(seconds));
 }
 
 void VGMInstr::addAttenuationModulator(ModSource source, ModDest destination, double decibels) {
-  addModulator(source, destination, ParamAmount::attenuationDb(decibels));
+  addModulator(source, destination, ModAmount::fromDecibels(decibels));
 }
 
 void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
@@ -227,7 +227,7 @@ void VGMInstr::addGlobalGenerator(ModDest destination, int32_t amount) {
   m_globalGenerators.push_back({destination, amount});
 }
 
-void VGMInstr::addGlobalGenerator(ModDest destination, ParamAmount amount) {
+void VGMInstr::addGlobalGenerator(ModDest destination, ModAmount amount) {
   if (!amount.valid()) {
     return;
   }
@@ -236,19 +236,19 @@ void VGMInstr::addGlobalGenerator(ModDest destination, ParamAmount amount) {
 }
 
 void VGMInstr::addGlobalGeneratorCents(ModDest destination, double cents) {
-  addGlobalGenerator(destination, ParamAmount::cents(cents));
+  addGlobalGenerator(destination, ModAmount::fromCents(cents));
 }
 
 void VGMInstr::addGlobalGeneratorHertz(ModDest destination, double hertz) {
-  addGlobalGenerator(destination, ParamAmount::hertz(hertz));
+  addGlobalGenerator(destination, ModAmount::fromHertz(hertz));
 }
 
 void VGMInstr::addGlobalGeneratorSeconds(ModDest destination, double seconds) {
-  addGlobalGenerator(destination, ParamAmount::seconds(seconds));
+  addGlobalGenerator(destination, ModAmount::fromSeconds(seconds));
 }
 
 void VGMInstr::addGlobalGeneratorDecibels(ModDest destination, double decibels) {
-  addGlobalGenerator(destination, ParamAmount::attenuationDb(decibels));
+  addGlobalGenerator(destination, ModAmount::fromDecibels(decibels));
 }
 
 void VGMInstr::addGlobalVibratoFrequency(double hertz) {

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "VGMInstrSet.h"
-#include <cmath>
 #include <spdlog/fmt/fmt.h>
 #include "VGMSampColl.h"
 #include "VGMSamp.h"
@@ -14,78 +13,11 @@
 #include "Root.h"
 #include "Format.h"
 #include "LogManager.h"
-#include "ScaleConversion.h"
 #include "helper.h"
-
-namespace {
-
-constexpr double kSf2LfoReferenceHz = 8.176;
-
-bool isValidFiniteNumber(double value) {
-  return std::isfinite(value);
-}
-
-int32_t hertzToInstrumentCents(double hertz) {
-  return static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / kSf2LfoReferenceHz)));
-}
-
-}  // namespace
 
 // ***********
 // VGMInstrSet
 // ***********
-
-InstrumentParamAmount InstrumentParamAmount::raw(int32_t amount) {
-  return InstrumentParamAmount(amount, true);
-}
-
-InstrumentParamAmount InstrumentParamAmount::cents(double cents) {
-  if (!isValidFiniteNumber(cents)) {
-    return InstrumentParamAmount(0, false);
-  }
-
-  return InstrumentParamAmount(static_cast<int32_t>(std::lround(cents)), true);
-}
-
-InstrumentParamAmount InstrumentParamAmount::hertz(double hertz) {
-  if (hertz <= 0.0 || !isValidFiniteNumber(hertz)) {
-    return InstrumentParamAmount(0, false);
-  }
-
-  return InstrumentParamAmount(hertzToInstrumentCents(hertz), true);
-}
-
-InstrumentParamAmount InstrumentParamAmount::hertzRange(double minHertz, double maxHertz) {
-  if (minHertz <= 0.0 || maxHertz <= 0.0 ||
-      !isValidFiniteNumber(minHertz) || !isValidFiniteNumber(maxHertz)) {
-    return InstrumentParamAmount(0, false);
-  }
-
-  const double minCents = static_cast<double>(hertzToInstrumentCents(minHertz));
-  const double maxCents = static_cast<double>(hertzToInstrumentCents(maxHertz));
-  const double fullScaleRange = (maxCents - minCents) * 128.0 / 127.0;
-  return InstrumentParamAmount(static_cast<int32_t>(std::lround(fullScaleRange)), true);
-}
-
-InstrumentParamAmount InstrumentParamAmount::seconds(double seconds) {
-  return InstrumentParamAmount(secondsToSf2Timecents(seconds), true);
-}
-
-InstrumentParamAmount InstrumentParamAmount::centibels(double centibels) {
-  if (!isValidFiniteNumber(centibels)) {
-    return InstrumentParamAmount(0, false);
-  }
-
-  return InstrumentParamAmount(static_cast<int32_t>(std::lround(centibels)), true);
-}
-
-InstrumentParamAmount InstrumentParamAmount::attenuationDb(double decibels) {
-  if (!isValidFiniteNumber(decibels)) {
-    return InstrumentParamAmount(0, false);
-  }
-
-  return InstrumentParamAmount(static_cast<int32_t>(std::lround(decibels * 10.0)), true);
-}
 
 VGMInstrSet::VGMInstrSet(const std::string &format, RawFile *file, uint32_t offset, uint32_t length,
                          std::string name, VGMSampColl *theSampColl)
@@ -217,13 +149,11 @@ void VGMInstr::setInstrNum(uint32_t theInstrNum) {
   instrNum = theInstrNum;
 }
 
-void VGMInstr::addModulator(InstrumentModSource source, InstrumentModDestination destination,
-                            int32_t amount) {
+void VGMInstr::addModulator(ModSource source, ModDest destination, int32_t amount) {
   m_modulators.push_back({source, destination, amount});
 }
 
-void VGMInstr::addModulator(InstrumentModSource source, InstrumentModDestination destination,
-                            InstrumentParamAmount amount) {
+void VGMInstr::addModulator(ModSource source, ModDest destination, ParamAmount amount) {
   if (!amount.valid()) {
     return;
   }
@@ -231,21 +161,43 @@ void VGMInstr::addModulator(InstrumentModSource source, InstrumentModDestination
   addModulator(source, destination, amount.value());
 }
 
+void VGMInstr::addPitchModulator(ModSource source, ModDest destination, double cents) {
+  addModulator(source, destination, ParamAmount::cents(cents));
+}
+
+void VGMInstr::addFrequencyRangeModulator(ModSource source, ModDest destination, double minHertz, double maxHertz) {
+  addModulator(source, destination, ParamAmount::hertzRange(minHertz, maxHertz));
+}
+
+void VGMInstr::addDelayModulator(ModSource source, ModDest destination, double seconds) {
+  addModulator(source, destination, ParamAmount::seconds(seconds));
+}
+
+void VGMInstr::addAttenuationModulator(ModSource source, ModDest destination, double decibels) {
+  addModulator(source, destination, ParamAmount::attenuationDb(decibels));
+}
+
 void VGMInstr::addModWheelToVibratoPitch(double cents) {
-  addModulator(InstrumentModSource::ModWheel, InstrumentModDestination::VibLfoToPitch,
-               InstrumentParamAmount::cents(cents));
+  addPitchModulator(ModSource::ModWheel, ModDest::VibLfoToPitch, cents);
 }
 
-void VGMInstr::addChannelPressureToVibratoRate(double cents) {
-  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoFrequency,
-               InstrumentParamAmount::cents(cents));
+void VGMInstr::addChannelPressureToVibratoRateModulator(double minHertz, double maxHertz) {
+  addFrequencyRangeModulator(ModSource::ChannelPressure,
+                             ModDest::VibLfoFreq,
+                             minHertz, maxHertz);
 }
 
-void VGMInstr::addGlobalGenerator(InstrumentModDestination destination, int32_t amount) {
+void VGMInstr::addChannelPressureToTremoloRateModulator(double minHertz, double maxHertz) {
+  addFrequencyRangeModulator(ModSource::ChannelPressure,
+                             ModDest::ModLfoFreq,
+                             minHertz, maxHertz);
+}
+
+void VGMInstr::addGlobalGenerator(ModDest destination, int32_t amount) {
   m_globalGenerators.push_back({destination, amount});
 }
 
-void VGMInstr::addGlobalGenerator(InstrumentModDestination destination, InstrumentParamAmount amount) {
+void VGMInstr::addGlobalGenerator(ModDest destination, ParamAmount amount) {
   if (!amount.valid()) {
     return;
   }
@@ -253,12 +205,28 @@ void VGMInstr::addGlobalGenerator(InstrumentModDestination destination, Instrume
   addGlobalGenerator(destination, amount.value());
 }
 
+void VGMInstr::addPitchGenerator(ModDest destination, double cents) {
+  addGlobalGenerator(destination, ParamAmount::cents(cents));
+}
+
+void VGMInstr::addFrequencyGenerator(ModDest destination, double hertz) {
+  addGlobalGenerator(destination, ParamAmount::hertz(hertz));
+}
+
+void VGMInstr::addDelayGenerator(ModDest destination, double seconds) {
+  addGlobalGenerator(destination, ParamAmount::seconds(seconds));
+}
+
+void VGMInstr::addAttenuationGenerator(ModDest destination, double decibels) {
+  addGlobalGenerator(destination, ParamAmount::attenuationDb(decibels));
+}
+
 void VGMInstr::addGlobalVibratoFrequency(double hertz) {
-  addGlobalGenerator(InstrumentModDestination::VibLfoFrequency, InstrumentParamAmount::hertz(hertz));
+  addFrequencyGenerator(ModDest::VibLfoFreq, hertz);
 }
 
 void VGMInstr::addGlobalTremoloFrequency(double hertz) {
-  addGlobalGenerator(InstrumentModDestination::ModLfoFrequency, InstrumentParamAmount::hertz(hertz));
+  addFrequencyGenerator(ModDest::ModLfoFreq, hertz);
 }
 
 VGMRgn *VGMInstr::addRgn(VGMRgn *rgn) {

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "VGMInstrSet.h"
+#include <cmath>
 #include <spdlog/fmt/fmt.h>
 #include "VGMSampColl.h"
 #include "VGMSamp.h"
@@ -147,6 +148,16 @@ void VGMInstr::setBank(uint32_t bankNum) {
 
 void VGMInstr::setInstrNum(uint32_t theInstrNum) {
   instrNum = theInstrNum;
+}
+
+void VGMInstr::addModulator(InstrumentModSource source, InstrumentModDestination destination,
+                            int32_t amount) {
+  m_modulators.push_back({source, destination, amount});
+}
+
+void VGMInstr::addModWheelToVibratoPitch(double cents) {
+  addModulator(InstrumentModSource::ModWheel, InstrumentModDestination::VibLfoToPitch,
+               static_cast<int32_t>(std::lround(cents)));
 }
 
 VGMRgn *VGMInstr::addRgn(VGMRgn *rgn) {

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -169,7 +169,7 @@ void VGMInstr::deleteRegions() {
   deleteVect(m_regions);
 }
 
-// Generator and Modulator methods
+// Modulator methods
 
 void VGMInstr::addModulator(ModSource source, ModDest destination, int32_t amount) {
   m_modulators.push_back({source, destination, amount});
@@ -220,6 +220,8 @@ void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
     addAttenuationModulator(ModSource::ChorusSend, ModDest::InitialAtten, maxDepthDb);
   }
 }
+
+// Generator methods
 
 void VGMInstr::addGlobalGenerator(ModDest destination, int32_t amount) {
   m_globalGenerators.push_back({destination, amount});

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -160,6 +160,11 @@ void VGMInstr::addModWheelToVibratoPitch(double cents) {
                static_cast<int32_t>(std::lround(cents)));
 }
 
+void VGMInstr::addChannelPressureToVibratoRate(double cents) {
+  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoFrequency,
+               static_cast<int32_t>(std::lround(cents)));
+}
+
 VGMRgn *VGMInstr::addRgn(VGMRgn *rgn) {
   m_regions.emplace_back(rgn);
   if (m_auto_add_regions_as_children)

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -14,11 +14,78 @@
 #include "Root.h"
 #include "Format.h"
 #include "LogManager.h"
+#include "ScaleConversion.h"
 #include "helper.h"
+
+namespace {
+
+constexpr double kSf2LfoReferenceHz = 8.176;
+
+bool isValidFiniteNumber(double value) {
+  return std::isfinite(value);
+}
+
+int32_t hertzToInstrumentCents(double hertz) {
+  return static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / kSf2LfoReferenceHz)));
+}
+
+}  // namespace
 
 // ***********
 // VGMInstrSet
 // ***********
+
+InstrumentParamAmount InstrumentParamAmount::raw(int32_t amount) {
+  return InstrumentParamAmount(amount, true);
+}
+
+InstrumentParamAmount InstrumentParamAmount::cents(double cents) {
+  if (!isValidFiniteNumber(cents)) {
+    return InstrumentParamAmount(0, false);
+  }
+
+  return InstrumentParamAmount(static_cast<int32_t>(std::lround(cents)), true);
+}
+
+InstrumentParamAmount InstrumentParamAmount::hertz(double hertz) {
+  if (hertz <= 0.0 || !isValidFiniteNumber(hertz)) {
+    return InstrumentParamAmount(0, false);
+  }
+
+  return InstrumentParamAmount(hertzToInstrumentCents(hertz), true);
+}
+
+InstrumentParamAmount InstrumentParamAmount::hertzRange(double minHertz, double maxHertz) {
+  if (minHertz <= 0.0 || maxHertz <= 0.0 ||
+      !isValidFiniteNumber(minHertz) || !isValidFiniteNumber(maxHertz)) {
+    return InstrumentParamAmount(0, false);
+  }
+
+  const double minCents = static_cast<double>(hertzToInstrumentCents(minHertz));
+  const double maxCents = static_cast<double>(hertzToInstrumentCents(maxHertz));
+  const double fullScaleRange = (maxCents - minCents) * 128.0 / 127.0;
+  return InstrumentParamAmount(static_cast<int32_t>(std::lround(fullScaleRange)), true);
+}
+
+InstrumentParamAmount InstrumentParamAmount::seconds(double seconds) {
+  return InstrumentParamAmount(secondsToSf2Timecents(seconds), true);
+}
+
+InstrumentParamAmount InstrumentParamAmount::centibels(double centibels) {
+  if (!isValidFiniteNumber(centibels)) {
+    return InstrumentParamAmount(0, false);
+  }
+
+  return InstrumentParamAmount(static_cast<int32_t>(std::lround(centibels)), true);
+}
+
+InstrumentParamAmount InstrumentParamAmount::attenuationDb(double decibels) {
+  if (!isValidFiniteNumber(decibels)) {
+    return InstrumentParamAmount(0, false);
+  }
+
+  return InstrumentParamAmount(static_cast<int32_t>(std::lround(decibels * 10.0)), true);
+}
 
 VGMInstrSet::VGMInstrSet(const std::string &format, RawFile *file, uint32_t offset, uint32_t length,
                          std::string name, VGMSampColl *theSampColl)
@@ -155,36 +222,43 @@ void VGMInstr::addModulator(InstrumentModSource source, InstrumentModDestination
   m_modulators.push_back({source, destination, amount});
 }
 
+void VGMInstr::addModulator(InstrumentModSource source, InstrumentModDestination destination,
+                            InstrumentParamAmount amount) {
+  if (!amount.valid()) {
+    return;
+  }
+
+  addModulator(source, destination, amount.value());
+}
+
 void VGMInstr::addModWheelToVibratoPitch(double cents) {
   addModulator(InstrumentModSource::ModWheel, InstrumentModDestination::VibLfoToPitch,
-               static_cast<int32_t>(std::lround(cents)));
+               InstrumentParamAmount::cents(cents));
 }
 
 void VGMInstr::addChannelPressureToVibratoRate(double cents) {
   addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoFrequency,
-               static_cast<int32_t>(std::lround(cents)));
+               InstrumentParamAmount::cents(cents));
 }
 
 void VGMInstr::addGlobalGenerator(InstrumentModDestination destination, int32_t amount) {
   m_globalGenerators.push_back({destination, amount});
 }
 
-void VGMInstr::addGlobalVibratoFrequency(double hertz) {
-  if (hertz <= 0.0 || !std::isfinite(hertz)) {
+void VGMInstr::addGlobalGenerator(InstrumentModDestination destination, InstrumentParamAmount amount) {
+  if (!amount.valid()) {
     return;
   }
 
-  addGlobalGenerator(InstrumentModDestination::VibLfoFrequency,
-                     static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / 8.176))));
+  addGlobalGenerator(destination, amount.value());
+}
+
+void VGMInstr::addGlobalVibratoFrequency(double hertz) {
+  addGlobalGenerator(InstrumentModDestination::VibLfoFrequency, InstrumentParamAmount::hertz(hertz));
 }
 
 void VGMInstr::addGlobalTremoloFrequency(double hertz) {
-  if (hertz <= 0.0 || !std::isfinite(hertz)) {
-    return;
-  }
-
-  addGlobalGenerator(InstrumentModDestination::ModLfoFrequency,
-                     static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / 8.176))));
+  addGlobalGenerator(InstrumentModDestination::ModLfoFrequency, InstrumentParamAmount::hertz(hertz));
 }
 
 VGMRgn *VGMInstr::addRgn(VGMRgn *rgn) {

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -205,7 +205,7 @@ void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
   addPitchModulator(ModSource::ModWheel, ModDest::VibLfoToPitch, maxDepthCents);
   // nullify default channel pressure to vib lfo pitch modulator
   addPitchModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, 0);
-  addFrequencyGenerator(ModDest::VibLfoFreq, minHertz);
+  addGlobalGeneratorHertz(ModDest::VibLfoFreq, minHertz);
   addFrequencyRangeModulator(ModSource::ChannelPressure, ModDest::VibLfoFreq, minHertz, maxHertz);
 }
 
@@ -213,7 +213,7 @@ void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
                                          double minHertz,
                                          double maxHertz,
                                          TremoloGainMode gainMode) {
-  addFrequencyGenerator(ModDest::ModLfoFreq, minHertz);
+  addGlobalGeneratorHertz(ModDest::ModLfoFreq, minHertz);
   addFrequencyRangeModulator(ModSource::ChannelPressure, ModDest::ModLfoFreq, minHertz, maxHertz);
   addAttenuationModulator(ModSource::ChorusSend, ModDest::ModLfoToVol, maxDepthDb);
   if (gainMode == TremoloGainMode::NoBoost) {
@@ -235,26 +235,26 @@ void VGMInstr::addGlobalGenerator(ModDest destination, ParamAmount amount) {
   addGlobalGenerator(destination, amount.value());
 }
 
-void VGMInstr::addPitchGenerator(ModDest destination, double cents) {
+void VGMInstr::addGlobalGeneratorCents(ModDest destination, double cents) {
   addGlobalGenerator(destination, ParamAmount::cents(cents));
 }
 
-void VGMInstr::addFrequencyGenerator(ModDest destination, double hertz) {
+void VGMInstr::addGlobalGeneratorHertz(ModDest destination, double hertz) {
   addGlobalGenerator(destination, ParamAmount::hertz(hertz));
 }
 
-void VGMInstr::addDelayGenerator(ModDest destination, double seconds) {
+void VGMInstr::addGlobalGeneratorSeconds(ModDest destination, double seconds) {
   addGlobalGenerator(destination, ParamAmount::seconds(seconds));
 }
 
-void VGMInstr::addAttenuationGenerator(ModDest destination, double decibels) {
+void VGMInstr::addGlobalGeneratorDecibels(ModDest destination, double decibels) {
   addGlobalGenerator(destination, ParamAmount::attenuationDb(decibels));
 }
 
 void VGMInstr::addGlobalVibratoFrequency(double hertz) {
-  addFrequencyGenerator(ModDest::VibLfoFreq, hertz);
+  addGlobalGeneratorHertz(ModDest::VibLfoFreq, hertz);
 }
 
 void VGMInstr::addGlobalTremoloFrequency(double hertz) {
-  addFrequencyGenerator(ModDest::ModLfoFreq, hertz);
+  addGlobalGeneratorHertz(ModDest::ModLfoFreq, hertz);
 }

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -205,7 +205,7 @@ void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
   addPitchModulator(ModSource::ModWheel, ModDest::VibLfoToPitch, maxDepthCents);
   // nullify default channel pressure to vib lfo pitch modulator
   addPitchModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, 0);
-  addGlobalGeneratorHertz(ModDest::VibLfoFreq, minHertz);
+  addGlobalGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(minHertz));
   addFrequencyRangeModulator(ModSource::ChannelPressure, ModDest::VibLfoFreq, minHertz, maxHertz);
 }
 
@@ -213,7 +213,7 @@ void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
                                          double minHertz,
                                          double maxHertz,
                                          TremoloGainMode gainMode) {
-  addGlobalGeneratorHertz(ModDest::ModLfoFreq, minHertz);
+  addGlobalGenerator(ModDest::ModLfoFreq, ModAmount::fromHertz(minHertz));
   addFrequencyRangeModulator(ModSource::ChannelPressure, ModDest::ModLfoFreq, minHertz, maxHertz);
   addAttenuationModulator(ModSource::ChorusSend, ModDest::ModLfoToVol, maxDepthDb);
   if (gainMode == TremoloGainMode::NoBoost) {
@@ -223,38 +223,18 @@ void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
 
 // Generator methods
 
-void VGMInstr::addGlobalGenerator(ModDest destination, int32_t amount) {
-  m_globalGenerators.push_back({destination, amount});
-}
-
 void VGMInstr::addGlobalGenerator(ModDest destination, ModAmount amount) {
   if (!amount.valid()) {
     return;
   }
 
-  addGlobalGenerator(destination, amount.value());
-}
-
-void VGMInstr::addGlobalGeneratorCents(ModDest destination, double cents) {
-  addGlobalGenerator(destination, ModAmount::fromCents(cents));
-}
-
-void VGMInstr::addGlobalGeneratorHertz(ModDest destination, double hertz) {
-  addGlobalGenerator(destination, ModAmount::fromHertz(hertz));
-}
-
-void VGMInstr::addGlobalGeneratorSeconds(ModDest destination, double seconds) {
-  addGlobalGenerator(destination, ModAmount::fromSeconds(seconds));
-}
-
-void VGMInstr::addGlobalGeneratorDecibels(ModDest destination, double decibels) {
-  addGlobalGenerator(destination, ModAmount::fromDecibels(decibels));
+  m_globalGenerators.push_back({destination, amount.value()});
 }
 
 void VGMInstr::addGlobalVibratoFrequency(double hertz) {
-  addGlobalGeneratorHertz(ModDest::VibLfoFreq, hertz);
+  addGlobalGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(hertz));
 }
 
 void VGMInstr::addGlobalTremoloFrequency(double hertz) {
-  addGlobalGeneratorHertz(ModDest::ModLfoFreq, hertz);
+  addGlobalGenerator(ModDest::ModLfoFreq, ModAmount::fromHertz(hertz));
 }

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -212,11 +212,11 @@ void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
 void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
                                          double minHertz,
                                          double maxHertz,
-                                         bool attenOnly) {
+                                         TremoloGainMode gainMode) {
   addFrequencyGenerator(ModDest::ModLfoFreq, minHertz);
   addFrequencyRangeModulator(ModSource::ChannelPressure, ModDest::ModLfoFreq, minHertz, maxHertz);
   addAttenuationModulator(ModSource::ChorusSend, ModDest::ModLfoToVol, maxDepthDb);
-  if (attenOnly) {
+  if (gainMode == TremoloGainMode::NoBoost) {
     addAttenuationModulator(ModSource::ChorusSend, ModDest::InitialAtten, maxDepthDb);
   }
 }

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -171,42 +171,22 @@ void VGMInstr::deleteRegions() {
 
 // Modulator methods
 
-void VGMInstr::addModulator(ModSource source, ModDest destination, int32_t amount) {
-  m_modulators.push_back({source, destination, amount});
-}
-
 void VGMInstr::addModulator(ModSource source, ModDest destination, ModAmount amount) {
   if (!amount.valid()) {
     return;
   }
 
-  addModulator(source, destination, amount.value());
-}
-
-void VGMInstr::addPitchModulator(ModSource source, ModDest destination, double cents) {
-  addModulator(source, destination, ModAmount::fromCents(cents));
-}
-
-void VGMInstr::addFrequencyRangeModulator(ModSource source, ModDest destination, double minHertz, double maxHertz) {
-  addModulator(source, destination, ModAmount::fromHertzRange(minHertz, maxHertz));
-}
-
-void VGMInstr::addDelayModulator(ModSource source, ModDest destination, double seconds) {
-  addModulator(source, destination, ModAmount::fromSeconds(seconds));
-}
-
-void VGMInstr::addAttenuationModulator(ModSource source, ModDest destination, double decibels) {
-  addModulator(source, destination, ModAmount::fromDecibels(decibels));
+  m_modulators.push_back({source, destination, amount.value()});
 }
 
 void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
                                          double minHertz,
                                          double maxHertz) {
-  addPitchModulator(ModSource::ModWheel, ModDest::VibLfoToPitch, maxDepthCents);
+  addModulator(ModSource::ModWheel, ModDest::VibLfoToPitch, ModAmount::fromCents(maxDepthCents));
   // nullify default channel pressure to vib lfo pitch modulator
-  addPitchModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, 0);
+  addModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, ModAmount::fromCents(0));
   addGlobalGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(minHertz));
-  addFrequencyRangeModulator(ModSource::ChannelPressure, ModDest::VibLfoFreq, minHertz, maxHertz);
+  addModulator(ModSource::ChannelPressure, ModDest::VibLfoFreq, ModAmount::fromHertzRange(minHertz, maxHertz));
 }
 
 void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
@@ -214,10 +194,10 @@ void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
                                          double maxHertz,
                                          TremoloGainMode gainMode) {
   addGlobalGenerator(ModDest::ModLfoFreq, ModAmount::fromHertz(minHertz));
-  addFrequencyRangeModulator(ModSource::ChannelPressure, ModDest::ModLfoFreq, minHertz, maxHertz);
-  addAttenuationModulator(ModSource::ChorusSend, ModDest::ModLfoToVol, maxDepthDb);
+  addModulator(ModSource::ChannelPressure, ModDest::ModLfoFreq, ModAmount::fromHertzRange(minHertz, maxHertz));
+  addModulator(ModSource::ChorusSend, ModDest::ModLfoToVol, ModAmount::fromDecibels(maxDepthDb));
   if (gainMode == TremoloGainMode::NoBoost) {
-    addAttenuationModulator(ModSource::ChorusSend, ModDest::InitialAtten, maxDepthDb);
+    addModulator(ModSource::ChorusSend, ModDest::InitialAtten, ModAmount::fromDecibels(maxDepthDb));
   }
 }
 

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -185,7 +185,7 @@ void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
   addModulator(ModSource::ModWheel, ModDest::VibLfoToPitch, ModAmount::fromCents(maxDepthCents));
   // nullify default channel pressure to vib lfo pitch modulator
   addModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, ModAmount::fromCents(0));
-  addGlobalGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(minHertz));
+  addGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(minHertz));
   addModulator(ModSource::ChannelPressure, ModDest::VibLfoFreq, ModAmount::fromHertzRange(minHertz, maxHertz));
 }
 
@@ -193,7 +193,7 @@ void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
                                          double minHertz,
                                          double maxHertz,
                                          TremoloGainMode gainMode) {
-  addGlobalGenerator(ModDest::ModLfoFreq, ModAmount::fromHertz(minHertz));
+  addGenerator(ModDest::ModLfoFreq, ModAmount::fromHertz(minHertz));
   addModulator(ModSource::ChannelPressure, ModDest::ModLfoFreq, ModAmount::fromHertzRange(minHertz, maxHertz));
   addModulator(ModSource::ChorusSend, ModDest::ModLfoToVol, ModAmount::fromDecibels(maxDepthDb));
   if (gainMode == TremoloGainMode::NoBoost) {
@@ -203,18 +203,18 @@ void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
 
 // Generator methods
 
-void VGMInstr::addGlobalGenerator(ModDest destination, ModAmount amount) {
+void VGMInstr::addGenerator(ModDest destination, ModAmount amount) {
   if (!amount.valid()) {
     return;
   }
 
-  m_globalGenerators.push_back({destination, amount.value()});
+  m_generators.push_back({destination, amount.value()});
 }
 
 void VGMInstr::addGlobalVibratoFrequency(double hertz) {
-  addGlobalGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(hertz));
+  addGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(hertz));
 }
 
 void VGMInstr::addGlobalTremoloFrequency(double hertz) {
-  addGlobalGenerator(ModDest::ModLfoFreq, ModAmount::fromHertz(hertz));
+  addGenerator(ModDest::ModLfoFreq, ModAmount::fromHertz(hertz));
 }

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -149,6 +149,28 @@ void VGMInstr::setInstrNum(uint32_t theInstrNum) {
   instrNum = theInstrNum;
 }
 
+VGMRgn *VGMInstr::addRgn(VGMRgn *rgn) {
+  m_regions.emplace_back(rgn);
+  if (m_auto_add_regions_as_children)
+    addChild(rgn);
+  return rgn;
+}
+
+VGMRgn *VGMInstr::addRgn(uint32_t offset, uint32_t length, int sampNum, uint8_t keyLow,
+                         uint8_t keyHigh, uint8_t velLow, uint8_t velHigh) {
+  VGMRgn *newRgn = new VGMRgn(this, offset, length, keyLow, keyHigh, velLow, velHigh, sampNum);
+  m_regions.emplace_back(newRgn);
+  if (m_auto_add_regions_as_children)
+    addChild(newRgn);
+  return newRgn;
+}
+
+void VGMInstr::deleteRegions() {
+  deleteVect(m_regions);
+}
+
+// Generator and Modulator methods
+
 void VGMInstr::addModulator(ModSource source, ModDest destination, int32_t amount) {
   m_modulators.push_back({source, destination, amount});
 }
@@ -177,20 +199,26 @@ void VGMInstr::addAttenuationModulator(ModSource source, ModDest destination, do
   addModulator(source, destination, ParamAmount::attenuationDb(decibels));
 }
 
-void VGMInstr::addModWheelToVibratoPitch(double cents) {
-  addPitchModulator(ModSource::ModWheel, ModDest::VibLfoToPitch, cents);
+void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
+                                         double minHertz,
+                                         double maxHertz) {
+  addPitchModulator(ModSource::ModWheel, ModDest::VibLfoToPitch, maxDepthCents);
+  // nullify default channel pressure to vib lfo pitch modulator
+  addPitchModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, 0);
+  addFrequencyGenerator(ModDest::VibLfoFreq, minHertz);
+  addFrequencyRangeModulator(ModSource::ChannelPressure, ModDest::VibLfoFreq, minHertz, maxHertz);
 }
 
-void VGMInstr::addChannelPressureToVibratoRateModulator(double minHertz, double maxHertz) {
-  addFrequencyRangeModulator(ModSource::ChannelPressure,
-                             ModDest::VibLfoFreq,
-                             minHertz, maxHertz);
-}
-
-void VGMInstr::addChannelPressureToTremoloRateModulator(double minHertz, double maxHertz) {
-  addFrequencyRangeModulator(ModSource::ChannelPressure,
-                             ModDest::ModLfoFreq,
-                             minHertz, maxHertz);
+void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
+                                         double minHertz,
+                                         double maxHertz,
+                                         bool attenOnly) {
+  addFrequencyGenerator(ModDest::ModLfoFreq, minHertz);
+  addFrequencyRangeModulator(ModSource::ChannelPressure, ModDest::ModLfoFreq, minHertz, maxHertz);
+  addAttenuationModulator(ModSource::ChorusSend, ModDest::ModLfoToVol, maxDepthDb);
+  if (attenOnly) {
+    addAttenuationModulator(ModSource::ChorusSend, ModDest::InitialAtten, maxDepthDb);
+  }
 }
 
 void VGMInstr::addGlobalGenerator(ModDest destination, int32_t amount) {
@@ -227,24 +255,4 @@ void VGMInstr::addGlobalVibratoFrequency(double hertz) {
 
 void VGMInstr::addGlobalTremoloFrequency(double hertz) {
   addFrequencyGenerator(ModDest::ModLfoFreq, hertz);
-}
-
-VGMRgn *VGMInstr::addRgn(VGMRgn *rgn) {
-  m_regions.emplace_back(rgn);
-  if (m_auto_add_regions_as_children)
-    addChild(rgn);
-  return rgn;
-}
-
-VGMRgn *VGMInstr::addRgn(uint32_t offset, uint32_t length, int sampNum, uint8_t keyLow,
-                         uint8_t keyHigh, uint8_t velLow, uint8_t velHigh) {
-  VGMRgn *newRgn = new VGMRgn(this, offset, length, keyLow, keyHigh, velLow, velHigh, sampNum);
-  m_regions.emplace_back(newRgn);
-  if (m_auto_add_regions_as_children)
-    addChild(newRgn);
-  return newRgn;
-}
-
-void VGMInstr::deleteRegions() {
-  deleteVect(m_regions);
 }

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -178,6 +178,15 @@ void VGMInstr::addGlobalVibratoFrequency(double hertz) {
                      static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / 8.176))));
 }
 
+void VGMInstr::addGlobalTremoloFrequency(double hertz) {
+  if (hertz <= 0.0 || !std::isfinite(hertz)) {
+    return;
+  }
+
+  addGlobalGenerator(InstrumentModDestination::ModLfoFrequency,
+                     static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / 8.176))));
+}
+
 VGMRgn *VGMInstr::addRgn(VGMRgn *rgn) {
   m_regions.emplace_back(rgn);
   if (m_auto_add_regions_as_children)

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -165,6 +165,19 @@ void VGMInstr::addChannelPressureToVibratoRate(double cents) {
                static_cast<int32_t>(std::lround(cents)));
 }
 
+void VGMInstr::addGlobalGenerator(InstrumentModDestination destination, int32_t amount) {
+  m_globalGenerators.push_back({destination, amount});
+}
+
+void VGMInstr::addGlobalVibratoFrequency(double hertz) {
+  if (hertz <= 0.0 || !std::isfinite(hertz)) {
+    return;
+  }
+
+  addGlobalGenerator(InstrumentModDestination::VibLfoFrequency,
+                     static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / 8.176))));
+}
+
 VGMRgn *VGMInstr::addRgn(VGMRgn *rgn) {
   m_regions.emplace_back(rgn);
   if (m_auto_add_regions_as_children)

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -71,6 +71,9 @@ public:
   void addModWheelToVibratoPitch(double cents);
   void addChannelPressureToVibratoRate(double cents);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
+  void addGlobalGenerator(InstrumentModDestination destination, int32_t amount);
+  void addGlobalVibratoFrequency(double hertz);
+  [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }
 
   VGMRgn *addRgn(VGMRgn *rgn);
   VGMRgn *addRgn(uint32_t offset, uint32_t length, int sampNum, uint8_t keyLow = 0,
@@ -92,4 +95,5 @@ private:
   bool m_auto_add_regions_as_children{true};
   std::vector<VGMRgn*> m_regions;
   std::vector<InstrumentModulator> m_modulators;
+  std::vector<InstrumentGenerator> m_globalGenerators;
 };

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -82,7 +82,7 @@ public:
 
   // Modulator support
   void addModulator(ModSource source, ModDest destination, int32_t amount);
-  void addModulator(ModSource source, ModDest destination, ParamAmount amount);
+  void addModulator(ModSource source, ModDest destination, ModAmount amount);
 
   // Helpers for adding modulators using more-intuitive units
   void addPitchModulator(ModSource source, ModDest destination, double cents);
@@ -98,7 +98,7 @@ public:
 
   // Generator support
   void addGlobalGenerator(ModDest destination, int32_t amount);
-  void addGlobalGenerator(ModDest destination, ParamAmount amount);
+  void addGlobalGenerator(ModDest destination, ModAmount amount);
   // Helpers for adding generators using more-intuitive units.
   void addGlobalGeneratorCents(ModDest destination, double cents);
   void addGlobalGeneratorHertz(ModDest destination, double hertz);

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -12,6 +12,11 @@ class VGMColl;
 
 constexpr float defaultReverbPercent = 0.25;
 
+enum class TremoloGainMode {
+  BipolarAroundNominal,
+  NoBoost,
+};
+
 // ***********
 // VGMInstrSet
 // ***********
@@ -81,7 +86,10 @@ public:
   void addDelayModulator(ModSource source, ModDest destination, double seconds);
   void addAttenuationModulator(ModSource source, ModDest destination, double decibels);
   void addStandardVibratoHandling(double maxDepthCents, double minHertz, double maxHertz);
-  void addStandardTremoloHandling(double maxDepthDb, double minHertz, double maxHertz, bool attenOnly);
+  void addStandardTremoloHandling(double maxDepthDb,
+                                  double minHertz,
+                                  double maxHertz,
+                                  TremoloGainMode gainMode);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
 
   // Generator support

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -97,13 +97,7 @@ public:
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
 
   // Generator support
-  void addGlobalGenerator(ModDest destination, int32_t amount);
   void addGlobalGenerator(ModDest destination, ModAmount amount);
-  // Helpers for adding generators using more-intuitive units.
-  void addGlobalGeneratorCents(ModDest destination, double cents);
-  void addGlobalGeneratorHertz(ModDest destination, double hertz);
-  void addGlobalGeneratorSeconds(ModDest destination, double seconds);
-  void addGlobalGeneratorDecibels(ModDest destination, double decibels);
   // Helpers for adding specific-generators
   void addGlobalVibratoFrequency(double hertz);
   void addGlobalTremoloFrequency(double hertz);

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "common.h"
-#include "InstrumentModulation.h"
+#include "Modulation.h"
 #include "VGMFile.h"
 
 class VGMSampColl;
@@ -87,14 +87,14 @@ public:
                                   double minHertz,
                                   double maxHertz,
                                   TremoloGainMode gainMode);
-  [[nodiscard]] const std::vector<SynthModulator>& modulators() const { return m_modulators; }
+  [[nodiscard]] const std::vector<Modulator>& modulators() const { return m_modulators; }
 
   // Generator support
   void addGenerator(ModDest destination, ModAmount amount);
   // Helpers for adding specific-generators
   void addGlobalVibratoFrequency(double hertz);
   void addGlobalTremoloFrequency(double hertz);
-  [[nodiscard]] const std::vector<SynthGenerator>& generators() const { return m_generators; }
+  [[nodiscard]] const std::vector<Generator>& generators() const { return m_generators; }
 
   virtual bool loadInstr() { return true; }
 
@@ -111,6 +111,6 @@ protected:
 private:
   bool m_auto_add_regions_as_children{true};
   std::vector<VGMRgn*> m_regions;
-  std::vector<SynthModulator> m_modulators;
-  std::vector<SynthGenerator> m_generators;
+  std::vector<Modulator> m_modulators;
+  std::vector<Generator> m_generators;
 };

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -99,12 +99,12 @@ public:
   // Generator support
   void addGlobalGenerator(ModDest destination, int32_t amount);
   void addGlobalGenerator(ModDest destination, ParamAmount amount);
-
   // Helpers for adding generators using more-intuitive units.
-  void addPitchGenerator(ModDest destination, double cents);
-  void addFrequencyGenerator(ModDest destination, double hertz);
-  void addDelayGenerator(ModDest destination, double seconds);
-  void addAttenuationGenerator(ModDest destination, double decibels);
+  void addGlobalGeneratorCents(ModDest destination, double cents);
+  void addGlobalGeneratorHertz(ModDest destination, double hertz);
+  void addGlobalGeneratorSeconds(ModDest destination, double seconds);
+  void addGlobalGeneratorDecibels(ModDest destination, double decibels);
+  // Helpers for adding specific-generators
   void addGlobalVibratoFrequency(double hertz);
   void addGlobalTremoloFrequency(double hertz);
   [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -67,20 +67,28 @@ public:
   inline void setBank(uint32_t bankNum);
   inline void setInstrNum(uint32_t theInstrNum);
 
+  VGMRgn *addRgn(VGMRgn *rgn);
+  VGMRgn *addRgn(uint32_t offset, uint32_t length, int sampNum, uint8_t keyLow = 0,
+                 uint8_t keyHigh = 0x7F, uint8_t velLow = 0, uint8_t velHigh = 0x7F);
+
+  // Modulator support
   void addModulator(ModSource source, ModDest destination, int32_t amount);
   void addModulator(ModSource source, ModDest destination, ParamAmount amount);
-  // Convenience helpers for format code that wants to work in musical units rather than SF2/DLS scalars.
+
+  // Helpers for adding modulators using more-intuitive units
   void addPitchModulator(ModSource source, ModDest destination, double cents);
-  void addFrequencyRangeModulator(ModSource source, ModDest destination,
-                                  double minHertz, double maxHertz);
+  void addFrequencyRangeModulator(ModSource source, ModDest destination, double minHertz, double maxHertz);
   void addDelayModulator(ModSource source, ModDest destination, double seconds);
   void addAttenuationModulator(ModSource source, ModDest destination, double decibels);
   void addStandardVibratoHandling(double maxDepthCents, double minHertz, double maxHertz);
   void addStandardTremoloHandling(double maxDepthDb, double minHertz, double maxHertz, bool attenOnly);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
+
+  // Generator support
   void addGlobalGenerator(ModDest destination, int32_t amount);
   void addGlobalGenerator(ModDest destination, ParamAmount amount);
-  // Generator helpers in musical units.
+
+  // Helpers for adding generators using more-intuitive units.
   void addPitchGenerator(ModDest destination, double cents);
   void addFrequencyGenerator(ModDest destination, double hertz);
   void addDelayGenerator(ModDest destination, double seconds);
@@ -88,10 +96,6 @@ public:
   void addGlobalVibratoFrequency(double hertz);
   void addGlobalTremoloFrequency(double hertz);
   [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }
-
-  VGMRgn *addRgn(VGMRgn *rgn);
-  VGMRgn *addRgn(uint32_t offset, uint32_t length, int sampNum, uint8_t keyLow = 0,
-                 uint8_t keyHigh = 0x7F, uint8_t velLow = 0, uint8_t velHigh = 0x7F);
 
   virtual bool loadInstr() { return true; }
 

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -87,14 +87,14 @@ public:
                                   double minHertz,
                                   double maxHertz,
                                   TremoloGainMode gainMode);
-  [[nodiscard]] const std::vector<Modulator>& modulators() const { return m_modulators; }
+  [[nodiscard]] const std::vector<SynthModulator>& modulators() const { return m_modulators; }
 
   // Generator support
   void addGenerator(ModDest destination, ModAmount amount);
   // Helpers for adding specific-generators
   void addGlobalVibratoFrequency(double hertz);
   void addGlobalTremoloFrequency(double hertz);
-  [[nodiscard]] const std::vector<Generator>& generators() const { return m_generators; }
+  [[nodiscard]] const std::vector<SynthGenerator>& generators() const { return m_generators; }
 
   virtual bool loadInstr() { return true; }
 
@@ -111,6 +111,6 @@ protected:
 private:
   bool m_auto_add_regions_as_children{true};
   std::vector<VGMRgn*> m_regions;
-  std::vector<Modulator> m_modulators;
-  std::vector<Generator> m_generators;
+  std::vector<SynthModulator> m_modulators;
+  std::vector<SynthGenerator> m_generators;
 };

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -75,9 +75,8 @@ public:
                                   double minHertz, double maxHertz);
   void addDelayModulator(ModSource source, ModDest destination, double seconds);
   void addAttenuationModulator(ModSource source, ModDest destination, double decibels);
-  void addModWheelToVibratoPitch(double cents);
-  void addChannelPressureToVibratoRateModulator(double minHertz, double maxHertz);
-  void addChannelPressureToTremoloRateModulator(double minHertz, double maxHertz);
+  void addStandardVibratoHandling(double maxDepthCents, double minHertz, double maxHertz);
+  void addStandardTremoloHandling(double maxDepthDb, double minHertz, double maxHertz, bool attenOnly);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
   void addGlobalGenerator(ModDest destination, int32_t amount);
   void addGlobalGenerator(ModDest destination, ParamAmount amount);

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "common.h"
+#include "InstrumentModulation.h"
 #include "VGMFile.h"
 
 class VGMSampColl;
@@ -66,6 +67,10 @@ public:
   inline void setBank(uint32_t bankNum);
   inline void setInstrNum(uint32_t theInstrNum);
 
+  void addModulator(InstrumentModSource source, InstrumentModDestination destination, int32_t amount);
+  void addModWheelToVibratoPitch(double cents);
+  [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
+
   VGMRgn *addRgn(VGMRgn *rgn);
   VGMRgn *addRgn(uint32_t offset, uint32_t length, int sampNum, uint8_t keyLow = 0,
                  uint8_t keyHigh = 0x7F, uint8_t velLow = 0, uint8_t velHigh = 0x7F);
@@ -85,4 +90,5 @@ protected:
 private:
   bool m_auto_add_regions_as_children{true};
   std::vector<VGMRgn*> m_regions;
+  std::vector<InstrumentModulator> m_modulators;
 };

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -67,13 +67,25 @@ public:
   inline void setBank(uint32_t bankNum);
   inline void setInstrNum(uint32_t theInstrNum);
 
-  void addModulator(InstrumentModSource source, InstrumentModDestination destination, int32_t amount);
-  void addModulator(InstrumentModSource source, InstrumentModDestination destination, InstrumentParamAmount amount);
+  void addModulator(ModSource source, ModDest destination, int32_t amount);
+  void addModulator(ModSource source, ModDest destination, ParamAmount amount);
+  // Convenience helpers for format code that wants to work in musical units rather than SF2/DLS scalars.
+  void addPitchModulator(ModSource source, ModDest destination, double cents);
+  void addFrequencyRangeModulator(ModSource source, ModDest destination,
+                                  double minHertz, double maxHertz);
+  void addDelayModulator(ModSource source, ModDest destination, double seconds);
+  void addAttenuationModulator(ModSource source, ModDest destination, double decibels);
   void addModWheelToVibratoPitch(double cents);
-  void addChannelPressureToVibratoRate(double cents);
+  void addChannelPressureToVibratoRateModulator(double minHertz, double maxHertz);
+  void addChannelPressureToTremoloRateModulator(double minHertz, double maxHertz);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
-  void addGlobalGenerator(InstrumentModDestination destination, int32_t amount);
-  void addGlobalGenerator(InstrumentModDestination destination, InstrumentParamAmount amount);
+  void addGlobalGenerator(ModDest destination, int32_t amount);
+  void addGlobalGenerator(ModDest destination, ParamAmount amount);
+  // Generator helpers in musical units.
+  void addPitchGenerator(ModDest destination, double cents);
+  void addFrequencyGenerator(ModDest destination, double hertz);
+  void addDelayGenerator(ModDest destination, double seconds);
+  void addAttenuationGenerator(ModDest destination, double decibels);
   void addGlobalVibratoFrequency(double hertz);
   void addGlobalTremoloFrequency(double hertz);
   [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -81,14 +81,7 @@ public:
                  uint8_t keyHigh = 0x7F, uint8_t velLow = 0, uint8_t velHigh = 0x7F);
 
   // Modulator support
-  void addModulator(ModSource source, ModDest destination, int32_t amount);
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
-
-  // Helpers for adding modulators using more-intuitive units
-  void addPitchModulator(ModSource source, ModDest destination, double cents);
-  void addFrequencyRangeModulator(ModSource source, ModDest destination, double minHertz, double maxHertz);
-  void addDelayModulator(ModSource source, ModDest destination, double seconds);
-  void addAttenuationModulator(ModSource source, ModDest destination, double decibels);
   void addStandardVibratoHandling(double maxDepthCents, double minHertz, double maxHertz);
   void addStandardTremoloHandling(double maxDepthDb,
                                   double minHertz,

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -68,10 +68,12 @@ public:
   inline void setInstrNum(uint32_t theInstrNum);
 
   void addModulator(InstrumentModSource source, InstrumentModDestination destination, int32_t amount);
+  void addModulator(InstrumentModSource source, InstrumentModDestination destination, InstrumentParamAmount amount);
   void addModWheelToVibratoPitch(double cents);
   void addChannelPressureToVibratoRate(double cents);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
   void addGlobalGenerator(InstrumentModDestination destination, int32_t amount);
+  void addGlobalGenerator(InstrumentModDestination destination, InstrumentParamAmount amount);
   void addGlobalVibratoFrequency(double hertz);
   void addGlobalTremoloFrequency(double hertz);
   [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -87,14 +87,14 @@ public:
                                   double minHertz,
                                   double maxHertz,
                                   TremoloGainMode gainMode);
-  [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
+  [[nodiscard]] const std::vector<SynthModulator>& modulators() const { return m_modulators; }
 
   // Generator support
-  void addGlobalGenerator(ModDest destination, ModAmount amount);
+  void addGenerator(ModDest destination, ModAmount amount);
   // Helpers for adding specific-generators
   void addGlobalVibratoFrequency(double hertz);
   void addGlobalTremoloFrequency(double hertz);
-  [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }
+  [[nodiscard]] const std::vector<SynthGenerator>& generators() const { return m_generators; }
 
   virtual bool loadInstr() { return true; }
 
@@ -111,6 +111,6 @@ protected:
 private:
   bool m_auto_add_regions_as_children{true};
   std::vector<VGMRgn*> m_regions;
-  std::vector<InstrumentModulator> m_modulators;
-  std::vector<InstrumentGenerator> m_globalGenerators;
+  std::vector<SynthModulator> m_modulators;
+  std::vector<SynthGenerator> m_generators;
 };

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -73,6 +73,7 @@ public:
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
   void addGlobalGenerator(InstrumentModDestination destination, int32_t amount);
   void addGlobalVibratoFrequency(double hertz);
+  void addGlobalTremoloFrequency(double hertz);
   [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }
 
   VGMRgn *addRgn(VGMRgn *rgn);

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -12,6 +12,10 @@ class VGMColl;
 
 constexpr float defaultReverbPercent = 0.25;
 
+// BipolarAroundNominal:
+//   SF2 modLfoToVolume is centered around nominal gain. Tremolo can boost above the note's normal volume.
+// NoBoost:
+//   Adds a matching initialAttenuation offset. Loudest tremolo point is nominal gain; all other points attenuate.
 enum class TremoloGainMode {
   BipolarAroundNominal,
   NoBoost,

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -69,6 +69,7 @@ public:
 
   void addModulator(InstrumentModSource source, InstrumentModDestination destination, int32_t amount);
   void addModWheelToVibratoPitch(double cents);
+  void addChannelPressureToVibratoRate(double cents);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
 
   VGMRgn *addRgn(VGMRgn *rgn);

--- a/src/main/components/seq/SeqEvent.cpp
+++ b/src/main/components/seq/SeqEvent.cpp
@@ -197,6 +197,17 @@ PitchBendSeqEvent::PitchBendSeqEvent(SeqTrack *pTrack,
                                      const std::string &name)
     : SeqEvent(pTrack, offset, length, name, Type::PitchBend), pitchbend(thePitchBend) { }
 
+// ***********************
+// ChannelPressureSeqEvent
+// ***********************
+
+ChannelPressureSeqEvent::ChannelPressureSeqEvent(SeqTrack *pTrack,
+                                                 uint8_t thePressure,
+                                                 uint32_t offset,
+                                                 uint32_t length,
+                                                 const std::string &name)
+    : SeqEvent(pTrack, offset, length, name, Type::ChannelPressure), pressure(thePressure) { }
+
 // **********************
 // PitchBendRangeSeqEvent
 // **********************
@@ -353,5 +364,3 @@ TimeSigSeqEvent::TimeSigSeqEvent(SeqTrack *pTrack,
                                  const std::string &name)
     : SeqEvent(pTrack, offset, length, name, Type::TimeSignature), numer(numerator), denom(denominator),
       ticksPerQuarter(theTicksPerQuarter) { }
-
-

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -328,6 +328,22 @@ class PitchBendSeqEvent : public SeqEvent {
   short pitchbend;
 };
 
+//  ***********************
+//  ChannelPressureSeqEvent
+//  ***********************
+
+class ChannelPressureSeqEvent : public SeqEvent {
+ public:
+  ChannelPressureSeqEvent(SeqTrack *pTrack, uint8_t pressure, uint32_t offset = 0,
+                          uint32_t length = 0, const std::string &name = "");
+
+  std::string description() override {
+    return fmt::format("{} - channel pressure: {}", name(), static_cast<int>(pressure));
+  };
+
+  uint8_t pressure;
+};
+
 //  **********************
 //  PitchBendRangeSeqEvent
 //  **********************

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -1160,6 +1160,34 @@ void SeqTrack::addPitchBendRangeNoItem(uint16_t cents) const {
     pMidiTrack->addPitchBendRange(channel, cents);
 }
 
+void SeqTrack::addChannelPressure(uint32_t offset,
+                                  uint32_t length,
+                                  uint8_t pressure,
+                                  const std::string &sEventName) {
+  bool isNewOffset = onEvent(offset, length);
+
+  recordSeqEvent<ChannelPressureSeqEvent>(isNewOffset, getTime(), pressure, offset, length, sEventName);
+  addChannelPressureNoItem(pressure);
+}
+
+void SeqTrack::addChannelPressureNoItem(uint8_t pressure) {
+  if (readMode == READMODE_CONVERT_TO_MIDI)
+    pMidiTrack->addChannelPressure(channel, pressure);
+}
+
+void SeqTrack::insertChannelPressure(uint32_t offset,
+                                     uint32_t length,
+                                     uint8_t pressure,
+                                     uint32_t absTime,
+                                     const std::string &sEventName) {
+  bool isNewOffset = onEvent(offset, length);
+
+  recordSeqEvent<ChannelPressureSeqEvent>(isNewOffset, absTime, pressure, offset, length, sEventName);
+
+  if (readMode == READMODE_CONVERT_TO_MIDI)
+    pMidiTrack->insertChannelPressure(channel, pressure, absTime);
+}
+
 void SeqTrack::addFineTuning(uint32_t offset, uint32_t length, double cents, const std::string &sEventName) {
   bool isNewOffset = onEvent(offset, length);
 

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -210,6 +210,9 @@ private:
   void addPitchBendAsPercent(uint32_t offset, uint32_t length, double percent, const std::string &sEventName = "Pitch Bend");
   void addPitchBendRange(uint32_t offset, uint32_t length, uint16_t cents, const std::string &sEventName = "Pitch Bend Range");
   void addPitchBendRangeNoItem(uint16_t cents) const;
+  void addChannelPressure(uint32_t offset, uint32_t length, uint8_t pressure, const std::string &sEventName = "Channel Pressure");
+  void addChannelPressureNoItem(uint8_t pressure);
+  void insertChannelPressure(uint32_t offset, uint32_t length, uint8_t pressure, uint32_t absTime, const std::string &sEventName = "Channel Pressure");
   void addFineTuning(uint32_t offset, uint32_t length, double cents, const std::string &sEventName = "Fine Tuning");
   void addFineTuningNoItem(double cents);
   void addCoarseTuning(uint32_t offset, uint32_t length, double semitones, const std::string &sEventName = "Coarse Tuning");

--- a/src/main/conversion/DLSConversion.cpp
+++ b/src/main/conversion/DLSConversion.cpp
@@ -269,7 +269,7 @@ bool mainDLSCreation(
           int32_t vibDelay = secondsToDlsTimecents(rgn->lfoVibDelaySeconds());
           newArt->addVibrato(vibDepth, vibFreq, vibDelay);
         }
-        for (const auto& generator : vgminstr->globalGenerators()) {
+        for (const auto& generator : vgminstr->generators()) {
           newArt->addGenerator(generator);
         }
         for (const auto& modulator : vgminstr->modulators()) {

--- a/src/main/conversion/DLSConversion.cpp
+++ b/src/main/conversion/DLSConversion.cpp
@@ -269,6 +269,9 @@ bool mainDLSCreation(
           int32_t vibDelay = secondsToDlsTimecents(rgn->lfoVibDelaySeconds());
           newArt->addVibrato(vibDepth, vibFreq, vibDelay);
         }
+        for (const auto& generator : vgminstr->globalGenerators()) {
+          newArt->addGenerator(generator);
+        }
         for (const auto& modulator : vgminstr->modulators()) {
           newArt->addModulator(modulator);
         }

--- a/src/main/conversion/DLSConversion.cpp
+++ b/src/main/conversion/DLSConversion.cpp
@@ -269,6 +269,9 @@ bool mainDLSCreation(
           int32_t vibDelay = secondsToDlsTimecents(rgn->lfoVibDelaySeconds());
           newArt->addVibrato(vibDepth, vibFreq, vibDelay);
         }
+        for (const auto& modulator : vgminstr->modulators()) {
+          newArt->addModulator(modulator);
+        }
 
         newWsmp->setPitchInfo(realUnityKey, totalFineTune, totalAttenuation);
       }

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -278,25 +278,25 @@ void DLSRgn::setWaveLinkInfo(uint16_t options, uint16_t phaseGroup, uint32_t the
 
 namespace {
 
-uint16_t dlsSourceForModSource(InstrumentModSource source) {
+uint16_t dlsSourceForModSource(ModSource source) {
   switch (source) {
-    case InstrumentModSource::ModWheel:
+    case ModSource::ModWheel:
       return CONN_SRC_CC1;
-    case InstrumentModSource::ChannelPressure:
+    case ModSource::ChannelPressure:
       return CONN_SRC_CHANNELPRESSURE;
-    case InstrumentModSource::PolyPressure:
+    case ModSource::PolyPressure:
       return CONN_SRC_POLYPRESSURE;
-    case InstrumentModSource::PitchWheel:
+    case ModSource::PitchWheel:
       return CONN_SRC_PITCHWHEEL;
-    case InstrumentModSource::Volume:
+    case ModSource::Volume:
       return CONN_SRC_CC7;
-    case InstrumentModSource::Pan:
+    case ModSource::Pan:
       return CONN_SRC_CC10;
-    case InstrumentModSource::Expression:
+    case ModSource::Expression:
       return CONN_SRC_CC11;
-    case InstrumentModSource::ReverbSend:
+    case ModSource::ReverbSend:
       return CONN_SRC_CC91;
-    case InstrumentModSource::ChorusSend:
+    case ModSource::ChorusSend:
       return CONN_SRC_CC93;
   }
   return CONN_SRC_NONE;
@@ -368,37 +368,37 @@ void DLSArt::addVibrato(int32_t depth, int32_t frequency, int32_t delay) {
 
 void DLSArt::addGenerator(const InstrumentGenerator& generator) {
   switch (generator.destination) {
-    case InstrumentModDestination::VibLfoToPitch:
+    case ModDest::VibLfoToPitch:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           CONN_SRC_VIBRATO, CONN_SRC_NONE, CONN_DST_PITCH, CONN_TRN_NONE,
           centsToDlsPitchScale(generator.amount)));
       break;
-    case InstrumentModDestination::VibLfoFrequency:
+    case ModDest::VibLfoFreq:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_VIB_FREQUENCY, CONN_TRN_NONE,
           centsToDlsPitchScale(generator.amount)));
       break;
-    case InstrumentModDestination::VibLfoStartDelay:
+    case ModDest::VibLfoDelay:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_VIB_STARTDELAY, CONN_TRN_NONE,
           toDls16Dot16Scale(generator.amount)));
       break;
-    case InstrumentModDestination::ModLfoToVolume:
+    case ModDest::ModLfoToVol:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           CONN_SRC_LFO, CONN_SRC_NONE, CONN_DST_ATTENUATION, CONN_TRN_NONE,
           toDls16Dot16Scale(generator.amount)));
       break;
-    case InstrumentModDestination::ModLfoFrequency:
+    case ModDest::ModLfoFreq:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_LFO_FREQUENCY, CONN_TRN_NONE,
           centsToDlsPitchScale(generator.amount)));
       break;
-    case InstrumentModDestination::ModLfoStartDelay:
+    case ModDest::ModLfoDelay:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_LFO_STARTDELAY, CONN_TRN_NONE,
           toDls16Dot16Scale(generator.amount)));
       break;
-    case InstrumentModDestination::InitialAttenuation:
+    case ModDest::InitialAtten:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_ATTENUATION, CONN_TRN_NONE,
           toDls16Dot16Scale(generator.amount)));
@@ -410,37 +410,37 @@ void DLSArt::addModulator(const InstrumentModulator& modulator) {
   const uint16_t source = dlsSourceForModSource(modulator.source);
 
   switch (modulator.destination) {
-    case InstrumentModDestination::VibLfoToPitch:
+    case ModDest::VibLfoToPitch:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           CONN_SRC_VIBRATO, source, CONN_DST_PITCH, CONN_TRN_NONE,
           centsToDlsPitchScale(modulator.amount)));
       break;
-    case InstrumentModDestination::VibLfoFrequency:
+    case ModDest::VibLfoFreq:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           source, CONN_SRC_NONE, CONN_DST_VIB_FREQUENCY, CONN_TRN_NONE,
           centsToDlsPitchScale(modulator.amount)));
       break;
-    case InstrumentModDestination::VibLfoStartDelay:
+    case ModDest::VibLfoDelay:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           source, CONN_SRC_NONE, CONN_DST_VIB_STARTDELAY, CONN_TRN_NONE,
           toDls16Dot16Scale(modulator.amount)));
       break;
-    case InstrumentModDestination::ModLfoFrequency:
+    case ModDest::ModLfoFreq:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           source, CONN_SRC_NONE, CONN_DST_LFO_FREQUENCY, CONN_TRN_NONE,
           centsToDlsPitchScale(modulator.amount)));
       break;
-    case InstrumentModDestination::ModLfoStartDelay:
+    case ModDest::ModLfoDelay:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           source, CONN_SRC_NONE, CONN_DST_LFO_STARTDELAY, CONN_TRN_NONE,
           toDls16Dot16Scale(modulator.amount)));
       break;
-    case InstrumentModDestination::ModLfoToVolume:
+    case ModDest::ModLfoToVol:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           CONN_SRC_LFO, source, CONN_DST_ATTENUATION, CONN_TRN_NONE,
           toDls16Dot16Scale(modulator.amount)));
       break;
-    case InstrumentModDestination::InitialAttenuation:
+    case ModDest::InitialAtten:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           source, CONN_SRC_NONE, CONN_DST_ATTENUATION, CONN_TRN_NONE,
           toDls16Dot16Scale(modulator.amount)));

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -366,7 +366,7 @@ void DLSArt::addVibrato(int32_t depth, int32_t frequency, int32_t delay) {
       CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_VIB_STARTDELAY, CONN_TRN_NONE, delay));
 }
 
-void DLSArt::addGenerator(const Generator& generator) {
+void DLSArt::addGenerator(const SynthGenerator& generator) {
   switch (generator.destination) {
     case ModDest::VibLfoToPitch:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
@@ -406,7 +406,7 @@ void DLSArt::addGenerator(const Generator& generator) {
   }
 }
 
-void DLSArt::addModulator(const Modulator& modulator) {
+void DLSArt::addModulator(const SynthModulator& modulator) {
   const uint16_t source = dlsSourceForModSource(modulator.source);
 
   switch (modulator.destination) {

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -366,6 +366,41 @@ void DLSArt::addVibrato(int32_t depth, int32_t frequency, int32_t delay) {
       CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_VIB_STARTDELAY, CONN_TRN_NONE, delay));
 }
 
+void DLSArt::addGenerator(const InstrumentGenerator& generator) {
+  switch (generator.destination) {
+    case InstrumentModDestination::VibLfoToPitch:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          CONN_SRC_VIBRATO, CONN_SRC_NONE, CONN_DST_PITCH, CONN_TRN_NONE,
+          centsToDlsPitchScale(generator.amount)));
+      break;
+    case InstrumentModDestination::VibLfoFrequency:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_VIB_FREQUENCY, CONN_TRN_NONE,
+          centsToDlsPitchScale(generator.amount)));
+      break;
+    case InstrumentModDestination::VibLfoStartDelay:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_VIB_STARTDELAY, CONN_TRN_NONE,
+          toDls16Dot16Scale(generator.amount)));
+      break;
+    case InstrumentModDestination::ModLfoToVolume:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          CONN_SRC_LFO, CONN_SRC_NONE, CONN_DST_ATTENUATION, CONN_TRN_NONE,
+          toDls16Dot16Scale(generator.amount)));
+      break;
+    case InstrumentModDestination::ModLfoFrequency:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_LFO_FREQUENCY, CONN_TRN_NONE,
+          centsToDlsPitchScale(generator.amount)));
+      break;
+    case InstrumentModDestination::ModLfoStartDelay:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_LFO_STARTDELAY, CONN_TRN_NONE,
+          toDls16Dot16Scale(generator.amount)));
+      break;
+  }
+}
+
 void DLSArt::addModulator(const InstrumentModulator& modulator) {
   const uint16_t source = dlsSourceForModSource(modulator.source);
 

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -366,7 +366,7 @@ void DLSArt::addVibrato(int32_t depth, int32_t frequency, int32_t delay) {
       CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_VIB_STARTDELAY, CONN_TRN_NONE, delay));
 }
 
-void DLSArt::addGenerator(const SynthGenerator& generator) {
+void DLSArt::addGenerator(const Generator& generator) {
   switch (generator.destination) {
     case ModDest::VibLfoToPitch:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
@@ -406,7 +406,7 @@ void DLSArt::addGenerator(const SynthGenerator& generator) {
   }
 }
 
-void DLSArt::addModulator(const SynthModulator& modulator) {
+void DLSArt::addModulator(const Modulator& modulator) {
   const uint16_t source = dlsSourceForModSource(modulator.source);
 
   switch (modulator.destination) {

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -398,6 +398,11 @@ void DLSArt::addGenerator(const InstrumentGenerator& generator) {
           CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_LFO_STARTDELAY, CONN_TRN_NONE,
           toDls16Dot16Scale(generator.amount)));
       break;
+    case InstrumentModDestination::InitialAttenuation:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_ATTENUATION, CONN_TRN_NONE,
+          toDls16Dot16Scale(generator.amount)));
+      break;
   }
 }
 
@@ -433,6 +438,11 @@ void DLSArt::addModulator(const InstrumentModulator& modulator) {
     case InstrumentModDestination::ModLfoToVolume:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           CONN_SRC_LFO, source, CONN_DST_ATTENUATION, CONN_TRN_NONE,
+          toDls16Dot16Scale(modulator.amount)));
+      break;
+    case InstrumentModDestination::InitialAttenuation:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          source, CONN_SRC_NONE, CONN_DST_ATTENUATION, CONN_TRN_NONE,
           toDls16Dot16Scale(modulator.amount)));
       break;
   }

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -282,12 +282,22 @@ uint16_t dlsSourceForModSource(InstrumentModSource source) {
   switch (source) {
     case InstrumentModSource::ModWheel:
       return CONN_SRC_CC1;
+    case InstrumentModSource::ChannelPressure:
+      return CONN_SRC_CHANNELPRESSURE;
+    case InstrumentModSource::PolyPressure:
+      return CONN_SRC_POLYPRESSURE;
+    case InstrumentModSource::PitchWheel:
+      return CONN_SRC_PITCHWHEEL;
     case InstrumentModSource::Volume:
       return CONN_SRC_CC7;
     case InstrumentModSource::Pan:
       return CONN_SRC_CC10;
     case InstrumentModSource::Expression:
       return CONN_SRC_CC11;
+    case InstrumentModSource::ReverbSend:
+      return CONN_SRC_CC91;
+    case InstrumentModSource::ChorusSend:
+      return CONN_SRC_CC93;
   }
   return CONN_SRC_NONE;
 }
@@ -346,14 +356,14 @@ void DLSArt::addPan(long pan) {
 void DLSArt::addVibrato(int32_t depth, int32_t frequency, int32_t delay) {
   if (depth != 0) {
     m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
-        CONN_SRC_LFO, CONN_SRC_NONE, CONN_DST_PITCH, CONN_TRN_NONE, depth));
+        CONN_SRC_VIBRATO, CONN_SRC_NONE, CONN_DST_PITCH, CONN_TRN_NONE, depth));
   }
 
   m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
-      CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_LFO_FREQUENCY, CONN_TRN_NONE, frequency));
+      CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_VIB_FREQUENCY, CONN_TRN_NONE, frequency));
 
   m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
-      CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_LFO_STARTDELAY, CONN_TRN_NONE, delay));
+      CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_VIB_STARTDELAY, CONN_TRN_NONE, delay));
 }
 
 void DLSArt::addModulator(const InstrumentModulator& modulator) {
@@ -362,16 +372,24 @@ void DLSArt::addModulator(const InstrumentModulator& modulator) {
   switch (modulator.destination) {
     case InstrumentModDestination::VibLfoToPitch:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
-          CONN_SRC_LFO, source, CONN_DST_PITCH, CONN_TRN_NONE,
+          CONN_SRC_VIBRATO, source, CONN_DST_PITCH, CONN_TRN_NONE,
           centsToDlsPitchScale(modulator.amount)));
       break;
     case InstrumentModDestination::VibLfoFrequency:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          source, CONN_SRC_NONE, CONN_DST_VIB_FREQUENCY, CONN_TRN_NONE,
+          centsToDlsPitchScale(modulator.amount)));
+      break;
+    case InstrumentModDestination::VibLfoStartDelay:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          source, CONN_SRC_NONE, CONN_DST_VIB_STARTDELAY, CONN_TRN_NONE,
+          toDls16Dot16Scale(modulator.amount)));
+      break;
     case InstrumentModDestination::ModLfoFrequency:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           source, CONN_SRC_NONE, CONN_DST_LFO_FREQUENCY, CONN_TRN_NONE,
           centsToDlsPitchScale(modulator.amount)));
       break;
-    case InstrumentModDestination::VibLfoStartDelay:
     case InstrumentModDestination::ModLfoStartDelay:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
           source, CONN_SRC_NONE, CONN_DST_LFO_STARTDELAY, CONN_TRN_NONE,

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -5,10 +5,12 @@
  */
 
 #include <algorithm>
+#include <limits>
 #include <numeric>
 #include <ranges>
 #include <vector>
 #include "DLSFile.h"
+#include "ScaleConversion.h"
 #include "VGMInstrSet.h"
 #include "VGMSamp.h"
 #include "Root.h"
@@ -274,6 +276,30 @@ void DLSRgn::setWaveLinkInfo(uint16_t options, uint16_t phaseGroup, uint32_t the
 //  DLSArt
 //  ******
 
+namespace {
+
+uint16_t dlsSourceForModSource(InstrumentModSource source) {
+  switch (source) {
+    case InstrumentModSource::ModWheel:
+      return CONN_SRC_CC1;
+    case InstrumentModSource::Volume:
+      return CONN_SRC_CC7;
+    case InstrumentModSource::Pan:
+      return CONN_SRC_CC10;
+    case InstrumentModSource::Expression:
+      return CONN_SRC_CC11;
+  }
+  return CONN_SRC_NONE;
+}
+
+int32_t toDls16Dot16Scale(int32_t amount) {
+  const int64_t scaled = static_cast<int64_t>(amount) * 65536;
+  return static_cast<int32_t>(std::clamp<int64_t>(
+      scaled, std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max()));
+}
+
+} // namespace
+
 uint32_t DLSArt::GetSize() const {
   uint32_t size = 0;
   size += LIST_HDR_SIZE;  //"lar2" list
@@ -328,6 +354,35 @@ void DLSArt::addVibrato(int32_t depth, int32_t frequency, int32_t delay) {
 
   m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
       CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_LFO_STARTDELAY, CONN_TRN_NONE, delay));
+}
+
+void DLSArt::addModulator(const InstrumentModulator& modulator) {
+  const uint16_t source = dlsSourceForModSource(modulator.source);
+
+  switch (modulator.destination) {
+    case InstrumentModDestination::VibLfoToPitch:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          CONN_SRC_LFO, source, CONN_DST_PITCH, CONN_TRN_NONE,
+          centsToDlsPitchScale(modulator.amount)));
+      break;
+    case InstrumentModDestination::VibLfoFrequency:
+    case InstrumentModDestination::ModLfoFrequency:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          source, CONN_SRC_NONE, CONN_DST_LFO_FREQUENCY, CONN_TRN_NONE,
+          centsToDlsPitchScale(modulator.amount)));
+      break;
+    case InstrumentModDestination::VibLfoStartDelay:
+    case InstrumentModDestination::ModLfoStartDelay:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          source, CONN_SRC_NONE, CONN_DST_LFO_STARTDELAY, CONN_TRN_NONE,
+          toDls16Dot16Scale(modulator.amount)));
+      break;
+    case InstrumentModDestination::ModLfoToVolume:
+      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
+          CONN_SRC_LFO, source, CONN_DST_ATTENUATION, CONN_TRN_NONE,
+          toDls16Dot16Scale(modulator.amount)));
+      break;
+  }
 }
 
 //  ***************

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -366,7 +366,7 @@ void DLSArt::addVibrato(int32_t depth, int32_t frequency, int32_t delay) {
       CONN_SRC_NONE, CONN_SRC_NONE, CONN_DST_VIB_STARTDELAY, CONN_TRN_NONE, delay));
 }
 
-void DLSArt::addGenerator(const InstrumentGenerator& generator) {
+void DLSArt::addGenerator(const SynthGenerator& generator) {
   switch (generator.destination) {
     case ModDest::VibLfoToPitch:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
@@ -406,7 +406,7 @@ void DLSArt::addGenerator(const InstrumentGenerator& generator) {
   }
 }
 
-void DLSArt::addModulator(const InstrumentModulator& modulator) {
+void DLSArt::addModulator(const SynthModulator& modulator) {
   const uint16_t source = dlsSourceForModSource(modulator.source);
 
   switch (modulator.destination) {

--- a/src/main/conversion/DLSFile.h
+++ b/src/main/conversion/DLSFile.h
@@ -201,8 +201,8 @@ public:
                long sustain_lev, long release_time, uint16_t rls_transform);
   void addPan(long pan);
   void addVibrato(int32_t depth, int32_t frequency, int32_t delay);
-  void addGenerator(const Generator& generator);
-  void addModulator(const Modulator& modulator);
+  void addGenerator(const SynthGenerator& generator);
+  void addModulator(const SynthModulator& modulator);
 
   uint32_t GetSize() const;
   void Write(std::vector<uint8_t> &buf) const;

--- a/src/main/conversion/DLSFile.h
+++ b/src/main/conversion/DLSFile.h
@@ -201,8 +201,8 @@ public:
                long sustain_lev, long release_time, uint16_t rls_transform);
   void addPan(long pan);
   void addVibrato(int32_t depth, int32_t frequency, int32_t delay);
-  void addGenerator(const InstrumentGenerator& generator);
-  void addModulator(const InstrumentModulator& modulator);
+  void addGenerator(const SynthGenerator& generator);
+  void addModulator(const SynthModulator& modulator);
 
   uint32_t GetSize() const;
   void Write(std::vector<uint8_t> &buf) const;

--- a/src/main/conversion/DLSFile.h
+++ b/src/main/conversion/DLSFile.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "common.h"
-#include "InstrumentModulation.h"
+#include "Modulation.h"
 #include "RiffFile.h"
 #include <filesystem>
 
@@ -201,8 +201,8 @@ public:
                long sustain_lev, long release_time, uint16_t rls_transform);
   void addPan(long pan);
   void addVibrato(int32_t depth, int32_t frequency, int32_t delay);
-  void addGenerator(const SynthGenerator& generator);
-  void addModulator(const SynthModulator& modulator);
+  void addGenerator(const Generator& generator);
+  void addModulator(const Modulator& modulator);
 
   uint32_t GetSize() const;
   void Write(std::vector<uint8_t> &buf) const;

--- a/src/main/conversion/DLSFile.h
+++ b/src/main/conversion/DLSFile.h
@@ -26,12 +26,17 @@ class VGMSamp;
 #define CONN_SRC_EG1 0x0004
 #define CONN_SRC_EG2 0x0005
 #define CONN_SRC_PITCHWHEEL 0x0006
+#define CONN_SRC_POLYPRESSURE 0x0007
+#define CONN_SRC_CHANNELPRESSURE 0x0008
+#define CONN_SRC_VIBRATO 0x0009
 
 /* Midi Controllers 0-127 */
 #define CONN_SRC_CC1 0x0081
 #define CONN_SRC_CC7 0x0087
 #define CONN_SRC_CC10 0x008a
 #define CONN_SRC_CC11 0x008b
+#define CONN_SRC_CC91 0x00db
+#define CONN_SRC_CC93 0x00dd
 
 /* Registered Parameter Numbers */
 #define CONN_SRC_RPN0 0x0100
@@ -48,6 +53,10 @@ class VGMSamp;
 /* LFO Destinations */
 #define CONN_DST_LFO_FREQUENCY 0x0104
 #define CONN_DST_LFO_STARTDELAY 0x0105
+
+/* DLS2 Vibrato LFO Destinations */
+#define CONN_DST_VIB_FREQUENCY 0x0114
+#define CONN_DST_VIB_STARTDELAY 0x0115
 
 /* EG1 Destinations */
 #define CONN_DST_EG1_ATTACKTIME 0x0206

--- a/src/main/conversion/DLSFile.h
+++ b/src/main/conversion/DLSFile.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "common.h"
+#include "InstrumentModulation.h"
 #include "RiffFile.h"
 #include <filesystem>
 
@@ -191,6 +192,7 @@ public:
                long sustain_lev, long release_time, uint16_t rls_transform);
   void addPan(long pan);
   void addVibrato(int32_t depth, int32_t frequency, int32_t delay);
+  void addModulator(const InstrumentModulator& modulator);
 
   uint32_t GetSize() const;
   void Write(std::vector<uint8_t> &buf) const;

--- a/src/main/conversion/DLSFile.h
+++ b/src/main/conversion/DLSFile.h
@@ -201,6 +201,7 @@ public:
                long sustain_lev, long release_time, uint16_t rls_transform);
   void addPan(long pan);
   void addVibrato(int32_t depth, int32_t frequency, int32_t delay);
+  void addGenerator(const InstrumentGenerator& generator);
   void addModulator(const InstrumentModulator& modulator);
 
   uint32_t GetSize() const;

--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -423,6 +423,14 @@ void MidiTrack::insertPitchBend(uint8_t channel, int16_t bend, uint32_t absTime)
   aEvents.push_back(new PitchBendEvent(this, channel, absTime, bend));
 }
 
+void MidiTrack::addChannelPressure(uint8_t channel, uint8_t pressure) {
+  aEvents.push_back(new ChannelPressureEvent(this, channel, getDelta(), pressure));
+}
+
+void MidiTrack::insertChannelPressure(uint8_t channel, uint8_t pressure, uint32_t absTime) {
+  aEvents.push_back(new ChannelPressureEvent(this, channel, absTime, pressure));
+}
+
 void MidiTrack::addPitchBendRange(uint8_t channel, uint16_t cents) {
   insertPitchBendRange(channel, cents, getDelta());
 }
@@ -896,6 +904,24 @@ uint32_t PitchBendEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
   buf.push_back(0xE0 + channel);
   buf.push_back(loByte);
   buf.push_back(hiByte);
+  return absTime;
+}
+
+//  ********************
+//  ChannelPressureEvent
+//  ********************
+
+ChannelPressureEvent::ChannelPressureEvent(MidiTrack *prntTrk,
+                                           uint8_t channel,
+                                           uint32_t absoluteTime,
+                                           uint8_t pressureAmt)
+    : MidiEvent(prntTrk, absoluteTime, channel, PRIORITY_MIDDLE), pressure(pressureAmt) {
+}
+
+uint32_t ChannelPressureEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
+  writeVarLength(buf, absTime - time);
+  buf.push_back(0xD0 + channel);
+  buf.push_back(pressure & 0x7F);
   return absTime;
 }
 

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -46,6 +46,7 @@ typedef enum {
   MIDIEVENT_PAN,
   MIDIEVENT_PROGRAMCHANGE,
   MIDIEVENT_PITCHBEND,
+  MIDIEVENT_CHANNELPRESSURE,
   MIDIEVENT_TEMPO,
   MIDIEVENT_TIMESIG,
   MIDIEVENT_MODULATION,
@@ -131,6 +132,8 @@ class MidiTrack {
 
   void addPitchBend(uint8_t channel, int16_t bend);
   void insertPitchBend(uint8_t channel, short bend, uint32_t absTime);
+  void addChannelPressure(uint8_t channel, uint8_t pressure);
+  void insertChannelPressure(uint8_t channel, uint8_t pressure, uint32_t absTime);
   void addPitchBendRange(uint8_t channel, uint16_t cents);
   void insertPitchBendRange(uint8_t channel, uint16_t cents, uint32_t absTime);
   void addFineTuning(uint8_t channel, uint8_t msb, uint8_t lsb);
@@ -518,6 +521,15 @@ class PitchBendEvent
   int16_t bend;
 };
 
+class ChannelPressureEvent
+    : public MidiEvent {
+ public:
+  ChannelPressureEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t pressure);
+  MidiEventType eventType() override { return MIDIEVENT_CHANNELPRESSURE; }
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+
+  uint8_t pressure;
+};
 
 class TempoEvent
     : public MidiEvent {

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -89,8 +89,8 @@ SynthFile* createSynthFile(
       if (nRgns == 0)  // do not write an instrument if it has no regions
         continue;
       SynthInstr* newInstr = synthfile->addInstr(vgminstr->bank, vgminstr->instrNum, vgminstr->reverb);
-      for (const auto& generator : vgminstr->globalGenerators()) {
-        newInstr->addGlobalGenerator(generator);
+      for (const auto& generator : vgminstr->generators()) {
+        newInstr->addGenerator(generator);
       }
       for (const auto& modulator : vgminstr->modulators()) {
         newInstr->addModulator(modulator);

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -89,6 +89,9 @@ SynthFile* createSynthFile(
       if (nRgns == 0)  // do not write an instrument if it has no regions
         continue;
       SynthInstr* newInstr = synthfile->addInstr(vgminstr->bank, vgminstr->instrNum, vgminstr->reverb);
+      for (const auto& generator : vgminstr->globalGenerators()) {
+        newInstr->addGlobalGenerator(generator);
+      }
       for (const auto& modulator : vgminstr->modulators()) {
         newInstr->addModulator(modulator);
       }

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -89,6 +89,9 @@ SynthFile* createSynthFile(
       if (nRgns == 0)  // do not write an instrument if it has no regions
         continue;
       SynthInstr* newInstr = synthfile->addInstr(vgminstr->bank, vgminstr->instrNum, vgminstr->reverb);
+      for (const auto& modulator : vgminstr->modulators()) {
+        newInstr->addModulator(modulator);
+      }
       for (uint32_t j = 0; j < nRgns; j++) {
         VGMRgn* rgn = vgminstr->regions()[j];
         //				if (rgn->sampNum+1 > sampColl->samples.size())	//does thereferenced sample exist?

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -18,7 +18,29 @@ namespace {
 
 SFModulator sf2SourceForModSource(InstrumentModSource source) {
   constexpr uint16_t midiContinuousController = 1u << 7;
-  return static_cast<SFModulator>(midiContinuousController | static_cast<uint8_t>(source));
+  constexpr uint16_t bipolar = 1u << 9;
+
+  switch (source) {
+    case InstrumentModSource::ModWheel:
+      return static_cast<SFModulator>(midiContinuousController | 1);
+    case InstrumentModSource::ChannelPressure:
+      return 13;
+    case InstrumentModSource::PolyPressure:
+      return 10;
+    case InstrumentModSource::PitchWheel:
+      return static_cast<SFModulator>(bipolar | 14);
+    case InstrumentModSource::Volume:
+      return static_cast<SFModulator>(midiContinuousController | 7);
+    case InstrumentModSource::Pan:
+      return static_cast<SFModulator>(midiContinuousController | 10);
+    case InstrumentModSource::Expression:
+      return static_cast<SFModulator>(midiContinuousController | 11);
+    case InstrumentModSource::ReverbSend:
+      return static_cast<SFModulator>(midiContinuousController | 91);
+    case InstrumentModSource::ChorusSend:
+      return static_cast<SFModulator>(midiContinuousController | 93);
+  }
+  return 0;
 }
 
 SFGenerator sf2GeneratorForModDestination(InstrumentModDestination destination) {

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -66,8 +66,13 @@ int16_t sf2AmountForModulator(const InstrumentModulator& modulator) {
       modulator.amount, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
 }
 
+int16_t sf2AmountForGenerator(const InstrumentGenerator& generator) {
+  return static_cast<int16_t>(std::clamp<int32_t>(
+      generator.amount, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
+}
+
 bool hasInstrumentGlobalZone(const SynthInstr* instr) {
-  return !instr->modulators().empty();
+  return !instr->globalGenerators().empty() || !instr->modulators().empty();
 }
 
 } // namespace
@@ -300,6 +305,7 @@ SF2File::SF2File(SynthFile *synthfile)
       sfInstBag globalInstBag{};
       globalInstBag.wInstGenNdx = static_cast<uint16_t>(instGenCounter);
       globalInstBag.wInstModNdx = static_cast<uint16_t>(instModCounter);
+      instGenCounter += static_cast<int>(instr->globalGenerators().size());
       instModCounter += static_cast<int>(instr->modulators().size());
       memcpy(ibagCk->data + (instBagCounter++ * sizeof(sfInstBag)), &globalInstBag, sizeof(sfInstBag));
     }
@@ -356,6 +362,7 @@ SF2File::SF2File(SynthFile *synthfile)
   //***********
   u32 numTotalGens = 1;
   for (const auto instr : synthfile->vInstrs) {
+    numTotalGens += static_cast<uint32_t>(instr->globalGenerators().size());
     for (const auto rgn : instr->vRgns) {
       numTotalGens += numOfGeneratorsForRgn(rgn);
     }
@@ -367,6 +374,14 @@ SF2File::SF2File(SynthFile *synthfile)
   dataPtr = 0;
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
+
+    for (const auto& generator : instr->globalGenerators()) {
+      sfInstGenList instGenList{};
+      instGenList.sfGenOper = sf2GeneratorForModDestination(generator.destination);
+      instGenList.genAmount.shAmount = sf2AmountForGenerator(generator);
+      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      dataPtr += sizeof(sfInstGenList);
+    }
 
     size_t numRgns = instr->vRgns.size();
     for (size_t j = 0; j < numRgns; j++) {

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -16,48 +16,48 @@
 
 namespace {
 
-SFModulator sf2SourceForModSource(InstrumentModSource source) {
+SFModulator sf2SourceForModSource(ModSource source) {
   constexpr uint16_t midiContinuousController = 1u << 7;
   constexpr uint16_t bipolar = 1u << 9;
 
   switch (source) {
-    case InstrumentModSource::ModWheel:
+    case ModSource::ModWheel:
       return static_cast<SFModulator>(midiContinuousController | 1);
-    case InstrumentModSource::ChannelPressure:
+    case ModSource::ChannelPressure:
       return 13;
-    case InstrumentModSource::PolyPressure:
+    case ModSource::PolyPressure:
       return 10;
-    case InstrumentModSource::PitchWheel:
+    case ModSource::PitchWheel:
       return static_cast<SFModulator>(bipolar | 14);
-    case InstrumentModSource::Volume:
+    case ModSource::Volume:
       return static_cast<SFModulator>(midiContinuousController | 7);
-    case InstrumentModSource::Pan:
+    case ModSource::Pan:
       return static_cast<SFModulator>(midiContinuousController | 10);
-    case InstrumentModSource::Expression:
+    case ModSource::Expression:
       return static_cast<SFModulator>(midiContinuousController | 11);
-    case InstrumentModSource::ReverbSend:
+    case ModSource::ReverbSend:
       return static_cast<SFModulator>(midiContinuousController | 91);
-    case InstrumentModSource::ChorusSend:
+    case ModSource::ChorusSend:
       return static_cast<SFModulator>(midiContinuousController | 93);
   }
   return 0;
 }
 
-SFGenerator sf2GeneratorForModDestination(InstrumentModDestination destination) {
+SFGenerator sf2GeneratorForModDestination(ModDest destination) {
   switch (destination) {
-    case InstrumentModDestination::VibLfoToPitch:
+    case ModDest::VibLfoToPitch:
       return vibLfoToPitch;
-    case InstrumentModDestination::VibLfoFrequency:
+    case ModDest::VibLfoFreq:
       return freqVibLFO;
-    case InstrumentModDestination::VibLfoStartDelay:
+    case ModDest::VibLfoDelay:
       return delayVibLFO;
-    case InstrumentModDestination::ModLfoToVolume:
+    case ModDest::ModLfoToVol:
       return modLfoToVolume;
-    case InstrumentModDestination::ModLfoFrequency:
+    case ModDest::ModLfoFreq:
       return freqModLFO;
-    case InstrumentModDestination::ModLfoStartDelay:
+    case ModDest::ModLfoDelay:
       return delayModLFO;
-    case InstrumentModDestination::InitialAttenuation:
+    case ModDest::InitialAtten:
       return initialAttenuation;
   }
   return endOper;

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -63,12 +63,12 @@ SFGenerator sf2GeneratorForModDestination(ModDest destination) {
   return endOper;
 }
 
-int16_t sf2AmountForModulator(const SynthModulator& modulator) {
+int16_t sf2AmountForModulator(const Modulator& modulator) {
   return static_cast<int16_t>(std::clamp<int32_t>(
       modulator.amount, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
 }
 
-int16_t sf2AmountForGenerator(const SynthGenerator& generator) {
+int16_t sf2AmountForGenerator(const Generator& generator) {
   return static_cast<int16_t>(std::clamp<int32_t>(
       generator.amount, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
 }

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -63,12 +63,12 @@ SFGenerator sf2GeneratorForModDestination(ModDest destination) {
   return endOper;
 }
 
-int16_t sf2AmountForModulator(const Modulator& modulator) {
+int16_t sf2AmountForModulator(const SynthModulator& modulator) {
   return static_cast<int16_t>(std::clamp<int32_t>(
       modulator.amount, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
 }
 
-int16_t sf2AmountForGenerator(const Generator& generator) {
+int16_t sf2AmountForGenerator(const SynthGenerator& generator) {
   return static_cast<int16_t>(std::clamp<int32_t>(
       generator.amount, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
 }

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -3,7 +3,9 @@
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
  */
+#include <algorithm>
 #include <cmath>
+#include <limits>
 #include "SF2File.h"
 #include "version.h"
 #include "VGMInstrSet.h"
@@ -11,6 +13,38 @@
 #include "ScaleConversion.h"
 #include "Root.h"
 #include "VGMRgn.h"
+
+namespace {
+
+SFModulator sf2SourceForModSource(InstrumentModSource source) {
+  constexpr uint16_t midiContinuousController = 1u << 7;
+  return static_cast<SFModulator>(midiContinuousController | static_cast<uint8_t>(source));
+}
+
+SFGenerator sf2GeneratorForModDestination(InstrumentModDestination destination) {
+  switch (destination) {
+    case InstrumentModDestination::VibLfoToPitch:
+      return vibLfoToPitch;
+    case InstrumentModDestination::VibLfoFrequency:
+      return freqVibLFO;
+    case InstrumentModDestination::VibLfoStartDelay:
+      return delayVibLFO;
+    case InstrumentModDestination::ModLfoToVolume:
+      return modLfoToVolume;
+    case InstrumentModDestination::ModLfoFrequency:
+      return freqModLFO;
+    case InstrumentModDestination::ModLfoStartDelay:
+      return delayModLFO;
+  }
+  return endOper;
+}
+
+int16_t sf2AmountForModulator(const InstrumentModulator& modulator) {
+  return static_cast<int16_t>(std::clamp<int32_t>(
+      modulator.amount, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
+}
+
+} // namespace
 
 SF2InfoListChunk::SF2InfoListChunk(const std::string& name)
     : LISTChunk("INFO") {
@@ -224,6 +258,7 @@ SF2File::SF2File(SynthFile *synthfile)
 
   rgnCounter = 0;
   int instGenCounter = 0;
+  int instModCounter = 0;
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
 
@@ -232,7 +267,8 @@ SF2File::SF2File(SynthFile *synthfile)
       sfInstBag instBag{};
       instBag.wInstGenNdx = instGenCounter;
       instGenCounter += numOfGeneratorsForRgn(instr->vRgns[j]);
-      instBag.wInstModNdx = 0;
+      instBag.wInstModNdx = static_cast<uint16_t>(instModCounter);
+      instModCounter += static_cast<int>(instr->modulators().size());
 
       memcpy(ibagCk->data + (rgnCounter++ * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
     }
@@ -240,17 +276,38 @@ SF2File::SF2File(SynthFile *synthfile)
   //  add terminal sfInstBag
   sfInstBag instBag{};
   instBag.wInstGenNdx = instGenCounter;
-  instBag.wInstModNdx = 0;
+  instBag.wInstModNdx = static_cast<uint16_t>(instModCounter);
   memcpy(ibagCk->data + (rgnCounter * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
   pdtaCk->addChildChunk(ibagCk);
 
   //***********
   // imod chunk
   //***********
+  uint32_t numTotalMods = 1;
+  for (const auto instr : synthfile->vInstrs) {
+    numTotalMods += static_cast<uint32_t>(instr->modulators().size() * instr->vRgns.size());
+  }
+
   Chunk *imodCk = new Chunk("imod");
-  //  create the terminal field
-  memset(&modList, 0, sizeof(sfModList));
-  imodCk->setData(&modList, sizeof(sfModList));
+  imodCk->setSize(numTotalMods * sizeof(sfInstModList));
+  imodCk->data = new uint8_t[imodCk->size()];
+  dataPtr = 0;
+  for (const auto instr : synthfile->vInstrs) {
+    for (size_t j = 0; j < instr->vRgns.size(); j++) {
+      for (const auto& modulator : instr->modulators()) {
+        sfInstModList instModList{};
+        instModList.sfModSrcOper = sf2SourceForModSource(modulator.source);
+        instModList.sfModDestOper = sf2GeneratorForModDestination(modulator.destination);
+        instModList.modAmount = sf2AmountForModulator(modulator);
+        instModList.sfModAmtSrcOper = 0;
+        instModList.sfModTransOper = linear;
+        memcpy(imodCk->data + dataPtr, &instModList, sizeof(sfInstModList));
+        dataPtr += sizeof(sfInstModList);
+      }
+    }
+  }
+  sfInstModList instModList{};
+  memcpy(imodCk->data + dataPtr, &instModList, sizeof(sfInstModList));
   pdtaCk->addChildChunk(imodCk);
 
   //***********

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -57,6 +57,8 @@ SFGenerator sf2GeneratorForModDestination(InstrumentModDestination destination) 
       return freqModLFO;
     case InstrumentModDestination::ModLfoStartDelay:
       return delayModLFO;
+    case InstrumentModDestination::InitialAttenuation:
+      return initialAttenuation;
   }
   return endOper;
 }

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -44,6 +44,10 @@ int16_t sf2AmountForModulator(const InstrumentModulator& modulator) {
       modulator.amount, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
 }
 
+bool hasInstrumentGlobalZone(const SynthInstr* instr) {
+  return !instr->modulators().empty();
+}
+
 } // namespace
 
 SF2InfoListChunk::SF2InfoListChunk(const std::string& name)
@@ -227,20 +231,23 @@ SF2File::SF2File(SynthFile *synthfile)
   Chunk *instCk = new Chunk("inst");
   instCk->setSize(static_cast<uint32_t>((synthfile->vInstrs.size() + 1) * sizeof(sfInst)));
   instCk->data = new uint8_t[instCk->size()];
-  uint16_t rgnCounter = 0;
+  uint16_t instBagCounter = 0;
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
 
     sfInst inst{};
     memcpy(inst.achInstName, instr->name.c_str(), std::min(instr->name.length(), static_cast<size_t>(20)));
-    inst.wInstBagNdx = rgnCounter;
-    rgnCounter += instr->vRgns.size();
+    inst.wInstBagNdx = instBagCounter;
+    instBagCounter += static_cast<uint16_t>(instr->vRgns.size());
+    if (hasInstrumentGlobalZone(instr)) {
+      instBagCounter++;
+    }
 
     memcpy(instCk->data + (i * sizeof(sfInst)), &inst, sizeof(sfInst));
   }
   //  add terminal sfInst
   sfInst inst{};
-  inst.wInstBagNdx = rgnCounter;
+  inst.wInstBagNdx = instBagCounter;
   memcpy(instCk->data + (numInstrs * sizeof(sfInst)), &inst, sizeof(sfInst));
   pdtaCk->addChildChunk(instCk);
 
@@ -249,35 +256,47 @@ SF2File::SF2File(SynthFile *synthfile)
   //***********
   Chunk *ibagCk = new Chunk("ibag");
 
-  uint32_t numTotalRgns = 0;
-  for (size_t i = 0; i < numInstrs; i++)
-    numTotalRgns += synthfile->vInstrs[i]->vRgns.size();
+  uint32_t numTotalInstBags = 0;
+  for (size_t i = 0; i < numInstrs; i++) {
+    SynthInstr *instr = synthfile->vInstrs[i];
+    numTotalInstBags += static_cast<uint32_t>(instr->vRgns.size());
+    if (hasInstrumentGlobalZone(instr)) {
+      numTotalInstBags++;
+    }
+  }
 
-  ibagCk->setSize((numTotalRgns + 1) * sizeof(sfInstBag));
+  ibagCk->setSize((numTotalInstBags + 1) * sizeof(sfInstBag));
   ibagCk->data = new uint8_t[ibagCk->size()];
 
-  rgnCounter = 0;
+  instBagCounter = 0;
   int instGenCounter = 0;
   int instModCounter = 0;
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
 
+    if (hasInstrumentGlobalZone(instr)) {
+      sfInstBag globalInstBag{};
+      globalInstBag.wInstGenNdx = static_cast<uint16_t>(instGenCounter);
+      globalInstBag.wInstModNdx = static_cast<uint16_t>(instModCounter);
+      instModCounter += static_cast<int>(instr->modulators().size());
+      memcpy(ibagCk->data + (instBagCounter++ * sizeof(sfInstBag)), &globalInstBag, sizeof(sfInstBag));
+    }
+
     size_t numRgns = instr->vRgns.size();
     for (size_t j = 0; j < numRgns; j++) {
       sfInstBag instBag{};
-      instBag.wInstGenNdx = instGenCounter;
+      instBag.wInstGenNdx = static_cast<uint16_t>(instGenCounter);
       instGenCounter += numOfGeneratorsForRgn(instr->vRgns[j]);
       instBag.wInstModNdx = static_cast<uint16_t>(instModCounter);
-      instModCounter += static_cast<int>(instr->modulators().size());
 
-      memcpy(ibagCk->data + (rgnCounter++ * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
+      memcpy(ibagCk->data + (instBagCounter++ * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
     }
   }
   //  add terminal sfInstBag
   sfInstBag instBag{};
-  instBag.wInstGenNdx = instGenCounter;
+  instBag.wInstGenNdx = static_cast<uint16_t>(instGenCounter);
   instBag.wInstModNdx = static_cast<uint16_t>(instModCounter);
-  memcpy(ibagCk->data + (rgnCounter * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
+  memcpy(ibagCk->data + (instBagCounter * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
   pdtaCk->addChildChunk(ibagCk);
 
   //***********
@@ -285,7 +304,9 @@ SF2File::SF2File(SynthFile *synthfile)
   //***********
   uint32_t numTotalMods = 1;
   for (const auto instr : synthfile->vInstrs) {
-    numTotalMods += static_cast<uint32_t>(instr->modulators().size() * instr->vRgns.size());
+    if (hasInstrumentGlobalZone(instr)) {
+      numTotalMods += static_cast<uint32_t>(instr->modulators().size());
+    }
   }
 
   Chunk *imodCk = new Chunk("imod");
@@ -293,17 +314,15 @@ SF2File::SF2File(SynthFile *synthfile)
   imodCk->data = new uint8_t[imodCk->size()];
   dataPtr = 0;
   for (const auto instr : synthfile->vInstrs) {
-    for (size_t j = 0; j < instr->vRgns.size(); j++) {
-      for (const auto& modulator : instr->modulators()) {
-        sfInstModList instModList{};
-        instModList.sfModSrcOper = sf2SourceForModSource(modulator.source);
-        instModList.sfModDestOper = sf2GeneratorForModDestination(modulator.destination);
-        instModList.modAmount = sf2AmountForModulator(modulator);
-        instModList.sfModAmtSrcOper = 0;
-        instModList.sfModTransOper = linear;
-        memcpy(imodCk->data + dataPtr, &instModList, sizeof(sfInstModList));
-        dataPtr += sizeof(sfInstModList);
-      }
+    for (const auto& modulator : instr->modulators()) {
+      sfInstModList instModList{};
+      instModList.sfModSrcOper = sf2SourceForModSource(modulator.source);
+      instModList.sfModDestOper = sf2GeneratorForModDestination(modulator.destination);
+      instModList.modAmount = sf2AmountForModulator(modulator);
+      instModList.sfModAmtSrcOper = 0;
+      instModList.sfModTransOper = linear;
+      memcpy(imodCk->data + dataPtr, &instModList, sizeof(sfInstModList));
+      dataPtr += sizeof(sfInstModList);
     }
   }
   sfInstModList instModList{};

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -63,18 +63,18 @@ SFGenerator sf2GeneratorForModDestination(ModDest destination) {
   return endOper;
 }
 
-int16_t sf2AmountForModulator(const InstrumentModulator& modulator) {
+int16_t sf2AmountForModulator(const SynthModulator& modulator) {
   return static_cast<int16_t>(std::clamp<int32_t>(
       modulator.amount, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
 }
 
-int16_t sf2AmountForGenerator(const InstrumentGenerator& generator) {
+int16_t sf2AmountForGenerator(const SynthGenerator& generator) {
   return static_cast<int16_t>(std::clamp<int32_t>(
       generator.amount, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
 }
 
 bool hasInstrumentGlobalZone(const SynthInstr* instr) {
-  return !instr->globalGenerators().empty() || !instr->modulators().empty();
+  return !instr->generators().empty() || !instr->modulators().empty();
 }
 
 } // namespace
@@ -307,7 +307,7 @@ SF2File::SF2File(SynthFile *synthfile)
       sfInstBag globalInstBag{};
       globalInstBag.wInstGenNdx = static_cast<uint16_t>(instGenCounter);
       globalInstBag.wInstModNdx = static_cast<uint16_t>(instModCounter);
-      instGenCounter += static_cast<int>(instr->globalGenerators().size());
+      instGenCounter += static_cast<int>(instr->generators().size());
       instModCounter += static_cast<int>(instr->modulators().size());
       memcpy(ibagCk->data + (instBagCounter++ * sizeof(sfInstBag)), &globalInstBag, sizeof(sfInstBag));
     }
@@ -364,7 +364,7 @@ SF2File::SF2File(SynthFile *synthfile)
   //***********
   u32 numTotalGens = 1;
   for (const auto instr : synthfile->vInstrs) {
-    numTotalGens += static_cast<uint32_t>(instr->globalGenerators().size());
+    numTotalGens += static_cast<uint32_t>(instr->generators().size());
     for (const auto rgn : instr->vRgns) {
       numTotalGens += numOfGeneratorsForRgn(rgn);
     }
@@ -377,7 +377,7 @@ SF2File::SF2File(SynthFile *synthfile)
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
 
-    for (const auto& generator : instr->globalGenerators()) {
+    for (const auto& generator : instr->generators()) {
       sfInstGenList instGenList{};
       instGenList.sfGenOper = sf2GeneratorForModDestination(generator.destination);
       instGenList.genAmount.shAmount = sf2AmountForGenerator(generator);

--- a/src/main/conversion/SF2File.h
+++ b/src/main/conversion/SF2File.h
@@ -87,21 +87,7 @@ typedef enum: uint16_t {
   endOper                     //                                      60
 } SFGenerator;
 
-typedef enum: uint16_t {
-  /* Start of MIDI modulation operators */
-  cc1_Mod,
-  cc7_Vol,
-  cc10_Pan,
-  cc64_Sustain,
-  cc91_Reverb,
-  cc93_Chorus,
-
-  ccPitchBend,
-  ccIndirectModX,
-  ccIndirectModY,
-
-  endMod
-} SFModulator;
+using SFModulator = uint16_t;
 
 typedef enum: uint16_t {
   linear

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -103,12 +103,29 @@ void SynthInstr::addModulator(InstrumentModSource source, InstrumentModDestinati
   m_modulators.push_back({source, destination, amount});
 }
 
+void SynthInstr::addModulator(InstrumentModSource source, InstrumentModDestination destination,
+                              InstrumentParamAmount amount) {
+  if (!amount.valid()) {
+    return;
+  }
+
+  addModulator(source, destination, amount.value());
+}
+
 void SynthInstr::addGlobalGenerator(const InstrumentGenerator& generator) {
   m_globalGenerators.push_back(generator);
 }
 
 void SynthInstr::addGlobalGenerator(InstrumentModDestination destination, int32_t amount) {
   m_globalGenerators.push_back({destination, amount});
+}
+
+void SynthInstr::addGlobalGenerator(InstrumentModDestination destination, InstrumentParamAmount amount) {
+  if (!amount.valid()) {
+    return;
+  }
+
+  addGlobalGenerator(destination, amount.value());
 }
 
 //  ********

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -103,6 +103,14 @@ void SynthInstr::addModulator(InstrumentModSource source, InstrumentModDestinati
   m_modulators.push_back({source, destination, amount});
 }
 
+void SynthInstr::addGlobalGenerator(const InstrumentGenerator& generator) {
+  m_globalGenerators.push_back(generator);
+}
+
+void SynthInstr::addGlobalGenerator(InstrumentModDestination destination, int32_t amount) {
+  m_globalGenerators.push_back({destination, amount});
+}
+
 //  ********
 //  SynthRgn
 //  ********

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -104,7 +104,7 @@ void SynthInstr::addModulator(ModSource source, ModDest destination,
 }
 
 void SynthInstr::addModulator(ModSource source, ModDest destination,
-                              ParamAmount amount) {
+                              ModAmount amount) {
   if (!amount.valid()) {
     return;
   }
@@ -120,7 +120,7 @@ void SynthInstr::addGlobalGenerator(ModDest destination, int32_t amount) {
   m_globalGenerators.push_back({destination, amount});
 }
 
-void SynthInstr::addGlobalGenerator(ModDest destination, ParamAmount amount) {
+void SynthInstr::addGlobalGenerator(ModDest destination, ModAmount amount) {
   if (!amount.valid()) {
     return;
   }

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -116,16 +116,12 @@ void SynthInstr::addGlobalGenerator(const InstrumentGenerator& generator) {
   m_globalGenerators.push_back(generator);
 }
 
-void SynthInstr::addGlobalGenerator(ModDest destination, int32_t amount) {
-  m_globalGenerators.push_back({destination, amount});
-}
-
 void SynthInstr::addGlobalGenerator(ModDest destination, ModAmount amount) {
   if (!amount.valid()) {
     return;
   }
 
-  addGlobalGenerator(destination, amount.value());
+  m_globalGenerators.push_back({destination, amount.value()});
 }
 
 //  ********

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -94,7 +94,7 @@ SynthRgn *SynthInstr::addRgn(const SynthRgn& rgn) {
   return vRgns.back();
 }
 
-void SynthInstr::addModulator(const Modulator& modulator) {
+void SynthInstr::addModulator(const SynthModulator& modulator) {
   m_modulators.push_back(modulator);
 }
 
@@ -107,7 +107,7 @@ void SynthInstr::addModulator(ModSource source, ModDest destination,
   m_modulators.push_back({source, destination, amount.value()});
 }
 
-void SynthInstr::addGenerator(const Generator& generator) {
+void SynthInstr::addGenerator(const SynthGenerator& generator) {
   m_generators.push_back(generator);
 }
 

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -98,13 +98,13 @@ void SynthInstr::addModulator(const InstrumentModulator& modulator) {
   m_modulators.push_back(modulator);
 }
 
-void SynthInstr::addModulator(InstrumentModSource source, InstrumentModDestination destination,
+void SynthInstr::addModulator(ModSource source, ModDest destination,
                               int32_t amount) {
   m_modulators.push_back({source, destination, amount});
 }
 
-void SynthInstr::addModulator(InstrumentModSource source, InstrumentModDestination destination,
-                              InstrumentParamAmount amount) {
+void SynthInstr::addModulator(ModSource source, ModDest destination,
+                              ParamAmount amount) {
   if (!amount.valid()) {
     return;
   }
@@ -116,11 +116,11 @@ void SynthInstr::addGlobalGenerator(const InstrumentGenerator& generator) {
   m_globalGenerators.push_back(generator);
 }
 
-void SynthInstr::addGlobalGenerator(InstrumentModDestination destination, int32_t amount) {
+void SynthInstr::addGlobalGenerator(ModDest destination, int32_t amount) {
   m_globalGenerators.push_back({destination, amount});
 }
 
-void SynthInstr::addGlobalGenerator(InstrumentModDestination destination, InstrumentParamAmount amount) {
+void SynthInstr::addGlobalGenerator(ModDest destination, ParamAmount amount) {
   if (!amount.valid()) {
     return;
   }

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -99,17 +99,12 @@ void SynthInstr::addModulator(const InstrumentModulator& modulator) {
 }
 
 void SynthInstr::addModulator(ModSource source, ModDest destination,
-                              int32_t amount) {
-  m_modulators.push_back({source, destination, amount});
-}
-
-void SynthInstr::addModulator(ModSource source, ModDest destination,
                               ModAmount amount) {
   if (!amount.valid()) {
     return;
   }
 
-  addModulator(source, destination, amount.value());
+  m_modulators.push_back({source, destination, amount.value()});
 }
 
 void SynthInstr::addGlobalGenerator(const InstrumentGenerator& generator) {

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -94,6 +94,15 @@ SynthRgn *SynthInstr::addRgn(const SynthRgn& rgn) {
   return vRgns.back();
 }
 
+void SynthInstr::addModulator(const InstrumentModulator& modulator) {
+  m_modulators.push_back(modulator);
+}
+
+void SynthInstr::addModulator(InstrumentModSource source, InstrumentModDestination destination,
+                              int32_t amount) {
+  m_modulators.push_back({source, destination, amount});
+}
+
 //  ********
 //  SynthRgn
 //  ********

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -94,7 +94,7 @@ SynthRgn *SynthInstr::addRgn(const SynthRgn& rgn) {
   return vRgns.back();
 }
 
-void SynthInstr::addModulator(const InstrumentModulator& modulator) {
+void SynthInstr::addModulator(const SynthModulator& modulator) {
   m_modulators.push_back(modulator);
 }
 
@@ -107,16 +107,16 @@ void SynthInstr::addModulator(ModSource source, ModDest destination,
   m_modulators.push_back({source, destination, amount.value()});
 }
 
-void SynthInstr::addGlobalGenerator(const InstrumentGenerator& generator) {
-  m_globalGenerators.push_back(generator);
+void SynthInstr::addGenerator(const SynthGenerator& generator) {
+  m_generators.push_back(generator);
 }
 
-void SynthInstr::addGlobalGenerator(ModDest destination, ModAmount amount) {
+void SynthInstr::addGenerator(ModDest destination, ModAmount amount) {
   if (!amount.valid()) {
     return;
   }
 
-  m_globalGenerators.push_back({destination, amount.value()});
+  m_generators.push_back({destination, amount.value()});
 }
 
 //  ********

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -94,7 +94,7 @@ SynthRgn *SynthInstr::addRgn(const SynthRgn& rgn) {
   return vRgns.back();
 }
 
-void SynthInstr::addModulator(const SynthModulator& modulator) {
+void SynthInstr::addModulator(const Modulator& modulator) {
   m_modulators.push_back(modulator);
 }
 
@@ -107,7 +107,7 @@ void SynthInstr::addModulator(ModSource source, ModDest destination,
   m_modulators.push_back({source, destination, amount.value()});
 }
 
-void SynthInstr::addGenerator(const SynthGenerator& generator) {
+void SynthInstr::addGenerator(const Generator& generator) {
   m_generators.push_back(generator);
 }
 

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "InstrumentModulation.h"
 #include "RiffFile.h"
 #include <vector>
 
@@ -45,12 +46,19 @@ class SynthInstr {
   SynthRgn *addRgn();
   SynthRgn *addRgn(const SynthRgn& rgn);
 
+  void addModulator(const InstrumentModulator& modulator);
+  void addModulator(InstrumentModSource source, InstrumentModDestination destination, int32_t amount);
+  [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
+
   uint32_t ulBank;
   uint32_t ulInstrument;
   std::string name;
   float reverb;
 
   std::vector<SynthRgn *> vRgns;
+
+private:
+  std::vector<InstrumentModulator> m_modulators;
 };
 
 class SynthSampInfo {

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -48,11 +48,11 @@ class SynthInstr {
 
   void addModulator(const InstrumentModulator& modulator);
   void addModulator(ModSource source, ModDest destination, int32_t amount);
-  void addModulator(ModSource source, ModDest destination, ParamAmount amount);
+  void addModulator(ModSource source, ModDest destination, ModAmount amount);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
   void addGlobalGenerator(const InstrumentGenerator& generator);
   void addGlobalGenerator(ModDest destination, int32_t amount);
-  void addGlobalGenerator(ModDest destination, ParamAmount amount);
+  void addGlobalGenerator(ModDest destination, ModAmount amount);
   [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }
 
   uint32_t ulBank;

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "InstrumentModulation.h"
+#include "Modulation.h"
 #include "RiffFile.h"
 #include <vector>
 
@@ -46,12 +46,12 @@ class SynthInstr {
   SynthRgn *addRgn();
   SynthRgn *addRgn(const SynthRgn& rgn);
 
-  void addModulator(const SynthModulator& modulator);
+  void addModulator(const Modulator& modulator);
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
-  [[nodiscard]] const std::vector<SynthModulator>& modulators() const { return m_modulators; }
-  void addGenerator(const SynthGenerator& generator);
+  [[nodiscard]] const std::vector<Modulator>& modulators() const { return m_modulators; }
+  void addGenerator(const Generator& generator);
   void addGenerator(ModDest destination, ModAmount amount);
-  [[nodiscard]] const std::vector<SynthGenerator>& generators() const { return m_generators; }
+  [[nodiscard]] const std::vector<Generator>& generators() const { return m_generators; }
 
   uint32_t ulBank;
   uint32_t ulInstrument;
@@ -61,8 +61,8 @@ class SynthInstr {
   std::vector<SynthRgn *> vRgns;
 
 private:
-  std::vector<SynthModulator> m_modulators;
-  std::vector<SynthGenerator> m_generators;
+  std::vector<Modulator> m_modulators;
+  std::vector<Generator> m_generators;
 };
 
 class SynthSampInfo {

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -47,12 +47,12 @@ class SynthInstr {
   SynthRgn *addRgn(const SynthRgn& rgn);
 
   void addModulator(const InstrumentModulator& modulator);
-  void addModulator(InstrumentModSource source, InstrumentModDestination destination, int32_t amount);
-  void addModulator(InstrumentModSource source, InstrumentModDestination destination, InstrumentParamAmount amount);
+  void addModulator(ModSource source, ModDest destination, int32_t amount);
+  void addModulator(ModSource source, ModDest destination, ParamAmount amount);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
   void addGlobalGenerator(const InstrumentGenerator& generator);
-  void addGlobalGenerator(InstrumentModDestination destination, int32_t amount);
-  void addGlobalGenerator(InstrumentModDestination destination, InstrumentParamAmount amount);
+  void addGlobalGenerator(ModDest destination, int32_t amount);
+  void addGlobalGenerator(ModDest destination, ParamAmount amount);
   [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }
 
   uint32_t ulBank;

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -47,7 +47,6 @@ class SynthInstr {
   SynthRgn *addRgn(const SynthRgn& rgn);
 
   void addModulator(const InstrumentModulator& modulator);
-  void addModulator(ModSource source, ModDest destination, int32_t amount);
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
   void addGlobalGenerator(const InstrumentGenerator& generator);

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -46,12 +46,12 @@ class SynthInstr {
   SynthRgn *addRgn();
   SynthRgn *addRgn(const SynthRgn& rgn);
 
-  void addModulator(const InstrumentModulator& modulator);
+  void addModulator(const SynthModulator& modulator);
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
-  [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
-  void addGlobalGenerator(const InstrumentGenerator& generator);
-  void addGlobalGenerator(ModDest destination, ModAmount amount);
-  [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }
+  [[nodiscard]] const std::vector<SynthModulator>& modulators() const { return m_modulators; }
+  void addGenerator(const SynthGenerator& generator);
+  void addGenerator(ModDest destination, ModAmount amount);
+  [[nodiscard]] const std::vector<SynthGenerator>& generators() const { return m_generators; }
 
   uint32_t ulBank;
   uint32_t ulInstrument;
@@ -61,8 +61,8 @@ class SynthInstr {
   std::vector<SynthRgn *> vRgns;
 
 private:
-  std::vector<InstrumentModulator> m_modulators;
-  std::vector<InstrumentGenerator> m_globalGenerators;
+  std::vector<SynthModulator> m_modulators;
+  std::vector<SynthGenerator> m_generators;
 };
 
 class SynthSampInfo {

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -48,9 +48,11 @@ class SynthInstr {
 
   void addModulator(const InstrumentModulator& modulator);
   void addModulator(InstrumentModSource source, InstrumentModDestination destination, int32_t amount);
+  void addModulator(InstrumentModSource source, InstrumentModDestination destination, InstrumentParamAmount amount);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
   void addGlobalGenerator(const InstrumentGenerator& generator);
   void addGlobalGenerator(InstrumentModDestination destination, int32_t amount);
+  void addGlobalGenerator(InstrumentModDestination destination, InstrumentParamAmount amount);
   [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }
 
   uint32_t ulBank;

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -46,12 +46,12 @@ class SynthInstr {
   SynthRgn *addRgn();
   SynthRgn *addRgn(const SynthRgn& rgn);
 
-  void addModulator(const Modulator& modulator);
+  void addModulator(const SynthModulator& modulator);
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
-  [[nodiscard]] const std::vector<Modulator>& modulators() const { return m_modulators; }
-  void addGenerator(const Generator& generator);
+  [[nodiscard]] const std::vector<SynthModulator>& modulators() const { return m_modulators; }
+  void addGenerator(const SynthGenerator& generator);
   void addGenerator(ModDest destination, ModAmount amount);
-  [[nodiscard]] const std::vector<Generator>& generators() const { return m_generators; }
+  [[nodiscard]] const std::vector<SynthGenerator>& generators() const { return m_generators; }
 
   uint32_t ulBank;
   uint32_t ulInstrument;
@@ -61,8 +61,8 @@ class SynthInstr {
   std::vector<SynthRgn *> vRgns;
 
 private:
-  std::vector<Modulator> m_modulators;
-  std::vector<Generator> m_generators;
+  std::vector<SynthModulator> m_modulators;
+  std::vector<SynthGenerator> m_generators;
 };
 
 class SynthSampInfo {

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -49,6 +49,9 @@ class SynthInstr {
   void addModulator(const InstrumentModulator& modulator);
   void addModulator(InstrumentModSource source, InstrumentModDestination destination, int32_t amount);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
+  void addGlobalGenerator(const InstrumentGenerator& generator);
+  void addGlobalGenerator(InstrumentModDestination destination, int32_t amount);
+  [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }
 
   uint32_t ulBank;
   uint32_t ulInstrument;
@@ -59,6 +62,7 @@ class SynthInstr {
 
 private:
   std::vector<InstrumentModulator> m_modulators;
+  std::vector<InstrumentGenerator> m_globalGenerators;
 };
 
 class SynthSampInfo {

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -51,7 +51,6 @@ class SynthInstr {
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
   [[nodiscard]] const std::vector<InstrumentModulator>& modulators() const { return m_modulators; }
   void addGlobalGenerator(const InstrumentGenerator& generator);
-  void addGlobalGenerator(ModDest destination, int32_t amount);
   void addGlobalGenerator(ModDest destination, ModAmount amount);
   [[nodiscard]] const std::vector<InstrumentGenerator>& globalGenerators() const { return m_globalGenerators; }
 


### PR DESCRIPTION
This adds a light abstraction for adding modulators and generators to an instrument at a global level (in DLS parlance they're called "connection blocks"). I know you're already familiar with this, but as a reminder: 
- **_Generators_** allow us to assign fixed values for instrument parameters, like fine tune, vibrato settings, pan, etc. Our code already adds generators at the region level to define all of a region's properties. 
- **_Modulators_** allow us to assign a source input to modify a parameter - for example, assigning a specific controller to change the vibrato rate up to a specified amount. They support other forms of input too, like channel pressure events.

Incidentally, I've also added support for ChannelPressure events.

As we've discussed on the ADSR PR, the DLS2 spec for connection blocks is more constraining than SF2 modulators. It can only utilize a small subset of controllers as sources, and we can't assign a source to control certain properties like vibrato delay. We will have to choose how we handle these limitations going forward - I'm inclined toward a system that allows users to map modulators as they like, even if that means breaking DLS support.

For the time being, I've set up the system to conform to the constraints of DLS. This will change quickly when we need vibrato delay modulator support.

Hopefully this doesn't step too much on the toes of your relevant draft PRs.

## Changes

- Introduces shared instrument modulation types (`ModSource`, `ModDest`, `InstrumentModulator`, `InstrumentGenerator`, `ParamAmount`) so format code can describe modulation in musical units instead of raw SF2/DLS scalars.
- Extends `VGMInstr` and `SynthInstr` to store instrument-global generators and modulators, with helper APIs for pitch, frequency, delay, attenuation, plus standardized vibrato/tremolo helper methods.
- Updates SF2 export to create true instrument global zones and write instrument-level `imod` and `igen` entries, including the required bag/index bookkeeping when a global zone is present.
- Updates DLS export to emit instrument-level articulation connection blocks from the same data, adds `InitialAttenuation` support, and switches vibrato-related routing to the DLS2-specific vibrato source/destination constants.
- Also updates vibrato handling to use the Vibrato LFO instead of the Modulation LFO. This is semantically more correct and will allow independent modulation LFO changes, but breaks support for DLS1.
- Expands supported modulation sources beyond Mod Wheel to include Channel Pressure, Poly Pressure, Pitch Wheel, Volume, Pan, Expression, Reverb Send, and Chorus Send.
- Adds Channel Pressure as a first-class sequence/MIDI event from `SeqEvent`/`SeqTrack` through `MidiTrack`, including absolute-time insertion and MIDI serialization as channel pressure (`0xD0`) events.
- Adds the corresponding event/item enum plumbing so Channel Pressure can be represented in the event model.

One more thing: The `VGMInstr::addStandardVibratoHandling(...)` and `VGMInstr::addStandardTremoloHandling(...)` helper methods are intended to provide easy setup of what I anticipate to be a common modulator / generator pattern for vibrato and tremolo support. However, I've only added support for one format (CapcomSnes - PR forthcoming). As support for vibrato is added to more formats, I expect these methods may change or others may be added. The objective, as always, is to make implementing formats as simple and intuitive as possible.

## Motivation and Context
The goal is create a system for adding vibrato and tremolo support using the intended MIDI/SF2 abstractions rather than many pitch bend and volume/expression controller events. We may want to add an option down the road to alternatively use pitch bend and volume/expression for maximum compatibility (the CPS driver already does this), but I think this is the better default approach, and it's less complicated.

## How Has This Been Tested?
The only regression I could anticipate would be the DLS change to use Vibrato LFO. I don't have a good way to test that, and I'm fairly confident the change is safe.

As for testing the generator and modulator functionality: I've been doing this while implementing vibrato and tremolo support in the CapcomSnes driver.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
