### PR TITLE
Add vibrato and tremolo support to CapcomSnes using modulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added Drum Kit support to the standard N-SPC driver (Nintendo's SNES SDK driver).
 - Added Drum Kit support to the SuzukiSnes driver (Seiken Densetsu 3, Super Mario RPG, etc)
 - Added many improvements to the KonamiSnes driver.
+- Added vibrato and tremolo support to the CapcomSnes driver.
 - Improved support for late-era Intelligent Systems SNES/SFC titles (Tetris Attack, Fire Emblem 4, Super Famicom Wars) 
 
 ### Changed

--- a/src/main/components/instr/Modulation.cpp
+++ b/src/main/components/instr/Modulation.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Modulation.h"
+#include <algorithm>
 #include <cmath>
 #include "ScaleConversion.h"
 
@@ -48,6 +49,20 @@ ModAmount ModAmount::fromHertzRange(double minHertz, double maxHertz) {
   const double maxCents = static_cast<double>(hertzToInstrumentCents(maxHertz));
   const double fullScaleRange = (maxCents - minCents) * 128.0 / 127.0;
   return ModAmount(static_cast<int32_t>(std::lround(fullScaleRange)), true);
+}
+
+uint8_t midiValueForHertzInRange(double hertz, double minHertz, double maxHertz) {
+  const ModAmount minAmount = ModAmount::fromHertz(minHertz);
+  const ModAmount rangeAmount = ModAmount::fromHertzRange(minHertz, maxHertz);
+  const ModAmount currentAmount = ModAmount::fromHertz(hertz);
+
+  if (!minAmount.valid() || !rangeAmount.valid() || !currentAmount.valid() || rangeAmount.value() <= 0) {
+    return 0;
+  }
+
+  const int midiValue = static_cast<int>(std::round(
+      128.0 * (currentAmount.value() - minAmount.value()) / static_cast<double>(rangeAmount.value())));
+  return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
 }
 
 ModAmount ModAmount::fromSeconds(double seconds) {

--- a/src/main/components/instr/Modulation.h
+++ b/src/main/components/instr/Modulation.h
@@ -53,6 +53,10 @@ private:
   bool m_valid;
 };
 
+// Convert an absolute frequency into the 7-bit MIDI value that drives a
+// ParamAmount::hertzRange(minHertz, maxHertz) modulator or generator.
+uint8_t midiValueForHertzInRange(double hertz, double minHertz, double maxHertz);
+
 struct SynthModulator {
   ModSource source;
   ModDest destination;

--- a/src/main/formats/CapcomSnes/CapcomSnesDefinitions.h
+++ b/src/main/formats/CapcomSnes/CapcomSnesDefinitions.h
@@ -1,0 +1,18 @@
+/*
+ * VGMTrans (c) 2002-2025
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+#pragma once
+
+namespace capcom_snes {
+
+inline constexpr double kLfoStepHz = 1000.0 / 16384.0;
+inline constexpr double kVibratoBaseHz = kLfoStepHz;
+inline constexpr double kVibratoMaxHz = 255.0 * kLfoStepHz;
+inline constexpr double kTremoloBaseHz = 2.0 * kLfoStepHz;
+inline constexpr double kTremoloMaxHz = 510.0 * kLfoStepHz;
+inline constexpr int kTremoloHalfDepthCentibels = 484;
+inline constexpr double kTremoloHalfDepthDb = kTremoloHalfDepthCentibels / 10.0;
+
+}  // namespace capcom_snes

--- a/src/main/formats/CapcomSnes/CapcomSnesDefinitions.h
+++ b/src/main/formats/CapcomSnes/CapcomSnesDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * VGMTrans (c) 2002-2025
+ * VGMTrans (c) 2002-2026
  * Licensed under the zlib license,
  * refer to the included LICENSE.txt file
  */

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -8,6 +8,17 @@
 #include "SNESDSP.h"
 #include "CapcomSnesFormat.h"
 
+namespace {
+
+constexpr double kCapcomLfoStepHz = 1000.0 / 16384.0;
+constexpr double kCapcomVibratoBaseHz = kCapcomLfoStepHz;
+constexpr double kCapcomVibratoMaxHz = 255.0 * kCapcomLfoStepHz;
+constexpr double kCapcomTremoloBaseHz = 2.0 * kCapcomLfoStepHz;
+constexpr double kCapcomTremoloMaxHz = 510.0 * kCapcomLfoStepHz;
+constexpr double kCapcomTremoloHalfDepthCentibels = 484.0;
+
+}  // namespace
+
 // ****************
 // CapcomSnesInstrSet
 // ****************
@@ -100,30 +111,30 @@ bool CapcomSnesInstr::loadInstr() {
   }
 
   // Vibrato has a full +/- octave range of 1200 cents (max depth value evaluates to 127/128 of range, just like SF2)
-  // Vibrato frequency range is 0x00 -> 0.061 Hz to 0xFF -> 15.564 Hz.
-  // SF2 cents are calculated via 1200log2(f/8.176):
-  // 0.061 Hz   -> about -8480 cents
-  // 15.564 Hz  -> about +1114 cents
-  // Full range is abs(-8480) + 1114 = 9594, but we want 0x7F to hit the actual max, so 9594 * (128/127) = 9670 cents
-  // Thus, we set the global base frequency to 0.061 and create a unipolar channel pressure modulator with range 9670.
+  // Vibrato frequency is a unipolar sweep from one Capcom LFO step up to 255 steps, so we use the
+  // step frequency as the global base and let channel pressure span the full range in Hz.
 
   // add ModWheel to Vibrato Depth modulator
   addModWheelToVibratoPitch(1200);
   // nullify default ChannelPressure to vibrato pitch depth modulator
-  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoToPitch, 0);
-  // add global zone vibrato frequency generator for default frequency of 0.061 hz. Tremolo at 0.122
-  addGlobalVibratoFrequency(0.061);
-  addGlobalTremoloFrequency(0.122);
-  // add ChannelPressure to Vibrato Frequency modulator, covering up to 15.564 Hz relative to the 0.061 Hz default
-  // for Tremolo, the range is 0.122 to 31.128 Hz
-  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoFrequency, 9670);
-  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::ModLfoFrequency, 9670);
+  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoToPitch,
+               InstrumentParamAmount::cents(0));
+  // add global zone vibrato frequency generator for the default base rate. Tremolo runs at twice the base rate.
+  addGlobalGenerator(InstrumentModDestination::VibLfoFrequency, InstrumentParamAmount::hertz(kCapcomVibratoBaseHz));
+  addGlobalGenerator(InstrumentModDestination::ModLfoFrequency, InstrumentParamAmount::hertz(kCapcomTremoloBaseHz));
+  // add ChannelPressure to Vibrato/Tremolo Frequency modulators, each spanning the full Capcom Hz range.
+  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoFrequency,
+               InstrumentParamAmount::hertzRange(kCapcomVibratoBaseHz, kCapcomVibratoMaxHz));
+  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::ModLfoFrequency,
+               InstrumentParamAmount::hertzRange(kCapcomTremoloBaseHz, kCapcomTremoloMaxHz));
 
   // Tremolo in the CapcomSnes driver only applies an attenuation - it never boosts the volume. This is different
   // from SF2.
   // add CC93 to Tremolo Depth modulator
-  addModulator(InstrumentModSource::ChorusSend, InstrumentModDestination::ModLfoToVolume, 484);
-  addModulator(InstrumentModSource::ChorusSend, InstrumentModDestination::InitialAttenuation, 484);
+  addModulator(InstrumentModSource::ChorusSend, InstrumentModDestination::ModLfoToVolume,
+               InstrumentParamAmount::centibels(kCapcomTremoloHalfDepthCentibels));
+  addModulator(InstrumentModSource::ChorusSend, InstrumentModDestination::InitialAttenuation,
+               InstrumentParamAmount::centibels(kCapcomTremoloHalfDepthCentibels));
 
 
   uint16_t addrSampStart = readShort(offDirEnt);

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -87,8 +87,7 @@ CapcomSnesInstr::CapcomSnesInstr(VGMInstrSet *instrSet,
                                  uint32_t theInstrNum,
                                  uint32_t spcDirAddr,
                                  const std::string &name) :
-    VGMInstr(instrSet, offset, 6, theBank, theInstrNum, name),
-    spcDirAddr(spcDirAddr) {
+    VGMInstr(instrSet, offset, 6, theBank, theInstrNum, name), spcDirAddr(spcDirAddr) {
 }
 
 CapcomSnesInstr::~CapcomSnesInstr() {}
@@ -99,6 +98,18 @@ bool CapcomSnesInstr::loadInstr() {
   if (offDirEnt + 4 > 0x10000) {
     return false;
   }
+
+  // Vibrato has a full +/- octave range of 1200 cents (max depth value evaluates to 127/128 of range, just like SF2)
+  // Vibrato frequency range is 0x00 -> 0.061 Hz to 0xFF -> 15.564 Hz.
+  // SF2 cents are calculated via 1200log2(f/8.176):
+  // 0.061 Hz   -> about -8480 cents
+  // 15.564 Hz  -> about +1114 cents
+  // Full range is abs(-8480) + 1114 = 9594, but we want 0x7F to hit the actual max, so 9594 * (128/127) = 9670 cents
+  // Thus, we set the global base frequency to 0.061 and create a unipolar channel pressure modulator with range 9670.
+  addModWheelToVibratoPitch(1200);
+  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoToPitch, 0);
+  addGlobalVibratoFrequency(0.061);
+  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoFrequency, 9670);
 
   uint16_t addrSampStart = readShort(offDirEnt);
 
