### PR TITLE
Vibrato delay modulator support

### DIFF
--- a/src/main/components/instr/Modulation.cpp
+++ b/src/main/components/instr/Modulation.cpp
@@ -19,10 +19,6 @@ int32_t hertzToInstrumentCents(double hertz) {
   return static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / kSf2LfoReferenceHz)));
 }
 
-double clampSecondsRangeMinimum(double seconds) {
-  return std::max(seconds, kSf2MinNormalDelaySeconds);
-}
-
 // Linearly map an absolute amount in destination units onto a 7-bit unipolar
 // MIDI controller value for the [minAmount, maxAmount] range, clamped to 0..127.
 uint8_t midiValueForAmountInRange(int32_t currentAmount, int32_t minAmount, int32_t maxAmount) {
@@ -36,6 +32,10 @@ uint8_t midiValueForAmountInRange(int32_t currentAmount, int32_t minAmount, int3
 }
 
 }  // namespace
+
+double clampSecondsRangeMinimum(double seconds) {
+  return std::max(seconds, kSf2MinNormalDelaySeconds);
+}
 
 ModAmount ModAmount::raw(int32_t amount) {
   return ModAmount(amount, true);

--- a/src/main/components/instr/Modulation.cpp
+++ b/src/main/components/instr/Modulation.cpp
@@ -12,9 +12,14 @@
 namespace {
 
 constexpr double kSf2LfoReferenceHz = 8.176;
+constexpr double kSf2MinNormalDelaySeconds = 1.0 / 1024.0;
 
 int32_t hertzToInstrumentCents(double hertz) {
   return static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / kSf2LfoReferenceHz)));
+}
+
+double clampSecondsRangeMinimum(double seconds) {
+  return std::max(seconds, kSf2MinNormalDelaySeconds);
 }
 
 // Linearly map an absolute amount in destination units onto a 7-bit unipolar
