### PR TITLE
CapcomSnes - make slurred notes overlap, and add legato pedal

### DIFF
--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -402,6 +402,15 @@ bool CapcomSnesTrack::readEvent() {
   bool bContinue = true;
 
   std::string desc;
+  auto applyNoteAttributes = [this](uint8_t attributes) {
+    const bool wasSlurred = isNoteSlurred();
+    noteAttributes &= ~(CAPCOM_SNES_MASK_NOTE_OCTAVE_UP | CAPCOM_SNES_MASK_NOTE_TRIPLET | CAPCOM_SNES_MASK_NOTE_SLURRED);
+    noteAttributes |= attributes;
+
+    if (isNoteSlurred() != wasSlurred) {
+      addLegatoPedalNoItem(isNoteSlurred());
+    }
+  };
 
   if (statusByte >= 0x20) {
     uint8_t keyIndex = statusByte & 0x1f;
@@ -550,8 +559,7 @@ bool CapcomSnesTrack::readEvent() {
 
       case EVENT_NOTE_ATTRIBUTES: {
         uint8_t attributes = readByte(curOffset++);
-        noteAttributes &= ~(CAPCOM_SNES_MASK_NOTE_OCTAVE_UP | CAPCOM_SNES_MASK_NOTE_TRIPLET | CAPCOM_SNES_MASK_NOTE_SLURRED);
-        noteAttributes |= attributes;
+        applyNoteAttributes(attributes);
         desc = fmt::format("Triplet: {}  Slur: {}  2-Octave Up: {}",
                         isNoteTriplet() ? "On" : "Off",
                         isNoteSlurred() ? "On" : "Off",
@@ -730,8 +738,7 @@ bool CapcomSnesTrack::readEvent() {
 
         if (repeatCount[repeatSlot] == 1) {
           repeatCount[repeatSlot] = 0;
-          noteAttributes &= ~(CAPCOM_SNES_MASK_NOTE_OCTAVE_UP | CAPCOM_SNES_MASK_NOTE_TRIPLET | CAPCOM_SNES_MASK_NOTE_SLURRED);
-          noteAttributes |= attributes;
+          applyNoteAttributes(attributes);
           curOffset = dest;
         }
 

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -471,7 +471,7 @@ bool CapcomSnesTrack::readEvent() {
           }
           addPortamentoControlNoItem(lastKey);
         }
-        addNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur);
+        addNoteByDur(beginOffset, curOffset - beginOffset, key, vel, dur + (isNoteSlurred() ? 1 : 0));
         addTime(len);
         lastKey = key;
         didRest = false;
@@ -534,6 +534,7 @@ bool CapcomSnesTrack::readEvent() {
 
       case EVENT_TOGGLE_SLUR:
         setNoteSlurred(!isNoteSlurred());
+        addLegatoPedalNoItem(isNoteSlurred());
         addGenericEvent(beginOffset, curOffset - beginOffset, "Toggle Slur/Tie", "", Type::Portamento);
         break;
 


### PR DESCRIPTION
This adds an extra tick to note duration when the slur flag is enabled. We do this so that connected notes will overlap, thus triggering the legato effect where the attack phase of the new note is skipped. In other words, the notes slide into each other. The driver anticipates that slurred notes will blend together, as it forces their duration to 100%, so this is not quite as hacky as it may seem.

Still, It's possible for rests to exist between slurred notes, in which case the driver still skip the attack phase of the new note. Unfortunately we can't support this short of forcing fluidsynth to use a different legato pedal mode. I expect this is pretty rare, though.

We're also adding legato pedal on and off events corresponding to slur on/off events. To clarify about behavior, the legato pedal isn't necessary to skip the attack phase when portamento (or, in our case, portamento control) is used, but it should matter if slur is enabled but portamento is not.

And of course, none of this works well in BASS MIDI.

## Audio demo

The effect is subtle. Try to spot the difference.

master

https://github.com/user-attachments/assets/20266076-f714-4aa0-8664-22bc252f21da


this branch

https://github.com/user-attachments/assets/31d774e7-a6ac-4b85-8127-ef0104d2d645


original

https://github.com/user-attachments/assets/555c877c-4fe6-424a-a9ff-a423a82fd810


## How Has This Been Tested?
Tested numerous CapcomSnes titles.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