@@ -148,29 +159,33 @@ CapcomSnesRgn::CapcomSnesRgn(CapcomSnesInstr *instr, uint32_t offset) :
   uint8_t adsr1 = readByte(offset + 1);
   uint8_t adsr2 = readByte(offset + 2);
   uint8_t gain = readByte(offset + 3);
-  int16_t pitch_scale = getShortBE(offset + 4);
-
-  constexpr double pitch_fixer = 4286.0 / 4096.0;
-  double fine_tuning;
-  double coarse_tuning;
-  fine_tuning = modf((log(pitch_scale * pitch_fixer / 256.0) / log(2.0)) * 12.0, &coarse_tuning);
-
-  // normalize
-  if (fine_tuning >= 0.5) {
-    coarse_tuning += 1.0;
-    fine_tuning -= 1.0;
-  }
-  else if (fine_tuning <= -0.5) {
-    coarse_tuning -= 1.0;
-    fine_tuning += 1.0;
-  }
+  int16_t pitchScale = getShortBE(offset + 4);
 
   addSampNum(srcn, offset, 1);
   addChild(offset + 1, 1, "ADSR1");
   addChild(offset + 2, 1, "ADSR2");
   addChild(offset + 3, 1, "GAIN");
-  addUnityKey(96 - static_cast<int>(coarse_tuning), offset + 4, 1);
-  addFineTune(static_cast<int16_t>(fine_tuning * 100.0), offset + 5, 1);
+
+  constexpr int baseUnityKey = 96;
+  // MMX pitch-table C is 0x10BE, but the driver writes 0x10B0 for that neutral C after its low-nibble
+  // pitch quantization. That's a -5.66 cent difference. We'll opt for driver-accurate.
+  constexpr double referencePitch = 0x10B0 / 4096.0;
+
+  const double ratio = pitchScale != 0 ? (static_cast<double>(pitchScale) / 256.0) * referencePitch : 1.0;
+  const double semitones = 12.0 * std::log2(ratio);
+  int coarse = static_cast<int>(std::lround(semitones));
+  int fine = static_cast<int>(std::lround((semitones - coarse) * 100.0));
+
+  if (fine >= 50) {
+    ++coarse;
+    fine -= 100;
+  } else if (fine < -50) {
+    --coarse;
+    fine += 100;
+  }
+
+  addUnityKey(baseUnityKey - coarse, offset + 4, 1);
+  addFineTune(static_cast<int16_t>(fine), offset + 5, 1);
   snesConvADSR<VGMRgn>(this, adsr1, adsr2, gain);
 
   uint8_t sl = (adsr2 >> 5);

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -6,18 +6,8 @@
 #include "CapcomSnesInstr.h"
 #include <spdlog/fmt/fmt.h>
 #include "SNESDSP.h"
+#include "CapcomSnesDefinitions.h"
 #include "CapcomSnesFormat.h"
-
-namespace {
-
-constexpr double kCapcomLfoStepHz = 1000.0 / 16384.0;
-constexpr double kCapcomVibratoBaseHz = kCapcomLfoStepHz;
-constexpr double kCapcomVibratoMaxHz = 255.0 * kCapcomLfoStepHz;
-constexpr double kCapcomTremoloBaseHz = 2.0 * kCapcomLfoStepHz;
-constexpr double kCapcomTremoloMaxHz = 510.0 * kCapcomLfoStepHz;
-constexpr double kCapcomTremoloHalfDepthDb = 48.4;
-
-}  // namespace
 
 // ****************
 // CapcomSnesInstrSet
@@ -115,8 +105,11 @@ bool CapcomSnesInstr::loadInstr() {
   // step frequency as the global base and let channel pressure span the full range in Hz.
   // Tremolo runs at twice the base vibrato rate and only attenuates, never boosts.
 
-  addStandardVibratoHandling(1200, kCapcomVibratoBaseHz, kCapcomVibratoMaxHz);
-  addStandardTremoloHandling(kCapcomTremoloHalfDepthDb, kCapcomTremoloBaseHz, kCapcomTremoloMaxHz, true);
+  addStandardVibratoHandling(1200, capcom_snes::kVibratoBaseHz, capcom_snes::kVibratoMaxHz);
+  addStandardTremoloHandling(capcom_snes::kTremoloHalfDepthDb,
+                             capcom_snes::kTremoloBaseHz,
+                             capcom_snes::kTremoloMaxHz,
+                             true);
 
 
   uint16_t addrSampStart = readShort(offDirEnt);

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -113,22 +113,10 @@ bool CapcomSnesInstr::loadInstr() {
   // Vibrato has a full +/- octave range of 1200 cents (max depth value evaluates to 127/128 of range, just like SF2)
   // Vibrato frequency is a unipolar sweep from one Capcom LFO step up to 255 steps, so we use the
   // step frequency as the global base and let channel pressure span the full range in Hz.
+  // Tremolo runs at twice the base vibrato rate and only attenuates, never boosts.
 
-  // add ModWheel to Vibrato Depth modulator
-  addModWheelToVibratoPitch(1200);
-  // nullify default ChannelPressure to vibrato pitch depth modulator
-  addPitchModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, 0);
-  // add global zone vibrato frequency generator for the default base rate. Tremolo runs at twice the base rate.
-  addFrequencyGenerator(ModDest::VibLfoFreq, kCapcomVibratoBaseHz);
-  addFrequencyGenerator(ModDest::ModLfoFreq, kCapcomTremoloBaseHz);
-  addChannelPressureToVibratoRateModulator(kCapcomVibratoBaseHz, kCapcomVibratoMaxHz);
-  addChannelPressureToTremoloRateModulator(kCapcomTremoloBaseHz, kCapcomTremoloMaxHz);
-
-  // Tremolo in the CapcomSnes driver only applies an attenuation - it never boosts the volume. This is different
-  // from SF2.
-  // add CC93 to Tremolo Depth modulator
-  addAttenuationModulator(ModSource::ChorusSend, ModDest::ModLfoToVol, kCapcomTremoloHalfDepthDb);
-  addAttenuationModulator(ModSource::ChorusSend, ModDest::InitialAtten, kCapcomTremoloHalfDepthDb);
+  addStandardVibratoHandling(1200, kCapcomVibratoBaseHz, kCapcomVibratoMaxHz);
+  addStandardTremoloHandling(kCapcomTremoloHalfDepthDb, kCapcomTremoloBaseHz, kCapcomTremoloMaxHz, true);
 
 
   uint16_t addrSampStart = readShort(offDirEnt);

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -106,10 +106,25 @@ bool CapcomSnesInstr::loadInstr() {
   // 15.564 Hz  -> about +1114 cents
   // Full range is abs(-8480) + 1114 = 9594, but we want 0x7F to hit the actual max, so 9594 * (128/127) = 9670 cents
   // Thus, we set the global base frequency to 0.061 and create a unipolar channel pressure modulator with range 9670.
+
+  // add ModWheel to Vibrato Depth modulator
   addModWheelToVibratoPitch(1200);
+  // nullify default ChannelPressure to vibrato pitch depth modulator
   addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoToPitch, 0);
+  // add global zone vibrato frequency generator for default frequency of 0.061 hz. Tremolo at 0.122
   addGlobalVibratoFrequency(0.061);
+  addGlobalTremoloFrequency(0.122);
+  // add ChannelPressure to Vibrato Frequency modulator, covering up to 15.564 Hz relative to the 0.061 Hz default
+  // for Tremolo, the range is 0.122 to 31.128 Hz
   addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoFrequency, 9670);
+  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::ModLfoFrequency, 9670);
+
+  // Tremolo in the CapcomSnes driver only applies an attenuation - it never boosts the volume. This is different
+  // from SF2.
+  // add CC93 to Tremolo Depth modulator
+  addModulator(InstrumentModSource::ChorusSend, InstrumentModDestination::ModLfoToVolume, 484);
+  addModulator(InstrumentModSource::ChorusSend, InstrumentModDestination::InitialAttenuation, 484);
+
 
   uint16_t addrSampStart = readShort(offDirEnt);
 

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -111,7 +111,6 @@ bool CapcomSnesInstr::loadInstr() {
                              capcom_snes::kTremoloMaxHz,
                              true);
 
-
   uint16_t addrSampStart = readShort(offDirEnt);
 
   CapcomSnesRgn *rgn = new CapcomSnesRgn(this, offset());

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -15,7 +15,7 @@ constexpr double kCapcomVibratoBaseHz = kCapcomLfoStepHz;
 constexpr double kCapcomVibratoMaxHz = 255.0 * kCapcomLfoStepHz;
 constexpr double kCapcomTremoloBaseHz = 2.0 * kCapcomLfoStepHz;
 constexpr double kCapcomTremoloMaxHz = 510.0 * kCapcomLfoStepHz;