@@ -82,11 +87,11 @@ ModAmount ModAmount::fromSeconds(double seconds) {
 }
 
 ModAmount ModAmount::fromSecondsRange(double minSeconds, double maxSeconds) {
-  if (!std::isfinite(minSeconds) || !std::isfinite(maxSeconds)) {
+  if (maxSeconds <= 0.0 || !std::isfinite(minSeconds) || !std::isfinite(maxSeconds)) {
     return ModAmount(0, false);
   }
 
-  const ModAmount minAmount = fromSeconds(minSeconds);
+  const ModAmount minAmount = fromSeconds(clampSecondsRangeMinimum(minSeconds));
   const ModAmount maxAmount = fromSeconds(maxSeconds);
   if (!minAmount.valid() || !maxAmount.valid()) {
     return ModAmount(0, false);
@@ -97,16 +102,17 @@ ModAmount ModAmount::fromSecondsRange(double minSeconds, double maxSeconds) {
 }
 
 uint8_t midiValueForSecondsInRange(double seconds, double minSeconds, double maxSeconds) {
-  const ModAmount minAmount = ModAmount::fromSeconds(minSeconds);
-  const ModAmount maxAmount = ModAmount::fromSeconds(maxSeconds);
-  const ModAmount currentAmount = ModAmount::fromSeconds(seconds);
+  const ModAmount minAmount = ModAmount::fromSeconds(clampSecondsRangeMinimum(minSeconds));
+  const ModAmount rangeAmount = ModAmount::fromSecondsRange(minSeconds, maxSeconds);
+  const ModAmount currentAmount = ModAmount::fromSeconds(clampSecondsRangeMinimum(seconds));
 
-  if (!minAmount.valid() || !maxAmount.valid() || !currentAmount.valid() ||
-      minAmount.value() == maxAmount.value()) {
+  if (!minAmount.valid() || !rangeAmount.valid() || !currentAmount.valid() || rangeAmount.value() == 0) {
     return 0;
   }
 
-  return midiValueForAmountInRange(currentAmount.value(), minAmount.value(), maxAmount.value());
+  return midiValueForAmountInRange(currentAmount.value(),
+                                   minAmount.value(),
+                                   minAmount.value() + rangeAmount.value());
 }
 
 ModAmount ModAmount::fromCentibels(double centibels) {

--- a/src/main/components/instr/Modulation.cpp
+++ b/src/main/components/instr/Modulation.cpp
@@ -17,6 +17,16 @@ int32_t hertzToInstrumentCents(double hertz) {
   return static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / kSf2LfoReferenceHz)));
 }
 
+uint8_t midiValueForAmountInRange(int32_t currentAmount, int32_t minAmount, int32_t maxAmount) {
+  if (minAmount == maxAmount) {
+    return 0;
+  }
+
+  const int midiValue = static_cast<int>(std::round(
+      128.0 * (currentAmount - minAmount) / static_cast<double>(maxAmount - minAmount)));
+  return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
+}
+
 }  // namespace
 
 ModAmount ModAmount::raw(int32_t amount) {
@@ -56,17 +66,45 @@ uint8_t midiValueForHertzInRange(double hertz, double minHertz, double maxHertz)
   const ModAmount rangeAmount = ModAmount::fromHertzRange(minHertz, maxHertz);
   const ModAmount currentAmount = ModAmount::fromHertz(hertz);
 
-  if (!minAmount.valid() || !rangeAmount.valid() || !currentAmount.valid() || rangeAmount.value() <= 0) {
+  if (!minAmount.valid() || !rangeAmount.valid() || !currentAmount.valid() || rangeAmount.value() == 0) {
     return 0;
   }
 
-  const int midiValue = static_cast<int>(std::round(
-      128.0 * (currentAmount.value() - minAmount.value()) / static_cast<double>(rangeAmount.value())));
-  return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
+  return midiValueForAmountInRange(currentAmount.value(),
+                                   minAmount.value(),
+                                   minAmount.value() + rangeAmount.value());
 }
 
 ModAmount ModAmount::fromSeconds(double seconds) {
   return ModAmount(secondsToSf2Timecents(seconds), true);
+}
+
+ModAmount ModAmount::fromSecondsRange(double minSeconds, double maxSeconds) {
+  if (!std::isfinite(minSeconds) || !std::isfinite(maxSeconds)) {
+    return ModAmount(0, false);
+  }
+
+  const ModAmount minAmount = fromSeconds(minSeconds);
+  const ModAmount maxAmount = fromSeconds(maxSeconds);
+  if (!minAmount.valid() || !maxAmount.valid()) {
+    return ModAmount(0, false);
+  }
+
+  const double fullScaleRange = (maxAmount.value() - minAmount.value()) * 128.0 / 127.0;
+  return ModAmount(static_cast<int32_t>(std::lround(fullScaleRange)), true);
+}
+
+uint8_t midiValueForSecondsInRange(double seconds, double minSeconds, double maxSeconds) {
+  const ModAmount minAmount = ModAmount::fromSeconds(minSeconds);
+  const ModAmount maxAmount = ModAmount::fromSeconds(maxSeconds);
+  const ModAmount currentAmount = ModAmount::fromSeconds(seconds);
+
+  if (!minAmount.valid() || !maxAmount.valid() || !currentAmount.valid() ||
+      minAmount.value() == maxAmount.value()) {
+    return 0;
+  }
+
+  return midiValueForAmountInRange(currentAmount.value(), minAmount.value(), maxAmount.value());
 }
 
 ModAmount ModAmount::fromCentibels(double centibels) {

--- a/src/main/components/instr/Modulation.cpp
+++ b/src/main/components/instr/Modulation.cpp
@@ -92,7 +92,8 @@ ModAmount ModAmount::fromSeconds(double seconds) {
 
 ModAmount ModAmount::fromSecondsRange(double minSeconds, double maxSeconds) {
   if (maxSeconds <= 0.0 || !std::isfinite(minSeconds) || !std::isfinite(maxSeconds)) {
-    L_WARN("ModAmount::fromSecondsRange received invalid seconds range: minSeconds={}, maxSeconds={}", minSeconds, maxSeconds);
+    L_WARN("ModAmount::fromSecondsRange received invalid seconds range: minSeconds={}, maxSeconds={}",
+           minSeconds, maxSeconds);
     return ModAmount(0, false);
   }
 

--- a/src/main/components/instr/Modulation.cpp
+++ b/src/main/components/instr/Modulation.cpp
@@ -17,6 +17,8 @@ int32_t hertzToInstrumentCents(double hertz) {
   return static_cast<int32_t>(std::lround(1200.0 * std::log2(hertz / kSf2LfoReferenceHz)));
 }
 
+// Linearly map an absolute amount in destination units onto a 7-bit unipolar
+// MIDI controller value for the [minAmount, maxAmount] range, clamped to 0..127.
 uint8_t midiValueForAmountInRange(int32_t currentAmount, int32_t minAmount, int32_t maxAmount) {
   if (minAmount == maxAmount) {
     return 0;

--- a/src/main/components/instr/Modulation.cpp
+++ b/src/main/components/instr/Modulation.cpp
@@ -7,6 +7,7 @@
 #include "Modulation.h"
 #include <algorithm>
 #include <cmath>
+#include "LogManager.h"
 #include "ScaleConversion.h"
 
 namespace {
@@ -42,6 +43,7 @@ ModAmount ModAmount::raw(int32_t amount) {
 
 ModAmount ModAmount::fromCents(double cents) {
   if (!std::isfinite(cents)) {
+    L_WARN("ModAmount::fromCents received invalid cents value: {}", cents);
     return ModAmount(0, false);
   }
 
@@ -50,6 +52,7 @@ ModAmount ModAmount::fromCents(double cents) {
 
 ModAmount ModAmount::fromHertz(double hertz) {
   if (hertz <= 0.0 || !std::isfinite(hertz)) {
+    L_WARN("ModAmount::fromHertz received invalid hertz value: {}", hertz);
     return ModAmount(0, false);
   }
 
@@ -59,6 +62,7 @@ ModAmount ModAmount::fromHertz(double hertz) {
 ModAmount ModAmount::fromHertzRange(double minHertz, double maxHertz) {
   if (minHertz <= 0.0 || maxHertz <= 0.0 ||
       !std::isfinite(minHertz) || !std::isfinite(maxHertz)) {
+    L_WARN("ModAmount::fromHertzRange received invalid hertz range: minHertz={}, maxHertz={}", minHertz, maxHertz);
     return ModAmount(0, false);
   }
 
@@ -88,6 +92,7 @@ ModAmount ModAmount::fromSeconds(double seconds) {
 
 ModAmount ModAmount::fromSecondsRange(double minSeconds, double maxSeconds) {
   if (maxSeconds <= 0.0 || !std::isfinite(minSeconds) || !std::isfinite(maxSeconds)) {
+    L_WARN("ModAmount::fromSecondsRange received invalid seconds range: minSeconds={}, maxSeconds={}", minSeconds, maxSeconds);
     return ModAmount(0, false);
   }
 
@@ -117,6 +122,7 @@ uint8_t midiValueForSecondsInRange(double seconds, double minSeconds, double max
 
 ModAmount ModAmount::fromCentibels(double centibels) {
   if (!std::isfinite(centibels)) {
+    L_WARN("ModAmount::fromCentibels received invalid centibels value: {}", centibels);
     return ModAmount(0, false);
   }
 
@@ -125,6 +131,7 @@ ModAmount ModAmount::fromCentibels(double centibels) {
 
 ModAmount ModAmount::fromDecibels(double decibels) {
   if (!std::isfinite(decibels)) {
+    L_WARN("ModAmount::fromDecibels received invalid decibels value: {}", decibels);
     return ModAmount(0, false);
   }
 

--- a/src/main/components/instr/Modulation.h
+++ b/src/main/components/instr/Modulation.h
@@ -60,6 +60,7 @@ private:
 // Convert an absolute frequency into the 7-bit MIDI value that drives a
 // ParamAmount::hertzRange(minHertz, maxHertz) modulator or generator.
 uint8_t midiValueForHertzInRange(double hertz, double minHertz, double maxHertz);
+double clampSecondsRangeMinimum(double seconds);
 uint8_t midiValueForSecondsInRange(double seconds, double minSeconds, double maxSeconds);
 
 struct SynthModulator {

--- a/src/main/components/instr/Modulation.h
+++ b/src/main/components/instr/Modulation.h
@@ -41,6 +41,8 @@ public:
   static ModAmount fromHertzRange(double minHertz, double maxHertz);
   static ModAmount fromSeconds(double seconds);
   // A 7-bit unipolar controller range in timecents, scaled so MIDI value 127 reaches maxSeconds.
+  // minSeconds is clamped to the smallest normal SF2 delay because the zero-delay sentinel
+  // cannot anchor a continuous range.
   static ModAmount fromSecondsRange(double minSeconds, double maxSeconds);
   static ModAmount fromCentibels(double centibels);
   static ModAmount fromDecibels(double decibels);

--- a/src/main/components/instr/Modulation.h
+++ b/src/main/components/instr/Modulation.h
@@ -40,6 +40,8 @@ public:
   // A 7-bit unipolar controller range in Hz, scaled so MIDI value 127 reaches maxHertz.
   static ModAmount fromHertzRange(double minHertz, double maxHertz);
   static ModAmount fromSeconds(double seconds);
+  // A 7-bit unipolar controller range in timecents, scaled so MIDI value 127 reaches maxSeconds.
+  static ModAmount fromSecondsRange(double minSeconds, double maxSeconds);
   static ModAmount fromCentibels(double centibels);
   static ModAmount fromDecibels(double decibels);
 
@@ -56,6 +58,7 @@ private:
 // Convert an absolute frequency into the 7-bit MIDI value that drives a
 // ParamAmount::hertzRange(minHertz, maxHertz) modulator or generator.
 uint8_t midiValueForHertzInRange(double hertz, double minHertz, double maxHertz);
+uint8_t midiValueForSecondsInRange(double seconds, double minSeconds, double maxSeconds);
 
 struct SynthModulator {
   ModSource source;

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -203,10 +203,11 @@ void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
   addGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(minHertz));
   addModulator(ModSource::ChannelPressure, ModDest::VibLfoFreq, ModAmount::fromHertzRange(minHertz, maxHertz));
   if (delayRange.has_value()) {
-    addGenerator(ModDest::VibLfoDelay, ModAmount::fromSeconds(delayRange->minSeconds));
+    const double minDelaySeconds = clampSecondsRangeMinimum(delayRange->minSeconds);
+    addGenerator(ModDest::VibLfoDelay, ModAmount::fromSeconds(minDelaySeconds));
     addModulator(ModSource::ChorusSend,
                  ModDest::VibLfoDelay,
-                 ModAmount::fromSecondsRange(delayRange->minSeconds, delayRange->maxSeconds));
+                 ModAmount::fromSecondsRange(minDelaySeconds, delayRange->maxSeconds));
   }
 }
 

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -194,13 +194,20 @@ bool VGMInstr::updateModulatorAmount(ModSource source, ModDest destination, ModA
 }
 
 void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
-                                         double minHertz,
-                                         double maxHertz) {
+                                          double minHertz,
+                                          double maxHertz,
+                                          std::optional<DelayRange> delayRange) {
   addModulator(ModSource::ModWheel, ModDest::VibLfoToPitch, ModAmount::fromCents(maxDepthCents));
   // nullify default channel pressure to vib lfo pitch modulator
   addModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, ModAmount::fromCents(0));
   addGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(minHertz));
   addModulator(ModSource::ChannelPressure, ModDest::VibLfoFreq, ModAmount::fromHertzRange(minHertz, maxHertz));
+  if (delayRange.has_value()) {
+    addGenerator(ModDest::VibLfoDelay, ModAmount::fromSeconds(delayRange->minSeconds));
+    addModulator(ModSource::ChorusSend,
+                 ModDest::VibLfoDelay,
+                 ModAmount::fromSecondsRange(delayRange->minSeconds, delayRange->maxSeconds));
+  }
 }
 
 void VGMInstr::addStandardTremoloHandling(double maxDepthDb,

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -179,6 +179,20 @@ void VGMInstr::addModulator(ModSource source, ModDest destination, ModAmount amo
   m_modulators.push_back({source, destination, amount.value()});
 }
 
+bool VGMInstr::updateModulatorAmount(ModSource source, ModDest destination, ModAmount amount) {
+  if (!amount.valid()) {
+    return false;
+  }
+
+  for (auto& modulator : m_modulators) {
+    if (modulator.source == source && modulator.destination == destination) {
+      modulator.amount = amount.value();
+      return true;
+    }
+  }
+  return false;
+}
+
 void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
                                          double minHertz,
                                          double maxHertz) {

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -82,6 +82,7 @@ public:
 
   // Modulator support
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
+  bool updateModulatorAmount(ModSource source, ModDest destination, ModAmount amount);
   void addStandardVibratoHandling(double maxDepthCents, double minHertz, double maxHertz);
   void addStandardTremoloHandling(double maxDepthDb,
                                   double minHertz,

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -2,6 +2,7 @@
 #include "common.h"
 #include "Modulation.h"
 #include "VGMFile.h"
+#include <optional>
 
 class VGMSampColl;
 class VGMInstr;
@@ -67,6 +68,11 @@ private:
 
 class VGMInstr : public VGMItem {
 public:
+  struct DelayRange {
+    double minSeconds;
+    double maxSeconds;
+  };
+
   VGMInstr(VGMInstrSet *parInstrSet, uint32_t offset, uint32_t length, uint32_t bank,
            uint32_t instrNum, std::string name = "Instrument",
            float reverb = defaultReverbPercent);
@@ -83,7 +89,10 @@ public:
   // Modulator support
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
   bool updateModulatorAmount(ModSource source, ModDest destination, ModAmount amount);
-  void addStandardVibratoHandling(double maxDepthCents, double minHertz, double maxHertz);
+  void addStandardVibratoHandling(double maxDepthCents,
+                                  double minHertz,
+                                  double maxHertz,
+                                  std::optional<DelayRange> delayRange = std::nullopt);
   void addStandardTremoloHandling(double maxDepthDb,
                                   double minHertz,
                                   double maxHertz,

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -421,9 +421,8 @@ void DLSArt::addModulator(const SynthModulator& modulator) {
           centsToDlsPitchScale(modulator.amount)));
       break;
     case ModDest::VibLfoDelay:
-      m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
-          source, CONN_SRC_NONE, CONN_DST_VIB_STARTDELAY, CONN_TRN_NONE,
-          toDls16Dot16Scale(modulator.amount)));
+      // DLS does not have a portable equivalent to SF2's controller-driven vibrato delay path.
+      // Keep static vibrato delay generators, but ignore delay modulators.
       break;
     case ModDest::ModLfoFreq:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(


### PR DESCRIPTION
This extends the modulation model with support for the vibLfoDelay destination. ModAmount now provides the helper `fromSecondsRange(...)` to easily specify an 'amount' value for the modulator's range, and `midiValueForSecondsInRange(...)` generates controller values for sequence conversion.

Vibrato delay range is made an optional parameter to `addStandardVibratoHandling(...)`. When provided it is mapped CC93 (for now).

This also adds L_WARN() calls to the ModAmount helpers when values cannot be converted.

DLS does not support vibrato delay, so we ignore it for DLS conversion.

## Motivation and Context
Vibrato delay is used by KonamiSnes, and probably other drivers.

## How Has This Been Tested?
This was put into practice on the KonamiSnes format. Resulting values were tested there.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
