### PR TITLE
Add basic support for Legato Pedal events (CC68)

### DIFF
--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -1477,6 +1477,11 @@ void InsertExpression(uint8_t expression, uint32_t absTime);
 void AddPanEvent(uint8_t pan);
 void InsertPanEvent(uint8_t pan, uint32_t absTime);*/
 
+void SeqTrack::addLegatoPedalNoItem(bool bOn) {
+  if (readMode == READMODE_CONVERT_TO_MIDI)
+    pMidiTrack->addLegatoPedal(channel, bOn);
+}
+
 void SeqTrack::addProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, const std::string &sEventName) {
   addProgramChange(offset, length, progNum, false, sEventName);
 }

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -247,6 +247,7 @@ private:
   void insertPortamentoTime14BitNoItem(uint16_t time, uint32_t absTime) const;
   void addPortamentoControlNoItem(uint8_t key) const;
   void insertPortamentoControlNoItem(uint8_t key, uint32_t absTime) const;
+  void addLegatoPedalNoItem(bool bOn);
   void addProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, const std::string &sEventName = "Program Change");
   void addProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, uint8_t chan, const std::string &sEventName = "Program Change");
   void addProgramChange(uint32_t offset, uint32_t length, uint32_t progNum, bool requireBank, const std::string &sEventName = "Program Change");

--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -383,6 +383,14 @@ void MidiTrack::insertMono(uint8_t channel, uint32_t absTime) {
   aEvents.push_back(new MonoEvent(this, channel, absTime));
 }
 
+void MidiTrack::addLegatoPedal(uint8_t channel, bool bOn) {
+  aEvents.push_back(new LegatoPedalEvent(this, channel, getDelta(), bOn));
+}
+
+void MidiTrack::insertLegatoPedal(uint8_t channel, bool bOn, uint32_t absTime) {
+  aEvents.push_back(new LegatoPedalEvent(this, channel, absTime, bOn));
+}
+
 void MidiTrack::addPan(uint8_t channel, uint8_t pan) {
   aEvents.push_back(new PanEvent(this, channel, getDelta(), pan));
 }

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -415,8 +415,8 @@ public:
 class LegatoPedalEvent
     : public ControllerEvent {
 public:
-  LegatoPedalEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t bOn)
-      : ControllerEvent(prntTrk, channel, absoluteTime, 68, (bOn) ? 0x7F : 0, PRIORITY_MIDDLE) { }
+  LegatoPedalEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, bool bOn)
+      : ControllerEvent(prntTrk, channel, absoluteTime, 68, (bOn) ? 0x7F : 0, PRIORITY_HIGH) { }
   MidiEventType eventType() override { return MIDIEVENT_LEGATOPEDAL; }
 };
 

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -417,7 +417,7 @@ class LegatoPedalEvent
 public:
   LegatoPedalEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t bOn)
       : ControllerEvent(prntTrk, channel, absoluteTime, 68, (bOn) ? 0x7F : 0, PRIORITY_MIDDLE) { }
-  virtual MidiEventType GetEventType() { return MIDIEVENT_LEGATOPEDAL; }
+  MidiEventType eventType() override { return MIDIEVENT_LEGATOPEDAL; }
 };
 
 class PanEvent

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -56,6 +56,7 @@ typedef enum {
   MIDIEVENT_PORTAMENTOTIME,
   MIDIEVENT_PORTAMENTOTIMEFINE,
   MIDIEVENT_PORTAMENTOCONTROL,
+  MIDIEVENT_LEGATOPEDAL,
   MIDIEVENT_MONO,
   MIDIEVENT_LFO,
   MIDIEVENT_VIBRATO,
@@ -129,6 +130,8 @@ class MidiTrack {
   void insertPortamentoControl(uint8_t channel, uint8_t key, uint32_t absTime);
   void addMono(uint8_t channel);
   void insertMono(uint8_t channel, uint32_t absTime);
+  void addLegatoPedal(uint8_t channel, bool bOn);
+  void insertLegatoPedal(uint8_t channel, bool bOn, uint32_t absTime);
 
   void addPitchBend(uint8_t channel, int16_t bend);
   void insertPitchBend(uint8_t channel, short bend, uint32_t absTime);
@@ -407,6 +410,14 @@ public:
       : ControllerEvent(prntTrk, channel, absoluteTime, 84, key, PRIORITY_MIDDLE) { }
   MidiEventType eventType() override { return MIDIEVENT_PORTAMENTOCONTROL; }
   uint32_t writeEvent(std::vector<uint8_t> &buf, uint32_t time) override;
+};
+
+class LegatoPedalEvent
+    : public ControllerEvent {
+public:
+  LegatoPedalEvent(MidiTrack *prntTrk, uint8_t channel, uint32_t absoluteTime, uint8_t bOn)
+      : ControllerEvent(prntTrk, channel, absoluteTime, 68, (bOn) ? 0x7F : 0, PRIORITY_MIDDLE) { }
+  virtual MidiEventType GetEventType() { return MIDIEVENT_LEGATOPEDAL; }
 };
 
 class PanEvent


### PR DESCRIPTION
This adds support for creating legato pedal events via a new LegatoPedalEvent subclass of MidiEvent and a new SeqTrack::addLegatoPedalNoItem(...) helper method.

The legato pedal is used to indicate that notes should sound connected instead of newly struck. Unfortunately, neither the MIDI standard nor the SoundFont 2 spec define specifically how it should be interpreted for synthesis. It seems a common interpretation is that the attack phase of an envelope should be skipped. This aligns with well with the behavior of some sound drivers we support, like CapcomSnes and CPS. 

Unfortunately, the default fluidsynth implementation only behaves in this way when legato pedal is down or portamento is enabled and notes overlap. I believe there may be a fluidsynth setting to change this behavior, but it remains a compatibility concern.

Regardless, I think it makes sense to add support for legato pedal events and to add them where they are clearly appropriate.

## Motivation and Context
CapcomSnes has a slur state that this aligns with.

## How Has This Been Tested?
Verified that MIDI events are being created as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
