### PR TITLE
CapcomSnes - more accurate portamento handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Added Drum Kit support to the standard N-SPC driver (Nintendo's SNES SDK driver).
 - Added Drum Kit support to the SuzukiSnes driver (Seiken Densetsu 3, Super Mario RPG, etc)
 - Added many improvements to the KonamiSnes driver.
-- Added vibrato and tremolo support to the CapcomSnes driver.
+- Added vibrato, tremolo and more accurate portamento support to the CapcomSnes driver.
 - Improved support for late-era Intelligent Systems SNES/SFC titles (Tetris Attack, Fire Emblem 4, Super Famicom Wars) 
 
 ### Changed

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -429,7 +429,7 @@ bool CapcomSnesTrack::readEvent() {
         addTie(beginOffset, curOffset - beginOffset, dur, "Tie", desc);
       }
       else {
-        if (portamentoMillisecondsPerCent > 0) {
+        if (portamentoMillisecondsPerCent > 0 && lastKey >= 0) {
           uint16_t portamentoDurInMillis = (abs(key - lastKey) * 100) * portamentoMillisecondsPerCent;
           if (portamentoDurInMillis != lastPortamentoTime) {
             addPortamentoTime14BitNoItem(portamentoDurInMillis);

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -165,10 +165,13 @@ void CapcomSnesTrack::resetVars() {
   durationRate = 0;
   transpose = 0;
   lastNoteSlurred = false;
+  didRest = false;
   lastKey = -1;
   lastVibratoDepth = 0;
   lastTremoloDepth = 0;
   lastLfoFrequency = 0;
+  lastPortamentoTime = 0;
+  portamentoMillisecondsPerCent = 0;
 
   for (uint8_t& i : repeatCount) {
     i = 0;
@@ -392,7 +395,7 @@ bool CapcomSnesTrack::readEvent() {
 
     if (rest) {
       addRest(beginOffset, curOffset - beginOffset, len);
-      lastKey = -1;
+      didRest = true;
     }
     else {
       // calculate duration of note:
@@ -419,16 +422,25 @@ bool CapcomSnesTrack::readEvent() {
 
       uint8_t key = (keyIndex - 1) + (getNoteOctave() * 12) + (isNoteOctaveUp() ? 24 : 0);
       uint8_t vel = 127;
-      if (lastNoteSlurred && key == lastKey) {
+      if (lastNoteSlurred && key == lastKey && !didRest) {
         addTime(dur);
         makePrevDurNoteEnd();
         addTime(len - dur);
         addTie(beginOffset, curOffset - beginOffset, dur, "Tie", desc);
       }
       else {
+        if (portamentoMillisecondsPerCent > 0) {
+          uint16_t portamentoDurInMillis = (abs(key - lastKey) * 100) * portamentoMillisecondsPerCent;
+          if (portamentoDurInMillis != lastPortamentoTime) {
+            addPortamentoTime14BitNoItem(portamentoDurInMillis);
+            lastPortamentoTime = portamentoDurInMillis;
+          }
+          addPortamentoControlNoItem(lastKey);
+        }
         addNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur);
         addTime(len);
         lastKey = key;
+        didRest = false;
       }
       lastNoteSlurred = isNoteSlurred();
     }
@@ -587,15 +599,20 @@ bool CapcomSnesTrack::readEvent() {
       }
 
       case EVENT_PORTAMENTO_TIME: {
-        // TODO: calculate portamento time in milliseconds
-        uint8_t newPortamentoTime = readByte(curOffset++);
+        // All tested versions of the format (V1-V3) use the same calculation for portamento time.
+        uint8_t portamentoTimeByte = readByte(curOffset++);
+        uint8_t step = (portamentoTimeByte << 1) & 0xFF;
+        double centsPerUpdate = step * (100.0 / 256.0);
+        // The voice stream/portamento update runs once every other 8 ms timer tick, i.e. about 62.5 updates per second
+        if (centsPerUpdate == 0)
+          portamentoMillisecondsPerCent = 0;
+        else
+          portamentoMillisecondsPerCent = (0.016 / centsPerUpdate) * 1000;
         addGenericEvent(beginOffset,
                         curOffset - beginOffset,
                         "Portamento Time",
-                        fmt::format("Time: {:d}", newPortamentoTime),
+                        fmt::format("cents/ms: {:.2f}", centsPerUpdate * 62.5 / 1000.0),
                         Type::PortamentoTime);
-        addPortamentoTimeNoItem(newPortamentoTime >> 1);
-        addPortamentoNoItem(newPortamentoTime != 0);
         break;
       }
 

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.h
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.h
@@ -117,10 +117,13 @@ class CapcomSnesTrack
   //int8_t transpose;
 
   bool lastNoteSlurred;
+  bool didRest;
   int8_t lastKey;
   uint8_t lastVibratoDepth;
   uint8_t lastTremoloDepth;
   uint8_t lastLfoFrequency;
+  uint16_t lastPortamentoTime;
+  double portamentoMillisecondsPerCent;
 
   static double getTuningInSemitones(int8_t tuning);
 };


### PR DESCRIPTION
This updates the portamento logic for CapcomSnes, adding the actual logic for portamento time calculation (using both coarse and fine MIDI events for 14-bit precision).

As before, this relied on loveemu's [disassembly and analysis of the CapcomSnes driver](https://github.com/loveemu/vgm-disasm/tree/master/snes/Capcom).

This uses Portamento Control events instead of Portamento On/Off events, as they are easier to work with and more explicit; we don't have to overlap notes to force a slide.

BASS MIDI does not support 14-bit portamento time, so preview in app is still inaccurate. It does support the coarse 7-bit event, but that resolution is inadequate for this control.

## How Has This Been Tested?
Tested a number of titles using the soon-to-be-updated juce3 branch which uses a fluidsynth-based VST for preview.

## Audio demo (using fluidsynth)

master

https://github.com/user-attachments/assets/caf48719-0a6d-4509-92ea-ac7d30df5b4a

this branch

https://github.com/user-attachments/assets/d8880189-d694-4005-adf5-6908ee0d8ff5

original

https://github.com/user-attachments/assets/17d96bb0-bb08-4427-ae59-5d85058f5ee0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
