### PR TITLE
shell: Open argv files and page large output

### DIFF
--- a/src/ui/shell/vgmtrans-shell.cpp
+++ b/src/ui/shell/vgmtrans-shell.cpp
@@ -15,6 +15,20 @@
 #include <string>
 #include <vector>
 #include <filesystem>
+#include <iostream>
+#include <functional>
+
+#ifdef _WIN32
+#include <io.h>
+#define dup _dup
+#define dup2 _dup2
+#define close _close
+#define fileno _fileno
+#define popen _popen
+#define pclose _pclose
+#else
+#include <unistd.h>
+#endif
 
 #include <fmt/base.h>
 #include <fmt/format.h>
@@ -105,6 +119,132 @@ bool helpRequested(int argc, char* argv[]) {
     }
   }
   return false;
+}
+
+std::string captureStdout(const std::function<void()>& fn) {
+  std::cout.flush();
+  std::fflush(stdout);
+
+  FILE* tmp = std::tmpfile();
+  if (!tmp) {
+    fn();
+    return {};
+  }
+
+  int stdoutFd = fileno(stdout);
+  int savedStdout = dup(stdoutFd);
+
+  if (savedStdout == -1) {
+    std::fclose(tmp);
+    fn();
+    return {};
+  }
+
+  int tmpFd = fileno(tmp);
+
+  auto restore = [&]() {
+    std::cout.flush();
+    std::fflush(stdout);
+    dup2(savedStdout, stdoutFd);
+    close(savedStdout);
+  };
+
+  if (dup2(tmpFd, stdoutFd) == -1) {
+    close(savedStdout);
+    std::fclose(tmp);
+    fn();
+    return {};
+  }
+
+  try {
+    fn();
+    restore();
+  } catch (...) {
+    restore();
+    std::fclose(tmp);
+    throw;
+  }
+
+  std::string output;
+  std::fseek(tmp, 0, SEEK_SET);
+
+  char buffer[8192];
+  while (size_t n = std::fread(buffer, 1, sizeof(buffer), tmp)) {
+    output.append(buffer, n);
+  }
+
+  std::fclose(tmp);
+  return output;
+}
+
+bool executableExists(const std::string& cmd) {
+#ifdef _WIN32
+  // On Windows, try to execute in a hidden way
+  std::string checkCmd = cmd + " >nul 2>&1 || (exit /b 1)";
+  return std::system(checkCmd.c_str()) == 0;
+#else
+  // On Unix, use 'command -v' to check if executable exists
+  std::string checkCmd = "command -v " + cmd + " >/dev/null 2>&1";
+  return std::system(checkCmd.c_str()) == 0;
+#endif
+}
+
+std::string defaultPager() {
+#ifdef _WIN32
+  return "more";
+#else
+  if (executableExists("less")) {
+    return "less -R";
+  }
+  if (executableExists("more")) {
+    return "more";
+  }
+  return {};
+#endif
+}
+
+std::string selectPager() {
+  if (const char* pager = std::getenv("PAGER")) {
+    if (*pager != '\0') {
+      return pager;
+    }
+  }
+
+  return defaultPager();
+}
+
+void pageLargeOutput(const std::string& output) {
+  size_t lineCount = 0;
+  for (char c : output) {
+    if (c == '\n') lineCount++;
+  }
+
+  const size_t OUTPUT_SIZE_THRESHOLD = 3000;  // characters
+  const size_t OUTPUT_LINE_THRESHOLD = 40;    // lines
+
+  if (output.size() > OUTPUT_SIZE_THRESHOLD || lineCount > OUTPUT_LINE_THRESHOLD) {
+    std::string pager = selectPager();
+
+    if (pager.empty()) {
+      fmt::print("{}", output);
+      return;
+    }
+
+    FILE* pipe = popen(pager.c_str(), "w");
+    if (!pipe) {
+      fmt::print("{}", output);
+      return;
+    }
+
+    fwrite(output.c_str(), 1, output.size(), pipe);
+
+    int status = pclose(pipe);
+    if (status != 0) {
+      fmt::print("{}", output);
+    }
+  } else {
+    fmt::print("{}", output);
+  }
 }
 
 void printHelp() {
@@ -208,15 +348,22 @@ int main(int argc, char* argv[]) {
 
     auto it = commandRegistry.find(cmdName);
     if (it != commandRegistry.end()) {
-      // Commands with verbs use dispatchVerb, control commands have direct handlers
-      if (!it->second.verbs.empty()) {
-        dispatchVerb(cmdName, args);
-      } else if (cmdName == "help") {
-        cmd_help(args);
-      } else if (cmdName == "exit" || cmdName == "quit") {
+      if (cmdName == "exit" || cmdName == "quit") {
         break;
-      } else if (cmdName == "load") {
-        cmd_load(args);
+      }
+
+      std::string output = captureStdout([&]() {
+        if (!it->second.verbs.empty()) {
+          dispatchVerb(cmdName, args);
+        } else if (cmdName == "help") {
+          cmd_help(args);
+        } else if (cmdName == "load") {
+          cmd_load(args);
+        }
+      });
+
+      if (!output.empty()) {
+        pageLargeOutput(output);
       }
     } else {
       fmt::println("Unknown command. Type 'help'.");

--- a/src/ui/shell/vgmtrans-shell.cpp
+++ b/src/ui/shell/vgmtrans-shell.cpp
@@ -5,16 +5,19 @@
  */
 
 #include <cstdio>
+
 #ifndef  _WIN32
 #include <signal.h>
 #endif
 
 #include <csignal>
 #include <cstdlib>
-#include <iostream>
 #include <string>
 #include <vector>
 #include <filesystem>
+
+#include <fmt/base.h>
+#include <fmt/format.h>
 
 #include "DBGVGMRoot.h"
 #include "commands.h"
@@ -105,8 +108,8 @@ bool helpRequested(int argc, char* argv[]) {
 }
 
 void printHelp() {
-  std::cout << "VGMTrans shell is an interactive command-line interface for inspecting loaded music data and exporting it." << std::endl;
-  std::cout << std::endl;
+  fmt::println("VGMTrans shell is an interactive command-line interface for inspecting loaded music data and exporting it.");
+  fmt::println("");
   cmd_help({});
 }
 
@@ -140,7 +143,7 @@ int main(int argc, char* argv[]) {
   }
 
   if (!dbgRoot.init()) {
-    std::cerr << "Failed to init VGMRoot" << std::endl;
+    fmt::println(stderr, "Failed to init VGMRoot");
     return 1;
   }
 
@@ -160,7 +163,7 @@ int main(int argc, char* argv[]) {
   std::filesystem::create_directories(historyFile.parent_path());
   linenoiseHistoryLoad(historyFile.string().c_str());
 
-  std::cout << "Welcome to the VGMTrans shell. Type 'help' for commands." << std::endl;
+  fmt::println("Welcome to the VGMTrans shell. Type 'help' for commands.");
 
   // Auto-load files passed as arguments
   for (int i = 1; i < argc; ++i) {
@@ -174,7 +177,6 @@ int main(int argc, char* argv[]) {
 
     if (g_sigint_received) {
       g_sigint_received = 0;
-      std::cout << "^C" << std::endl;
       if (result)
         linenoiseFree(result);
       continue;
@@ -217,9 +219,10 @@ int main(int argc, char* argv[]) {
         cmd_load(args);
       }
     } else {
-      std::cout << "Unknown command. Type 'help'." << std::endl;
+      fmt::println("Unknown command. Type 'help'.");
     }
   }
 
+  fmt::println("Goodbye!");
   return 0;
 }

--- a/src/ui/shell/vgmtrans-shell.cpp
+++ b/src/ui/shell/vgmtrans-shell.cpp
@@ -162,6 +162,12 @@ int main(int argc, char* argv[]) {
 
   std::cout << "Welcome to the VGMTrans shell. Type 'help' for commands." << std::endl;
 
+  // Auto-load files passed as arguments
+  for (int i = 1; i < argc; ++i) {
+    std::vector<std::string> loadArgs = {"load", argv[i]};
+    cmd_load(loadArgs);
+  }
+
   char* result;
   while (true) {
     result = linenoise("(vgmt) ");

--- a/src/ui/shell/vgmtrans-shell.cpp
+++ b/src/ui/shell/vgmtrans-shell.cpp
@@ -94,6 +94,22 @@ void completionHook(const char* buf, linenoiseCompletions* lc) {
   }
 }
 
+bool helpRequested(int argc, char* argv[]) {
+  for (int i = 1; i < argc; ++i) {
+    std::string arg(argv[i]);
+    if (arg == "-h" || arg == "--help") {
+      return true;
+    }
+  }
+  return false;
+}
+
+void printHelp() {
+  std::cout << "VGMTrans shell is an interactive command-line interface for inspecting loaded music data and exporting it." << std::endl;
+  std::cout << std::endl;
+  cmd_help({});
+}
+
 std::filesystem::path configDirectory(const std::string& app_name) {
 #ifdef _WIN32
   if (const char* appdata = std::getenv("APPDATA")) {
@@ -117,6 +133,12 @@ std::filesystem::path configDirectory(const std::string& app_name) {
 }
 
 int main(int argc, char* argv[]) {
+  if (helpRequested(argc, argv)) {
+    registerCommands();
+    printHelp();
+    return 0;
+  }
+
   if (!dbgRoot.init()) {
     std::cerr << "Failed to init VGMRoot" << std::endl;
     return 1;


### PR DESCRIPTION
## Description
This change makes the shell more convenient for interactive use and large output inspection.

It adds support for opening files passed as command-line arguments on startup, so `vgmtrans-shell somefile` now loads the file automatically. It also adds output paging for long command results, with a pager selection flow that prefers `$PAGER`, then falls back to `less -R` on Unix when available, then `more`, and finally direct printing if no pager is available.

## Motivation and Context
The shell previously required a manual `load` command even when the user already had a file path on the command line. Large listing commands also dumped too much text into terminal scrollback, which made inspection awkward.

## How Has This Been Tested?
Trying to use vgmtrans-shell with various commands. Untested on Windows

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