-constexpr double kCapcomTremoloHalfDepthCentibels = 484.0;
+constexpr double kCapcomTremoloHalfDepthDb = 48.4;
 
 }  // namespace
 
@@ -117,24 +117,18 @@ bool CapcomSnesInstr::loadInstr() {
   // add ModWheel to Vibrato Depth modulator
   addModWheelToVibratoPitch(1200);
   // nullify default ChannelPressure to vibrato pitch depth modulator
-  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoToPitch,
-               InstrumentParamAmount::cents(0));
+  addPitchModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, 0);
   // add global zone vibrato frequency generator for the default base rate. Tremolo runs at twice the base rate.
-  addGlobalGenerator(InstrumentModDestination::VibLfoFrequency, InstrumentParamAmount::hertz(kCapcomVibratoBaseHz));
-  addGlobalGenerator(InstrumentModDestination::ModLfoFrequency, InstrumentParamAmount::hertz(kCapcomTremoloBaseHz));
-  // add ChannelPressure to Vibrato/Tremolo Frequency modulators, each spanning the full Capcom Hz range.
-  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::VibLfoFrequency,
-               InstrumentParamAmount::hertzRange(kCapcomVibratoBaseHz, kCapcomVibratoMaxHz));
-  addModulator(InstrumentModSource::ChannelPressure, InstrumentModDestination::ModLfoFrequency,
-               InstrumentParamAmount::hertzRange(kCapcomTremoloBaseHz, kCapcomTremoloMaxHz));
+  addFrequencyGenerator(ModDest::VibLfoFreq, kCapcomVibratoBaseHz);
+  addFrequencyGenerator(ModDest::ModLfoFreq, kCapcomTremoloBaseHz);
+  addChannelPressureToVibratoRateModulator(kCapcomVibratoBaseHz, kCapcomVibratoMaxHz);
+  addChannelPressureToTremoloRateModulator(kCapcomTremoloBaseHz, kCapcomTremoloMaxHz);
 
   // Tremolo in the CapcomSnes driver only applies an attenuation - it never boosts the volume. This is different
   // from SF2.
   // add CC93 to Tremolo Depth modulator
-  addModulator(InstrumentModSource::ChorusSend, InstrumentModDestination::ModLfoToVolume,
-               InstrumentParamAmount::centibels(kCapcomTremoloHalfDepthCentibels));
-  addModulator(InstrumentModSource::ChorusSend, InstrumentModDestination::InitialAttenuation,
-               InstrumentParamAmount::centibels(kCapcomTremoloHalfDepthCentibels));
+  addAttenuationModulator(ModSource::ChorusSend, ModDest::ModLfoToVol, kCapcomTremoloHalfDepthDb);
+  addAttenuationModulator(ModSource::ChorusSend, ModDest::InitialAtten, kCapcomTremoloHalfDepthDb);
 
 
   uint16_t addrSampStart = readShort(offDirEnt);

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -109,7 +109,7 @@ bool CapcomSnesInstr::loadInstr() {
   addStandardTremoloHandling(capcom_snes::kTremoloHalfDepthDb,
                              capcom_snes::kTremoloBaseHz,
                              capcom_snes::kTremoloMaxHz,
-                             true);
+                             TremoloGainMode::NoBoost);
 
   uint16_t addrSampStart = readShort(offDirEnt);
 

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -176,7 +176,7 @@ CapcomSnesRgn::CapcomSnesRgn(CapcomSnesInstr *instr, uint32_t offset) :
 
   constexpr int baseUnityKey = 96;
   // MMX pitch-table C is 0x10BE, but the driver writes 0x10B0 for that neutral C after its low-nibble
-  // pitch quantization. That's a -5.66 cent difference. We'll opt for driver-accurate.
+  // pitch quantization. That's a -5.66 cent difference. Using 0x10BE would give pitches that are on avg more sharp.
   constexpr double referencePitch = 0x10B0 / 4096.0;
 
   const double ratio = pitchScale != 0 ? (static_cast<double>(pitchScale) / 256.0) * referencePitch : 1.0;

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -184,6 +184,14 @@ void CapcomSnesTrack::setLfoOutputsEnabled(bool enabled) {
   }
 }
 
