### PR TITLE
CapcomSnes - update V2+ volume calculation

### DIFF
--- a/src/main/components/seq/SeqEvent.cpp
+++ b/src/main/components/seq/SeqEvent.cpp
@@ -120,6 +120,13 @@ MastVolSeqEvent::MastVolSeqEvent(SeqTrack *pTrack,
                                  const std::string &name)
     : SeqEvent(pTrack, offset, length, name, Type::MasterVolume), vol(volume) { }
 
+MastVolSeqEvent::MastVolSeqEvent(SeqTrack *pTrack,
+                                 double volume,
+                                 uint32_t offset,
+                                 uint32_t length,
+                                 const std::string &name)
+    : SeqEvent(pTrack, offset, length, name, Type::MasterVolume), percentVol(volume) { }
+
 // ****************
 // MastVolSlideSeqEvent
 // ****************

--- a/src/main/components/seq/SeqEvent.h
+++ b/src/main/components/seq/SeqEvent.h
@@ -195,12 +195,18 @@ class MastVolSeqEvent : public SeqEvent {
  public:
     MastVolSeqEvent(SeqTrack *pTrack, uint8_t volume, uint32_t offset = 0, uint32_t length = 0,
                     const std::string &name = "");
+    MastVolSeqEvent(SeqTrack *pTrack, double volume, uint32_t offset = 0, uint32_t length = 0,
+                    const std::string &name = "");
 
     std::string description() override {
-        return fmt::format("{} - master volume: {}", name(), static_cast<int>(vol));
+      if (percentVol > 0) {
+        return fmt::format("{} - master volume: {:.1f}", name(), percentVol);
+      }
+      return fmt::format("{} - master volume: {}", name(), vol);
     };
 
-  uint8_t vol;
+  uint8_t vol = -1;
+  double percentVol = -1;
 };
 
 //  ****************

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -1039,6 +1039,13 @@ void SeqTrack::addMasterVol(uint32_t offset, uint32_t length, uint8_t newVol, co
   addMasterVolNoItem(newVol);
 }
 
+void SeqTrack::addMasterVol(u32 offset, u32 length, double volPercent, Resolution res, const std::string &sEventName) {
+  bool isNewOffset = onEvent(offset, length);
+
+  recordSeqEvent<MastVolSeqEvent>(isNewOffset, getTime(), volPercent, offset, length, sEventName);
+  addLevelNoItem(volPercent, LevelController::MasterVolume, res, -1);
+}
+
 void SeqTrack::addMasterVolNoItem(uint8_t newVol) {
   addLevelNoItem(newVol / 127.0, LevelController::MasterVolume, Resolution::SevenBit);
 }

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -198,7 +198,7 @@ private:
   void insertExpression(uint32_t offset, uint32_t length, uint8_t level, uint32_t absTime, const std::string &sEventName = "Expression");
   void insertExpressionNoItem(uint8_t level, uint32_t absTime);
   void addMasterVol(uint32_t offset, uint32_t length, uint8_t vol, const std::string &sEventName = "Master Volume");
-  void addMasterVol(u32 offset, u32 length, double volPercent, Resolution res, const std::string &sEventName = "Master Volume");
+  void addMasterVol(uint32_t offset, uint32_t length, double volPercent, Resolution res, const std::string &sEventName = "Master Volume");
   void addMasterVolNoItem(uint8_t newVol);
   void addMastVolSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targVol, const std::string &sEventName = "Master Volume Slide");
 

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -198,6 +198,7 @@ private:
   void insertExpression(uint32_t offset, uint32_t length, uint8_t level, uint32_t absTime, const std::string &sEventName = "Expression");
   void insertExpressionNoItem(uint8_t level, uint32_t absTime);
   void addMasterVol(uint32_t offset, uint32_t length, uint8_t vol, const std::string &sEventName = "Master Volume");
