### PR TITLE
Portamento control transpose fix + KonamiArcade portamento time fix

### DIFF
--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -855,6 +855,19 @@ uint32_t ControllerEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
   return absTime;
 }
 
+//  **********************
+//  PortamentoControlEvent
+//  **********************
+
+uint32_t PortamentoControlEvent::writeEvent(std::vector<uint8_t> &buf, uint32_t time) {
+  // Add the global transpose into the starting key of the portamento control event
+  u8 originalDataByte = dataByte;
+  dataByte = std::clamp<s16>(dataByte + prntTrk->parentSeq->globalTranspose, 0, 127);
+  u32 result = ControllerEvent::writeEvent(buf, time);
+  dataByte = originalDataByte;
+  return result;
+}
+
 //  **********
 //  SysexEvent
 //  **********

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -406,6 +406,7 @@ public:
   PortamentoControlEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t key)
       : ControllerEvent(prntTrk, channel, absoluteTime, 84, key, PRIORITY_MIDDLE) { }
   MidiEventType eventType() override { return MIDIEVENT_PORTAMENTOCONTROL; }
+  uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
 };
 
 class PanEvent

--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
@@ -388,7 +388,7 @@ bool KonamiArcadeTrack::readEvent() {
       // Slide note
       u8 slideStartNote = note - m_slideModeDepth;
       addNoteByDurNoItem(slideStartNote, linearVel, m_slideModeDelay + 1);
-      insertPortamentoTime14BitNoItem(m_slideModeDuration * m_microsecsPerTick, m_slideModeDelay);
+      insertPortamentoTime14BitNoItem(m_slideModeDuration * m_microsecsPerTick, getTime() + m_slideModeDelay);
       insertPortamentoControlNoItem(slideStartNote, getTime() + m_slideModeDelay);
       insertNoteByDur(beginOffset, curOffset - beginOffset, note, linearVel, actualDuration - m_slideModeDelay, getTime() + m_slideModeDelay);
     } else {


### PR DESCRIPTION
A couple small fixes related to portamento:

- fix portamento control events not offsetting their start key with global transpose
- fix KonamiArcade inserting some portamento time events at an incorrect time (seems I forgot to add `getTime()` to offset from the current time)

## Motivation and Context
Discovered the global transpose issue while improving portamento time on CapcomSnes.

## How Has This Been Tested?
This fixed issues in both CapcomSnes (forthcoming) and KonamiArcade. The likelihood of regression seems low.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