+void CapcomSnesTrack::addVibratoDepthEvent(uint32_t offset, uint32_t length, uint8_t depth) {
+  bool isNewOffset = onEvent(offset, length);
+
+  // Add the event to the UI, but, but don't emit the MIDI event while the driver has the LFO disabled.
+  recordSeqEvent<ModulationSeqEvent>(isNewOffset, getTime(), depth, offset, length, "Vibrato Depth");
+  addModulationNoItem(areLfoOutputsEnabled() ? depth : 0);
+}
+
 void CapcomSnesTrack::handleLfoRateChange(uint8_t lfoRateByte) {
   // Rate 0 gates the active LFOs off without clearing the stored depths.
   if (lfoRateByte == 0 && lastLfoFrequency != 0) {
@@ -753,12 +761,12 @@ bool CapcomSnesTrack::readEvent() {
           case 0:
             // Vibrato Depth
             lastVibratoDepth = lfoAmount & 0x7F;
-            addModulation(beginOffset, curOffset - beginOffset, lastVibratoDepth, "Vibrato Depth");
+            addVibratoDepthEvent(beginOffset, curOffset - beginOffset, lastVibratoDepth);
             break;
           case 1:
             // Tremolo Depth
             lastTremoloDepth = convertTremoloDepthToMidiValue(lfoAmount, parentSeq->version);
-            addControllerEventNoItem(93, lastTremoloDepth);
+            addControllerEventNoItem(93, areLfoOutputsEnabled() ? lastTremoloDepth : 0);
             desc = fmt::format("Amount: {:d}", lfoAmount);
             addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth", desc, Type::Lfo);
             break;

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -731,7 +731,7 @@ bool CapcomSnesTrack::readEvent() {
           case 0:
             // Vibrato Depth
             lastVibratoDepth = lfoAmount & 0x7F;
-            addModulation(beginOffset, curOffset - beginOffset, lfoAmount, "Vibrato Depth");
+            addModulation(beginOffset, curOffset - beginOffset, lastVibratoDepth, "Vibrato Depth");
             break;
           case 1:
             // Tremolo Depth
@@ -742,12 +742,12 @@ bool CapcomSnesTrack::readEvent() {
             break;
           case 2:
             // LFO Rate
-            if (lfoAmount == 0 && lastLfoFrequency != 0) {// && lastVibratoDepth != 0) {
+            if (lfoAmount == 0 && lastLfoFrequency != 0) {
               if (lastVibratoDepth != 0)
                 addModulationNoItem(0);
               if (lastTremoloDepth != 0)
                 addControllerEventNoItem(93, 0);
-            } else if (lfoAmount != 0 && lastLfoFrequency == 0) { // && lastVibratoDepth != 0) {
+            } else if (lfoAmount != 0 && lastLfoFrequency == 0) {
               if (lastVibratoDepth != 0)
                 addModulationNoItem(lastVibratoDepth);
               if (lastTremoloDepth != 0)

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -236,6 +236,63 @@ void CapcomSnesTrack::setNoteSlurred(bool slurred) {
 double CapcomSnesTrack::getTuningInSemitones(int8_t tuning) {
   return tuning / 256.0;
 }
+static const int table[17] = {
+  0x00,0x0c,0x19,0x26,0x33,0x40,0x4c,0x59,
+  0x66,0x73,0x80,0x8c,0x99,0xb3,0xcc,0xe6,0xff
+};
+
+// 968 can produce a modLfoToVolume outside useful range, but is still a legal in-range value for SF2.
+#define TREMOLO_HALF_AMOUNT 484
+
+int tremolo_scalar_at_trough(int T) {
+  if (T <= 0) return 250;
+  if (T >= 127) return 0;
+
+  int I = 0x7E81 - T * 255;
+
+  if (I <= 0) return 0;
+
+  int J = I >> 3;
+  int n = J >> 8;
+  int frac = J & 0xFF;
+
+  if (n < 0) return 0;
+  if (n >= 16) return table[16];
+
+  return table[n] + ((table[n + 1] - table[n]) * frac) / 256;
+}
+
+int tremolo_T_to_cc92(int T) {
+  int s = tremolo_scalar_at_trough(T);
+
+  double depth_cb;
+
+  if (s <= 0) {
+    // SF2 practical mute floor.
+    depth_cb = 960.0;
+  } else {
+    // Source driver loudest scalar is approximately 250.
+    depth_cb = 200.0 * log10(250.0 / (double)s);
+
+    if (depth_cb < 0.0) depth_cb = 0.0;
+    if (depth_cb > 960.0) depth_cb = 960.0;
+  }
+
+  // Correct-depth-range mapping:
+  //   depth_cb ~= 2 * TREMOLO_HALF_AMOUNT * CC93 / 128
+  //
+  // Therefore:
+  //   CC93 ~= depth_cb * 128 / (2 * TREMOLO_HALF_AMOUNT)
+
+  int cc = (int)floor(
+    depth_cb * 128.0 / (2.0 * (double)TREMOLO_HALF_AMOUNT) + 0.5
+  );
+
+  if (cc < 0) cc = 0;
+  if (cc > 127) cc = 127;
+
+  return cc;
+}
 
 // Convert from Hz -> SF2 cents (linear to exponential) -> CC
 uint8_t sourceFreqByteToCc(uint8_t freqByte) {
@@ -672,6 +729,7 @@ bool CapcomSnesTrack::readEvent() {
             break;
           case 1:
             // Tremolo Depth
+            addControllerEventNoItem(93, tremolo_T_to_cc92(lfoAmount));
             desc = fmt::format("Amount: {:d}", lfoType, lfoAmount);
             addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth", desc, Type::Lfo);
             break;

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -166,6 +166,7 @@ void CapcomSnesTrack::resetVars() {
   lastNoteSlurred = false;
   lastKey = -1;
   lastVibratoDepth = 0;
+  lastTremoloDepth = 0;
   lastLfoFrequency = 0;
 
   for (uint8_t& i : repeatCount) {
@@ -263,19 +264,15 @@ uint8_t convertCapcomVolumeToMidi(uint8_t sourceVolume) {
 }
 
 int computeTremoloScalarAtTrough(int sourceDepth) {
-  if (sourceDepth <= 0) {
-    return kCapcomTremoloPeakScalar;
-  }
-  if (sourceDepth >= 127) {
+  sourceDepth = std::clamp(sourceDepth, 0, 127);
+
+  if (sourceDepth == 0)
+    return 250;
+  if (sourceDepth == 127)
     return 0;
-  }
 
   // Tremolo depth walks the same loudness curve as volume, but in reverse.
   const int inverseCurvePosition = 0x7E81 - sourceDepth * 255;
-  if (inverseCurvePosition <= 0) {
-    return 0;
-  }
-
   const int scaledCurvePosition = inverseCurvePosition >> 3;
   return interpolateCapcomVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
 }
@@ -722,21 +719,28 @@ bool CapcomSnesTrack::readEvent() {
         switch (lfoType) {
           case 0:
             // Vibrato Depth
-            lastVibratoDepth = lfoAmount;
+            lastVibratoDepth = lfoAmount & 0x7F;
             addModulation(beginOffset, curOffset - beginOffset, lfoAmount, "Vibrato Depth");
             break;
           case 1:
             // Tremolo Depth
-            addControllerEventNoItem(93, convertTremoloDepthToMidiValue(lfoAmount));
-            desc = fmt::format("Amount: {:d}", lfoType, lfoAmount);
+            lastTremoloDepth = convertTremoloDepthToMidiValue(lfoAmount);
+            addControllerEventNoItem(93, lastTremoloDepth);
+            desc = fmt::format("Amount: {:d}", lfoAmount);
             addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth", desc, Type::Lfo);
             break;
           case 2:
             // LFO Rate
-            if (lfoAmount == 0 && lastLfoFrequency != 0 && lastVibratoDepth != 0) {
-              addModulationNoItem(0);
-            } else if (lfoAmount != 0 && lastLfoFrequency == 0 && lastVibratoDepth != 0) {
-              addModulationNoItem(lastVibratoDepth);
+            if (lfoAmount == 0 && lastLfoFrequency != 0) {// && lastVibratoDepth != 0) {
+              if (lastVibratoDepth != 0)
+                addModulationNoItem(0);
+              if (lastTremoloDepth != 0)
+                addControllerEventNoItem(93, 0);
+            } else if (lfoAmount != 0 && lastLfoFrequency == 0) { // && lastVibratoDepth != 0) {
+              if (lastVibratoDepth != 0)
+                addModulationNoItem(lastVibratoDepth);
+              if (lastTremoloDepth != 0)
+                addControllerEventNoItem(93, lastTremoloDepth);
             }
             lastLfoFrequency = lfoAmount;
             addChannelPressure(beginOffset,

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -5,6 +5,7 @@
  */
 #include <sstream>
 #include "CapcomSnesSeq.h"
+#include "InstrumentModulation.h"
 #include "ScaleConversion.h"
 
 DECLARE_FORMAT(CapcomSnes);
@@ -299,14 +300,14 @@ uint8_t sourceFreqByteToCc(uint8_t freqByte) {
   if (freqByte == 0)
     return 0; // this is a special-case that disables vibrato
 
-  constexpr double sf2ZeroHz = 8.176;
   constexpr double sourceHzStep = 1000.0 / 16384.0;
-
-  constexpr double baseCents = -8479.0;
-  constexpr double modAmount = 9669.0;
+  constexpr double baseHz = sourceHzStep;
+  const double baseCents = static_cast<double>(InstrumentParamAmount::hertz(baseHz).value());
+  const double modAmount = static_cast<double>(
+      InstrumentParamAmount::hertzRange(baseHz, 255.0 * sourceHzStep).value());
 
   double hz = static_cast<double>(freqByte) * sourceHzStep;
-  double cents = 1200.0 * std::log2(hz / sf2ZeroHz);
+  double cents = static_cast<double>(InstrumentParamAmount::hertz(hz).value());
 
   int cc = static_cast<int>(std::round(128.0 * (cents - baseCents) / modAmount));
   return static_cast<uint8_t>(std::clamp(cc, 0, 127));

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include "CapcomSnesSeq.h"
 #include "CapcomSnesDefinitions.h"
-#include "InstrumentModulation.h"
+#include "Modulation.h"
 #include "ScaleConversion.h"
 
 DECLARE_FORMAT(CapcomSnes);

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -5,6 +5,7 @@
  */
 #include <sstream>
 #include "CapcomSnesSeq.h"
+#include "CapcomSnesDefinitions.h"
 #include "InstrumentModulation.h"
 #include "ScaleConversion.h"
 
@@ -174,6 +175,28 @@ void CapcomSnesTrack::resetVars() {
   }
 }
 
+void CapcomSnesTrack::setLfoOutputsEnabled(bool enabled) {
+  if (lastVibratoDepth != 0) {
+    addModulationNoItem(enabled ? lastVibratoDepth : 0);
+  }
+  if (lastTremoloDepth != 0) {
+    addControllerEventNoItem(93, enabled ? lastTremoloDepth : 0);
+  }
+}
+
+void CapcomSnesTrack::handleLfoRateChange(uint8_t lfoRateByte) {
+  // Rate 0 gates the active LFOs off without clearing the stored depths.
+  if (lfoRateByte == 0 && lastLfoFrequency != 0) {
+    setLfoOutputsEnabled(false);
+  }
+  else if (lfoRateByte != 0 && lastLfoFrequency == 0) {
+    // Reactivate vibrato and tremolo if appropriate
+    setLfoOutputsEnabled(true);
+  }
+
+  lastLfoFrequency = lfoRateByte;
+}
+
 
 uint8_t CapcomSnesTrack::getNoteOctave() const {
   return noteAttributes & CAPCOM_SNES_MASK_NOTE_OCTAVE;
@@ -244,7 +267,6 @@ constexpr int kVolumeCurveLastIndex = 16;
 constexpr int kTremoloPeakScalarV1 = 255;
 constexpr int kTremoloPeakScalarV2 = 250;
 constexpr double kTremoloMuteFloorCentibels = 960.0;
-constexpr int kTremoloHalfAmount = 484;
 
 int interpolateVolumeCurve(int curveIndex, int curveFraction) {
   if (curveIndex >= kVolumeCurveLastIndex) {
@@ -256,7 +278,7 @@ int interpolateVolumeCurve(int curveIndex, int curveFraction) {
   return lower + ((upper - lower) * curveFraction) / 256;
 }
 
-uint8_t calculateV2Volume(uint8_t sourceVolume) {
+uint8_t calculateCurveVolume(uint8_t sourceVolume) {
   const int scaledCurvePosition = sourceVolume * kVolumeCurveLastIndex;
   return interpolateVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
 }
@@ -270,7 +292,7 @@ int computeV1TremoloScalarAtTrough(int sourceDepth) {
   return 255 - ((2 * depth * 255) >> 8);
 }
 
-int computeV2TremoloScalarAtTrough(int sourceDepth) {
+int computeVolumeCurveTremoloScalarAtTrough(int sourceDepth) {
   sourceDepth = std::clamp(sourceDepth, 0, 127);
 
   if (sourceDepth == 0)
@@ -294,7 +316,7 @@ int convertTremoloDepthToMidiValue(int sourceDepth, CapcomSnesVersion version) {
   }
   else {
     peakScalar = kTremoloPeakScalarV2;
-    troughScalar = computeV2TremoloScalarAtTrough(sourceDepth);
+    troughScalar = computeVolumeCurveTremoloScalarAtTrough(sourceDepth);
   }
   double depthCentibels = kTremoloMuteFloorCentibels;
 
@@ -306,7 +328,9 @@ int convertTremoloDepthToMidiValue(int sourceDepth, CapcomSnesVersion version) {
   // SF2 tremolo depth is expressed as +/- modLfoToVolume around zero, so the
   // MIDI value needs to map into twice the stored half-range.
   const int midiValue = static_cast<int>(
-      floor(depthCentibels * 128.0 / (2.0 * static_cast<double>(kTremoloHalfAmount)) + 0.5));
+      floor(depthCentibels * 128.0 /
+            (2.0 * static_cast<double>(capcom_snes::kTremoloHalfDepthCentibels)) +
+            0.5));
   return std::clamp(midiValue, 0, 127);
 }
 
@@ -314,12 +338,11 @@ uint8_t convertLfoRateByteToMidiVal(uint8_t freqByte) {
   if (freqByte == 0)
     return 0; // this is a special-case that disables vibrato
 
-  // CapcomSnes stores rate as a multiple of a fixed LFO step; the shared helper
+  // The driver stores rate as a multiple of a fixed LFO step; the shared helper
   // handles the Hz -> 7-bit MIDI mapping that matches the instrument modulator.
-  constexpr double kCapcomLfoStepHz = 1000.0 / 16384.0;
-  return midiValueForHertzInRange(static_cast<double>(freqByte) * kCapcomLfoStepHz,
-                                  kCapcomLfoStepHz,
-                                  255.0 * kCapcomLfoStepHz);
+  return midiValueForHertzInRange(static_cast<double>(freqByte) * capcom_snes::kLfoStepHz,
+                                  capcom_snes::kVibratoBaseHz,
+                                  capcom_snes::kVibratoMaxHz);
 }
 
 }  // namespace
@@ -515,8 +538,8 @@ bool CapcomSnesTrack::readEvent() {
           midiVolume = newVolume >> 1;
         }
         else {
-          // Later drivers shape volume through the engine's 17-point loudness curve.
-          midiVolume = calculateV2Volume(newVolume);
+          // V2/V3 drivers shape volume through the engine's 17-point loudness curve.
+          midiVolume = calculateCurveVolume(newVolume);
         }
 
         addVol(beginOffset, curOffset - beginOffset, midiVolume);
@@ -717,7 +740,7 @@ bool CapcomSnesTrack::readEvent() {
         }
         else {
           // Master volume follows the same loudness curve as per-track volume.
-          midiVolume = calculateV2Volume(newVolume);
+          midiVolume = calculateCurveVolume(newVolume);
         }
 
         addMasterVol(beginOffset, curOffset - beginOffset, midiVolume);
@@ -742,25 +765,15 @@ bool CapcomSnesTrack::readEvent() {
             break;
           case 2:
             // LFO Rate
-            if (lfoAmount == 0 && lastLfoFrequency != 0) {
-              if (lastVibratoDepth != 0)
-                addModulationNoItem(0);
-              if (lastTremoloDepth != 0)
-                addControllerEventNoItem(93, 0);
-            } else if (lfoAmount != 0 && lastLfoFrequency == 0) {
-              if (lastVibratoDepth != 0)
-                addModulationNoItem(lastVibratoDepth);
-              if (lastTremoloDepth != 0)
-                addControllerEventNoItem(93, lastTremoloDepth);
-            }
-            lastLfoFrequency = lfoAmount;
+            handleLfoRateChange(lfoAmount);
             addChannelPressure(beginOffset,
                                curOffset - beginOffset,
                                convertLfoRateByteToMidiVal(lfoAmount),
                                "LFO Rate");
             break;
           case 3:
-            // Reset LFO phase on note on. argument 1 enables, 0 disables. On by default.
+            // Flag to reset LFO phase on note activation. 1 enables. 0 disables. V1: off by default, V2+: on by default
+            // SoundFont 2 and DLS always reset LFO phase when a note is activated. This cannot be changed.
             desc = fmt::format("Type: {:d}  Amount: {:d}", lfoType, lfoAmount);
             addGenericEvent(beginOffset, curOffset - beginOffset, "Reset LFO at Note On", desc, Type::Lfo);
             break;

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -237,66 +237,67 @@ void CapcomSnesTrack::setNoteSlurred(bool slurred) {
 double CapcomSnesTrack::getTuningInSemitones(int8_t tuning) {
   return tuning / 256.0;
 }
-static const int table[17] = {
-  0x00,0x0c,0x19,0x26,0x33,0x40,0x4c,0x59,
-  0x66,0x73,0x80,0x8c,0x99,0xb3,0xcc,0xe6,0xff
-};
+namespace {
 
-// 968 can produce a modLfoToVolume outside useful range, but is still a legal in-range value for SF2.
-#define TREMOLO_HALF_AMOUNT 484
+constexpr int kCapcomVolumeCurveLastIndex = 16;
+constexpr int kCapcomTremoloPeakScalar = 250;
+constexpr double kSf2TremoloMuteFloorCentibels = 960.0;
 
-int tremolo_scalar_at_trough(int T) {
-  if (T <= 0) return 250;
-  if (T >= 127) return 0;
+// 968 can produce a modLfoToVolume outside the practical range, but it is still
+// a legal SF2 value, so keep the conversion centered on half that amount.
+constexpr int kSf2TremoloHalfAmount = 484;
 
-  int I = 0x7E81 - T * 255;
-
-  if (I <= 0) return 0;
-
-  int J = I >> 3;
-  int n = J >> 8;
-  int frac = J & 0xFF;
-
-  if (n < 0) return 0;
-  if (n >= 16) return table[16];
-
-  return table[n] + ((table[n + 1] - table[n]) * frac) / 256;
-}
-
-int tremolo_T_to_cc92(int T) {
-  int s = tremolo_scalar_at_trough(T);
-
-  double depth_cb;
-
-  if (s <= 0) {
-    // SF2 practical mute floor.
-    depth_cb = 960.0;
-  } else {
-    // Source driver loudest scalar is approximately 250.
-    depth_cb = 200.0 * log10(250.0 / (double)s);
-
-    if (depth_cb < 0.0) depth_cb = 0.0;
-    if (depth_cb > 960.0) depth_cb = 960.0;
+int interpolateCapcomVolumeCurve(int curveIndex, int curveFraction) {
+  if (curveIndex >= kCapcomVolumeCurveLastIndex) {
+    return CapcomSnesSeq::volTable[kCapcomVolumeCurveLastIndex];
   }
 
-  // Correct-depth-range mapping:
-  //   depth_cb ~= 2 * TREMOLO_HALF_AMOUNT * CC93 / 128
-  //
-  // Therefore:
-  //   CC93 ~= depth_cb * 128 / (2 * TREMOLO_HALF_AMOUNT)
-
-  int cc = (int)floor(
-    depth_cb * 128.0 / (2.0 * (double)TREMOLO_HALF_AMOUNT) + 0.5
-  );
-
-  if (cc < 0) cc = 0;
-  if (cc > 127) cc = 127;
-
-  return cc;
+  const int lower = CapcomSnesSeq::volTable[curveIndex];
+  const int upper = CapcomSnesSeq::volTable[curveIndex + 1];
+  return lower + ((upper - lower) * curveFraction) / 256;
 }
 
-// Convert from Hz -> SF2 cents (linear to exponential) -> CC
-uint8_t sourceFreqByteToCc(uint8_t freqByte) {
+uint8_t convertCapcomVolumeToMidi(uint8_t sourceVolume) {
+  const int scaledCurvePosition = sourceVolume * kCapcomVolumeCurveLastIndex;
+  return interpolateCapcomVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
+}
+
+int computeTremoloScalarAtTrough(int sourceDepth) {
+  if (sourceDepth <= 0) {
+    return kCapcomTremoloPeakScalar;
+  }
+  if (sourceDepth >= 127) {
+    return 0;
+  }
+
+  // Tremolo depth walks the same loudness curve as volume, but in reverse.
+  const int inverseCurvePosition = 0x7E81 - sourceDepth * 255;
+  if (inverseCurvePosition <= 0) {
+    return 0;
+  }
+
+  const int scaledCurvePosition = inverseCurvePosition >> 3;
+  return interpolateCapcomVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
+}
+
+int convertTremoloDepthToMidiValue(int sourceDepth) {
+  const int troughScalar = computeTremoloScalarAtTrough(sourceDepth);
+  double depthCentibels = kSf2TremoloMuteFloorCentibels;
+
+  if (troughScalar > 0) {
+    depthCentibels = 200.0 * log10(kCapcomTremoloPeakScalar / static_cast<double>(troughScalar));
+    depthCentibels = std::clamp(depthCentibels, 0.0, kSf2TremoloMuteFloorCentibels);
+  }
+
+  // SF2 tremolo depth is expressed as +/- modLfoToVolume around zero, so the
+  // MIDI value needs to map into twice the stored half-range.
+  const int midiValue = static_cast<int>(
+      floor(depthCentibels * 128.0 / (2.0 * static_cast<double>(kSf2TremoloHalfAmount)) + 0.5));
+  return std::clamp(midiValue, 0, 127);
+}
+
+// Convert from Hz -> SF2 cents (linear to exponential) -> channel pressure.
+uint8_t convertLfoRateByteToChannelPressure(uint8_t freqByte) {
   if (freqByte == 0)
     return 0; // this is a special-case that disables vibrato
 
@@ -312,6 +313,8 @@ uint8_t sourceFreqByteToCc(uint8_t freqByte) {
   int cc = static_cast<int>(std::round(128.0 * (cents - baseCents) / modAmount));
   return static_cast<uint8_t>(std::clamp(cc, 0, 127));
 }
+
+}  // namespace
 
 bool CapcomSnesTrack::readEvent() {
   CapcomSnesSeq *parentSeq = static_cast<CapcomSnesSeq*>(this->parentSeq);
@@ -504,11 +507,8 @@ bool CapcomSnesTrack::readEvent() {
           midiVolume = newVolume >> 1;
         }
         else {
-          // use volume table (with linear interpolation)
-          uint8_t volIndex = (newVolume * 16) >> 8;
-          uint8_t volRate = (newVolume * 16) & 0xff;
-          midiVolume = CapcomSnesSeq::volTable[volIndex]
-              + ((CapcomSnesSeq::volTable[volIndex + 1] - CapcomSnesSeq::volTable[volIndex]) * volRate / 256);
+          // Later drivers shape volume through the engine's 17-point loudness curve.
+          midiVolume = convertCapcomVolumeToMidi(newVolume);
         }
 
         addVol(beginOffset, curOffset - beginOffset, midiVolume);
@@ -708,11 +708,8 @@ bool CapcomSnesTrack::readEvent() {
           midiVolume = newVolume >> 1;
         }
         else {
-          // use volume table (with linear interpolation)
-          uint8_t volIndex = (newVolume * 16) >> 8;
-          uint8_t volRate = (newVolume * 16) & 0xff;
-          midiVolume = CapcomSnesSeq::volTable[volIndex]
-              + ((CapcomSnesSeq::volTable[volIndex + 1] - CapcomSnesSeq::volTable[volIndex]) * volRate / 256);
+          // Master volume follows the same loudness curve as per-track volume.
+          midiVolume = convertCapcomVolumeToMidi(newVolume);
         }
 
         addMasterVol(beginOffset, curOffset - beginOffset, midiVolume);
@@ -730,7 +727,7 @@ bool CapcomSnesTrack::readEvent() {
             break;
           case 1:
             // Tremolo Depth
-            addControllerEventNoItem(93, tremolo_T_to_cc92(lfoAmount));
+            addControllerEventNoItem(93, convertTremoloDepthToMidiValue(lfoAmount));
             desc = fmt::format("Amount: {:d}", lfoType, lfoAmount);
             addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth", desc, Type::Lfo);
             break;
@@ -742,7 +739,10 @@ bool CapcomSnesTrack::readEvent() {
               addModulationNoItem(lastVibratoDepth);
             }
             lastLfoFrequency = lfoAmount;
-            addChannelPressure(beginOffset, curOffset - beginOffset, sourceFreqByteToCc(lfoAmount), "LFO Rate");
+            addChannelPressure(beginOffset,
+                               curOffset - beginOffset,
+                               convertLfoRateByteToChannelPressure(lfoAmount),
+                               "LFO Rate");
             break;
           case 3:
             // Reset LFO phase on note on. argument 1 enables, 0 disables. On by default.

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -241,7 +241,8 @@ double CapcomSnesTrack::getTuningInSemitones(int8_t tuning) {
 namespace {
 
 constexpr int kCapcomVolumeCurveLastIndex = 16;
-constexpr int kCapcomTremoloPeakScalar = 250;
+constexpr int kCapcomV1TremoloPeakScalar = 255;
+constexpr int kCapcomV2TremoloPeakScalar = 250;
 constexpr double kSf2TremoloMuteFloorCentibels = 960.0;
 
 // 968 can produce a modLfoToVolume outside the practical range, but it is still
@@ -263,7 +264,16 @@ uint8_t convertCapcomVolumeToMidi(uint8_t sourceVolume) {
   return interpolateCapcomVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
 }
 
-int computeTremoloScalarAtTrough(int sourceDepth) {
+int computeV1TremoloScalarAtTrough(int sourceDepth) {
+  const int depth = sourceDepth & 0x7f;
+
+  if (depth == 0)
+    return 255;
+
+  return 255 - ((2 * depth * 255) >> 8);
+}
+
+int computeV2TremoloScalarAtTrough(int sourceDepth) {
   sourceDepth = std::clamp(sourceDepth, 0, 127);
 
   if (sourceDepth == 0)
@@ -277,12 +287,22 @@ int computeTremoloScalarAtTrough(int sourceDepth) {
   return interpolateCapcomVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
 }
 
-int convertTremoloDepthToMidiValue(int sourceDepth) {
-  const int troughScalar = computeTremoloScalarAtTrough(sourceDepth);
+int convertTremoloDepthToMidiValue(int sourceDepth, CapcomSnesVersion version) {
+  int peakScalar;
+  int troughScalar;
+
+  if (version == CAPCOMSNES_V1_BGM_IN_LIST) {
+    peakScalar = kCapcomV1TremoloPeakScalar;
+    troughScalar = computeV1TremoloScalarAtTrough(sourceDepth);
+  }
+  else {
+    peakScalar = kCapcomV2TremoloPeakScalar;
+    troughScalar = computeV2TremoloScalarAtTrough(sourceDepth);
+  }
   double depthCentibels = kSf2TremoloMuteFloorCentibels;
 
   if (troughScalar > 0) {
-    depthCentibels = 200.0 * log10(kCapcomTremoloPeakScalar / static_cast<double>(troughScalar));
+    depthCentibels = 200.0 * log10(peakScalar / static_cast<double>(troughScalar));
     depthCentibels = std::clamp(depthCentibels, 0.0, kSf2TremoloMuteFloorCentibels);
   }
 
@@ -724,7 +744,7 @@ bool CapcomSnesTrack::readEvent() {
             break;
           case 1:
             // Tremolo Depth
-            lastTremoloDepth = convertTremoloDepthToMidiValue(lfoAmount);
+            lastTremoloDepth = convertTremoloDepthToMidiValue(lfoAmount, parentSeq->version);
             addControllerEventNoItem(93, lastTremoloDepth);
             desc = fmt::format("Amount: {:d}", lfoAmount);
             addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth", desc, Type::Lfo);

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -278,12 +278,13 @@ int interpolateVolumeCurve(int curveIndex, int curveFraction) {
   return lower + ((upper - lower) * curveFraction) / 256;
 }
 
-uint8_t calculateCurveVolume(uint8_t sourceVolume) {
+uint8_t calculateVolumeV2(uint8_t sourceVolume) {
+  // Unlike V1, this uses a volume curve table
   const int scaledCurvePosition = sourceVolume * kVolumeCurveLastIndex;
   return interpolateVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
 }
 
-int computeV1TremoloScalarAtTrough(int sourceDepth) {
+int calculateTremoloScalarAtTroughV1(int sourceDepth) {
   const int depth = sourceDepth & 0x7f;
 
   if (depth == 0)
@@ -292,7 +293,8 @@ int computeV1TremoloScalarAtTrough(int sourceDepth) {
   return 255 - ((2 * depth * 255) >> 8);
 }
 
-int computeVolumeCurveTremoloScalarAtTrough(int sourceDepth) {
+int calculateTremoloScalarAtTroughV2(int sourceDepth) {
+  // The V2 handler uses the volume curve table
   sourceDepth = std::clamp(sourceDepth, 0, 127);
 
   if (sourceDepth == 0)
@@ -312,11 +314,11 @@ int convertTremoloDepthToMidiValue(int sourceDepth, CapcomSnesVersion version) {
 
   if (version == CAPCOMSNES_V1_BGM_IN_LIST) {
     peakScalar = kTremoloPeakScalarV1;
-    troughScalar = computeV1TremoloScalarAtTrough(sourceDepth);
+    troughScalar = calculateTremoloScalarAtTroughV1(sourceDepth);
   }
   else {
     peakScalar = kTremoloPeakScalarV2;
-    troughScalar = computeVolumeCurveTremoloScalarAtTrough(sourceDepth);
+    troughScalar = calculateTremoloScalarAtTroughV2(sourceDepth);
   }
   double depthCentibels = kTremoloMuteFloorCentibels;
 
@@ -325,12 +327,9 @@ int convertTremoloDepthToMidiValue(int sourceDepth, CapcomSnesVersion version) {
     depthCentibels = std::clamp(depthCentibels, 0.0, kTremoloMuteFloorCentibels);
   }
 
-  // SF2 tremolo depth is expressed as +/- modLfoToVolume around zero, so the
-  // MIDI value needs to map into twice the stored half-range.
+  // SF2 tremolo depth is expressed as +/- modLfoToVolume, so the MIDI value must map to the full range, not just half.
   const int midiValue = static_cast<int>(
-      floor(depthCentibels * 128.0 /
-            (2.0 * static_cast<double>(capcom_snes::kTremoloHalfDepthCentibels)) +
-            0.5));
+      floor(depthCentibels * 128.0 / (2.0 * static_cast<double>(capcom_snes::kTremoloHalfDepthCentibels)) + 0.5));
   return std::clamp(midiValue, 0, 127);
 }
 
@@ -539,7 +538,7 @@ bool CapcomSnesTrack::readEvent() {
         }
         else {
           // V2/V3 drivers shape volume through the engine's 17-point loudness curve.
-          midiVolume = calculateCurveVolume(newVolume);
+          midiVolume = calculateVolumeV2(newVolume);
         }
 
         addVol(beginOffset, curOffset - beginOffset, midiVolume);
@@ -740,7 +739,7 @@ bool CapcomSnesTrack::readEvent() {
         }
         else {
           // Master volume follows the same loudness curve as per-track volume.
-          midiVolume = calculateCurveVolume(newVolume);
+          midiVolume = calculateVolumeV2(newVolume);
         }
 
         addMasterVol(beginOffset, curOffset - beginOffset, midiVolume);

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -240,18 +240,15 @@ double CapcomSnesTrack::getTuningInSemitones(int8_t tuning) {
 }
 namespace {
 
-constexpr int kCapcomVolumeCurveLastIndex = 16;
-constexpr int kCapcomV1TremoloPeakScalar = 255;
-constexpr int kCapcomV2TremoloPeakScalar = 250;
-constexpr double kSf2TremoloMuteFloorCentibels = 960.0;
+constexpr int kVolumeCurveLastIndex = 16;
+constexpr int kTremoloPeakScalarV1 = 255;
+constexpr int kTremoloPeakScalarV2 = 250;
+constexpr double kTremoloMuteFloorCentibels = 960.0;
+constexpr int kTremoloHalfAmount = 484;
 
-// 968 can produce a modLfoToVolume outside the practical range, but it is still
-// a legal SF2 value, so keep the conversion centered on half that amount.
-constexpr int kSf2TremoloHalfAmount = 484;
-
-int interpolateCapcomVolumeCurve(int curveIndex, int curveFraction) {
-  if (curveIndex >= kCapcomVolumeCurveLastIndex) {
-    return CapcomSnesSeq::volTable[kCapcomVolumeCurveLastIndex];
+int interpolateVolumeCurve(int curveIndex, int curveFraction) {
+  if (curveIndex >= kVolumeCurveLastIndex) {
+    return CapcomSnesSeq::volTable[kVolumeCurveLastIndex];
   }
 
   const int lower = CapcomSnesSeq::volTable[curveIndex];
@@ -259,9 +256,9 @@ int interpolateCapcomVolumeCurve(int curveIndex, int curveFraction) {
   return lower + ((upper - lower) * curveFraction) / 256;
 }
 
-uint8_t convertCapcomVolumeToMidi(uint8_t sourceVolume) {
-  const int scaledCurvePosition = sourceVolume * kCapcomVolumeCurveLastIndex;
-  return interpolateCapcomVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
+uint8_t calculateV2Volume(uint8_t sourceVolume) {
+  const int scaledCurvePosition = sourceVolume * kVolumeCurveLastIndex;
+  return interpolateVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
 }
 
 int computeV1TremoloScalarAtTrough(int sourceDepth) {
@@ -284,7 +281,7 @@ int computeV2TremoloScalarAtTrough(int sourceDepth) {
   // Tremolo depth walks the same loudness curve as volume, but in reverse.
   const int inverseCurvePosition = 0x7E81 - sourceDepth * 255;
   const int scaledCurvePosition = inverseCurvePosition >> 3;
-  return interpolateCapcomVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
+  return interpolateVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
 }
 
 int convertTremoloDepthToMidiValue(int sourceDepth, CapcomSnesVersion version) {
@@ -292,40 +289,39 @@ int convertTremoloDepthToMidiValue(int sourceDepth, CapcomSnesVersion version) {
   int troughScalar;
 
   if (version == CAPCOMSNES_V1_BGM_IN_LIST) {
-    peakScalar = kCapcomV1TremoloPeakScalar;
+    peakScalar = kTremoloPeakScalarV1;
     troughScalar = computeV1TremoloScalarAtTrough(sourceDepth);
   }
   else {
-    peakScalar = kCapcomV2TremoloPeakScalar;
+    peakScalar = kTremoloPeakScalarV2;
     troughScalar = computeV2TremoloScalarAtTrough(sourceDepth);
   }
-  double depthCentibels = kSf2TremoloMuteFloorCentibels;
+  double depthCentibels = kTremoloMuteFloorCentibels;
 
   if (troughScalar > 0) {
     depthCentibels = 200.0 * log10(peakScalar / static_cast<double>(troughScalar));
-    depthCentibels = std::clamp(depthCentibels, 0.0, kSf2TremoloMuteFloorCentibels);
+    depthCentibels = std::clamp(depthCentibels, 0.0, kTremoloMuteFloorCentibels);
   }
 
   // SF2 tremolo depth is expressed as +/- modLfoToVolume around zero, so the
   // MIDI value needs to map into twice the stored half-range.
   const int midiValue = static_cast<int>(
-      floor(depthCentibels * 128.0 / (2.0 * static_cast<double>(kSf2TremoloHalfAmount)) + 0.5));
+      floor(depthCentibels * 128.0 / (2.0 * static_cast<double>(kTremoloHalfAmount)) + 0.5));
   return std::clamp(midiValue, 0, 127);
 }
 
-// Convert from Hz -> SF2 cents (linear to exponential) -> channel pressure.
-uint8_t convertLfoRateByteToChannelPressure(uint8_t freqByte) {
+// Convert from Hz -> SF2 cents (linear to exponential) -> 7-bit MIDI value scaled to the modulator amount
+uint8_t convertLfoRateByteToMidiVal(uint8_t freqByte) {
   if (freqByte == 0)
     return 0; // this is a special-case that disables vibrato
 
   constexpr double sourceHzStep = 1000.0 / 16384.0;
   constexpr double baseHz = sourceHzStep;
-  const double baseCents = static_cast<double>(ParamAmount::hertz(baseHz).value());
-  const double modAmount = static_cast<double>(
-      ParamAmount::hertzRange(baseHz, 255.0 * sourceHzStep).value());
+  const double baseCents = ParamAmount::hertz(baseHz).value();
+  const double modAmount = ParamAmount::hertzRange(baseHz, 255.0 * sourceHzStep).value();
 
   double hz = static_cast<double>(freqByte) * sourceHzStep;
-  double cents = static_cast<double>(ParamAmount::hertz(hz).value());
+  double cents = ParamAmount::hertz(hz).value();
 
   int cc = static_cast<int>(std::round(128.0 * (cents - baseCents) / modAmount));
   return static_cast<uint8_t>(std::clamp(cc, 0, 127));
@@ -525,7 +521,7 @@ bool CapcomSnesTrack::readEvent() {
         }
         else {
           // Later drivers shape volume through the engine's 17-point loudness curve.
-          midiVolume = convertCapcomVolumeToMidi(newVolume);
+          midiVolume = calculateV2Volume(newVolume);
         }
 
         addVol(beginOffset, curOffset - beginOffset, midiVolume);
@@ -726,7 +722,7 @@ bool CapcomSnesTrack::readEvent() {
         }
         else {
           // Master volume follows the same loudness curve as per-track volume.
-          midiVolume = convertCapcomVolumeToMidi(newVolume);
+          midiVolume = calculateV2Volume(newVolume);
         }
 
         addMasterVol(beginOffset, curOffset - beginOffset, midiVolume);
@@ -765,7 +761,7 @@ bool CapcomSnesTrack::readEvent() {
             lastLfoFrequency = lfoAmount;
             addChannelPressure(beginOffset,
                                curOffset - beginOffset,
-                               convertLfoRateByteToChannelPressure(lfoAmount),
+                               convertLfoRateByteToMidiVal(lfoAmount),
                                "LFO Rate");
             break;
           case 3:

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -310,21 +310,16 @@ int convertTremoloDepthToMidiValue(int sourceDepth, CapcomSnesVersion version) {
   return std::clamp(midiValue, 0, 127);
 }
 
-// Convert from Hz -> SF2 cents (linear to exponential) -> 7-bit MIDI value scaled to the modulator amount
 uint8_t convertLfoRateByteToMidiVal(uint8_t freqByte) {
   if (freqByte == 0)
     return 0; // this is a special-case that disables vibrato
 
-  constexpr double sourceHzStep = 1000.0 / 16384.0;
-  constexpr double baseHz = sourceHzStep;
-  const double baseCents = ParamAmount::hertz(baseHz).value();
-  const double modAmount = ParamAmount::hertzRange(baseHz, 255.0 * sourceHzStep).value();
-
-  double hz = static_cast<double>(freqByte) * sourceHzStep;
-  double cents = ParamAmount::hertz(hz).value();
-
-  int cc = static_cast<int>(std::round(128.0 * (cents - baseCents) / modAmount));
-  return static_cast<uint8_t>(std::clamp(cc, 0, 127));
+  // CapcomSnes stores rate as a multiple of a fixed LFO step; the shared helper
+  // handles the Hz -> 7-bit MIDI mapping that matches the instrument modulator.
+  constexpr double kCapcomLfoStepHz = 1000.0 / 16384.0;
+  return midiValueForHertzInRange(static_cast<double>(freqByte) * kCapcomLfoStepHz,
+                                  kCapcomLfoStepHz,
+                                  255.0 * kCapcomLfoStepHz);
 }
 
 }  // namespace

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -302,12 +302,12 @@ uint8_t sourceFreqByteToCc(uint8_t freqByte) {
 
   constexpr double sourceHzStep = 1000.0 / 16384.0;
   constexpr double baseHz = sourceHzStep;
-  const double baseCents = static_cast<double>(InstrumentParamAmount::hertz(baseHz).value());
+  const double baseCents = static_cast<double>(ParamAmount::hertz(baseHz).value());
   const double modAmount = static_cast<double>(
-      InstrumentParamAmount::hertzRange(baseHz, 255.0 * sourceHzStep).value());
+      ParamAmount::hertzRange(baseHz, 255.0 * sourceHzStep).value());
 
   double hz = static_cast<double>(freqByte) * sourceHzStep;
-  double cents = static_cast<double>(InstrumentParamAmount::hertz(hz).value());
+  double cents = static_cast<double>(ParamAmount::hertz(hz).value());
 
   int cc = static_cast<int>(std::round(128.0 * (cents - baseCents) / modAmount));
   return static_cast<uint8_t>(std::clamp(cc, 0, 127));

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -164,6 +164,9 @@ void CapcomSnesTrack::resetVars() {
   transpose = 0;
   lastNoteSlurred = false;
   lastKey = -1;
+  lastVibratoDepth = 0;
+  lastLfoFrequency = 0;
+
   for (uint8_t& i : repeatCount) {
     i = 0;
   }
@@ -232,6 +235,24 @@ void CapcomSnesTrack::setNoteSlurred(bool slurred) {
 
 double CapcomSnesTrack::getTuningInSemitones(int8_t tuning) {
   return tuning / 256.0;
+}
+
+// Convert from Hz -> SF2 cents (linear to exponential) -> CC
+uint8_t sourceFreqByteToCc(uint8_t freqByte) {
+  if (freqByte == 0)
+    return 0; // this is a special-case that disables vibrato
+
+  constexpr double sf2ZeroHz = 8.176;
+  constexpr double sourceHzStep = 1000.0 / 16384.0;
+
+  constexpr double baseCents = -8479.0;
+  constexpr double modAmount = 9669.0;
+
+  double hz = static_cast<double>(freqByte) * sourceHzStep;
+  double cents = 1200.0 * std::log2(hz / sf2ZeroHz);
+
+  int cc = static_cast<int>(std::round(128.0 * (cents - baseCents) / modAmount));
+  return static_cast<uint8_t>(std::clamp(cc, 0, 127));
 }
 
 bool CapcomSnesTrack::readEvent() {
@@ -643,8 +664,33 @@ bool CapcomSnesTrack::readEvent() {
       case EVENT_LFO: {
         uint8_t lfoType = readByte(curOffset++);
         uint8_t lfoAmount = readByte(curOffset++);
-        desc = fmt::format("Type: {:d}  Amount: {:d}", lfoType, lfoAmount);
-        addGenericEvent(beginOffset, curOffset - beginOffset, "LFO Param", desc, Type::Lfo);
+        switch (lfoType) {
+          case 0:
+            // Vibrato Depth
+            lastVibratoDepth = lfoAmount;
+            addModulation(beginOffset, curOffset - beginOffset, lfoAmount, "Vibrato Depth");
+            break;
+          case 1:
+            // Tremolo Depth
+            desc = fmt::format("Amount: {:d}", lfoType, lfoAmount);
+            addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth", desc, Type::Lfo);
+            break;
+          case 2:
+            // LFO Rate
+            if (lfoAmount == 0 && lastLfoFrequency != 0 && lastVibratoDepth != 0) {
+              addModulationNoItem(0);
+            } else if (lfoAmount != 0 && lastLfoFrequency == 0 && lastVibratoDepth != 0) {
+              addModulationNoItem(lastVibratoDepth);
+            }
+            lastLfoFrequency = lfoAmount;
+            addChannelPressure(beginOffset, curOffset - beginOffset, sourceFreqByteToCc(lfoAmount), "LFO Rate");
+            break;
+          case 3:
+            // Reset LFO phase on note on. argument 1 enables, 0 disables. On by default.
+            desc = fmt::format("Type: {:d}  Amount: {:d}", lfoType, lfoAmount);
+            addGenericEvent(beginOffset, curOffset - beginOffset, "Reset LFO at Note On", desc, Type::Lfo);
+            break;
+        }
         break;
       }
 

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.h
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.h
@@ -106,6 +106,8 @@ class CapcomSnesTrack
   void setNoteSlurred(bool slurred);
 
  private:
+  [[nodiscard]] bool areLfoOutputsEnabled() const { return lastLfoFrequency != 0; }
+  void addVibratoDepthEvent(uint32_t offset, uint32_t length, uint8_t depth);
   void setLfoOutputsEnabled(bool enabled);
   void handleLfoRateChange(uint8_t lfoRateByte);
 

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.h
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.h
@@ -113,6 +113,8 @@ class CapcomSnesTrack
 
   bool lastNoteSlurred;
   int8_t lastKey;
+  uint8_t lastVibratoDepth;
+  uint8_t lastLfoFrequency;
 
   static double getTuningInSemitones(int8_t tuning);
 };

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.h
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.h
@@ -114,6 +114,7 @@ class CapcomSnesTrack
   bool lastNoteSlurred;
   int8_t lastKey;
   uint8_t lastVibratoDepth;
+  uint8_t lastTremoloDepth;
   uint8_t lastLfoFrequency;
 
   static double getTuningInSemitones(int8_t tuning);

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.h
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.h
@@ -106,6 +106,9 @@ class CapcomSnesTrack
   void setNoteSlurred(bool slurred);
 
  private:
+  void setLfoOutputsEnabled(bool enabled);
+  void handleLfoRateChange(uint8_t lfoRateByte);
+
   uint8_t repeatCount[CAPCOM_SNES_REPEAT_SLOT_MAX];      // repeat count for repeat command
   uint8_t noteAttributes;
   uint8_t durationRate;


### PR DESCRIPTION
## Summary

This is a follow-up to #851, putting that work into practice. This adds a set of modulators and generators to CapcomSnesInstr and updates CapcomSnesSeq to output MIDI events for the mapped modulator sources on vibrato and tremolo events.

This relied on @loveemu's [diassembly and analysis of the CapcomSnes driver](https://github.com/loveemu/vgm-disasm/tree/master/snes/Capcom).

## Changes:

- Added vibrato/tremolo model constants in `CapcomSnesDefinitions.h`
- Configured `CapcomSnesInstr` to emit vibrato and tremolo modulators
- Added `midiValueForHertzInRange(...)` to `InstrumentModulation` so formats can map an absolute LFO frequency back to the 7-bit MIDI value that drives a `ParamAmount::hertzRange(...)` modulator.
- Expanded `CapcomSnesSeq` LFO event handling so it now distinguishes:
  - vibrato depth
  - tremolo depth
  - LFO rate
  - reset-LFO-phase flag (SF2/DLS can only support resetting phase on note activation - the default V2 behavior)
- Added version-specific tremolo depth conversion:
  - V1 uses simple scalar behavior
  - V2/V3 use the volume-curve-based behavior
- Added a helper for volume-curve interpolation and reused that helper for both volume and tremolo calculations.
- Cleaned up pitch-scale to coarse/fine tuning conversion in `CapcomSnesInstr` for readability and improved its accuracy.

## Discussion

First off: BASS MIDI doesn't seem to support SoundFont 2 modulators, so we're not hearing vibrato/tremolo in-app. This provides a fire under my ass to finally migrate out of BASS MIDI.

We may want to update which sources we use in the modulators. Right now, it's configured as:
- CC1 (Mod wheel) -> Vibrato depth
- CC93 (Effects 3 Depth) -> Tremolo depth
- Channel Pressure -> Vibrato and Tremolo rate (they share the same LFO)

More standard sources would be CC92 for Tremolo Depth and CC76 for Vibrato rate. However, DLS does not support these CCs.

I envision adding a conversion option dialog that allows users to assign the sources for these modulators. This would entail adding methods to handle this routing on both instrument and sequence sides (ie, instead of `addModWheel(...)` we call `addVibratoDepth(...)`).

As we work through more formats, I expect the scope of the requirements and complications will become clearer.

## How Has This Been Tested?
Painfully using [this tool](https://www.pg-fl.jp/music/js-synthesizer/index.en.htm) based on fluidsynth. SpessaSynth seems buggy in pitch-related ways unrelated to vibrato. I would opt to test this in-app with my fluidsynth-based juce plugin branch, but bringing it up-to-date is a small project unto itself.

## Audio demo (unmute)

master

https://github.com/user-attachments/assets/ee55ebf3-2288-4d52-95d0-1c77c78d433b

this branch

https://github.com/user-attachments/assets/50081a3f-e40e-44c8-ae98-117b795da0db

actual

https://github.com/user-attachments/assets/ba2ee50a-1d63-458c-8bb7-a6fe20730de3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
