### PR TITLE
CapcomSnes - fix CapcomSnes pan for v2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Added Drum Kit support to the standard N-SPC driver (Nintendo's SNES SDK driver).
 - Added Drum Kit support to the SuzukiSnes driver (Seiken Densetsu 3, Super Mario RPG, etc)
 - Added many improvements to the KonamiSnes driver.
-- Added vibrato, tremolo and more accurate portamento support to the CapcomSnes driver.
+- Added vibrato, tremolo, more accurate portamento support, and fixed pan calculation in the CapcomSnes driver.
 - Improved support for late-era Intelligent Systems SNES/SFC titles (Tetris Attack, Fire Emblem 4, Super Famicom Wars) 
 
 ### Changed

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -279,6 +279,30 @@ constexpr int kTremoloPeakScalarV1 = 255;
 constexpr int kTremoloPeakScalarV2 = 250;
 constexpr double kTremoloMuteFloorCentibels = 960.0;
 
+struct PanConversionResult {
+  uint8_t midiPan;
+  double volumeScale;
+};
+
+int interpolatePanFactor(uint16_t panPosition) {
+  const int panIndex = panPosition >> 8;
+  const int panRate = panPosition & 0xff;
+  const int lower = CapcomSnesSeq::panTable[panIndex];
+  const int upper = CapcomSnesSeq::panTable[panIndex + 1];
+  return lower + ((upper - lower) * panRate >> 8);
+}
+
+PanConversionResult calculatePanV2(uint8_t biasedPan) {
+  const uint16_t rightPanPosition = static_cast<uint16_t>(biasedPan) * 20;
+  const uint16_t leftPanPosition = 0x1400 - rightPanPosition;
+  const double volumeLeft = interpolatePanFactor(leftPanPosition) / 128.0;
+  const double volumeRight = interpolatePanFactor(rightPanPosition) / 128.0;
+
+  PanConversionResult result{};
+  result.midiPan = convertVolumeBalanceToStdMidiPan(volumeLeft, volumeRight, &result.volumeScale);
+  return result;
+}
+
 int interpolateVolumeCurve(int curveIndex, int curveFraction) {
   if (curveIndex >= kVolumeCurveLastIndex) {
     return CapcomSnesSeq::volTable[kVolumeCurveLastIndex];
@@ -734,23 +758,16 @@ bool CapcomSnesTrack::readEvent() {
 
       case EVENT_PAN: {
         uint8_t newPan = readByte(curOffset++) + 0x80; // signed -> unsigned
-        double volumeScale;
-
-        uint8_t panIn7bit;
+        PanConversionResult pan{};
         if (parentSeq->version == CAPCOMSNES_V1_BGM_IN_LIST) {
-          panIn7bit = newPan >> 1;
+          pan.midiPan = convert7bitLinearPercentPanValToStdMidiVal(newPan >> 1, &pan.volumeScale);
         }
         else {
-          // use pan table (with linear interpolation)
-          uint8_t panIndex = (newPan * 20) >> 8;
-          uint8_t panRate = (newPan * 20) & 0xff;
-          panIn7bit = CapcomSnesSeq::panTable[panIndex]
-              + ((CapcomSnesSeq::panTable[panIndex + 1] - CapcomSnesSeq::panTable[panIndex]) * panRate >> 8);
+          pan = calculatePanV2(newPan);
         }
-        uint8_t midiPan = convert7bitLinearPercentPanValToStdMidiVal(panIn7bit, &volumeScale);
 
-        addPan(beginOffset, curOffset - beginOffset, midiPan);
-        addExpressionNoItem(std::round(127.0 * volumeScale));
+        addPan(beginOffset, curOffset - beginOffset, pan.midiPan);
+        addExpressionNoItem(std::round(127.0 * pan.volumeScale));
         break;
       }
 


### PR DESCRIPTION
This fixes both the pan calculation and pan volume adjustment. The old code was off by quite a bit on both fronts, which was made evident by the [prior PR](https://github.com/vgmtrans/vgmtrans/pull/855)'s audio demo. A center pan would be offset to the right, and the more centered a channel, the quieter it was relativel to what it should be by around 10-20%.

This relied on @loveemu's [disassembly and analysis of the CapcomSnes driver](https://github.com/loveemu/vgm-disasm/tree/master/snes/Capcom).

## How Has This Been Tested?
Tested a range of songs by ear.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
