### PR TITLE
Fixes for issues flagged by UBSan

### DIFF
--- a/src/main/conversion/RiffFile.cpp
+++ b/src/main/conversion/RiffFile.cpp
@@ -31,8 +31,12 @@ void Chunk::setData(const void *src, uint32_t datasize) {
 
 void Chunk::write(uint8_t *buffer) {
   uint32_t padsize = paddedSize(m_size) - m_size;
+
   memcpy(buffer, id, 4);
-  *reinterpret_cast<uint32_t*>(buffer + 4) = m_size + padsize; // Microsoft says the chunkSize doesn't contain padding size, but many software cannot handle the alignment.
+
+  uint32_t value = m_size + padsize;
+  memcpy(buffer + 4, &value, sizeof(value));
+
   memcpy(buffer + 8, data, paddedSize(m_size));
 }
 
@@ -52,19 +56,20 @@ void ListTypeChunk::write(uint8_t *buffer) {
   memcpy(buffer, this->id, 4);
   memcpy(buffer + 8, this->type, 4);
 
-  uint32_t bufOffset = 12;
-  for (auto iter = this->childChunks.begin(); iter != childChunks.end(); ++iter) {
+  size_t bufOffset = 12;
+  for (auto iter = this->childChunks.begin(); iter != this->childChunks.end(); ++iter) {
     (*iter)->write(buffer + bufOffset);
     bufOffset += (*iter)->size();
   }
 
-  uint32_t size = bufOffset;
+  uint32_t size = static_cast<uint32_t>(bufOffset);
   uint32_t padsize = paddedSize(size) - size;
-  *reinterpret_cast<uint32_t*>(buffer + 4) = size + padsize - 8; // Microsoft says the chunkSize doesn't contain padding size, but many software cannot handle the alignment.
 
+  uint32_t value = size + padsize - 8;
+  memcpy(buffer + 4, &value, sizeof(value));
   // Add pad byte
   if (padsize != 0) {
-    memset(data + size, 0, padsize);
+    memset(buffer + size, 0, padsize);
   }
 }
 
@@ -72,3 +77,4 @@ RiffFile::RiffFile(const std::string& file_name, const std::string& form)
     : RIFFChunk(form),
       name(file_name) {
 }
+

--- a/src/ui/qt/workarea/MdiArea.cpp
+++ b/src/ui/qt/workarea/MdiArea.cpp
@@ -290,16 +290,18 @@ void MdiArea::newView(VGMFile *file) {
 void MdiArea::removeView(const VGMFile *file) {
   // Let's check if we have a VGMFileView to remove
   auto it = fileToWindowMap.find(file);
-  if (it != fileToWindowMap.end()) {
-    // Sanity check
-    if (it->second) {
-      // Close the tab (automatically deletes it)
-      // Workaround for QTBUG-5446 (removeMdiSubWindow would be a better option)
-      it->second->close();
-    }
-    // Get rid of the saved pointers
-    windowToFileMap.erase(it->second);
-    fileToWindowMap.erase(file);
+  if (it == fileToWindowMap.end()) {
+    return; // Already removed
+  }
+
+  QMdiSubWindow *window = it->second;
+  windowToFileMap.erase(window);
+  fileToWindowMap.erase(it);
+
+  if (window) {
+    // Close the tab (automatically deletes it)
+    // Workaround for QTBUG-5446 (removeMdiSubWindow would be a better option)
+    window->close();
   }
 }
 

--- a/src/ui/qt/workarea/VGMFileTreeView.cpp
+++ b/src/ui/qt/workarea/VGMFileTreeView.cpp
@@ -387,10 +387,13 @@ void VGMFileTreeView::onShowDetailsChanged(bool show) {
 void VGMFileTreeView::updateItemTextRecursively(QTreeWidgetItem* item) {
   if (!item) return;
 
-  VGMTreeItem* vgmTreeItem = static_cast<VGMTreeItem*>(item);
-
-  if (VGMItem* vgmitem = m_treeItemToVGMItem[item]) {
-    setItemText(vgmitem, vgmTreeItem);
+  // The invisibleRootItem() is a plain QTreeWidgetItem, not a VGMTreeItem.
+  if (item->type() == VGMTreeItem::ItemType) {
+    auto* vgmTreeItem = static_cast<VGMTreeItem*>(item);
+    auto it = m_treeItemToVGMItem.find(item);
+    if (it != m_treeItemToVGMItem.end() && it->second) {
+      setItemText(it->second, vgmTreeItem);
+    }
   }
 
   // Recursively update children

--- a/src/ui/qt/workarea/VGMFileTreeView.h
+++ b/src/ui/qt/workarea/VGMFileTreeView.h
@@ -43,9 +43,9 @@ private:
 // ***********************************
 
 class VGMTreeItem : public QTreeWidgetItem {
+public:
   static constexpr auto ItemType = QTreeWidgetItem::UserType + 1;
 
-public:
   VGMTreeItem(QString name, VGMItem *item, QTreeWidget *parent = nullptr,
               VGMItem *item_parent = nullptr)
       : QTreeWidgetItem(parent, ItemType), m_name(std::move(name)), m_item(item),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Prevent a misaligned write in RiffFile (undefined behaviour, problematic on arm)
  - I'm aware of the endianess issue but I think the codebase is already riddled with "machine is little endian" assumptions
- Fixed a bug where we were clearing the wrong buffer in RiffFile
- Fix a crash in closing a RawFile while HexView is open
- Fixed a bad cast in the item tree view

## Motivation and Context
I've started using UBSan and ASAN at all times while in debug mode. I find these can be especially useful when AI tools are employed, as machine-generated C++ can have subtle memory bugs. These came up while testing other things. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tried a bunch of conversions. No longer triggers ubsan.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