+  void addMasterVol(u32 offset, u32 length, double volPercent, Resolution res, const std::string &sEventName = "Master Volume");
   void addMasterVolNoItem(uint8_t newVol);
   void addMastVolSlide(uint32_t offset, uint32_t length, uint32_t dur, uint8_t targVol, const std::string &sEventName = "Master Volume Slide");
 

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -305,18 +305,28 @@ PanConversionResult calculatePanV2(uint8_t biasedPan) {
 
 int interpolateVolumeCurve(int curveIndex, int curveFraction) {
   if (curveIndex >= kVolumeCurveLastIndex) {
-    return CapcomSnesSeq::volTable[kVolumeCurveLastIndex];
+    return CapcomSnesSeq::volTable[kVolumeCurveLastIndex]; // 0xff
   }
 
   const int lower = CapcomSnesSeq::volTable[curveIndex];
   const int upper = CapcomSnesSeq::volTable[curveIndex + 1];
-  return lower + ((upper - lower) * curveFraction) / 256;
+  return lower + (((upper - lower) * curveFraction) >> 8);
 }
 
-uint8_t calculateVolumeV2(uint8_t sourceVolume) {
-  // Unlike V1, this uses a volume curve table
-  const int scaledCurvePosition = sourceVolume * kVolumeCurveLastIndex;
-  return interpolateVolumeCurve(scaledCurvePosition >> 8, scaledCurvePosition & 0xff);
+int calculateVolumeScalar(uint8_t sourceVolume) {
+  // The driver's intended range is 0x00..0x80 with 0x80 resolving to full volume.
+  if (sourceVolume >= 0x80) {
+    return CapcomSnesSeq::volTable[kVolumeCurveLastIndex]; // 0xff
+  }
+  const int curveIndex = sourceVolume >> 3;
+  const int curveFraction = ((sourceVolume & 0x07) << 5) | 0x1f;
+
+  return interpolateVolumeCurve(curveIndex, curveFraction);
+}
+
+double calculateVolumeV2(uint8_t sourceVolume) {
+  const int scalar = calculateVolumeScalar(sourceVolume); // 0..255
+  return static_cast<double>(scalar) / 255.0;
 }
 
 int calculateTremoloScalarAtTroughV1(int sourceDepth) {
@@ -579,13 +589,13 @@ bool CapcomSnesTrack::readEvent() {
         if (parentSeq->version == CAPCOMSNES_V1_BGM_IN_LIST) {
           // linear volume
           midiVolume = newVolume >> 1;
+          addVol(beginOffset, curOffset - beginOffset, midiVolume);
         }
         else {
           // V2/V3 drivers shape volume through the engine's 17-point loudness curve.
-          midiVolume = calculateVolumeV2(newVolume);
+          double percentAmp = calculateVolumeV2(newVolume);
+          addVol(beginOffset, curOffset - beginOffset, percentAmp, Resolution::FourteenBit);
         }
-
-        addVol(beginOffset, curOffset - beginOffset, midiVolume);
         break;
       }
 

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -585,11 +585,9 @@ bool CapcomSnesTrack::readEvent() {
       case EVENT_VOLUME: {
         uint8_t newVolume = readByte(curOffset++);
 
-        uint8_t midiVolume;
         if (parentSeq->version == CAPCOMSNES_V1_BGM_IN_LIST) {
           // linear volume
-          midiVolume = newVolume >> 1;
-          addVol(beginOffset, curOffset - beginOffset, midiVolume);
+          addVol(beginOffset, curOffset - beginOffset, newVolume >> 1);
         }
         else {
           // V2/V3 drivers shape volume through the engine's 17-point loudness curve.
@@ -784,17 +782,15 @@ bool CapcomSnesTrack::readEvent() {
       case EVENT_MASTER_VOLUME: {
         uint8_t newVolume = readByte(curOffset++);
 
-        uint8_t midiVolume;
         if (parentSeq->version == CAPCOMSNES_V1_BGM_IN_LIST) {
           // linear volume
-          midiVolume = newVolume >> 1;
+          addMasterVol(beginOffset, curOffset - beginOffset, newVolume >> 1);
         }
         else {
           // Master volume follows the same loudness curve as per-track volume.
-          midiVolume = calculateVolumeV2(newVolume);
+          double percentAmp = calculateVolumeV2(newVolume);
+          addMasterVol(beginOffset, curOffset - beginOffset, percentAmp);
         }
-
-        addMasterVol(beginOffset, curOffset - beginOffset, midiVolume);
         break;
       }
 

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -789,7 +789,7 @@ bool CapcomSnesTrack::readEvent() {
         else {
           // Master volume follows the same loudness curve as per-track volume.
           double percentAmp = calculateVolumeV2(newVolume);
-          addMasterVol(beginOffset, curOffset - beginOffset, percentAmp);
+          addMasterVol(beginOffset, curOffset - beginOffset, percentAmp, Resolution::FourteenBit);
         }
         break;
       }


### PR DESCRIPTION
The prior volume calculation for V2+ was only using the bottom half of the volume table. This meant both that volumes were lower than they should be and that we were distorting the non-linear curve of the volume table. I found that this new implementation is used even in Capcom's last Super Famicom title.

Like before, I used @loveemu's [reverse engineering work on the CapcomSnes driver](https://github.com/loveemu/vgm-disasm/tree/master/snes/Capcom).

### _Update_

I've now added:
```
void addMasterVol(u32 offset, u32 length, double volPercent, Resolution res, const std::string &sEventName = "Master Volume");
```
The equivalent to the addVol(...) overloaded method which accepts a double for volume and a resolution parameter. I've also added a corresponding constructor for `MastVolSeqEvent`.

We need to route the CapcomSnes master volume values through the same functions as channel volume. Since I've updated calculateVolV2 to return a double instead of a 7-bit uint for better precision, it follows that we need to support actually added a floating point master volume through the SeqTrack addX helper methods.

## How Has This Been Tested?
Tested a range of titles. No apparent regression.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
