### PR TITLE
KonamiSnes: vibrato support

### DIFF
--- a/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
@@ -12,89 +12,15 @@ namespace konami_snes {
 
 inline constexpr double kTimerHz = 250.0;
 inline constexpr uint8_t kDefaultVibratoMaxDepth = 0xff;
-inline constexpr uint8_t kDefaultV1VibratoMaxRateStep = 0x7f;
-// We define minimum ranges for vibrato depth and rate, in case the sequence uses a very small range
+inline constexpr uint8_t kDefaultLegacyVibratoMaxRateStep = 0x7f;
 inline constexpr uint8_t kMinVibratoMaxDepth = 0x10;
-// At the default tempo FF, effective step 09 is the first Konami rate that reaches about 8.176 Hz.
 inline constexpr uint8_t kMinVibratoMaxRateStep = 0x09;
-
-inline constexpr bool usesV1Vibrato(KonamiSnesVersion version) {
-  return version == KONAMISNES_V1;
-}
-
-inline constexpr uint8_t v1VibratoRateStep(uint8_t rate) {
-  return (rate == 0 || rate == 0x80)
-      ? 0
-      : static_cast<uint8_t>((rate < 0x80) ? rate : (0x100 - rate));
-}
-
-inline constexpr uint8_t v2VibratoRateStep(uint8_t rate) {
-  return (rate == 0xff) ? 16 : (rate >= 0x80) ? 8 : (rate >= 0x40) ? 4 : (rate >= 0x20) ? 2 : 1;
-}
-
-inline constexpr bool hasActiveVibrato(KonamiSnesVersion version, uint8_t rate, uint8_t depth) {
-  return depth != 0 && (usesV1Vibrato(version) ? (v1VibratoRateStep(rate) != 0) : (rate != 0));
-}
-
-inline constexpr double vibratoDepthCents(KonamiSnesVersion version, uint8_t depth) {
-  if (usesV1Vibrato(version)) {
-    return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
-  }
-
-  return (depth < 0x80) ? (depth * (100.0 / 128.0)) : ((depth - 126.0) * 50.0);
-}
-
-inline constexpr uint16_t vibratoRateFactor(KonamiSnesVersion version, uint8_t rate, uint8_t tempo) {
-  if (usesV1Vibrato(version)) {
-    return static_cast<uint16_t>(v1VibratoRateStep(rate) * (tempo == 0 ? 1 : tempo));
-  }
-
-  return (rate == 0) ? 0 : static_cast<uint16_t>(rate * v2VibratoRateStep(rate));
-}
-
-inline constexpr uint16_t defaultVibratoMaxRateFactor(KonamiSnesVersion version) {
-  return usesV1Vibrato(version)
-      ? static_cast<uint16_t>(kDefaultV1VibratoMaxRateStep * 0xff)
-      : static_cast<uint16_t>(0xff * v2VibratoRateStep(0xff));
-}
-
-inline constexpr uint16_t minVibratoMaxRateFactor(KonamiSnesVersion version) {
-  return usesV1Vibrato(version)
-      ? static_cast<uint16_t>(kMinVibratoMaxRateStep * 0xff)
-      : kMinVibratoMaxRateStep;
-}
-
-inline constexpr double vibratoBaseHz(KonamiSnesVersion version) {
-  return usesV1Vibrato(version) ? (kTimerHz / 65536.0) : (kTimerHz / 16384.0);
-}
-
-// The driver delays vibrato until the first eligible sustain update after note-on, so even delay 0
-// maps more closely to a one-tick wait than to SF2's instantaneous sentinel.
-inline constexpr double kV1VibratoDelayBaseSeconds = 256.0 / kTimerHz;
-inline constexpr double vibratoDelaySeconds(KonamiSnesVersion version, uint8_t delay, uint8_t tempo) {
-  if (usesV1Vibrato(version)) {
-    return (kV1VibratoDelayBaseSeconds * (delay + 1.0)) / (tempo == 0 ? 1 : tempo);
-  }
-
-  return (delay + 1.0) / kTimerHz;
-}
-
-inline constexpr double minVibratoDelaySeconds(KonamiSnesVersion version) {
-  return usesV1Vibrato(version) ? vibratoDelaySeconds(version, 0, 0xff) : vibratoDelaySeconds(version, 0, 0);
-}
-
-inline constexpr double maxVibratoDelaySeconds(KonamiSnesVersion version) {
-  return usesV1Vibrato(version) ? vibratoDelaySeconds(version, 0xff, 1) : vibratoDelaySeconds(version, 0xc7, 0);
-}
-
-inline constexpr uint8_t vibratoDelayFromArg1(KonamiSnesVersion version, uint8_t arg1) {
-  return (!usesV1Vibrato(version) && arg1 >= 0xc8) ? 0 : arg1;
-}
-
-inline constexpr uint8_t vibratoInlineFadeLength(KonamiSnesVersion version, uint8_t arg1) {
-  return (!usesV1Vibrato(version) && arg1 >= 0xc8) ? static_cast<uint8_t>(arg1 - 0xc7) : 0;
-}
-
+inline constexpr uint8_t kLateEraVibratoFadeThreshold = 0xc8;
 inline constexpr uint8_t kVibratoDelayController = 93;
+
+// V1 and V2 use the older Contra-style vibrato. V3-V6 use the later Goemon-style logic.
+inline constexpr bool usesLegacyVibrato(KonamiSnesVersion version) {
+  return version == KONAMISNES_V1 || version == KONAMISNES_V2;
+}
 
 }  // namespace konami_snes

--- a/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
@@ -12,6 +12,10 @@ namespace konami_snes {
 inline constexpr double kTimerHz = 250.0;
 inline constexpr uint8_t kDefaultVibratoMaxDepth = 0xff;
 inline constexpr uint8_t kDefaultVibratoMaxRateStep = 0x7f;
+// We define minimum ranges for vibrato depth and rate, in case the sequence uses a very small range
+inline constexpr uint8_t kMinVibratoMaxDepth = 0x10;
+// At the default tempo FF, effective step 09 is the first Konami rate that reaches about 8.176 Hz.
+inline constexpr uint8_t kMinVibratoMaxRateStep = 0x09;
 
 inline constexpr uint8_t effectiveVibratoRateStep(uint8_t rate) {
   return (rate == 0 || rate == 0x80)

--- a/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
@@ -1,0 +1,31 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace konami_snes {
+
+inline constexpr double kTimerHz = 250.0;
+
+// The driver advances vibrato phase by the raw rate byte once per music tick, and music ticks
+// themselves are scaled by the current tempo byte. Splitting the factors this way lets the
+// SoundFont modulators track rate and tempo separately without collapsing all tempos into one
+// coarse controller range.
+inline constexpr double kVibratoBaseHz = kTimerHz / 65536.0;
+inline constexpr double kVibratoMaxRateFactor = 128.0;
+inline constexpr double kVibratoMaxTempoFactor = 255.0;
+inline constexpr double kVibratoMaxDepthCents = 255.0 * 12.5;
+
+// Konami delays vibrato until the first eligible sustain update after note-on, so even delay 0
+// maps more closely to a one-tick wait than to SF2's instantaneous sentinel.
+inline constexpr double kVibratoDelayBaseSeconds = 256.0 / kTimerHz;
+inline constexpr double kVibratoMaxDelayCountFactor = 256.0;
+
+inline constexpr uint8_t kVibratoTempoController = 91;
+inline constexpr uint8_t kVibratoDelayController = 93;
+
+}  // namespace konami_snes

--- a/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
@@ -6,46 +6,94 @@
 #pragma once
 
 #include <cstdint>
+#include "KonamiSnesFormat.h"
 
 namespace konami_snes {
 
 inline constexpr double kTimerHz = 250.0;
 inline constexpr uint8_t kDefaultVibratoMaxDepth = 0xff;
-inline constexpr uint8_t kDefaultVibratoMaxRateStep = 0x7f;
+inline constexpr uint8_t kDefaultV1VibratoMaxRateStep = 0x7f;
 // We define minimum ranges for vibrato depth and rate, in case the sequence uses a very small range
 inline constexpr uint8_t kMinVibratoMaxDepth = 0x10;
 // At the default tempo FF, effective step 09 is the first Konami rate that reaches about 8.176 Hz.
 inline constexpr uint8_t kMinVibratoMaxRateStep = 0x09;
 
-inline constexpr uint8_t effectiveVibratoRateStep(uint8_t rate) {
+inline constexpr bool usesV1Vibrato(KonamiSnesVersion version) {
+  return version == KONAMISNES_V1;
+}
+
+inline constexpr uint8_t v1VibratoRateStep(uint8_t rate) {
   return (rate == 0 || rate == 0x80)
       ? 0
       : static_cast<uint8_t>((rate < 0x80) ? rate : (0x100 - rate));
 }
 
-inline constexpr double vibratoDepthCents(uint8_t depth) {
-  return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
+inline constexpr uint8_t v2VibratoRateStep(uint8_t rate) {
+  return (rate == 0xff) ? 16 : (rate >= 0x80) ? 8 : (rate >= 0x40) ? 4 : (rate >= 0x20) ? 2 : 1;
 }
 
-inline constexpr uint16_t kDefaultVibratoMaxRateFactor =
-    static_cast<uint16_t>(kDefaultVibratoMaxRateStep * 0xff);
-inline constexpr uint16_t kMinVibratoMaxRateFactor =
-    static_cast<uint16_t>(kMinVibratoMaxRateStep * 0xff);
+inline constexpr bool hasActiveVibrato(KonamiSnesVersion version, uint8_t rate, uint8_t depth) {
+  return depth != 0 && (usesV1Vibrato(version) ? (v1VibratoRateStep(rate) != 0) : (rate != 0));
+}
 
-// The driver advances vibrato phase by the raw rate byte once per music tick, and music ticks
-// themselves are scaled by the current tempo byte. We fold both factors together on the sequence
-// side and emit the final effective frequency directly.
-inline constexpr double kVibratoBaseHz = kTimerHz / 65536.0;
-inline constexpr double kVibratoMaxTempoFactor = 255.0;
+inline constexpr double vibratoDepthCents(KonamiSnesVersion version, uint8_t depth) {
+  if (usesV1Vibrato(version)) {
+    return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
+  }
+
+  return (depth < 0x80) ? (depth * (100.0 / 128.0)) : ((depth - 126.0) * 50.0);
+}
+
+inline constexpr uint16_t vibratoRateFactor(KonamiSnesVersion version, uint8_t rate, uint8_t tempo) {
+  if (usesV1Vibrato(version)) {
+    return static_cast<uint16_t>(v1VibratoRateStep(rate) * (tempo == 0 ? 1 : tempo));
+  }
+
+  return (rate == 0) ? 0 : static_cast<uint16_t>(rate * v2VibratoRateStep(rate));
+}
+
+inline constexpr uint16_t defaultVibratoMaxRateFactor(KonamiSnesVersion version) {
+  return usesV1Vibrato(version)
+      ? static_cast<uint16_t>(kDefaultV1VibratoMaxRateStep * 0xff)
+      : static_cast<uint16_t>(0xff * v2VibratoRateStep(0xff));
+}
+
+inline constexpr uint16_t minVibratoMaxRateFactor(KonamiSnesVersion version) {
+  return usesV1Vibrato(version)
+      ? static_cast<uint16_t>(kMinVibratoMaxRateStep * 0xff)
+      : kMinVibratoMaxRateStep;
+}
+
+inline constexpr double vibratoBaseHz(KonamiSnesVersion version) {
+  return usesV1Vibrato(version) ? (kTimerHz / 65536.0) : (kTimerHz / 16384.0);
+}
 
 // The driver delays vibrato until the first eligible sustain update after note-on, so even delay 0
-// maps more closely to a one-tick wait than to SF2's instantaneous sentinel. We fold the inverse
-// tempo factor into the emitted delay value, so the helper's delay range spans the final absolute
-// delay in seconds.
-inline constexpr double kVibratoDelayBaseSeconds = 256.0 / kTimerHz;
-inline constexpr double kVibratoMaxDelayCountFactor = 256.0;
-inline constexpr double kVibratoMinDelaySeconds = kVibratoDelayBaseSeconds / kVibratoMaxTempoFactor;
-inline constexpr double kVibratoMaxDelaySeconds = kVibratoDelayBaseSeconds * kVibratoMaxDelayCountFactor;
+// maps more closely to a one-tick wait than to SF2's instantaneous sentinel.
+inline constexpr double kV1VibratoDelayBaseSeconds = 256.0 / kTimerHz;
+inline constexpr double vibratoDelaySeconds(KonamiSnesVersion version, uint8_t delay, uint8_t tempo) {
+  if (usesV1Vibrato(version)) {
+    return (kV1VibratoDelayBaseSeconds * (delay + 1.0)) / (tempo == 0 ? 1 : tempo);
+  }
+
+  return (delay + 1.0) / kTimerHz;
+}
+
+inline constexpr double minVibratoDelaySeconds(KonamiSnesVersion version) {
+  return usesV1Vibrato(version) ? vibratoDelaySeconds(version, 0, 0xff) : vibratoDelaySeconds(version, 0, 0);
+}
+
+inline constexpr double maxVibratoDelaySeconds(KonamiSnesVersion version) {
+  return usesV1Vibrato(version) ? vibratoDelaySeconds(version, 0xff, 1) : vibratoDelaySeconds(version, 0xc7, 0);
+}
+
+inline constexpr uint8_t vibratoDelayFromArg1(KonamiSnesVersion version, uint8_t arg1) {
+  return (!usesV1Vibrato(version) && arg1 >= 0xc8) ? 0 : arg1;
+}
+
+inline constexpr uint8_t vibratoInlineFadeLength(KonamiSnesVersion version, uint8_t arg1) {
+  return (!usesV1Vibrato(version) && arg1 >= 0xc8) ? static_cast<uint8_t>(arg1 - 0xc7) : 0;
+}
 
 inline constexpr uint8_t kVibratoDelayController = 93;
 

--- a/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
@@ -10,15 +10,25 @@
 namespace konami_snes {
 
 inline constexpr double kTimerHz = 250.0;
+inline constexpr uint8_t kDefaultVibratoMaxDepth = 0xff;
+inline constexpr uint8_t kDefaultVibratoMaxRateStep = 0x7f;
+
+inline constexpr uint8_t effectiveVibratoRateStep(uint8_t rate) {
+  return (rate == 0 || rate == 0x80)
+      ? 0
+      : static_cast<uint8_t>((rate < 0x80) ? rate : (0x100 - rate));
+}
+
+inline constexpr double vibratoDepthCents(uint8_t depth) {
+  return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
+}
 
 // The driver advances vibrato phase by the raw rate byte once per music tick, and music ticks
 // themselves are scaled by the current tempo byte. Splitting the factors this way lets the
 // SoundFont modulators track rate and tempo separately without collapsing all tempos into one
 // coarse controller range.
 inline constexpr double kVibratoBaseHz = kTimerHz / 65536.0;
-inline constexpr double kVibratoMaxRateFactor = 128.0;
 inline constexpr double kVibratoMaxTempoFactor = 255.0;
-inline constexpr double kVibratoMaxDepthCents = 255.0 * 12.5;
 
 // Konami delays vibrato until the first eligible sustain update after note-on, so even delay 0
 // maps more closely to a one-tick wait than to SF2's instantaneous sentinel.

--- a/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesDefinitions.h
@@ -27,19 +27,26 @@ inline constexpr double vibratoDepthCents(uint8_t depth) {
   return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
 }
 
+inline constexpr uint16_t kDefaultVibratoMaxRateFactor =
+    static_cast<uint16_t>(kDefaultVibratoMaxRateStep * 0xff);
+inline constexpr uint16_t kMinVibratoMaxRateFactor =
+    static_cast<uint16_t>(kMinVibratoMaxRateStep * 0xff);
+
 // The driver advances vibrato phase by the raw rate byte once per music tick, and music ticks
-// themselves are scaled by the current tempo byte. Splitting the factors this way lets the
-// SoundFont modulators track rate and tempo separately without collapsing all tempos into one
-// coarse controller range.
+// themselves are scaled by the current tempo byte. We fold both factors together on the sequence
+// side and emit the final effective frequency directly.
 inline constexpr double kVibratoBaseHz = kTimerHz / 65536.0;
 inline constexpr double kVibratoMaxTempoFactor = 255.0;
 
-// Konami delays vibrato until the first eligible sustain update after note-on, so even delay 0
-// maps more closely to a one-tick wait than to SF2's instantaneous sentinel.
+// The driver delays vibrato until the first eligible sustain update after note-on, so even delay 0
+// maps more closely to a one-tick wait than to SF2's instantaneous sentinel. We fold the inverse
+// tempo factor into the emitted delay value, so the helper's delay range spans the final absolute
+// delay in seconds.
 inline constexpr double kVibratoDelayBaseSeconds = 256.0 / kTimerHz;
 inline constexpr double kVibratoMaxDelayCountFactor = 256.0;
+inline constexpr double kVibratoMinDelaySeconds = kVibratoDelayBaseSeconds / kVibratoMaxTempoFactor;
+inline constexpr double kVibratoMaxDelaySeconds = kVibratoDelayBaseSeconds * kVibratoMaxDelayCountFactor;
 
-inline constexpr uint8_t kVibratoTempoController = 91;
 inline constexpr uint8_t kVibratoDelayController = 93;
 
 }  // namespace konami_snes

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -6,7 +6,9 @@
 
 #include "KonamiSnesInstr.h"
 #include "KonamiSnesDefinitions.h"
+#include "KonamiSnesSeq.h"
 #include "SNESDSP.h"
+#include "VGMColl.h"
 #include <algorithm>
 #include <spdlog/fmt/fmt.h>
 
@@ -29,6 +31,22 @@ constexpr bool usesLegacyPanRange(KonamiSnesVersion version) {
 
 constexpr uint8_t percussionPanLimit(KonamiSnesVersion version) {
   return usesLegacyPanRange(version) ? 0x14 : 0x28;
+}
+
+void applyVibratoExportScaling(KonamiSnesInstrSet* instrSet, uint8_t maxDepth, uint8_t maxRate) {
+  const uint8_t depthForExport = std::max<uint8_t>(maxDepth, 1);
+  const uint8_t rateForExport = std::max<uint8_t>(maxRate, 1);
+  const double maxDepthCents = konami_snes::vibratoDepthCents(depthForExport);
+  const double maxRateHz = konami_snes::kVibratoBaseHz * rateForExport;
+
+  for (auto* instr : instrSet->exportInstrs()) {
+    instr->updateModulatorAmount(ModSource::ModWheel,
+                                 ModDest::VibLfoToPitch,
+                                 ModAmount::fromCents(maxDepthCents));
+    instr->updateModulatorAmount(ModSource::ChannelPressure,
+                                 ModDest::VibLfoFreq,
+                                 ModAmount::fromHertzRange(konami_snes::kVibratoBaseHz, maxRateHz));
+  }
 }
 
 int getPercussionKey(RawFile *file, uint32_t addrInstrHeader) {
@@ -109,7 +127,9 @@ KonamiSnesInstrSet::KonamiSnesInstrSet(RawFile *file,
     bankedInstrOffset(bankedInstrOffset),
     firstBankedInstr(firstBankedInstr),
     percInstrOffset(percInstrOffset),
-    spcDirAddr(spcDirAddr) {
+    spcDirAddr(spcDirAddr),
+    maxVibratoDepth(konami_snes::kDefaultVibratoMaxDepth),
+    maxVibratoRate(konami_snes::kDefaultVibratoMaxRateStep) {
 }
 
 KonamiSnesInstrSet::~KonamiSnesInstrSet() {
@@ -195,6 +215,34 @@ bool KonamiSnesInstrSet::parseInstrPointers() {
   return true;
 }
 
+void KonamiSnesInstrSet::useColl(const VGMColl* coll) {
+  maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
+  maxVibratoRate = konami_snes::kDefaultVibratoMaxRateStep;
+
+  if (coll == nullptr || coll->seq() == nullptr) {
+    applyVibratoExportScaling(this, maxVibratoDepth, maxVibratoRate);
+    return;
+  }
+
+  const auto* seq = dynamic_cast<const KonamiSnesSeq*>(coll->seq());
+  if (seq != nullptr && seq->rawFile() == rawFile() && seq->version == version) {
+    if (seq->maxVibratoDepth != 0) {
+      maxVibratoDepth = seq->maxVibratoDepth;
+    }
+    if (seq->maxVibratoRate != 0) {
+      maxVibratoRate = seq->maxVibratoRate;
+    }
+  }
+
+  applyVibratoExportScaling(this, maxVibratoDepth, maxVibratoRate);
+}
+
+void KonamiSnesInstrSet::unuseColl() {
+  maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
+  maxVibratoRate = konami_snes::kDefaultVibratoMaxRateStep;
+  applyVibratoExportScaling(this, maxVibratoDepth, maxVibratoRate);
+}
+
 // ***************
 // KonamiSnesInstr
 // ***************
@@ -225,13 +273,13 @@ bool KonamiSnesInstr::loadInstr() {
   //   CC93 -> delay count
   addModulator(ModSource::ModWheel,
                ModDest::VibLfoToPitch,
-               ModAmount::fromCents(konami_snes::kVibratoMaxDepthCents));
+               ModAmount::fromCents(konami_snes::vibratoDepthCents(konami_snes::kDefaultVibratoMaxDepth)));
   addModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, ModAmount::fromCents(0));
   addGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(konami_snes::kVibratoBaseHz));
   addModulator(ModSource::ChannelPressure,
                ModDest::VibLfoFreq,
                ModAmount::fromHertzRange(konami_snes::kVibratoBaseHz,
-                                         konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxRateFactor));
+                                         konami_snes::kVibratoBaseHz * konami_snes::kDefaultVibratoMaxRateStep));
   addModulator(ModSource::ReverbSend,
                ModDest::VibLfoFreq,
                ModAmount::fromHertzRange(konami_snes::kVibratoBaseHz,

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -33,11 +33,11 @@ constexpr uint8_t percussionPanLimit(KonamiSnesVersion version) {
   return usesLegacyPanRange(version) ? 0x14 : 0x28;
 }
 
-void applyVibratoExportScaling(KonamiSnesInstrSet* instrSet, uint8_t maxDepth, uint8_t maxRate) {
+void applyVibratoExportScaling(KonamiSnesInstrSet* instrSet, uint8_t maxDepth, uint16_t maxRateFactor) {
   const uint8_t clampedMaxDepth = std::max(maxDepth, konami_snes::kMinVibratoMaxDepth);
-  const uint8_t clampedMaxRate = std::max(maxRate, konami_snes::kMinVibratoMaxRateStep);
+  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, konami_snes::kMinVibratoMaxRateFactor);
   const double maxDepthCents = konami_snes::vibratoDepthCents(clampedMaxDepth);
-  const double maxRateHz = konami_snes::kVibratoBaseHz * clampedMaxRate;
+  const double maxRateHz = konami_snes::kVibratoBaseHz * clampedMaxRateFactor;
 
   for (auto* instr : instrSet->exportInstrs()) {
     instr->updateModulatorAmount(ModSource::ModWheel,
@@ -129,7 +129,7 @@ KonamiSnesInstrSet::KonamiSnesInstrSet(RawFile *file,
     percInstrOffset(percInstrOffset),
     spcDirAddr(spcDirAddr),
     maxVibratoDepth(konami_snes::kDefaultVibratoMaxDepth),
-    maxVibratoRate(konami_snes::kDefaultVibratoMaxRateStep) {
+    maxVibratoRateFactor(konami_snes::kDefaultVibratoMaxRateFactor) {
 }
 
 KonamiSnesInstrSet::~KonamiSnesInstrSet() {
@@ -217,23 +217,23 @@ bool KonamiSnesInstrSet::parseInstrPointers() {
 
 void KonamiSnesInstrSet::useColl(const VGMColl* coll) {
   maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
-  maxVibratoRate = konami_snes::kDefaultVibratoMaxRateStep;
+  maxVibratoRateFactor = konami_snes::kDefaultVibratoMaxRateFactor;
 
   if (coll != nullptr && coll->seq() != nullptr) {
     const auto* seq = dynamic_cast<const KonamiSnesSeq*>(coll->seq());
     if (seq != nullptr && seq->rawFile() == rawFile() && seq->version == version) {
       maxVibratoDepth = seq->maxVibratoDepth;
-      maxVibratoRate = seq->maxVibratoRate;
+      maxVibratoRateFactor = seq->maxVibratoRateFactor;
     }
   }
 
-  applyVibratoExportScaling(this, maxVibratoDepth, maxVibratoRate);
+  applyVibratoExportScaling(this, maxVibratoDepth, maxVibratoRateFactor);
 }
 
 void KonamiSnesInstrSet::unuseColl() {
   maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
-  maxVibratoRate = konami_snes::kDefaultVibratoMaxRateStep;
-  applyVibratoExportScaling(this, maxVibratoDepth, maxVibratoRate);
+  maxVibratoRateFactor = konami_snes::kDefaultVibratoMaxRateFactor;
+  applyVibratoExportScaling(this, maxVibratoDepth, maxVibratoRateFactor);
 }
 
 // ***************
@@ -258,36 +258,18 @@ KonamiSnesInstr::~KonamiSnesInstr() {
 }
 
 bool KonamiSnesInstr::loadInstr() {
-  // Konami vibrato is driven per track from E4 and is relative to the current tempo, so we split
-  // the SoundFont frequency and delay modulators across separate controller factors:
+  // Konami vibrato is driven per track from E4:
   //   CC1  -> depth
-  //   ch. pressure -> rate step
-  //   CC91 -> tempo factor (raises vibrato frequency and shortens delay)
-  //   CC93 -> delay count
-  addModulator(ModSource::ModWheel,
-               ModDest::VibLfoToPitch,
-               ModAmount::fromCents(konami_snes::vibratoDepthCents(konami_snes::kDefaultVibratoMaxDepth)));
-  addModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, ModAmount::fromCents(0));
-  addGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(konami_snes::kVibratoBaseHz));
-  addModulator(ModSource::ChannelPressure,
-               ModDest::VibLfoFreq,
-               ModAmount::fromHertzRange(konami_snes::kVibratoBaseHz,
-                                         konami_snes::kVibratoBaseHz * konami_snes::kDefaultVibratoMaxRateStep));
-  addModulator(ModSource::ReverbSend,
-               ModDest::VibLfoFreq,
-               ModAmount::fromHertzRange(konami_snes::kVibratoBaseHz,
-                                         konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxTempoFactor));
-  addGenerator(ModDest::VibLfoDelay, ModAmount::fromSeconds(konami_snes::kVibratoDelayBaseSeconds));
-  addModulator(ModSource::ChorusSend,
-               ModDest::VibLfoDelay,
-               ModAmount::fromSecondsRange(
-                   konami_snes::kVibratoDelayBaseSeconds,
-                   konami_snes::kVibratoDelayBaseSeconds * konami_snes::kVibratoMaxDelayCountFactor));
-  addModulator(ModSource::ReverbSend,
-               ModDest::VibLfoDelay,
-               ModAmount::fromSecondsRange(
-                   konami_snes::kVibratoDelayBaseSeconds,
-                   konami_snes::kVibratoDelayBaseSeconds / konami_snes::kVibratoMaxTempoFactor));
+  //   ch. pressure -> final effective vibrato frequency
+  //   CC93 -> final effective vibrato delay
+  addStandardVibratoHandling(
+      konami_snes::vibratoDepthCents(konami_snes::kDefaultVibratoMaxDepth),
+      konami_snes::kVibratoBaseHz,
+      konami_snes::kVibratoBaseHz * konami_snes::kDefaultVibratoMaxRateFactor,
+      VGMInstr::DelayRange {
+          konami_snes::kVibratoMinDelaySeconds,
+          konami_snes::kVibratoMaxDelaySeconds,
+      });
 
   if (percussion) {
     const auto percussionHeaders = collectPercussionHeaders(rawFile(), version, offset(), spcDirAddr);

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -33,12 +33,59 @@ constexpr uint8_t percussionPanLimit(KonamiSnesVersion version) {
   return usesLegacyPanRange(version) ? 0x14 : 0x28;
 }
 
+constexpr uint8_t modernVibratoRateStep(uint8_t rate) {
+  return (rate == 0xff) ? 16 : (rate >= 0x80) ? 8 : (rate >= 0x40) ? 4 : (rate >= 0x20) ? 2 : 1;
+}
+
+double maxVibratoDepthCents(KonamiSnesVersion version, uint8_t depth) {
+  if (konami_snes::usesLegacyVibrato(version)) {
+    return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
+  }
+
+  // V3-V6 keep the normal range smaller, then jump into a much larger high-depth mode.
+  return (depth < 0x80) ? (depth * (100.0 / 128.0)) : ((depth - 126.0) * 50.0);
+}
+
+uint16_t defaultVibratoMaxRateFactor(KonamiSnesVersion version) {
+  return konami_snes::usesLegacyVibrato(version)
+      ? static_cast<uint16_t>(konami_snes::kDefaultLegacyVibratoMaxRateStep * 0xff)
+      : static_cast<uint16_t>(0xff * modernVibratoRateStep(0xff));
+}
+
+uint16_t minVibratoMaxRateFactor(KonamiSnesVersion version) {
+  return konami_snes::usesLegacyVibrato(version)
+      ? static_cast<uint16_t>(konami_snes::kMinVibratoMaxRateStep * 0xff)
+      : konami_snes::kMinVibratoMaxRateStep;
+}
+
+double vibratoBaseHz(KonamiSnesVersion version) {
+  return konami_snes::usesLegacyVibrato(version)
+      ? (konami_snes::kTimerHz / 65536.0)
+      : (konami_snes::kTimerHz / 16384.0);
+}
+
+double minVibratoDelaySeconds(KonamiSnesVersion version) {
+  if (konami_snes::usesLegacyVibrato(version)) {
+    return (256.0 / konami_snes::kTimerHz) / 0xff;
+  }
+
+  return 1.0 / konami_snes::kTimerHz;
+}
+
+double maxVibratoDelaySeconds(KonamiSnesVersion version) {
+  if (konami_snes::usesLegacyVibrato(version)) {
+    return (256.0 / konami_snes::kTimerHz) * 0x100;
+  }
+
+  return 200.0 / konami_snes::kTimerHz;
+}
+
 void applyVibratoExportScaling(KonamiSnesInstrSet* instrSet, uint8_t maxDepth, uint16_t maxRateFactor) {
   const auto version = instrSet->version;
   const uint8_t clampedMaxDepth = std::max(maxDepth, konami_snes::kMinVibratoMaxDepth);
-  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, konami_snes::minVibratoMaxRateFactor(version));
-  const double maxDepthCents = konami_snes::vibratoDepthCents(version, clampedMaxDepth);
-  const double baseHz = konami_snes::vibratoBaseHz(version);
+  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, minVibratoMaxRateFactor(version));
+  const double maxDepthCents = maxVibratoDepthCents(version, clampedMaxDepth);
+  const double baseHz = vibratoBaseHz(version);
   const double maxRateHz = baseHz * clampedMaxRateFactor;
 
   for (auto* instr : instrSet->exportInstrs()) {
@@ -131,7 +178,7 @@ KonamiSnesInstrSet::KonamiSnesInstrSet(RawFile *file,
     percInstrOffset(percInstrOffset),
     spcDirAddr(spcDirAddr),
     maxVibratoDepth(konami_snes::kDefaultVibratoMaxDepth),
-    maxVibratoRateFactor(konami_snes::defaultVibratoMaxRateFactor(ver)) {
+    maxVibratoRateFactor(defaultVibratoMaxRateFactor(ver)) {
 }
 
 KonamiSnesInstrSet::~KonamiSnesInstrSet() {
@@ -219,7 +266,7 @@ bool KonamiSnesInstrSet::parseInstrPointers() {
 
 void KonamiSnesInstrSet::useColl(const VGMColl* coll) {
   maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
-  maxVibratoRateFactor = konami_snes::defaultVibratoMaxRateFactor(version);
+  maxVibratoRateFactor = defaultVibratoMaxRateFactor(version);
 
   if (coll != nullptr && coll->seq() != nullptr) {
     const auto* seq = dynamic_cast<const KonamiSnesSeq*>(coll->seq());
@@ -234,7 +281,7 @@ void KonamiSnesInstrSet::useColl(const VGMColl* coll) {
 
 void KonamiSnesInstrSet::unuseColl() {
   maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
-  maxVibratoRateFactor = konami_snes::defaultVibratoMaxRateFactor(version);
+  maxVibratoRateFactor = defaultVibratoMaxRateFactor(version);
   applyVibratoExportScaling(this, maxVibratoDepth, maxVibratoRateFactor);
 }
 
@@ -265,12 +312,12 @@ bool KonamiSnesInstr::loadInstr() {
   //   ch. pressure -> final effective vibrato frequency
   //   CC93 -> final effective vibrato delay
   addStandardVibratoHandling(
-      konami_snes::vibratoDepthCents(version, konami_snes::kDefaultVibratoMaxDepth),
-      konami_snes::vibratoBaseHz(version),
-      konami_snes::vibratoBaseHz(version) * konami_snes::defaultVibratoMaxRateFactor(version),
+      maxVibratoDepthCents(version, konami_snes::kDefaultVibratoMaxDepth),
+      vibratoBaseHz(version),
+      vibratoBaseHz(version) * defaultVibratoMaxRateFactor(version),
       VGMInstr::DelayRange {
-          konami_snes::minVibratoDelaySeconds(version),
-          konami_snes::maxVibratoDelaySeconds(version),
+          minVibratoDelaySeconds(version),
+          maxVibratoDelaySeconds(version),
       });
 
   if (percussion) {

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "KonamiSnesInstr.h"
+#include "KonamiSnesDefinitions.h"
 #include "SNESDSP.h"
 #include <algorithm>
 #include <spdlog/fmt/fmt.h>
@@ -216,6 +217,37 @@ KonamiSnesInstr::~KonamiSnesInstr() {
 }
 
 bool KonamiSnesInstr::loadInstr() {
+  // Konami vibrato is driven per track from E4 and is relative to the current tempo, so we split
+  // the SoundFont frequency and delay modulators across separate controller factors:
+  //   CC1  -> depth
+  //   ch. pressure -> rate step
+  //   CC91 -> tempo factor (raises vibrato frequency and shortens delay)
+  //   CC93 -> delay count
+  addModulator(ModSource::ModWheel,
+               ModDest::VibLfoToPitch,
+               ModAmount::fromCents(konami_snes::kVibratoMaxDepthCents));
+  addModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, ModAmount::fromCents(0));
+  addGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(konami_snes::kVibratoBaseHz));
+  addModulator(ModSource::ChannelPressure,
+               ModDest::VibLfoFreq,
+               ModAmount::fromHertzRange(konami_snes::kVibratoBaseHz,
+                                         konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxRateFactor));
+  addModulator(ModSource::ReverbSend,
+               ModDest::VibLfoFreq,
+               ModAmount::fromHertzRange(konami_snes::kVibratoBaseHz,
+                                         konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxTempoFactor));
+  addGenerator(ModDest::VibLfoDelay, ModAmount::fromSeconds(konami_snes::kVibratoDelayBaseSeconds));
+  addModulator(ModSource::ChorusSend,
+               ModDest::VibLfoDelay,
+               ModAmount::fromSecondsRange(
+                   konami_snes::kVibratoDelayBaseSeconds,
+                   konami_snes::kVibratoDelayBaseSeconds * konami_snes::kVibratoMaxDelayCountFactor));
+  addModulator(ModSource::ReverbSend,
+               ModDest::VibLfoDelay,
+               ModAmount::fromSecondsRange(
+                   konami_snes::kVibratoDelayBaseSeconds,
+                   konami_snes::kVibratoDelayBaseSeconds / konami_snes::kVibratoMaxTempoFactor));
+
   if (percussion) {
     const auto percussionHeaders = collectPercussionHeaders(rawFile(), version, offset(), spcDirAddr);
     for (const auto &header : percussionHeaders) {

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -37,6 +37,8 @@ constexpr uint8_t modernVibratoRateStep(uint8_t rate) {
   return (rate == 0xff) ? 16 : (rate >= 0x80) ? 8 : (rate >= 0x40) ? 4 : (rate >= 0x20) ? 2 : 1;
 }
 
+// Mirrors the sequence-side depth curve so the instrument modulator range matches the MIDI values
+// we emit during conversion.
 double maxVibratoDepthCents(KonamiSnesVersion version, uint8_t depth) {
   if (konami_snes::usesLegacyVibrato(version)) {
     return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
@@ -46,6 +48,8 @@ double maxVibratoDepthCents(KonamiSnesVersion version, uint8_t depth) {
   return (depth < 0x80) ? (depth * (100.0 / 128.0)) : ((depth - 126.0) * 50.0);
 }
 
+// Uses the same folded "base Hz * factor" model as the sequence helpers so the tracked maxima can
+// be applied directly during export.
 uint16_t defaultVibratoMaxRateFactor(KonamiSnesVersion version) {
   return konami_snes::usesLegacyVibrato(version)
       ? static_cast<uint16_t>(konami_snes::kDefaultLegacyVibratoMaxRateStep * 0xff)
@@ -80,6 +84,8 @@ double maxVibratoDelaySeconds(KonamiSnesVersion version) {
   return 200.0 / konami_snes::kTimerHz;
 }
 
+// Rewrites the shared vibrato modulators to the sequence-specific maxima collected on the first
+// pass, while keeping the controller mapping itself identical across instrument loads.
 void applyVibratoExportScaling(KonamiSnesInstrSet* instrSet, uint8_t maxDepth, uint16_t maxRateFactor) {
   const auto version = instrSet->version;
   const uint8_t clampedMaxDepth = std::max(maxDepth, konami_snes::kMinVibratoMaxDepth);

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -34,10 +34,12 @@ constexpr uint8_t percussionPanLimit(KonamiSnesVersion version) {
 }
 
 void applyVibratoExportScaling(KonamiSnesInstrSet* instrSet, uint8_t maxDepth, uint16_t maxRateFactor) {
+  const auto version = instrSet->version;
   const uint8_t clampedMaxDepth = std::max(maxDepth, konami_snes::kMinVibratoMaxDepth);
-  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, konami_snes::kMinVibratoMaxRateFactor);
-  const double maxDepthCents = konami_snes::vibratoDepthCents(clampedMaxDepth);
-  const double maxRateHz = konami_snes::kVibratoBaseHz * clampedMaxRateFactor;
+  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, konami_snes::minVibratoMaxRateFactor(version));
+  const double maxDepthCents = konami_snes::vibratoDepthCents(version, clampedMaxDepth);
+  const double baseHz = konami_snes::vibratoBaseHz(version);
+  const double maxRateHz = baseHz * clampedMaxRateFactor;
 
   for (auto* instr : instrSet->exportInstrs()) {
     instr->updateModulatorAmount(ModSource::ModWheel,
@@ -45,7 +47,7 @@ void applyVibratoExportScaling(KonamiSnesInstrSet* instrSet, uint8_t maxDepth, u
                                  ModAmount::fromCents(maxDepthCents));
     instr->updateModulatorAmount(ModSource::ChannelPressure,
                                  ModDest::VibLfoFreq,
-                                 ModAmount::fromHertzRange(konami_snes::kVibratoBaseHz, maxRateHz));
+                                 ModAmount::fromHertzRange(baseHz, maxRateHz));
   }
 }
 
@@ -129,7 +131,7 @@ KonamiSnesInstrSet::KonamiSnesInstrSet(RawFile *file,
     percInstrOffset(percInstrOffset),
     spcDirAddr(spcDirAddr),
     maxVibratoDepth(konami_snes::kDefaultVibratoMaxDepth),
-    maxVibratoRateFactor(konami_snes::kDefaultVibratoMaxRateFactor) {
+    maxVibratoRateFactor(konami_snes::defaultVibratoMaxRateFactor(ver)) {
 }
 
 KonamiSnesInstrSet::~KonamiSnesInstrSet() {
@@ -217,7 +219,7 @@ bool KonamiSnesInstrSet::parseInstrPointers() {
 
 void KonamiSnesInstrSet::useColl(const VGMColl* coll) {
   maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
-  maxVibratoRateFactor = konami_snes::kDefaultVibratoMaxRateFactor;
+  maxVibratoRateFactor = konami_snes::defaultVibratoMaxRateFactor(version);
 
   if (coll != nullptr && coll->seq() != nullptr) {
     const auto* seq = dynamic_cast<const KonamiSnesSeq*>(coll->seq());
@@ -232,7 +234,7 @@ void KonamiSnesInstrSet::useColl(const VGMColl* coll) {
 
 void KonamiSnesInstrSet::unuseColl() {
   maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
-  maxVibratoRateFactor = konami_snes::kDefaultVibratoMaxRateFactor;
+  maxVibratoRateFactor = konami_snes::defaultVibratoMaxRateFactor(version);
   applyVibratoExportScaling(this, maxVibratoDepth, maxVibratoRateFactor);
 }
 
@@ -263,12 +265,12 @@ bool KonamiSnesInstr::loadInstr() {
   //   ch. pressure -> final effective vibrato frequency
   //   CC93 -> final effective vibrato delay
   addStandardVibratoHandling(
-      konami_snes::vibratoDepthCents(konami_snes::kDefaultVibratoMaxDepth),
-      konami_snes::kVibratoBaseHz,
-      konami_snes::kVibratoBaseHz * konami_snes::kDefaultVibratoMaxRateFactor,
+      konami_snes::vibratoDepthCents(version, konami_snes::kDefaultVibratoMaxDepth),
+      konami_snes::vibratoBaseHz(version),
+      konami_snes::vibratoBaseHz(version) * konami_snes::defaultVibratoMaxRateFactor(version),
       VGMInstr::DelayRange {
-          konami_snes::kVibratoMinDelaySeconds,
-          konami_snes::kVibratoMaxDelaySeconds,
+          konami_snes::minVibratoDelaySeconds(version),
+          konami_snes::maxVibratoDelaySeconds(version),
       });
 
   if (percussion) {

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -34,10 +34,10 @@ constexpr uint8_t percussionPanLimit(KonamiSnesVersion version) {
 }
 
 void applyVibratoExportScaling(KonamiSnesInstrSet* instrSet, uint8_t maxDepth, uint8_t maxRate) {
-  const uint8_t depthForExport = std::max<uint8_t>(maxDepth, 1);
-  const uint8_t rateForExport = std::max<uint8_t>(maxRate, 1);
-  const double maxDepthCents = konami_snes::vibratoDepthCents(depthForExport);
-  const double maxRateHz = konami_snes::kVibratoBaseHz * rateForExport;
+  const uint8_t clampedMaxDepth = std::max(maxDepth, konami_snes::kMinVibratoMaxDepth);
+  const uint8_t clampedMaxRate = std::max(maxRate, konami_snes::kMinVibratoMaxRateStep);
+  const double maxDepthCents = konami_snes::vibratoDepthCents(clampedMaxDepth);
+  const double maxRateHz = konami_snes::kVibratoBaseHz * clampedMaxRate;
 
   for (auto* instr : instrSet->exportInstrs()) {
     instr->updateModulatorAmount(ModSource::ModWheel,
@@ -219,17 +219,10 @@ void KonamiSnesInstrSet::useColl(const VGMColl* coll) {
   maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
   maxVibratoRate = konami_snes::kDefaultVibratoMaxRateStep;
 
-  if (coll == nullptr || coll->seq() == nullptr) {
-    applyVibratoExportScaling(this, maxVibratoDepth, maxVibratoRate);
-    return;
-  }
-
-  const auto* seq = dynamic_cast<const KonamiSnesSeq*>(coll->seq());
-  if (seq != nullptr && seq->rawFile() == rawFile() && seq->version == version) {
-    if (seq->maxVibratoDepth != 0) {
+  if (coll != nullptr && coll->seq() != nullptr) {
+    const auto* seq = dynamic_cast<const KonamiSnesSeq*>(coll->seq());
+    if (seq != nullptr && seq->rawFile() == rawFile() && seq->version == version) {
       maxVibratoDepth = seq->maxVibratoDepth;
-    }
-    if (seq->maxVibratoRate != 0) {
       maxVibratoRate = seq->maxVibratoRate;
     }
   }

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -5,8 +5,8 @@
  */
 
 #include "KonamiSnesInstr.h"
-#include "KonamiSnesDefinitions.h"
 #include "KonamiSnesSeq.h"
+#include "KonamiSnesVibrato.h"
 #include "SNESDSP.h"
 #include "VGMColl.h"
 #include <algorithm>
@@ -33,65 +33,14 @@ constexpr uint8_t percussionPanLimit(KonamiSnesVersion version) {
   return usesLegacyPanRange(version) ? 0x14 : 0x28;
 }
 
-constexpr uint8_t modernVibratoRateStep(uint8_t rate) {
-  return (rate == 0xff) ? 16 : (rate >= 0x80) ? 8 : (rate >= 0x40) ? 4 : (rate >= 0x20) ? 2 : 1;
-}
-
-// Mirrors the sequence-side depth curve so the instrument modulator range matches the MIDI values
-// we emit during conversion.
-double maxVibratoDepthCents(KonamiSnesVersion version, uint8_t depth) {
-  if (konami_snes::usesLegacyVibrato(version)) {
-    return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
-  }
-
-  // V3-V6 keep the normal range smaller, then jump into a much larger high-depth mode.
-  return (depth < 0x80) ? (depth * (100.0 / 128.0)) : ((depth - 126.0) * 50.0);
-}
-
-// Uses the same folded "base Hz * factor" model as the sequence helpers so the tracked maxima can
-// be applied directly during export.
-uint16_t defaultVibratoMaxRateFactor(KonamiSnesVersion version) {
-  return konami_snes::usesLegacyVibrato(version)
-      ? static_cast<uint16_t>(konami_snes::kDefaultLegacyVibratoMaxRateStep * 0xff)
-      : static_cast<uint16_t>(0xff * modernVibratoRateStep(0xff));
-}
-
-uint16_t minVibratoMaxRateFactor(KonamiSnesVersion version) {
-  return konami_snes::usesLegacyVibrato(version)
-      ? static_cast<uint16_t>(konami_snes::kMinVibratoMaxRateStep * 0xff)
-      : konami_snes::kMinVibratoMaxRateStep;
-}
-
-double vibratoBaseHz(KonamiSnesVersion version) {
-  return konami_snes::usesLegacyVibrato(version)
-      ? (konami_snes::kTimerHz / 65536.0)
-      : (konami_snes::kTimerHz / 16384.0);
-}
-
-double minVibratoDelaySeconds(KonamiSnesVersion version) {
-  if (konami_snes::usesLegacyVibrato(version)) {
-    return (256.0 / konami_snes::kTimerHz) / 0xff;
-  }
-
-  return 1.0 / konami_snes::kTimerHz;
-}
-
-double maxVibratoDelaySeconds(KonamiSnesVersion version) {
-  if (konami_snes::usesLegacyVibrato(version)) {
-    return (256.0 / konami_snes::kTimerHz) * 0x100;
-  }
-
-  return 200.0 / konami_snes::kTimerHz;
-}
-
 // Rewrites the shared vibrato modulators to the sequence-specific maxima collected on the first
 // pass, while keeping the controller mapping itself identical across instrument loads.
 void applyVibratoExportScaling(KonamiSnesInstrSet* instrSet, uint8_t maxDepth, uint16_t maxRateFactor) {
   const auto version = instrSet->version;
   const uint8_t clampedMaxDepth = std::max(maxDepth, konami_snes::kMinVibratoMaxDepth);
-  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, minVibratoMaxRateFactor(version));
-  const double maxDepthCents = maxVibratoDepthCents(version, clampedMaxDepth);
-  const double baseHz = vibratoBaseHz(version);
+  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, konami_snes::vibrato::minMaxRateFactor(version));
+  const double maxDepthCents = konami_snes::vibrato::maxDepthCents(version, clampedMaxDepth);
+  const double baseHz = konami_snes::vibrato::baseHz(version);
   const double maxRateHz = baseHz * clampedMaxRateFactor;
 
   for (auto* instr : instrSet->exportInstrs()) {
@@ -182,9 +131,7 @@ KonamiSnesInstrSet::KonamiSnesInstrSet(RawFile *file,
     bankedInstrOffset(bankedInstrOffset),
     firstBankedInstr(firstBankedInstr),
     percInstrOffset(percInstrOffset),
-    spcDirAddr(spcDirAddr),
-    maxVibratoDepth(konami_snes::kDefaultVibratoMaxDepth),
-    maxVibratoRateFactor(defaultVibratoMaxRateFactor(ver)) {
+    spcDirAddr(spcDirAddr) {
 }
 
 KonamiSnesInstrSet::~KonamiSnesInstrSet() {
@@ -271,8 +218,8 @@ bool KonamiSnesInstrSet::parseInstrPointers() {
 }
 
 void KonamiSnesInstrSet::useColl(const VGMColl* coll) {
-  maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
-  maxVibratoRateFactor = defaultVibratoMaxRateFactor(version);
+  uint8_t maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
+  uint16_t maxVibratoRateFactor = konami_snes::vibrato::defaultMaxRateFactor(version);
 
   if (coll != nullptr && coll->seq() != nullptr) {
     const auto* seq = dynamic_cast<const KonamiSnesSeq*>(coll->seq());
@@ -286,9 +233,9 @@ void KonamiSnesInstrSet::useColl(const VGMColl* coll) {
 }
 
 void KonamiSnesInstrSet::unuseColl() {
-  maxVibratoDepth = konami_snes::kDefaultVibratoMaxDepth;
-  maxVibratoRateFactor = defaultVibratoMaxRateFactor(version);
-  applyVibratoExportScaling(this, maxVibratoDepth, maxVibratoRateFactor);
+  applyVibratoExportScaling(this,
+                            konami_snes::kDefaultVibratoMaxDepth,
+                            konami_snes::vibrato::defaultMaxRateFactor(version));
 }
 
 // ***************
@@ -318,12 +265,12 @@ bool KonamiSnesInstr::loadInstr() {
   //   ch. pressure -> final effective vibrato frequency
   //   CC93 -> final effective vibrato delay
   addStandardVibratoHandling(
-      maxVibratoDepthCents(version, konami_snes::kDefaultVibratoMaxDepth),
-      vibratoBaseHz(version),
-      vibratoBaseHz(version) * defaultVibratoMaxRateFactor(version),
+      konami_snes::vibrato::maxDepthCents(version, konami_snes::kDefaultVibratoMaxDepth),
+      konami_snes::vibrato::baseHz(version),
+      konami_snes::vibrato::baseHz(version) * konami_snes::vibrato::defaultMaxRateFactor(version),
       VGMInstr::DelayRange {
-          minVibratoDelaySeconds(version),
-          maxVibratoDelaySeconds(version),
+          konami_snes::vibrato::minDelaySeconds(version),
+          konami_snes::vibrato::maxDelaySeconds(version),
       });
 
   if (percussion) {

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.h
@@ -4,6 +4,8 @@
 #include "VGMRgn.h"
 #include "KonamiSnesFormat.h"
 
+class VGMColl;
+
 // ******************
 // KonamiSnesInstrSet
 // ******************
@@ -25,6 +27,8 @@ class KonamiSnesInstrSet:
 
   virtual bool parseHeader();
   virtual bool parseInstrPointers();
+  void useColl(const VGMColl* coll) override;
+  void unuseColl() override;
 
   KonamiSnesVersion version;
 
@@ -34,6 +38,8 @@ class KonamiSnesInstrSet:
   uint32_t percInstrOffset;
   uint32_t spcDirAddr;
   std::vector<uint8_t> usedSRCNs;
+  uint8_t maxVibratoDepth;
+  uint8_t maxVibratoRate;
 };
 
 // ***************

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.h
@@ -39,7 +39,7 @@ class KonamiSnesInstrSet:
   uint32_t spcDirAddr;
   std::vector<uint8_t> usedSRCNs;
   uint8_t maxVibratoDepth;
-  uint8_t maxVibratoRate;
+  uint16_t maxVibratoRateFactor;
 };
 
 // ***************

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.h
@@ -38,8 +38,6 @@ class KonamiSnesInstrSet:
   uint32_t percInstrOffset;
   uint32_t spcDirAddr;
   std::vector<uint8_t> usedSRCNs;
-  uint8_t maxVibratoDepth;
-  uint16_t maxVibratoRateFactor;
 };
 
 // ***************

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -75,19 +75,11 @@ FadeStepResult advanceFade(ValueType& current,
   return FadeStepResult::Running;
 }
 
-uint8_t effectiveVibratoRateStep(uint8_t rate) {
-  if (rate == 0 || rate == 0x80) {
-    return 0;
-  }
-
-  return static_cast<uint8_t>((rate < 0x80) ? rate : (0x100 - rate));
-}
-
 bool hasActiveVibrato(uint8_t rate, uint8_t depth) {
-  return depth != 0 && effectiveVibratoRateStep(rate) != 0;
+  return depth != 0 && konami_snes::effectiveVibratoRateStep(rate) != 0;
 }
 
-uint8_t convertVibratoDepthToMidi(uint8_t targetDepth, uint16_t currentDepth) {
+uint8_t convertVibratoDepthToMidi(uint8_t targetDepth, uint16_t currentDepth, uint8_t maxDepth) {
   if (targetDepth == 0 || currentDepth == 0) {
     return 0;
   }
@@ -95,19 +87,22 @@ uint8_t convertVibratoDepthToMidi(uint8_t targetDepth, uint16_t currentDepth) {
   const double depthCents = (targetDepth < 0x80)
       ? (currentDepth * (100.0 / (32.0 * 256.0)))
       : (currentDepth * (100.0 / (8.0 * 256.0)));
-  const int midiValue = static_cast<int>(std::lround(128.0 * depthCents / konami_snes::kVibratoMaxDepthCents));
+  const double maxDepthCents = konami_snes::vibratoDepthCents(
+      maxDepth != 0 ? maxDepth : konami_snes::kDefaultVibratoMaxDepth);
+  const int midiValue = static_cast<int>(std::lround(128.0 * depthCents / maxDepthCents));
   return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
 }
 
-uint8_t convertVibratoRateToMidi(uint8_t rate) {
-  const uint8_t effectiveRate = effectiveVibratoRateStep(rate);
+uint8_t convertVibratoRateToMidi(uint8_t rate, uint8_t maxRate) {
+  const uint8_t effectiveRate = konami_snes::effectiveVibratoRateStep(rate);
   if (effectiveRate == 0) {
     return 0;
   }
 
   return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * effectiveRate,
                                   konami_snes::kVibratoBaseHz,
-                                  konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxRateFactor);
+                                  konami_snes::kVibratoBaseHz *
+                                      (maxRate != 0 ? maxRate : konami_snes::kDefaultVibratoMaxRateStep));
 }
 
 uint8_t convertTempoFactorToMidi(uint8_t tempo) {
@@ -183,7 +178,10 @@ const uint8_t KonamiSnesSeq::VOL_TABLE[] = {
 };
 
 KonamiSnesSeq::KonamiSnesSeq(RawFile *file, KonamiSnesVersion ver, uint32_t seqdataOffset, std::string newName)
-    : VGMSeq(KonamiSnesFormat::name, file, seqdataOffset, 0, newName), version(ver) {
+    : VGMSeq(KonamiSnesFormat::name, file, seqdataOffset, 0, newName),
+      maxVibratoDepth(0),
+      maxVibratoRate(0),
+      version(ver) {
   setAllowDiscontinuousTrackData(true);
   bLoadTickByTick = true;
 
@@ -200,6 +198,11 @@ KonamiSnesSeq::~KonamiSnesSeq(void) {
 
 void KonamiSnesSeq::resetVars(void) {
   VGMSeq::resetVars();
+
+  if (readMode != READMODE_CONVERT_TO_MIDI) {
+    maxVibratoDepth = 0;
+    maxVibratoRate = 0;
+  }
 
   // The driver starts from tempo/speed FF unless the sequence overrides it.
   tempo = KONAMI_SNES_DEFAULT_TEMPO;
@@ -505,7 +508,7 @@ void KonamiSnesTrack::onTickBegin() {
         vibratoFade.currentDepth = std::min<uint16_t>(targetDepth, vibratoFade.currentDepth + vibratoFade.step);
       }
 
-      const uint8_t midiDepth = convertVibratoDepthToMidi(vibratoDepth, vibratoFade.currentDepth);
+      const uint8_t midiDepth = convertVibratoDepthToMidi(vibratoDepth, vibratoFade.currentDepth, seq().maxVibratoDepth);
       if (midiDepth != vibratoFade.midiDepth) {
         addModulationNoItem(midiDepth);
         vibratoFade.midiDepth = midiDepth;
@@ -1258,12 +1261,23 @@ bool KonamiSnesTrack::readEvent() {
       vibratoFade = {};
       const bool active = hasActiveVibrato(vibratoRate, vibratoDepth);
       const bool deferDepthForFade = active && immediateFadeLength != 0;
-      const uint8_t midiDepth = deferDepthForFade ? 0 : (active ? convertVibratoDepthToMidi(vibratoDepth, static_cast<uint16_t>(vibratoDepth) << 8) : 0);
+      if (readMode != READMODE_CONVERT_TO_MIDI && active) {
+        parentSeq.maxVibratoDepth = std::max(parentSeq.maxVibratoDepth, vibratoDepth);
+        parentSeq.maxVibratoRate =
+            std::max(parentSeq.maxVibratoRate, konami_snes::effectiveVibratoRateStep(vibratoRate));
+      }
+
+      const uint8_t midiDepth = deferDepthForFade
+          ? 0
+          : (active ? convertVibratoDepthToMidi(vibratoDepth,
+                                                static_cast<uint16_t>(vibratoDepth) << 8,
+                                                parentSeq.maxVibratoDepth)
+                    : 0);
       addModulationNoItem(midiDepth);
       vibratoFade.currentDepth = static_cast<uint16_t>(deferDepthForFade ? 0 : vibratoDepth) << 8;
       vibratoFade.midiDepth = midiDepth;
       if (active) {
-        addChannelPressureNoItem(convertVibratoRateToMidi(vibratoRate));
+        addChannelPressureNoItem(convertVibratoRateToMidi(vibratoRate, parentSeq.maxVibratoRate));
         addControllerEventNoItem(konami_snes::kVibratoDelayController, convertVibratoDelayToMidi(vibratoDelay));
         syncVibratoTempo();
       }

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -30,6 +30,94 @@ constexpr uint8_t timerFrequency(KonamiSnesVersion version) {
   return version == KONAMISNES_V1 ? 0x20 : 0x40;
 }
 
+constexpr uint8_t legacyVibratoRateStep(uint8_t rate) {
+  return (rate == 0 || rate == 0x80)
+      ? 0
+      : static_cast<uint8_t>((rate < 0x80) ? rate : (0x100 - rate));
+}
+
+constexpr uint8_t modernVibratoRateStep(uint8_t rate) {
+  return (rate == 0xff) ? 16 : (rate >= 0x80) ? 8 : (rate >= 0x40) ? 4 : (rate >= 0x20) ? 2 : 1;
+}
+
+bool hasActiveVibrato(KonamiSnesVersion version, uint8_t rate, uint8_t depth) {
+  return depth != 0 &&
+         (konami_snes::usesLegacyVibrato(version) ? (legacyVibratoRateStep(rate) != 0) : (rate != 0));
+}
+
+double maxVibratoDepthCents(KonamiSnesVersion version, uint8_t depth) {
+  if (konami_snes::usesLegacyVibrato(version)) {
+    return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
+  }
+
+  // V3-V6 use a narrower normal range and a much larger high-depth mode.
+  return (depth < 0x80) ? (depth * (100.0 / 128.0)) : ((depth - 126.0) * 50.0);
+}
+
+double currentVibratoDepthCents(KonamiSnesVersion version, uint8_t targetDepth, uint16_t currentDepth) {
+  if (konami_snes::usesLegacyVibrato(version)) {
+    return (targetDepth < 0x80)
+        ? (currentDepth * (100.0 / (32.0 * 256.0)))
+        : (currentDepth * (100.0 / (8.0 * 256.0)));
+  }
+
+  return (currentDepth < 0x8000)
+      ? (currentDepth * (100.0 / (128.0 * 256.0)))
+      : ((currentDepth - (126.0 * 256.0)) * (50.0 / 256.0));
+}
+
+uint16_t minVibratoMaxRateFactor(KonamiSnesVersion version) {
+  return konami_snes::usesLegacyVibrato(version)
+      ? static_cast<uint16_t>(konami_snes::kMinVibratoMaxRateStep * 0xff)
+      : konami_snes::kMinVibratoMaxRateStep;
+}
+
+double vibratoBaseHz(KonamiSnesVersion version) {
+  return konami_snes::usesLegacyVibrato(version)
+      ? (konami_snes::kTimerHz / 65536.0)
+      : (konami_snes::kTimerHz / 16384.0);
+}
+
+uint16_t vibratoRateFactor(KonamiSnesVersion version, uint8_t rate, uint8_t tempo) {
+  if (konami_snes::usesLegacyVibrato(version)) {
+    return static_cast<uint16_t>(legacyVibratoRateStep(rate) * std::max<uint8_t>(tempo, 1));
+  }
+
+  return (rate == 0) ? 0 : static_cast<uint16_t>(rate * modernVibratoRateStep(rate));
+}
+
+double vibratoDelaySeconds(KonamiSnesVersion version, uint8_t delay, uint8_t tempo) {
+  if (konami_snes::usesLegacyVibrato(version)) {
+    const double baseSeconds = 256.0 / konami_snes::kTimerHz;
+    return (baseSeconds * (delay + 1.0)) / std::max<uint8_t>(tempo, 1);
+  }
+
+  return (delay + 1.0) / konami_snes::kTimerHz;
+}
+
+double minVibratoDelaySeconds(KonamiSnesVersion version) {
+  return konami_snes::usesLegacyVibrato(version)
+      ? vibratoDelaySeconds(version, 0, 0xff)
+      : vibratoDelaySeconds(version, 0, 0);
+}
+
+double maxVibratoDelaySeconds(KonamiSnesVersion version) {
+  return konami_snes::usesLegacyVibrato(version)
+      ? vibratoDelaySeconds(version, 0xff, 1)
+      : vibratoDelaySeconds(version, 0xc7, 0);
+}
+
+uint8_t vibratoDelayFromArg1(KonamiSnesVersion version, uint8_t arg1) {
+  // V3-V6 overload E4 arg1: 00-C7 is delay, C8-FF means inline fade with zero delay.
+  return (!konami_snes::usesLegacyVibrato(version) && arg1 >= konami_snes::kLateEraVibratoFadeThreshold) ? 0 : arg1;
+}
+
+uint8_t vibratoInlineFadeLength(KonamiSnesVersion version, uint8_t arg1) {
+  return (!konami_snes::usesLegacyVibrato(version) && arg1 >= konami_snes::kLateEraVibratoFadeThreshold)
+      ? static_cast<uint8_t>(arg1 - (konami_snes::kLateEraVibratoFadeThreshold - 1))
+      : 0;
+}
+
 void fillEventRange(std::map<uint8_t, KonamiSnesSeqEventType>& eventMap,
                     uint8_t firstStatusByte,
                     uint8_t lastStatusByte,
@@ -84,20 +172,14 @@ uint8_t convertVibratoDepthToMidi(KonamiSnesVersion version,
   }
 
   const uint8_t clampedMaxDepth = std::max(maxDepth, konami_snes::kMinVibratoMaxDepth);
-  const double depthCents = konami_snes::usesV1Vibrato(version)
-      ? ((targetDepth < 0x80)
-            ? (currentDepth * (100.0 / (32.0 * 256.0)))
-            : (currentDepth * (100.0 / (8.0 * 256.0))))
-      : ((currentDepth < 0x8000)
-            ? (currentDepth * (100.0 / (128.0 * 256.0)))
-            : ((currentDepth - (126.0 * 256.0)) * (50.0 / 256.0)));
-  const double maxDepthCents = konami_snes::vibratoDepthCents(version, clampedMaxDepth);
+  const double depthCents = currentVibratoDepthCents(version, targetDepth, currentDepth);
+  const double maxDepthCents = maxVibratoDepthCents(version, clampedMaxDepth);
   const int midiValue = static_cast<int>(std::lround(128.0 * depthCents / maxDepthCents));
   return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
 }
 
 uint16_t effectiveVibratoRateFactor(KonamiSnesVersion version, uint8_t rate, uint8_t tempo) {
-  const uint16_t effectiveRateFactor = konami_snes::vibratoRateFactor(version, rate, tempo);
+  const uint16_t effectiveRateFactor = vibratoRateFactor(version, rate, tempo);
   if (effectiveRateFactor == 0) {
     return 0;
   }
@@ -114,16 +196,14 @@ uint8_t convertVibratoRateToMidi(KonamiSnesVersion version,
     return 0;
   }
 
-  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, konami_snes::minVibratoMaxRateFactor(version));
-  const double baseHz = konami_snes::vibratoBaseHz(version);
+  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, minVibratoMaxRateFactor(version));
+  const double baseHz = vibratoBaseHz(version);
   return midiValueForHertzInRange(baseHz * effectiveRateFactor, baseHz, baseHz * clampedMaxRateFactor);
 }
 
 uint8_t convertVibratoDelayToMidi(KonamiSnesVersion version, uint8_t delay, uint8_t tempo) {
-  const double delaySeconds = konami_snes::vibratoDelaySeconds(version, delay, tempo);
-  return midiValueForSecondsInRange(delaySeconds,
-                                    konami_snes::minVibratoDelaySeconds(version),
-                                    konami_snes::maxVibratoDelaySeconds(version));
+  const double delaySeconds = vibratoDelaySeconds(version, delay, tempo);
+  return midiValueForSecondsInRange(delaySeconds, minVibratoDelaySeconds(version), maxVibratoDelaySeconds(version));
 }
 }
 
@@ -187,7 +267,7 @@ const uint8_t KonamiSnesSeq::VOL_TABLE[] = {
 KonamiSnesSeq::KonamiSnesSeq(RawFile *file, KonamiSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(KonamiSnesFormat::name, file, seqdataOffset, 0, newName),
       maxVibratoDepth(konami_snes::kMinVibratoMaxDepth),
-      maxVibratoRateFactor(konami_snes::minVibratoMaxRateFactor(ver)),
+      maxVibratoRateFactor(minVibratoMaxRateFactor(ver)),
       version(ver) {
   setAllowDiscontinuousTrackData(true);
   bLoadTickByTick = true;
@@ -208,7 +288,7 @@ void KonamiSnesSeq::resetVars(void) {
 
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     maxVibratoDepth = konami_snes::kMinVibratoMaxDepth;
-    maxVibratoRateFactor = konami_snes::minVibratoMaxRateFactor(version);
+    maxVibratoRateFactor = minVibratoMaxRateFactor(version);
   }
 
   // The driver starts from tempo/speed FF unless the sequence overrides it.
@@ -446,7 +526,7 @@ double KonamiSnesTrack::getTuningInSemitones(int8_t tuning) {
 }
 
 void KonamiSnesTrack::syncVibratoRateAndDelay() {
-  if (!konami_snes::hasActiveVibrato(seq().version, vibratoRate, vibratoDepth)) {
+  if (!hasActiveVibrato(seq().version, vibratoRate, vibratoDepth)) {
     return;
   }
 
@@ -967,7 +1047,7 @@ void KonamiSnesTrack::applyCurrentTempo() {
   if (newTempo != parentSeq.tempo) {
     parentSeq.tempo = newTempo;
     addTempoBPMNoItem(parentSeq.getTempoInBPM(newTempo));
-    if (konami_snes::usesV1Vibrato(parentSeq.version)) {
+    if (konami_snes::usesLegacyVibrato(parentSeq.version)) {
       for (SeqTrack *track : parentSeq.aTracks) {
         static_cast<KonamiSnesTrack*>(track)->syncVibratoRateAndDelay();
       }
@@ -1096,7 +1176,7 @@ bool KonamiSnesTrack::readEvent() {
       const bool isTiedNote = prevNoteSlurred && key == prevNoteKey;
 
       if (!isTiedNote && vibratoFade.length != 0 &&
-          konami_snes::hasActiveVibrato(seq().version, vibratoRate, vibratoDepth)) {
+          hasActiveVibrato(seq().version, vibratoRate, vibratoDepth)) {
         vibratoFade.delayRemaining = vibratoDelay;
         vibratoFade.ticksRemaining = vibratoFade.length;
         vibratoFade.currentDepth = 0;
@@ -1269,8 +1349,8 @@ bool KonamiSnesTrack::readEvent() {
       uint8_t vibratoArg1 = readByte(curOffset++);
       uint8_t newVibratoRate = readByte(curOffset++);
       uint8_t newVibratoDepth = readByte(curOffset++);
-      const uint8_t builtInFadeLength = konami_snes::vibratoInlineFadeLength(parentSeq.version, vibratoArg1);
-      const uint8_t newVibratoDelay = konami_snes::vibratoDelayFromArg1(parentSeq.version, vibratoArg1);
+      const uint8_t builtInFadeLength = vibratoInlineFadeLength(parentSeq.version, vibratoArg1);
+      const uint8_t newVibratoDelay = vibratoDelayFromArg1(parentSeq.version, vibratoArg1);
       desc = (builtInFadeLength != 0)
           ? fmt::format("Fade Length: {:d}  Rate: {:d}  Depth: {:d}",
                         builtInFadeLength, newVibratoRate, newVibratoDepth)
@@ -1292,7 +1372,7 @@ bool KonamiSnesTrack::readEvent() {
         vibratoFade.step = static_cast<uint16_t>((static_cast<uint16_t>(vibratoDepth) << 8) / builtInFadeLength);
       }
 
-      const bool active = konami_snes::hasActiveVibrato(parentSeq.version, vibratoRate, vibratoDepth);
+      const bool active = hasActiveVibrato(parentSeq.version, vibratoRate, vibratoDepth);
       const bool deferDepthForFade = active && immediateFadeLength != 0;
       if (readMode != READMODE_CONVERT_TO_MIDI && active) {
         parentSeq.maxVibratoDepth = std::max(parentSeq.maxVibratoDepth, vibratoDepth);
@@ -1429,7 +1509,7 @@ bool KonamiSnesTrack::readEvent() {
       clearActiveTempoFade();
       parentSeq.tempo = newTempo;
       addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
-      if (konami_snes::usesV1Vibrato(parentSeq.version)) {
+      if (konami_snes::usesLegacyVibrato(parentSeq.version)) {
         for (SeqTrack *track : parentSeq.aTracks) {
           static_cast<KonamiSnesTrack*>(track)->syncVibratoRateAndDelay();
         }

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -87,12 +87,14 @@ bool hasActiveVibrato(uint8_t rate, uint8_t depth) {
   return depth != 0 && effectiveVibratoRateStep(rate) != 0;
 }
 
-uint8_t convertVibratoDepthToMidi(uint8_t depth) {
-  if (depth == 0) {
+uint8_t convertVibratoDepthToMidi(uint8_t targetDepth, uint16_t currentDepth) {
+  if (targetDepth == 0 || currentDepth == 0) {
     return 0;
   }
 
-  const double depthCents = (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
+  const double depthCents = (targetDepth < 0x80)
+      ? (currentDepth * (100.0 / (32.0 * 256.0)))
+      : (currentDepth * (100.0 / (8.0 * 256.0)));
   const int midiValue = static_cast<int>(std::lround(128.0 * depthCents / konami_snes::kVibratoMaxDepthCents));
   return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
 }
@@ -503,11 +505,12 @@ void KonamiSnesTrack::onTickBegin() {
         vibratoFade.currentDepth = std::min<uint16_t>(targetDepth, vibratoFade.currentDepth + vibratoFade.step);
       }
 
-      const uint8_t midiDepth = convertVibratoDepthToMidi(static_cast<uint8_t>(vibratoFade.currentDepth >> 8));
+      const uint8_t midiDepth = convertVibratoDepthToMidi(vibratoDepth, vibratoFade.currentDepth);
       if (midiDepth != vibratoFade.midiDepth) {
         addModulationNoItem(midiDepth);
         vibratoFade.midiDepth = midiDepth;
       }
+      printf("currentDepth: %d. targetDepth: %d.  midiDepth: %d\n", vibratoFade.currentDepth, targetDepth, midiDepth);
     }
   }
 
@@ -1255,7 +1258,7 @@ bool KonamiSnesTrack::readEvent() {
       vibratoFade = {};
       const bool active = hasActiveVibrato(vibratoRate, vibratoDepth);
       const bool deferDepthForFade = active && immediateFadeLength != 0;
-      const uint8_t midiDepth = deferDepthForFade ? 0 : (active ? convertVibratoDepthToMidi(vibratoDepth) : 0);
+      const uint8_t midiDepth = deferDepthForFade ? 0 : (active ? convertVibratoDepthToMidi(vibratoDepth, static_cast<uint16_t>(vibratoDepth) << 8) : 0);
       addModulationNoItem(midiDepth);
       vibratoFade.currentDepth = static_cast<uint16_t>(deferDepthForFade ? 0 : vibratoDepth) << 8;
       vibratoFade.midiDepth = midiDepth;

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -4,9 +4,8 @@
  * refer to the included LICENSE.txt file
  */
 #include "KonamiSnesSeq.h"
-#include "KonamiSnesDefinitions.h"
 #include "KonamiSnesInstr.h"
-#include "Modulation.h"
+#include "KonamiSnesVibrato.h"
 #include "ScaleConversion.h"
 #include "spdlog/fmt/fmt.h"
 #include <algorithm>
@@ -28,111 +27,6 @@ constexpr uint8_t noteDurationRateMax(KonamiSnesVersion version) {
 
 constexpr uint8_t timerFrequency(KonamiSnesVersion version) {
   return version == KONAMISNES_V1 ? 0x20 : 0x40;
-}
-
-// V1/V2 advance the vibrato phase directly by an 8-bit signed-ish step each music tick.
-// Values above 0x80 wrap back around to the same speed in the opposite phase direction.
-constexpr uint8_t legacyVibratoRateStep(uint8_t rate) {
-  return (rate == 0 || rate == 0x80)
-      ? 0
-      : static_cast<uint8_t>((rate < 0x80) ? rate : (0x100 - rate));
-}
-
-// V3-V6 quantize the phase advance into a small set of buckets and use the raw byte as an
-// overflow rate, so the final speed is rate * bucketStep rather than just rate.
-constexpr uint8_t modernVibratoRateStep(uint8_t rate) {
-  return (rate == 0xff) ? 16 : (rate >= 0x80) ? 8 : (rate >= 0x40) ? 4 : (rate >= 0x20) ? 2 : 1;
-}
-
-// Later drivers treat any nonzero rate as active. In the legacy driver, some rate bytes still
-// produce a zero phase step, so they should not count as active vibrato
-bool hasActiveVibrato(KonamiSnesVersion version, uint8_t rate, uint8_t depth) {
-  return depth != 0 &&
-         (konami_snes::usesLegacyVibrato(version) ? (legacyVibratoRateStep(rate) != 0) : (rate != 0));
-}
-
-// Converts a raw vibrato depth byte into the full-scale pitch range for the exported instrument.
-double maxVibratoDepthCents(KonamiSnesVersion version, uint8_t depth) {
-  if (konami_snes::usesLegacyVibrato(version)) {
-    return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
-  }
-
-  // V3-V6 use a narrower normal range and a much larger high-depth mode.
-  return (depth < 0x80) ? (depth * (100.0 / 128.0)) : ((depth - 126.0) * 50.0);
-}
-
-// Converts the current 8.8 fade depth into cents using the same piecewise depth curve as the
-// target depth above, so the fade emits the same shape the driver uses internally.
-double currentVibratoDepthCents(KonamiSnesVersion version, uint8_t targetDepth, uint16_t currentDepth) {
-  if (konami_snes::usesLegacyVibrato(version)) {
-    return (targetDepth < 0x80)
-        ? (currentDepth * (100.0 / (32.0 * 256.0)))
-        : (currentDepth * (100.0 / (8.0 * 256.0)));
-  }
-
-  return (currentDepth < 0x8000)
-      ? (currentDepth * (100.0 / (128.0 * 256.0)))
-      : ((currentDepth - (126.0 * 256.0)) * (50.0 / 256.0));
-}
-
-// The tracked first-pass max only needs a floor, not the full default export range.
-uint16_t minVibratoMaxRateFactor(KonamiSnesVersion version) {
-  return konami_snes::usesLegacyVibrato(version)
-      ? static_cast<uint16_t>(konami_snes::kMinVibratoMaxRateStep * 0xff)
-      : konami_snes::kMinVibratoMaxRateStep;
-}
-
-// Both driver families are expressed as "base Hz times a dimensionless factor", but the base unit
-// differs because late-era vibrato uses a 64-step phase with overflow timing.
-double vibratoBaseHz(KonamiSnesVersion version) {
-  return konami_snes::usesLegacyVibrato(version)
-      ? (konami_snes::kTimerHz / 65536.0)
-      : (konami_snes::kTimerHz / 16384.0);
-}
-
-// Produces the factor multiplied by vibratoBaseHz(version) to get the final exported LFO rate.
-// Legacy vibrato folds tempo in here; late-era vibrato does not.
-uint16_t vibratoRateFactor(KonamiSnesVersion version, uint8_t rate, uint8_t tempo) {
-  if (konami_snes::usesLegacyVibrato(version)) {
-    return static_cast<uint16_t>(legacyVibratoRateStep(rate) * std::max<uint8_t>(tempo, 1));
-  }
-
-  return (rate == 0) ? 0 : static_cast<uint16_t>(rate * modernVibratoRateStep(rate));
-}
-
-// Legacy delay is measured in music ticks, so real time shrinks as tempo rises. Late-era delay is
-// already based on the fixed 250 Hz update, so it is independent of tempo.
-double vibratoDelaySeconds(KonamiSnesVersion version, uint8_t delay, uint8_t tempo) {
-  if (konami_snes::usesLegacyVibrato(version)) {
-    const double baseSeconds = 256.0 / konami_snes::kTimerHz;
-    return (baseSeconds * (delay + 1.0)) / std::max<uint8_t>(tempo, 1);
-  }
-
-  return (delay + 1.0) / konami_snes::kTimerHz;
-}
-
-double minVibratoDelaySeconds(KonamiSnesVersion version) {
-  return konami_snes::usesLegacyVibrato(version)
-      ? vibratoDelaySeconds(version, 0, 0xff)
-      : vibratoDelaySeconds(version, 0, 0);
-}
-
-double maxVibratoDelaySeconds(KonamiSnesVersion version) {
-  return konami_snes::usesLegacyVibrato(version)
-      ? vibratoDelaySeconds(version, 0xff, 1)
-      : vibratoDelaySeconds(version, 0xc7, 0);
-}
-
-uint8_t vibratoDelayFromArg1(KonamiSnesVersion version, uint8_t arg1) {
-  // V3-V6 overload E4 arg1: 00-C7 is delay, C8-FF means inline fade with zero delay.
-  return (!konami_snes::usesLegacyVibrato(version) && arg1 >= konami_snes::kLateEraVibratoFadeThreshold) ? 0 : arg1;
-}
-
-// The overloaded V3-V6 E4 argument maps C8-FF to fade lengths 1-56.
-uint8_t vibratoInlineFadeLength(KonamiSnesVersion version, uint8_t arg1) {
-  return (!konami_snes::usesLegacyVibrato(version) && arg1 >= konami_snes::kLateEraVibratoFadeThreshold)
-      ? static_cast<uint8_t>(arg1 - (konami_snes::kLateEraVibratoFadeThreshold - 1))
-      : 0;
 }
 
 void fillEventRange(std::map<uint8_t, KonamiSnesSeqEventType>& eventMap,
@@ -189,38 +83,31 @@ uint8_t convertVibratoDepthToMidi(KonamiSnesVersion version,
   }
 
   const uint8_t clampedMaxDepth = std::max(maxDepth, konami_snes::kMinVibratoMaxDepth);
-  const double depthCents = currentVibratoDepthCents(version, targetDepth, currentDepth);
-  const double maxDepthCents = maxVibratoDepthCents(version, clampedMaxDepth);
+  const double depthCents = konami_snes::vibrato::currentDepthCents(version, targetDepth, currentDepth);
+  const double maxDepthCents = konami_snes::vibrato::maxDepthCents(version, clampedMaxDepth);
   const int midiValue = static_cast<int>(std::lround(128.0 * depthCents / maxDepthCents));
   return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
-}
-
-uint16_t effectiveVibratoRateFactor(KonamiSnesVersion version, uint8_t rate, uint8_t tempo) {
-  const uint16_t effectiveRateFactor = vibratoRateFactor(version, rate, tempo);
-  if (effectiveRateFactor == 0) {
-    return 0;
-  }
-
-  return effectiveRateFactor;
 }
 
 uint8_t convertVibratoRateToMidi(KonamiSnesVersion version,
                                  uint8_t rate,
                                  uint8_t tempo,
                                  uint16_t maxRateFactor) {
-  const uint16_t effectiveRateFactor = effectiveVibratoRateFactor(version, rate, tempo);
+  const uint16_t effectiveRateFactor = konami_snes::vibrato::rateFactor(version, rate, tempo);
   if (effectiveRateFactor == 0) {
     return 0;
   }
 
-  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, minVibratoMaxRateFactor(version));
-  const double baseHz = vibratoBaseHz(version);
+  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, konami_snes::vibrato::minMaxRateFactor(version));
+  const double baseHz = konami_snes::vibrato::baseHz(version);
   return midiValueForHertzInRange(baseHz * effectiveRateFactor, baseHz, baseHz * clampedMaxRateFactor);
 }
 
 uint8_t convertVibratoDelayToMidi(KonamiSnesVersion version, uint8_t delay, uint8_t tempo) {
-  const double delaySeconds = vibratoDelaySeconds(version, delay, tempo);
-  return midiValueForSecondsInRange(delaySeconds, minVibratoDelaySeconds(version), maxVibratoDelaySeconds(version));
+  const double delaySeconds = konami_snes::vibrato::delaySeconds(version, delay, tempo);
+  return midiValueForSecondsInRange(delaySeconds,
+                                    konami_snes::vibrato::minDelaySeconds(version),
+                                    konami_snes::vibrato::maxDelaySeconds(version));
 }
 }
 
@@ -284,7 +171,7 @@ const uint8_t KonamiSnesSeq::VOL_TABLE[] = {
 KonamiSnesSeq::KonamiSnesSeq(RawFile *file, KonamiSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(KonamiSnesFormat::name, file, seqdataOffset, 0, newName),
       maxVibratoDepth(konami_snes::kMinVibratoMaxDepth),
-      maxVibratoRateFactor(minVibratoMaxRateFactor(ver)),
+      maxVibratoRateFactor(konami_snes::vibrato::minMaxRateFactor(ver)),
       version(ver) {
   setAllowDiscontinuousTrackData(true);
   bLoadTickByTick = true;
@@ -305,7 +192,7 @@ void KonamiSnesSeq::resetVars(void) {
 
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     maxVibratoDepth = konami_snes::kMinVibratoMaxDepth;
-    maxVibratoRateFactor = minVibratoMaxRateFactor(version);
+    maxVibratoRateFactor = konami_snes::vibrato::minMaxRateFactor(version);
   }
 
   // The driver starts from tempo/speed FF unless the sequence overrides it.
@@ -543,14 +430,14 @@ double KonamiSnesTrack::getTuningInSemitones(int8_t tuning) {
 }
 
 void KonamiSnesTrack::syncVibratoRateAndDelay() {
-  if (!hasActiveVibrato(seq().version, vibratoRate, vibratoDepth)) {
+  if (!konami_snes::vibrato::isActive(seq().version, vibratoRate, vibratoDepth)) {
     return;
   }
 
   auto &parentSeq = seq();
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     parentSeq.maxVibratoRateFactor = std::max(parentSeq.maxVibratoRateFactor,
-                                              effectiveVibratoRateFactor(parentSeq.version, vibratoRate, parentSeq.tempo));
+                                              konami_snes::vibrato::rateFactor(parentSeq.version, vibratoRate, parentSeq.tempo));
   }
 
   addChannelPressureNoItem(convertVibratoRateToMidi(parentSeq.version,
@@ -1193,7 +1080,7 @@ bool KonamiSnesTrack::readEvent() {
       const bool isTiedNote = prevNoteSlurred && key == prevNoteKey;
 
       if (!isTiedNote && vibratoFade.length != 0 &&
-          hasActiveVibrato(seq().version, vibratoRate, vibratoDepth)) {
+          konami_snes::vibrato::isActive(seq().version, vibratoRate, vibratoDepth)) {
         vibratoFade.delayRemaining = vibratoDelay;
         vibratoFade.ticksRemaining = vibratoFade.length;
         vibratoFade.currentDepth = 0;
@@ -1366,8 +1253,8 @@ bool KonamiSnesTrack::readEvent() {
       uint8_t vibratoArg1 = readByte(curOffset++);
       uint8_t newVibratoRate = readByte(curOffset++);
       uint8_t newVibratoDepth = readByte(curOffset++);
-      const uint8_t builtInFadeLength = vibratoInlineFadeLength(parentSeq.version, vibratoArg1);
-      const uint8_t newVibratoDelay = vibratoDelayFromArg1(parentSeq.version, vibratoArg1);
+      const uint8_t builtInFadeLength = konami_snes::vibrato::inlineFadeLength(parentSeq.version, vibratoArg1);
+      const uint8_t newVibratoDelay = konami_snes::vibrato::delayFromArg1(parentSeq.version, vibratoArg1);
       desc = (builtInFadeLength != 0)
           ? fmt::format("Fade Length: {:d}  Rate: {:d}  Depth: {:d}",
                         builtInFadeLength, newVibratoRate, newVibratoDepth)
@@ -1389,7 +1276,7 @@ bool KonamiSnesTrack::readEvent() {
         vibratoFade.step = static_cast<uint16_t>((static_cast<uint16_t>(vibratoDepth) << 8) / builtInFadeLength);
       }
 
-      const bool active = hasActiveVibrato(parentSeq.version, vibratoRate, vibratoDepth);
+      const bool active = konami_snes::vibrato::isActive(parentSeq.version, vibratoRate, vibratoDepth);
       const bool deferDepthForFade = active && immediateFadeLength != 0;
       if (readMode != READMODE_CONVERT_TO_MIDI && active) {
         parentSeq.maxVibratoDepth = std::max(parentSeq.maxVibratoDepth, vibratoDepth);

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -93,8 +93,7 @@ uint8_t convertVibratoDepthToMidi(uint8_t depth) {
   }
 
   const double depthCents = (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
-  const int midiValue = static_cast<int>(std::lround(
-      128.0 * depthCents / konami_snes::kVibratoMaxDepthCents));
+  const int midiValue = static_cast<int>(std::lround(128.0 * depthCents / konami_snes::kVibratoMaxDepthCents));
   return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
 }
 
@@ -417,6 +416,7 @@ void KonamiSnesTrack::resetVars(void) {
   vibratoDelay = 0;
   vibratoRate = 0;
   vibratoDepth = 0;
+  vibratoFade = {};
   pitchBendRangeCents = KONAMI_SNES_STD_PITCH_BEND_RANGE_CENTS;
   currentPitchBend = 0;
 }
@@ -487,6 +487,28 @@ void KonamiSnesTrack::onTickBegin() {
       clearActiveVolumeFade();
     }
     applyCurrentVolume();
+  }
+
+  if (vibratoFade.ticksRemaining != 0) {
+    if (vibratoFade.delayRemaining != 0) {
+      vibratoFade.delayRemaining -= 1;
+    }
+    else {
+      const uint16_t targetDepth = static_cast<uint16_t>(vibratoDepth) << 8;
+      vibratoFade.ticksRemaining -= 1;
+      if (vibratoFade.ticksRemaining == 0) {
+        vibratoFade.currentDepth = targetDepth;
+      }
+      else {
+        vibratoFade.currentDepth = std::min<uint16_t>(targetDepth, vibratoFade.currentDepth + vibratoFade.step);
+      }
+
+      const uint8_t midiDepth = convertVibratoDepthToMidi(static_cast<uint8_t>(vibratoFade.currentDepth >> 8));
+      if (midiDepth != vibratoFade.midiDepth) {
+        addModulationNoItem(midiDepth);
+        vibratoFade.midiDepth = midiDepth;
+      }
+    }
   }
 
   if (pitchSlide.length == 0 || !pitchSlide.baseValid) {
@@ -1043,8 +1065,19 @@ bool KonamiSnesTrack::readEvent() {
       const uint32_t noteLengthBytes = curOffset - beginOffset;
       resetPitchForNote(key);
       const auto slide = consumePitchSlide();
+      const bool isTiedNote = prevNoteSlurred && key == prevNoteKey;
 
-      if (prevNoteSlurred && key == prevNoteKey) {
+      if (!isTiedNote && vibratoFade.length != 0 && hasActiveVibrato(vibratoRate, vibratoDepth)) {
+        vibratoFade.delayRemaining = vibratoDelay;
+        vibratoFade.ticksRemaining = vibratoFade.length;
+        vibratoFade.currentDepth = 0;
+        if (vibratoFade.midiDepth != 0) {
+          addModulationNoItem(0);
+          vibratoFade.midiDepth = 0;
+        }
+      }
+
+      if (isTiedNote) {
         // TODO: Note volume can be changed during a tied note
         // See the end of Konami Logo sequence for example
         makePrevDurNoteEnd(getTime() + dur);
@@ -1210,11 +1243,22 @@ bool KonamiSnesTrack::readEvent() {
       desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}",
                          newVibratoDelay, newVibratoRate, newVibratoDepth);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, Type::Vibrato);
+
+      uint8_t immediateFadeLength = 0;
+      if (readByte(curOffset) == 0xf9) {
+        immediateFadeLength = readByte(curOffset + 1);
+      }
+
       vibratoDelay = newVibratoDelay;
       vibratoRate = newVibratoRate;
       vibratoDepth = newVibratoDepth;
+      vibratoFade = {};
       const bool active = hasActiveVibrato(vibratoRate, vibratoDepth);
-      addModulationNoItem(active ? convertVibratoDepthToMidi(vibratoDepth) : 0);
+      const bool deferDepthForFade = active && immediateFadeLength != 0;
+      const uint8_t midiDepth = deferDepthForFade ? 0 : (active ? convertVibratoDepthToMidi(vibratoDepth) : 0);
+      addModulationNoItem(midiDepth);
+      vibratoFade.currentDepth = static_cast<uint16_t>(deferDepthForFade ? 0 : vibratoDepth) << 8;
+      vibratoFade.midiDepth = midiDepth;
       if (active) {
         addChannelPressureNoItem(convertVibratoRateToMidi(vibratoRate));
         addControllerEventNoItem(konami_snes::kVibratoDelayController, convertVibratoDelayToMidi(vibratoDelay));
@@ -1499,6 +1543,14 @@ bool KonamiSnesTrack::readEvent() {
       desc = fmt::format("Fade Length: {:d}", fadeSpeed);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Fade", desc,
                       Type::Vibrato);
+      if (fadeSpeed == 0) {
+        vibratoFade.length = 0;
+        vibratoFade.step = 0;
+      }
+      else {
+        vibratoFade.length = fadeSpeed;
+        vibratoFade.step = static_cast<uint16_t>((static_cast<uint16_t>(vibratoDepth) << 8) / fadeSpeed);
+      }
       break;
     }
 

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -426,6 +426,14 @@ void KonamiSnesTrack::resetVars(void) {
   currentPitchBend = 0;
 }
 
+void KonamiSnesTrack::addInitialMidiEvents(int trackNum) {
+  SeqTrack::addInitialMidiEvents(trackNum);
+  addModulationNoItem(0);
+  addChannelPressureNoItem(0);
+  addControllerEventNoItem(konami_snes::kVibratoTempoController, 0);
+  addControllerEventNoItem(konami_snes::kVibratoDelayController, 0);
+}
+
 KonamiSnesSeq& KonamiSnesTrack::seq() {
   return *static_cast<KonamiSnesSeq*>(parentSeq);
 }
@@ -513,7 +521,6 @@ void KonamiSnesTrack::onTickBegin() {
         addModulationNoItem(midiDepth);
         vibratoFade.midiDepth = midiDepth;
       }
-      printf("currentDepth: %d. targetDepth: %d.  midiDepth: %d\n", vibratoFade.currentDepth, targetDepth, midiDepth);
     }
   }
 
@@ -1280,6 +1287,11 @@ bool KonamiSnesTrack::readEvent() {
         addChannelPressureNoItem(convertVibratoRateToMidi(vibratoRate, parentSeq.maxVibratoRate));
         addControllerEventNoItem(konami_snes::kVibratoDelayController, convertVibratoDelayToMidi(vibratoDelay));
         syncVibratoTempo();
+      }
+      else {
+        addChannelPressureNoItem(0);
+        addControllerEventNoItem(konami_snes::kVibratoDelayController, 0);
+        addControllerEventNoItem(konami_snes::kVibratoTempoController, 0);
       }
       break;
     }

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -4,7 +4,9 @@
  * refer to the included LICENSE.txt file
  */
 #include "KonamiSnesSeq.h"
+#include "KonamiSnesDefinitions.h"
 #include "KonamiSnesInstr.h"
+#include "Modulation.h"
 #include "ScaleConversion.h"
 #include "spdlog/fmt/fmt.h"
 #include <algorithm>
@@ -149,8 +151,11 @@ KonamiSnesSeq::~KonamiSnesSeq(void) {
 void KonamiSnesSeq::resetVars(void) {
   VGMSeq::resetVars();
 
-  tempo = 0;
+  // The driver starts from tempo/speed FF unless the sequence overrides it.
+  tempo = 0xff;
   tempoFade = {};
+  tempoFade.currentTempo = tempo << 8;
+  tempoFade.targetTempo = tempoFade.currentTempo;
   tempoFadeLastUpdatedTime = static_cast<uint32_t>(-1);
 }
 
@@ -360,6 +365,7 @@ void KonamiSnesTrack::resetVars(void) {
   panFade.targetPan = panFade.currentPan;
   volumeFade = {};
   pitchSlide = {};
+  vibrato = {};
   pitchBendRangeCents = KONAMI_SNES_STD_PITCH_BEND_RANGE_CENTS;
   currentPitchBend = 0;
 }
@@ -374,6 +380,107 @@ const KonamiSnesSeq& KonamiSnesTrack::seq() const {
 
 double KonamiSnesTrack::getTuningInSemitones(int8_t tuning) {
   return tuning * 4 / 256.0;
+}
+
+uint8_t KonamiSnesTrack::currentTempoByte() const {
+  return std::max<uint8_t>(seq().tempo, 1);
+}
+
+uint8_t KonamiSnesTrack::effectiveVibratoRateStep(uint8_t rate) {
+  if (rate == 0 || rate == 0x80) {
+    return 0;
+  }
+
+  return static_cast<uint8_t>((rate < 0x80) ? rate : (0x100 - rate));
+}
+
+double KonamiSnesTrack::vibratoDepthCents(uint8_t depth) {
+  return (depth < 0x80)
+      ? (depth * (100.0 / 32.0))
+      : (depth * (100.0 / 8.0));
+}
+
+uint8_t KonamiSnesTrack::convertVibratoDepthToMidi(uint8_t depth) {
+  if (depth == 0) {
+    return 0;
+  }
+
+  const int midiValue = static_cast<int>(std::lround(
+      128.0 * vibratoDepthCents(depth) / konami_snes::kVibratoMaxDepthCents));
+  return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
+}
+
+uint8_t KonamiSnesTrack::convertVibratoRateToMidi(uint8_t rate) {
+  const uint8_t effectiveRate = effectiveVibratoRateStep(rate);
+  if (effectiveRate == 0) {
+    return 0;
+  }
+
+  return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * effectiveRate,
+                                  konami_snes::kVibratoBaseHz,
+                                  konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxRateFactor);
+}
+
+uint8_t KonamiSnesTrack::convertTempoFactorToMidi(uint8_t tempo) {
+  const uint8_t clampedTempo = std::max<uint8_t>(tempo, 1);
+  return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * clampedTempo,
+                                  konami_snes::kVibratoBaseHz,
+                                  konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxTempoFactor);
+}
+
+uint8_t KonamiSnesTrack::convertVibratoDelayToMidi(uint8_t delay) {
+  const double delaySeconds = konami_snes::kVibratoDelayBaseSeconds * (static_cast<double>(delay) + 1.0);
+  return midiValueForSecondsInRange(delaySeconds,
+                                    konami_snes::kVibratoDelayBaseSeconds,
+                                    konami_snes::kVibratoDelayBaseSeconds *
+                                        konami_snes::kVibratoMaxDelayCountFactor);
+}
+
+bool KonamiSnesTrack::hasActiveVibrato() const {
+  return vibrato.depth != 0 && effectiveVibratoRateStep(vibrato.rate) != 0;
+}
+
+void KonamiSnesTrack::beginVibrato(uint8_t delay, uint8_t rate, uint8_t depth) {
+  vibrato.delay = delay;
+  vibrato.rate = rate;
+  vibrato.depth = depth;
+  applyCurrentVibrato();
+}
+
+void KonamiSnesTrack::applyCurrentVibrato() {
+  const uint8_t midiDepth = hasActiveVibrato() ? convertVibratoDepthToMidi(vibrato.depth) : 0;
+  if (midiDepth != vibrato.midiDepth) {
+    addModulationNoItem(midiDepth);
+    vibrato.midiDepth = midiDepth;
+  }
+
+  if (!hasActiveVibrato()) {
+    return;
+  }
+
+  const uint8_t midiRate = convertVibratoRateToMidi(vibrato.rate);
+  if (midiRate != vibrato.midiRate) {
+    addChannelPressureNoItem(midiRate);
+    vibrato.midiRate = midiRate;
+  }
+
+  const uint8_t midiTempo = convertTempoFactorToMidi(currentTempoByte());
+  if (midiTempo != vibrato.midiTempo) {
+    addControllerEventNoItem(konami_snes::kVibratoTempoController, midiTempo);
+    vibrato.midiTempo = midiTempo;
+  }
+
+  const uint8_t midiDelay = convertVibratoDelayToMidi(vibrato.delay);
+  if (midiDelay != vibrato.midiDelay) {
+    addControllerEventNoItem(konami_snes::kVibratoDelayController, midiDelay);
+    vibrato.midiDelay = midiDelay;
+  }
+}
+
+void KonamiSnesTrack::refreshAllTrackVibrato() {
+  for (SeqTrack *track : seq().aTracks) {
+    static_cast<KonamiSnesTrack*>(track)->applyCurrentVibrato();
+  }
 }
 
 
@@ -404,6 +511,10 @@ void KonamiSnesTrack::onTickBegin() {
       }
       applyCurrentTempo();
     }
+  }
+
+  if (hasActiveVibrato()) {
+    applyCurrentVibrato();
   }
 
   const auto panResult = advanceFade(panFade.currentPan, panFade.targetPan, panFade.delta,
@@ -854,6 +965,7 @@ void KonamiSnesTrack::applyCurrentTempo() {
   if (newTempo != parentSeq.tempo) {
     parentSeq.tempo = newTempo;
     addTempoBPMNoItem(parentSeq.getTempoInBPM(newTempo));
+    refreshAllTrackVibrato();
   }
 }
 
@@ -1142,6 +1254,7 @@ bool KonamiSnesTrack::readEvent() {
       desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}",
                          vibratoDelay, vibratoRate, vibratoDepth);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, Type::Vibrato);
+      beginVibrato(vibratoDelay, vibratoRate, vibratoDepth);
       break;
     }
 
@@ -1256,6 +1369,7 @@ bool KonamiSnesTrack::readEvent() {
       clearActiveTempoFade();
       parentSeq.tempo = newTempo;
       addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
+      refreshAllTrackVibrato();
       break;
     }
 

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -93,30 +93,34 @@ uint8_t convertVibratoDepthToMidi(uint8_t targetDepth, uint16_t currentDepth, ui
   return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
 }
 
-uint8_t convertVibratoRateToMidi(uint8_t rate, uint8_t maxRate) {
+uint16_t effectiveVibratoRateFactor(uint8_t rate, uint8_t tempo) {
   const uint8_t effectiveRate = konami_snes::effectiveVibratoRateStep(rate);
   if (effectiveRate == 0) {
     return 0;
   }
 
-  const uint8_t clampedMaxRate = std::max(maxRate, konami_snes::kMinVibratoMaxRateStep);
-  return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * effectiveRate,
-                                  konami_snes::kVibratoBaseHz,
-                                  konami_snes::kVibratoBaseHz * clampedMaxRate);
+  return static_cast<uint16_t>(effectiveRate * std::max<uint8_t>(tempo, 1));
 }
 
-uint8_t convertTempoFactorToMidi(uint8_t tempo) {
-  const uint8_t clampedTempo = std::max<uint8_t>(tempo, 1);
-  return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * clampedTempo,
+uint8_t convertVibratoRateToMidi(uint8_t rate, uint8_t tempo, uint16_t maxRateFactor) {
+  const uint16_t effectiveRateFactor = effectiveVibratoRateFactor(rate, tempo);
+  if (effectiveRateFactor == 0) {
+    return 0;
+  }
+
+  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, konami_snes::kMinVibratoMaxRateFactor);
+  return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * effectiveRateFactor,
                                   konami_snes::kVibratoBaseHz,
-                                  konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxTempoFactor);
+                                  konami_snes::kVibratoBaseHz * clampedMaxRateFactor);
 }
 
-uint8_t convertVibratoDelayToMidi(uint8_t delay) {
-  const double delaySeconds = konami_snes::kVibratoDelayBaseSeconds * (static_cast<double>(delay) + 1.0);
+uint8_t convertVibratoDelayToMidi(uint8_t delay, uint8_t tempo) {
+  const double delaySeconds =
+      (konami_snes::kVibratoDelayBaseSeconds * (static_cast<double>(delay) + 1.0)) /
+      std::max<uint8_t>(tempo, 1);
   return midiValueForSecondsInRange(delaySeconds,
-                                    konami_snes::kVibratoDelayBaseSeconds,
-                                    konami_snes::kVibratoDelayBaseSeconds * konami_snes::kVibratoMaxDelayCountFactor);
+                                    konami_snes::kVibratoMinDelaySeconds,
+                                    konami_snes::kVibratoMaxDelaySeconds);
 }
 }
 
@@ -180,7 +184,7 @@ const uint8_t KonamiSnesSeq::VOL_TABLE[] = {
 KonamiSnesSeq::KonamiSnesSeq(RawFile *file, KonamiSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(KonamiSnesFormat::name, file, seqdataOffset, 0, newName),
       maxVibratoDepth(konami_snes::kMinVibratoMaxDepth),
-      maxVibratoRate(konami_snes::kMinVibratoMaxRateStep),
+      maxVibratoRateFactor(konami_snes::kMinVibratoMaxRateFactor),
       version(ver) {
   setAllowDiscontinuousTrackData(true);
   bLoadTickByTick = true;
@@ -201,7 +205,7 @@ void KonamiSnesSeq::resetVars(void) {
 
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     maxVibratoDepth = konami_snes::kMinVibratoMaxDepth;
-    maxVibratoRate = konami_snes::kMinVibratoMaxRateStep;
+    maxVibratoRateFactor = konami_snes::kMinVibratoMaxRateFactor;
   }
 
   // The driver starts from tempo/speed FF unless the sequence overrides it.
@@ -438,12 +442,19 @@ double KonamiSnesTrack::getTuningInSemitones(int8_t tuning) {
   return tuning * 4 / 256.0;
 }
 
-void KonamiSnesTrack::syncVibratoTempo() {
+void KonamiSnesTrack::syncVibratoRateAndDelay() {
   if (!hasActiveVibrato(vibratoRate, vibratoDepth)) {
     return;
   }
 
-  addControllerEventNoItem(konami_snes::kVibratoTempoController, convertTempoFactorToMidi(seq().tempo));
+  auto &parentSeq = seq();
+  if (readMode != READMODE_CONVERT_TO_MIDI) {
+    parentSeq.maxVibratoRateFactor = std::max(parentSeq.maxVibratoRateFactor,
+                                              effectiveVibratoRateFactor(vibratoRate, parentSeq.tempo));
+  }
+
+  addChannelPressureNoItem(convertVibratoRateToMidi(vibratoRate, parentSeq.tempo, parentSeq.maxVibratoRateFactor));
+  addControllerEventNoItem(konami_snes::kVibratoDelayController, convertVibratoDelayToMidi(vibratoDelay, parentSeq.tempo));
 }
 
 
@@ -947,7 +958,7 @@ void KonamiSnesTrack::applyCurrentTempo() {
     parentSeq.tempo = newTempo;
     addTempoBPMNoItem(parentSeq.getTempoInBPM(newTempo));
     for (SeqTrack *track : parentSeq.aTracks) {
-      static_cast<KonamiSnesTrack*>(track)->syncVibratoTempo();
+      static_cast<KonamiSnesTrack*>(track)->syncVibratoRateAndDelay();
     }
   }
 }
@@ -1262,8 +1273,6 @@ bool KonamiSnesTrack::readEvent() {
       const bool deferDepthForFade = active && immediateFadeLength != 0;
       if (readMode != READMODE_CONVERT_TO_MIDI && active) {
         parentSeq.maxVibratoDepth = std::max(parentSeq.maxVibratoDepth, vibratoDepth);
-        parentSeq.maxVibratoRate =
-            std::max(parentSeq.maxVibratoRate, konami_snes::effectiveVibratoRateStep(vibratoRate));
       }
 
       const uint8_t midiDepth = deferDepthForFade
@@ -1276,14 +1285,11 @@ bool KonamiSnesTrack::readEvent() {
       vibratoFade.currentDepth = static_cast<uint16_t>(deferDepthForFade ? 0 : vibratoDepth) << 8;
       vibratoFade.midiDepth = midiDepth;
       if (active) {
-        addChannelPressureNoItem(convertVibratoRateToMidi(vibratoRate, parentSeq.maxVibratoRate));
-        addControllerEventNoItem(konami_snes::kVibratoDelayController, convertVibratoDelayToMidi(vibratoDelay));
-        syncVibratoTempo();
+        syncVibratoRateAndDelay();
       }
       else {
         addChannelPressureNoItem(0);
         addControllerEventNoItem(konami_snes::kVibratoDelayController, 0);
-        addControllerEventNoItem(konami_snes::kVibratoTempoController, 0);
       }
       break;
     }
@@ -1400,7 +1406,7 @@ bool KonamiSnesTrack::readEvent() {
       parentSeq.tempo = newTempo;
       addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
       for (SeqTrack *track : parentSeq.aTracks) {
-        static_cast<KonamiSnesTrack*>(track)->syncVibratoTempo();
+        static_cast<KonamiSnesTrack*>(track)->syncVibratoRateAndDelay();
       }
       break;
     }

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -84,11 +84,11 @@ uint8_t convertVibratoDepthToMidi(uint8_t targetDepth, uint16_t currentDepth, ui
     return 0;
   }
 
+  const uint8_t clampedMaxDepth = std::max(maxDepth, konami_snes::kMinVibratoMaxDepth);
   const double depthCents = (targetDepth < 0x80)
       ? (currentDepth * (100.0 / (32.0 * 256.0)))
       : (currentDepth * (100.0 / (8.0 * 256.0)));
-  const double maxDepthCents = konami_snes::vibratoDepthCents(
-      maxDepth != 0 ? maxDepth : konami_snes::kDefaultVibratoMaxDepth);
+  const double maxDepthCents = konami_snes::vibratoDepthCents(clampedMaxDepth);
   const int midiValue = static_cast<int>(std::lround(128.0 * depthCents / maxDepthCents));
   return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
 }
@@ -99,10 +99,10 @@ uint8_t convertVibratoRateToMidi(uint8_t rate, uint8_t maxRate) {
     return 0;
   }
 
+  const uint8_t clampedMaxRate = std::max(maxRate, konami_snes::kMinVibratoMaxRateStep);
   return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * effectiveRate,
                                   konami_snes::kVibratoBaseHz,
-                                  konami_snes::kVibratoBaseHz *
-                                      (maxRate != 0 ? maxRate : konami_snes::kDefaultVibratoMaxRateStep));
+                                  konami_snes::kVibratoBaseHz * clampedMaxRate);
 }
 
 uint8_t convertTempoFactorToMidi(uint8_t tempo) {
@@ -179,8 +179,8 @@ const uint8_t KonamiSnesSeq::VOL_TABLE[] = {
 
 KonamiSnesSeq::KonamiSnesSeq(RawFile *file, KonamiSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(KonamiSnesFormat::name, file, seqdataOffset, 0, newName),
-      maxVibratoDepth(0),
-      maxVibratoRate(0),
+      maxVibratoDepth(konami_snes::kMinVibratoMaxDepth),
+      maxVibratoRate(konami_snes::kMinVibratoMaxRateStep),
       version(ver) {
   setAllowDiscontinuousTrackData(true);
   bLoadTickByTick = true;
@@ -200,8 +200,8 @@ void KonamiSnesSeq::resetVars(void) {
   VGMSeq::resetVars();
 
   if (readMode != READMODE_CONVERT_TO_MIDI) {
-    maxVibratoDepth = 0;
-    maxVibratoRate = 0;
+    maxVibratoDepth = konami_snes::kMinVibratoMaxDepth;
+    maxVibratoRate = konami_snes::kMinVibratoMaxRateStep;
   }
 
   // The driver starts from tempo/speed FF unless the sequence overrides it.
@@ -424,14 +424,6 @@ void KonamiSnesTrack::resetVars(void) {
   vibratoFade = {};
   pitchBendRangeCents = KONAMI_SNES_STD_PITCH_BEND_RANGE_CENTS;
   currentPitchBend = 0;
-}
-
-void KonamiSnesTrack::addInitialMidiEvents(int trackNum) {
-  SeqTrack::addInitialMidiEvents(trackNum);
-  addModulationNoItem(0);
-  addChannelPressureNoItem(0);
-  addControllerEventNoItem(konami_snes::kVibratoTempoController, 0);
-  addControllerEventNoItem(konami_snes::kVibratoDelayController, 0);
 }
 
 KonamiSnesSeq& KonamiSnesTrack::seq() {

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -75,52 +75,55 @@ FadeStepResult advanceFade(ValueType& current,
   return FadeStepResult::Running;
 }
 
-bool hasActiveVibrato(uint8_t rate, uint8_t depth) {
-  return depth != 0 && konami_snes::effectiveVibratoRateStep(rate) != 0;
-}
-
-uint8_t convertVibratoDepthToMidi(uint8_t targetDepth, uint16_t currentDepth, uint8_t maxDepth) {
+uint8_t convertVibratoDepthToMidi(KonamiSnesVersion version,
+                                  uint8_t targetDepth,
+                                  uint16_t currentDepth,
+                                  uint8_t maxDepth) {
   if (targetDepth == 0 || currentDepth == 0) {
     return 0;
   }
 
   const uint8_t clampedMaxDepth = std::max(maxDepth, konami_snes::kMinVibratoMaxDepth);
-  const double depthCents = (targetDepth < 0x80)
-      ? (currentDepth * (100.0 / (32.0 * 256.0)))
-      : (currentDepth * (100.0 / (8.0 * 256.0)));
-  const double maxDepthCents = konami_snes::vibratoDepthCents(clampedMaxDepth);
+  const double depthCents = konami_snes::usesV1Vibrato(version)
+      ? ((targetDepth < 0x80)
+            ? (currentDepth * (100.0 / (32.0 * 256.0)))
+            : (currentDepth * (100.0 / (8.0 * 256.0))))
+      : ((currentDepth < 0x8000)
+            ? (currentDepth * (100.0 / (128.0 * 256.0)))
+            : ((currentDepth - (126.0 * 256.0)) * (50.0 / 256.0)));
+  const double maxDepthCents = konami_snes::vibratoDepthCents(version, clampedMaxDepth);
   const int midiValue = static_cast<int>(std::lround(128.0 * depthCents / maxDepthCents));
   return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
 }
 
-uint16_t effectiveVibratoRateFactor(uint8_t rate, uint8_t tempo) {
-  const uint8_t effectiveRate = konami_snes::effectiveVibratoRateStep(rate);
-  if (effectiveRate == 0) {
-    return 0;
-  }
-
-  return static_cast<uint16_t>(effectiveRate * std::max<uint8_t>(tempo, 1));
-}
-
-uint8_t convertVibratoRateToMidi(uint8_t rate, uint8_t tempo, uint16_t maxRateFactor) {
-  const uint16_t effectiveRateFactor = effectiveVibratoRateFactor(rate, tempo);
+uint16_t effectiveVibratoRateFactor(KonamiSnesVersion version, uint8_t rate, uint8_t tempo) {
+  const uint16_t effectiveRateFactor = konami_snes::vibratoRateFactor(version, rate, tempo);
   if (effectiveRateFactor == 0) {
     return 0;
   }
 
-  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, konami_snes::kMinVibratoMaxRateFactor);
-  return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * effectiveRateFactor,
-                                  konami_snes::kVibratoBaseHz,
-                                  konami_snes::kVibratoBaseHz * clampedMaxRateFactor);
+  return effectiveRateFactor;
 }
 
-uint8_t convertVibratoDelayToMidi(uint8_t delay, uint8_t tempo) {
-  const double delaySeconds =
-      (konami_snes::kVibratoDelayBaseSeconds * (static_cast<double>(delay) + 1.0)) /
-      std::max<uint8_t>(tempo, 1);
+uint8_t convertVibratoRateToMidi(KonamiSnesVersion version,
+                                 uint8_t rate,
+                                 uint8_t tempo,
+                                 uint16_t maxRateFactor) {
+  const uint16_t effectiveRateFactor = effectiveVibratoRateFactor(version, rate, tempo);
+  if (effectiveRateFactor == 0) {
+    return 0;
+  }
+
+  const uint16_t clampedMaxRateFactor = std::max(maxRateFactor, konami_snes::minVibratoMaxRateFactor(version));
+  const double baseHz = konami_snes::vibratoBaseHz(version);
+  return midiValueForHertzInRange(baseHz * effectiveRateFactor, baseHz, baseHz * clampedMaxRateFactor);
+}
+
+uint8_t convertVibratoDelayToMidi(KonamiSnesVersion version, uint8_t delay, uint8_t tempo) {
+  const double delaySeconds = konami_snes::vibratoDelaySeconds(version, delay, tempo);
   return midiValueForSecondsInRange(delaySeconds,
-                                    konami_snes::kVibratoMinDelaySeconds,
-                                    konami_snes::kVibratoMaxDelaySeconds);
+                                    konami_snes::minVibratoDelaySeconds(version),
+                                    konami_snes::maxVibratoDelaySeconds(version));
 }
 }
 
@@ -184,7 +187,7 @@ const uint8_t KonamiSnesSeq::VOL_TABLE[] = {
 KonamiSnesSeq::KonamiSnesSeq(RawFile *file, KonamiSnesVersion ver, uint32_t seqdataOffset, std::string newName)
     : VGMSeq(KonamiSnesFormat::name, file, seqdataOffset, 0, newName),
       maxVibratoDepth(konami_snes::kMinVibratoMaxDepth),
-      maxVibratoRateFactor(konami_snes::kMinVibratoMaxRateFactor),
+      maxVibratoRateFactor(konami_snes::minVibratoMaxRateFactor(ver)),
       version(ver) {
   setAllowDiscontinuousTrackData(true);
   bLoadTickByTick = true;
@@ -205,7 +208,7 @@ void KonamiSnesSeq::resetVars(void) {
 
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     maxVibratoDepth = konami_snes::kMinVibratoMaxDepth;
-    maxVibratoRateFactor = konami_snes::kMinVibratoMaxRateFactor;
+    maxVibratoRateFactor = konami_snes::minVibratoMaxRateFactor(version);
   }
 
   // The driver starts from tempo/speed FF unless the sequence overrides it.
@@ -443,18 +446,22 @@ double KonamiSnesTrack::getTuningInSemitones(int8_t tuning) {
 }
 
 void KonamiSnesTrack::syncVibratoRateAndDelay() {
-  if (!hasActiveVibrato(vibratoRate, vibratoDepth)) {
+  if (!konami_snes::hasActiveVibrato(seq().version, vibratoRate, vibratoDepth)) {
     return;
   }
 
   auto &parentSeq = seq();
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     parentSeq.maxVibratoRateFactor = std::max(parentSeq.maxVibratoRateFactor,
-                                              effectiveVibratoRateFactor(vibratoRate, parentSeq.tempo));
+                                              effectiveVibratoRateFactor(parentSeq.version, vibratoRate, parentSeq.tempo));
   }
 
-  addChannelPressureNoItem(convertVibratoRateToMidi(vibratoRate, parentSeq.tempo, parentSeq.maxVibratoRateFactor));
-  addControllerEventNoItem(konami_snes::kVibratoDelayController, convertVibratoDelayToMidi(vibratoDelay, parentSeq.tempo));
+  addChannelPressureNoItem(convertVibratoRateToMidi(parentSeq.version,
+                                                    vibratoRate,
+                                                    parentSeq.tempo,
+                                                    parentSeq.maxVibratoRateFactor));
+  addControllerEventNoItem(konami_snes::kVibratoDelayController,
+                           convertVibratoDelayToMidi(parentSeq.version, vibratoDelay, parentSeq.tempo));
 }
 
 
@@ -519,7 +526,10 @@ void KonamiSnesTrack::onTickBegin() {
         vibratoFade.currentDepth = std::min<uint16_t>(targetDepth, vibratoFade.currentDepth + vibratoFade.step);
       }
 
-      const uint8_t midiDepth = convertVibratoDepthToMidi(vibratoDepth, vibratoFade.currentDepth, seq().maxVibratoDepth);
+      const uint8_t midiDepth = convertVibratoDepthToMidi(seq().version,
+                                                          vibratoDepth,
+                                                          vibratoFade.currentDepth,
+                                                          seq().maxVibratoDepth);
       if (midiDepth != vibratoFade.midiDepth) {
         addModulationNoItem(midiDepth);
         vibratoFade.midiDepth = midiDepth;
@@ -957,8 +967,10 @@ void KonamiSnesTrack::applyCurrentTempo() {
   if (newTempo != parentSeq.tempo) {
     parentSeq.tempo = newTempo;
     addTempoBPMNoItem(parentSeq.getTempoInBPM(newTempo));
-    for (SeqTrack *track : parentSeq.aTracks) {
-      static_cast<KonamiSnesTrack*>(track)->syncVibratoRateAndDelay();
+    if (konami_snes::usesV1Vibrato(parentSeq.version)) {
+      for (SeqTrack *track : parentSeq.aTracks) {
+        static_cast<KonamiSnesTrack*>(track)->syncVibratoRateAndDelay();
+      }
     }
   }
 }
@@ -1083,7 +1095,8 @@ bool KonamiSnesTrack::readEvent() {
       const auto slide = consumePitchSlide();
       const bool isTiedNote = prevNoteSlurred && key == prevNoteKey;
 
-      if (!isTiedNote && vibratoFade.length != 0 && hasActiveVibrato(vibratoRate, vibratoDepth)) {
+      if (!isTiedNote && vibratoFade.length != 0 &&
+          konami_snes::hasActiveVibrato(seq().version, vibratoRate, vibratoDepth)) {
         vibratoFade.delayRemaining = vibratoDelay;
         vibratoFade.ticksRemaining = vibratoFade.length;
         vibratoFade.currentDepth = 0;
@@ -1253,14 +1266,19 @@ bool KonamiSnesTrack::readEvent() {
     }
 
     case EVENT_VIBRATO: {
-      uint8_t newVibratoDelay = readByte(curOffset++);
+      uint8_t vibratoArg1 = readByte(curOffset++);
       uint8_t newVibratoRate = readByte(curOffset++);
       uint8_t newVibratoDepth = readByte(curOffset++);
-      desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}",
-                         newVibratoDelay, newVibratoRate, newVibratoDepth);
+      const uint8_t builtInFadeLength = konami_snes::vibratoInlineFadeLength(parentSeq.version, vibratoArg1);
+      const uint8_t newVibratoDelay = konami_snes::vibratoDelayFromArg1(parentSeq.version, vibratoArg1);
+      desc = (builtInFadeLength != 0)
+          ? fmt::format("Fade Length: {:d}  Rate: {:d}  Depth: {:d}",
+                        builtInFadeLength, newVibratoRate, newVibratoDepth)
+          : fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}",
+                        newVibratoDelay, newVibratoRate, newVibratoDepth);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, Type::Vibrato);
 
-      uint8_t immediateFadeLength = 0;
+      uint8_t immediateFadeLength = builtInFadeLength;
       if (readByte(curOffset) == 0xf9) {
         immediateFadeLength = readByte(curOffset + 1);
       }
@@ -1269,7 +1287,12 @@ bool KonamiSnesTrack::readEvent() {
       vibratoRate = newVibratoRate;
       vibratoDepth = newVibratoDepth;
       vibratoFade = {};
-      const bool active = hasActiveVibrato(vibratoRate, vibratoDepth);
+      if (builtInFadeLength != 0) {
+        vibratoFade.length = builtInFadeLength;
+        vibratoFade.step = static_cast<uint16_t>((static_cast<uint16_t>(vibratoDepth) << 8) / builtInFadeLength);
+      }
+
+      const bool active = konami_snes::hasActiveVibrato(parentSeq.version, vibratoRate, vibratoDepth);
       const bool deferDepthForFade = active && immediateFadeLength != 0;
       if (readMode != READMODE_CONVERT_TO_MIDI && active) {
         parentSeq.maxVibratoDepth = std::max(parentSeq.maxVibratoDepth, vibratoDepth);
@@ -1277,7 +1300,8 @@ bool KonamiSnesTrack::readEvent() {
 
       const uint8_t midiDepth = deferDepthForFade
           ? 0
-          : (active ? convertVibratoDepthToMidi(vibratoDepth,
+          : (active ? convertVibratoDepthToMidi(parentSeq.version,
+                                                vibratoDepth,
                                                 static_cast<uint16_t>(vibratoDepth) << 8,
                                                 parentSeq.maxVibratoDepth)
                     : 0);
@@ -1405,8 +1429,10 @@ bool KonamiSnesTrack::readEvent() {
       clearActiveTempoFade();
       parentSeq.tempo = newTempo;
       addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
-      for (SeqTrack *track : parentSeq.aTracks) {
-        static_cast<KonamiSnesTrack*>(track)->syncVibratoRateAndDelay();
+      if (konami_snes::usesV1Vibrato(parentSeq.version)) {
+        for (SeqTrack *track : parentSeq.aTracks) {
+          static_cast<KonamiSnesTrack*>(track)->syncVibratoRateAndDelay();
+        }
       }
       break;
     }

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -30,21 +30,28 @@ constexpr uint8_t timerFrequency(KonamiSnesVersion version) {
   return version == KONAMISNES_V1 ? 0x20 : 0x40;
 }
 
+// V1/V2 advance the vibrato phase directly by an 8-bit signed-ish step each music tick.
+// Values above 0x80 wrap back around to the same speed in the opposite phase direction.
 constexpr uint8_t legacyVibratoRateStep(uint8_t rate) {
   return (rate == 0 || rate == 0x80)
       ? 0
       : static_cast<uint8_t>((rate < 0x80) ? rate : (0x100 - rate));
 }
 
+// V3-V6 quantize the phase advance into a small set of buckets and use the raw byte as an
+// overflow rate, so the final speed is rate * bucketStep rather than just rate.
 constexpr uint8_t modernVibratoRateStep(uint8_t rate) {
   return (rate == 0xff) ? 16 : (rate >= 0x80) ? 8 : (rate >= 0x40) ? 4 : (rate >= 0x20) ? 2 : 1;
 }
 
+// Later drivers treat any nonzero rate as active. In the legacy driver, some rate bytes still
+// produce a zero phase step, so they should not count as active vibrato
 bool hasActiveVibrato(KonamiSnesVersion version, uint8_t rate, uint8_t depth) {
   return depth != 0 &&
          (konami_snes::usesLegacyVibrato(version) ? (legacyVibratoRateStep(rate) != 0) : (rate != 0));
 }
 
+// Converts a raw vibrato depth byte into the full-scale pitch range for the exported instrument.
 double maxVibratoDepthCents(KonamiSnesVersion version, uint8_t depth) {
   if (konami_snes::usesLegacyVibrato(version)) {
     return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
@@ -54,6 +61,8 @@ double maxVibratoDepthCents(KonamiSnesVersion version, uint8_t depth) {
   return (depth < 0x80) ? (depth * (100.0 / 128.0)) : ((depth - 126.0) * 50.0);
 }
 
+// Converts the current 8.8 fade depth into cents using the same piecewise depth curve as the
+// target depth above, so the fade emits the same shape the driver uses internally.
 double currentVibratoDepthCents(KonamiSnesVersion version, uint8_t targetDepth, uint16_t currentDepth) {
   if (konami_snes::usesLegacyVibrato(version)) {
     return (targetDepth < 0x80)
@@ -66,18 +75,23 @@ double currentVibratoDepthCents(KonamiSnesVersion version, uint8_t targetDepth, 
       : ((currentDepth - (126.0 * 256.0)) * (50.0 / 256.0));
 }
 
+// The tracked first-pass max only needs a floor, not the full default export range.
 uint16_t minVibratoMaxRateFactor(KonamiSnesVersion version) {
   return konami_snes::usesLegacyVibrato(version)
       ? static_cast<uint16_t>(konami_snes::kMinVibratoMaxRateStep * 0xff)
       : konami_snes::kMinVibratoMaxRateStep;
 }
 
+// Both driver families are expressed as "base Hz times a dimensionless factor", but the base unit
+// differs because late-era vibrato uses a 64-step phase with overflow timing.
 double vibratoBaseHz(KonamiSnesVersion version) {
   return konami_snes::usesLegacyVibrato(version)
       ? (konami_snes::kTimerHz / 65536.0)
       : (konami_snes::kTimerHz / 16384.0);
 }
 
+// Produces the factor multiplied by vibratoBaseHz(version) to get the final exported LFO rate.
+// Legacy vibrato folds tempo in here; late-era vibrato does not.
 uint16_t vibratoRateFactor(KonamiSnesVersion version, uint8_t rate, uint8_t tempo) {
   if (konami_snes::usesLegacyVibrato(version)) {
     return static_cast<uint16_t>(legacyVibratoRateStep(rate) * std::max<uint8_t>(tempo, 1));
@@ -86,6 +100,8 @@ uint16_t vibratoRateFactor(KonamiSnesVersion version, uint8_t rate, uint8_t temp
   return (rate == 0) ? 0 : static_cast<uint16_t>(rate * modernVibratoRateStep(rate));
 }
 
+// Legacy delay is measured in music ticks, so real time shrinks as tempo rises. Late-era delay is
+// already based on the fixed 250 Hz update, so it is independent of tempo.
 double vibratoDelaySeconds(KonamiSnesVersion version, uint8_t delay, uint8_t tempo) {
   if (konami_snes::usesLegacyVibrato(version)) {
     const double baseSeconds = 256.0 / konami_snes::kTimerHz;
@@ -112,6 +128,7 @@ uint8_t vibratoDelayFromArg1(KonamiSnesVersion version, uint8_t arg1) {
   return (!konami_snes::usesLegacyVibrato(version) && arg1 >= konami_snes::kLateEraVibratoFadeThreshold) ? 0 : arg1;
 }
 
+// The overloaded V3-V6 E4 argument maps C8-FF to fade lengths 1-56.
 uint8_t vibratoInlineFadeLength(KonamiSnesVersion version, uint8_t arg1) {
   return (!konami_snes::usesLegacyVibrato(version) && arg1 >= konami_snes::kLateEraVibratoFadeThreshold)
       ? static_cast<uint8_t>(arg1 - (konami_snes::kLateEraVibratoFadeThreshold - 1))

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -20,6 +20,7 @@ constexpr uint16_t SEQ_PPQN = 48;
 constexpr uint16_t KONAMI_SNES_STD_PITCH_BEND_RANGE_CENTS = 200;
 constexpr int16_t MIDI_PITCH_BEND_MIN = -8192;
 constexpr int16_t MIDI_PITCH_BEND_MAX = 8191;
+constexpr uint8_t KONAMI_SNES_DEFAULT_TEMPO = 0xff;
 
 constexpr uint8_t noteDurationRateMax(KonamiSnesVersion version) {
   return version == KONAMISNES_V1 ? 100 : 127;
@@ -72,6 +73,54 @@ FadeStepResult advanceFade(ValueType& current,
   }
 
   return FadeStepResult::Running;
+}
+
+uint8_t effectiveVibratoRateStep(uint8_t rate) {
+  if (rate == 0 || rate == 0x80) {
+    return 0;
+  }
+
+  return static_cast<uint8_t>((rate < 0x80) ? rate : (0x100 - rate));
+}
+
+bool hasActiveVibrato(uint8_t rate, uint8_t depth) {
+  return depth != 0 && effectiveVibratoRateStep(rate) != 0;
+}
+
+uint8_t convertVibratoDepthToMidi(uint8_t depth) {
+  if (depth == 0) {
+    return 0;
+  }
+
+  const double depthCents = (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
+  const int midiValue = static_cast<int>(std::lround(
+      128.0 * depthCents / konami_snes::kVibratoMaxDepthCents));
+  return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
+}
+
+uint8_t convertVibratoRateToMidi(uint8_t rate) {
+  const uint8_t effectiveRate = effectiveVibratoRateStep(rate);
+  if (effectiveRate == 0) {
+    return 0;
+  }
+
+  return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * effectiveRate,
+                                  konami_snes::kVibratoBaseHz,
+                                  konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxRateFactor);
+}
+
+uint8_t convertTempoFactorToMidi(uint8_t tempo) {
+  const uint8_t clampedTempo = std::max<uint8_t>(tempo, 1);
+  return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * clampedTempo,
+                                  konami_snes::kVibratoBaseHz,
+                                  konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxTempoFactor);
+}
+
+uint8_t convertVibratoDelayToMidi(uint8_t delay) {
+  const double delaySeconds = konami_snes::kVibratoDelayBaseSeconds * (static_cast<double>(delay) + 1.0);
+  return midiValueForSecondsInRange(delaySeconds,
+                                    konami_snes::kVibratoDelayBaseSeconds,
+                                    konami_snes::kVibratoDelayBaseSeconds * konami_snes::kVibratoMaxDelayCountFactor);
 }
 }
 
@@ -152,7 +201,7 @@ void KonamiSnesSeq::resetVars(void) {
   VGMSeq::resetVars();
 
   // The driver starts from tempo/speed FF unless the sequence overrides it.
-  tempo = 0xff;
+  tempo = KONAMI_SNES_DEFAULT_TEMPO;
   tempoFade = {};
   tempoFade.currentTempo = tempo << 8;
   tempoFade.targetTempo = tempoFade.currentTempo;
@@ -365,7 +414,9 @@ void KonamiSnesTrack::resetVars(void) {
   panFade.targetPan = panFade.currentPan;
   volumeFade = {};
   pitchSlide = {};
-  vibrato = {};
+  vibratoDelay = 0;
+  vibratoRate = 0;
+  vibratoDepth = 0;
   pitchBendRangeCents = KONAMI_SNES_STD_PITCH_BEND_RANGE_CENTS;
   currentPitchBend = 0;
 }
@@ -382,105 +433,12 @@ double KonamiSnesTrack::getTuningInSemitones(int8_t tuning) {
   return tuning * 4 / 256.0;
 }
 
-uint8_t KonamiSnesTrack::currentTempoByte() const {
-  return std::max<uint8_t>(seq().tempo, 1);
-}
-
-uint8_t KonamiSnesTrack::effectiveVibratoRateStep(uint8_t rate) {
-  if (rate == 0 || rate == 0x80) {
-    return 0;
-  }
-
-  return static_cast<uint8_t>((rate < 0x80) ? rate : (0x100 - rate));
-}
-
-double KonamiSnesTrack::vibratoDepthCents(uint8_t depth) {
-  return (depth < 0x80)
-      ? (depth * (100.0 / 32.0))
-      : (depth * (100.0 / 8.0));
-}
-
-uint8_t KonamiSnesTrack::convertVibratoDepthToMidi(uint8_t depth) {
-  if (depth == 0) {
-    return 0;
-  }
-
-  const int midiValue = static_cast<int>(std::lround(
-      128.0 * vibratoDepthCents(depth) / konami_snes::kVibratoMaxDepthCents));
-  return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
-}
-
-uint8_t KonamiSnesTrack::convertVibratoRateToMidi(uint8_t rate) {
-  const uint8_t effectiveRate = effectiveVibratoRateStep(rate);
-  if (effectiveRate == 0) {
-    return 0;
-  }
-
-  return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * effectiveRate,
-                                  konami_snes::kVibratoBaseHz,
-                                  konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxRateFactor);
-}
-
-uint8_t KonamiSnesTrack::convertTempoFactorToMidi(uint8_t tempo) {
-  const uint8_t clampedTempo = std::max<uint8_t>(tempo, 1);
-  return midiValueForHertzInRange(konami_snes::kVibratoBaseHz * clampedTempo,
-                                  konami_snes::kVibratoBaseHz,
-                                  konami_snes::kVibratoBaseHz * konami_snes::kVibratoMaxTempoFactor);
-}
-
-uint8_t KonamiSnesTrack::convertVibratoDelayToMidi(uint8_t delay) {
-  const double delaySeconds = konami_snes::kVibratoDelayBaseSeconds * (static_cast<double>(delay) + 1.0);
-  return midiValueForSecondsInRange(delaySeconds,
-                                    konami_snes::kVibratoDelayBaseSeconds,
-                                    konami_snes::kVibratoDelayBaseSeconds *
-                                        konami_snes::kVibratoMaxDelayCountFactor);
-}
-
-bool KonamiSnesTrack::hasActiveVibrato() const {
-  return vibrato.depth != 0 && effectiveVibratoRateStep(vibrato.rate) != 0;
-}
-
-void KonamiSnesTrack::beginVibrato(uint8_t delay, uint8_t rate, uint8_t depth) {
-  vibrato.delay = delay;
-  vibrato.rate = rate;
-  vibrato.depth = depth;
-  applyCurrentVibrato();
-}
-
-void KonamiSnesTrack::applyCurrentVibrato() {
-  const uint8_t midiDepth = hasActiveVibrato() ? convertVibratoDepthToMidi(vibrato.depth) : 0;
-  if (midiDepth != vibrato.midiDepth) {
-    addModulationNoItem(midiDepth);
-    vibrato.midiDepth = midiDepth;
-  }
-
-  if (!hasActiveVibrato()) {
+void KonamiSnesTrack::syncVibratoTempo() {
+  if (!hasActiveVibrato(vibratoRate, vibratoDepth)) {
     return;
   }
 
-  const uint8_t midiRate = convertVibratoRateToMidi(vibrato.rate);
-  if (midiRate != vibrato.midiRate) {
-    addChannelPressureNoItem(midiRate);
-    vibrato.midiRate = midiRate;
-  }
-
-  const uint8_t midiTempo = convertTempoFactorToMidi(currentTempoByte());
-  if (midiTempo != vibrato.midiTempo) {
-    addControllerEventNoItem(konami_snes::kVibratoTempoController, midiTempo);
-    vibrato.midiTempo = midiTempo;
-  }
-
-  const uint8_t midiDelay = convertVibratoDelayToMidi(vibrato.delay);
-  if (midiDelay != vibrato.midiDelay) {
-    addControllerEventNoItem(konami_snes::kVibratoDelayController, midiDelay);
-    vibrato.midiDelay = midiDelay;
-  }
-}
-
-void KonamiSnesTrack::refreshAllTrackVibrato() {
-  for (SeqTrack *track : seq().aTracks) {
-    static_cast<KonamiSnesTrack*>(track)->applyCurrentVibrato();
-  }
+  addControllerEventNoItem(konami_snes::kVibratoTempoController, convertTempoFactorToMidi(seq().tempo));
 }
 
 
@@ -511,10 +469,6 @@ void KonamiSnesTrack::onTickBegin() {
       }
       applyCurrentTempo();
     }
-  }
-
-  if (hasActiveVibrato()) {
-    applyCurrentVibrato();
   }
 
   const auto panResult = advanceFade(panFade.currentPan, panFade.targetPan, panFade.delta,
@@ -965,7 +919,9 @@ void KonamiSnesTrack::applyCurrentTempo() {
   if (newTempo != parentSeq.tempo) {
     parentSeq.tempo = newTempo;
     addTempoBPMNoItem(parentSeq.getTempoInBPM(newTempo));
-    refreshAllTrackVibrato();
+    for (SeqTrack *track : parentSeq.aTracks) {
+      static_cast<KonamiSnesTrack*>(track)->syncVibratoTempo();
+    }
   }
 }
 
@@ -1248,13 +1204,22 @@ bool KonamiSnesTrack::readEvent() {
     }
 
     case EVENT_VIBRATO: {
-      uint8_t vibratoDelay = readByte(curOffset++);
-      uint8_t vibratoRate = readByte(curOffset++);
-      uint8_t vibratoDepth = readByte(curOffset++);
+      uint8_t newVibratoDelay = readByte(curOffset++);
+      uint8_t newVibratoRate = readByte(curOffset++);
+      uint8_t newVibratoDepth = readByte(curOffset++);
       desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}",
-                         vibratoDelay, vibratoRate, vibratoDepth);
+                         newVibratoDelay, newVibratoRate, newVibratoDepth);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, Type::Vibrato);
-      beginVibrato(vibratoDelay, vibratoRate, vibratoDepth);
+      vibratoDelay = newVibratoDelay;
+      vibratoRate = newVibratoRate;
+      vibratoDepth = newVibratoDepth;
+      const bool active = hasActiveVibrato(vibratoRate, vibratoDepth);
+      addModulationNoItem(active ? convertVibratoDepthToMidi(vibratoDepth) : 0);
+      if (active) {
+        addChannelPressureNoItem(convertVibratoRateToMidi(vibratoRate));
+        addControllerEventNoItem(konami_snes::kVibratoDelayController, convertVibratoDelayToMidi(vibratoDelay));
+        syncVibratoTempo();
+      }
       break;
     }
 
@@ -1369,7 +1334,9 @@ bool KonamiSnesTrack::readEvent() {
       clearActiveTempoFade();
       parentSeq.tempo = newTempo;
       addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
-      refreshAllTrackVibrato();
+      for (SeqTrack *track : parentSeq.aTracks) {
+        static_cast<KonamiSnesTrack*>(track)->syncVibratoTempo();
+      }
       break;
     }
 

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.h
@@ -115,6 +115,7 @@ class KonamiSnesTrack
  public:
   KonamiSnesTrack(KonamiSnesSeq *parentFile, uint32_t offset = 0, uint32_t length = 0);
   void resetVars() override;
+  void addInitialMidiEvents(int trackNum) override;
   bool readEvent() override;
   void onTickBegin() override;
 

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.h
@@ -115,7 +115,6 @@ class KonamiSnesTrack
  public:
   KonamiSnesTrack(KonamiSnesSeq *parentFile, uint32_t offset = 0, uint32_t length = 0);
   void resetVars() override;
-  void addInitialMidiEvents(int trackNum) override;
   bool readEvent() override;
   void onTickBegin() override;
 

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.h
@@ -88,7 +88,7 @@ class KonamiSnesSeq
   ActiveTempoFade tempoFade;
   uint32_t tempoFadeLastUpdatedTime;
   uint8_t maxVibratoDepth;
-  uint8_t maxVibratoRate;
+  uint16_t maxVibratoRateFactor;
 
   KonamiSnesVersion version;
   std::map<uint8_t, KonamiSnesSeqEventType> EventMap;
@@ -238,7 +238,7 @@ class KonamiSnesTrack
   void beginTempoFade(const TempoFade& fade);
   void clearActiveTempoFade();
   void applyCurrentTempo();
-  void syncVibratoTempo();
+  void syncVibratoRateAndDelay();
   void setPitchBendRange(uint16_t cents);
   void setPitchBend(int16_t bend);
   void applyCurrentPitchBend();

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.h
@@ -87,6 +87,8 @@ class KonamiSnesSeq
   uint8_t tempo;
   ActiveTempoFade tempoFade;
   uint32_t tempoFadeLastUpdatedTime;
+  uint8_t maxVibratoDepth;
+  uint8_t maxVibratoRate;
 
   KonamiSnesVersion version;
   std::map<uint8_t, KonamiSnesSeqEventType> EventMap;

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.h
@@ -200,16 +200,6 @@ class KonamiSnesTrack
     bool useLength = false;
   };
 
-  struct ActiveVibrato {
-    uint8_t delay = 0;
-    uint8_t rate = 0;
-    uint8_t depth = 0;
-    uint8_t midiDepth = 0;
-    uint8_t midiRate = 0;
-    uint8_t midiTempo = 0;
-    uint8_t midiDelay = 0;
-  };
-
   std::optional<PitchSlide> consumePitchSlide();
   PitchSlide readPitchSlide(KonamiSnesSeqEventType eventType, uint32_t offset);
   void addPitchSlideEvent(const PitchSlide& slide);
@@ -237,17 +227,7 @@ class KonamiSnesTrack
   void beginTempoFade(const TempoFade& fade);
   void clearActiveTempoFade();
   void applyCurrentTempo();
-  void beginVibrato(uint8_t delay, uint8_t rate, uint8_t depth);
-  void applyCurrentVibrato();
-  void refreshAllTrackVibrato();
-  [[nodiscard]] uint8_t currentTempoByte() const;
-  [[nodiscard]] bool hasActiveVibrato() const;
-  static uint8_t effectiveVibratoRateStep(uint8_t rate);
-  static double vibratoDepthCents(uint8_t depth);
-  static uint8_t convertVibratoDepthToMidi(uint8_t depth);
-  static uint8_t convertVibratoRateToMidi(uint8_t rate);
-  static uint8_t convertTempoFactorToMidi(uint8_t tempo);
-  static uint8_t convertVibratoDelayToMidi(uint8_t delay);
+  void syncVibratoTempo();
   void setPitchBendRange(uint16_t cents);
   void setPitchBend(int16_t bend);
   void applyCurrentPitchBend();
@@ -264,7 +244,9 @@ class KonamiSnesTrack
   ActivePanFade panFade;
   ActiveVolumeSlide volumeFade;
   ActivePitchSlide pitchSlide;
-  ActiveVibrato vibrato;
+  uint8_t vibratoDelay;
+  uint8_t vibratoRate;
+  uint8_t vibratoDepth;
   uint16_t pitchBendRangeCents;
   int16_t currentPitchBend;
 };

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.h
@@ -200,6 +200,16 @@ class KonamiSnesTrack
     bool useLength = false;
   };
 
+  struct ActiveVibrato {
+    uint8_t delay = 0;
+    uint8_t rate = 0;
+    uint8_t depth = 0;
+    uint8_t midiDepth = 0;
+    uint8_t midiRate = 0;
+    uint8_t midiTempo = 0;
+    uint8_t midiDelay = 0;
+  };
+
   std::optional<PitchSlide> consumePitchSlide();
   PitchSlide readPitchSlide(KonamiSnesSeqEventType eventType, uint32_t offset);
   void addPitchSlideEvent(const PitchSlide& slide);
@@ -227,6 +237,17 @@ class KonamiSnesTrack
   void beginTempoFade(const TempoFade& fade);
   void clearActiveTempoFade();
   void applyCurrentTempo();
+  void beginVibrato(uint8_t delay, uint8_t rate, uint8_t depth);
+  void applyCurrentVibrato();
+  void refreshAllTrackVibrato();
+  [[nodiscard]] uint8_t currentTempoByte() const;
+  [[nodiscard]] bool hasActiveVibrato() const;
+  static uint8_t effectiveVibratoRateStep(uint8_t rate);
+  static double vibratoDepthCents(uint8_t depth);
+  static uint8_t convertVibratoDepthToMidi(uint8_t depth);
+  static uint8_t convertVibratoRateToMidi(uint8_t rate);
+  static uint8_t convertTempoFactorToMidi(uint8_t tempo);
+  static uint8_t convertVibratoDelayToMidi(uint8_t delay);
   void setPitchBendRange(uint16_t cents);
   void setPitchBend(int16_t bend);
   void applyCurrentPitchBend();
@@ -243,6 +264,7 @@ class KonamiSnesTrack
   ActivePanFade panFade;
   ActiveVolumeSlide volumeFade;
   ActivePitchSlide pitchSlide;
+  ActiveVibrato vibrato;
   uint16_t pitchBendRangeCents;
   int16_t currentPitchBend;
 };

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.h
@@ -200,6 +200,15 @@ class KonamiSnesTrack
     bool useLength = false;
   };
 
+  struct ActiveVibratoFade {
+    uint8_t length = 0;
+    uint16_t step = 0;
+    uint8_t delayRemaining = 0;
+    uint8_t ticksRemaining = 0;
+    uint16_t currentDepth = 0;
+    uint8_t midiDepth = 0;
+  };
+
   std::optional<PitchSlide> consumePitchSlide();
   PitchSlide readPitchSlide(KonamiSnesSeqEventType eventType, uint32_t offset);
   void addPitchSlideEvent(const PitchSlide& slide);
@@ -247,6 +256,7 @@ class KonamiSnesTrack
   uint8_t vibratoDelay;
   uint8_t vibratoRate;
   uint8_t vibratoDepth;
+  ActiveVibratoFade vibratoFade;
   uint16_t pitchBendRangeCents;
   int16_t currentPitchBend;
 };

--- a/src/main/formats/KonamiSnes/KonamiSnesVibrato.h
+++ b/src/main/formats/KonamiSnes/KonamiSnesVibrato.h
@@ -1,0 +1,113 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+#pragma once
+
+#include <cstdint>
+#include "KonamiSnesDefinitions.h"
+
+namespace konami_snes::vibrato {
+
+// V1/V2 advance the phase directly once per music tick. Rates above 0x80 wrap around to the same
+// speed in the opposite phase direction, and 0x80 never moves the phase at all.
+inline constexpr uint8_t legacyRateStep(uint8_t rate) {
+  return (rate == 0 || rate == 0x80)
+      ? 0
+      : static_cast<uint8_t>((rate < 0x80) ? rate : (0x100 - rate));
+}
+
+// V3-V6 accumulate the raw rate byte and only advance the 64-step phase on overflow, so each rate
+// bucket maps to a fixed phase step.
+inline constexpr uint8_t lateEraRateStep(uint8_t rate) {
+  return (rate == 0xff) ? 16 : (rate >= 0x80) ? 8 : (rate >= 0x40) ? 4 : (rate >= 0x20) ? 2 : 1;
+}
+
+inline constexpr bool isActive(KonamiSnesVersion version, uint8_t rate, uint8_t depth) {
+  return depth != 0 && (usesLegacyVibrato(version) ? (legacyRateStep(rate) != 0) : (rate != 0));
+}
+
+// Converts a raw vibrato depth byte into the full exported pitch range for the instrument.
+inline double maxDepthCents(KonamiSnesVersion version, uint8_t depth) {
+  if (usesLegacyVibrato(version)) {
+    return (depth < 0x80) ? (depth * (100.0 / 32.0)) : (depth * (100.0 / 8.0));
+  }
+
+  return (depth < 0x80) ? (depth * (100.0 / 128.0)) : ((depth - 126.0) * 50.0);
+}
+
+// Legacy depth mode is chosen from the target E4 depth byte. Later drivers switch depth curves
+// once the live 8.8 fade depth crosses 0x80.
+inline double currentDepthCents(KonamiSnesVersion version, uint8_t targetDepth, uint16_t currentDepth) {
+  if (usesLegacyVibrato(version)) {
+    return (targetDepth < 0x80)
+        ? (currentDepth * (100.0 / (32.0 * 256.0)))
+        : (currentDepth * (100.0 / (8.0 * 256.0)));
+  }
+
+  return (currentDepth < 0x8000)
+      ? (currentDepth * (100.0 / (128.0 * 256.0)))
+      : ((currentDepth - (126.0 * 256.0)) * (50.0 / 256.0));
+}
+
+inline constexpr uint16_t defaultMaxRateFactor(KonamiSnesVersion version) {
+  return usesLegacyVibrato(version)
+      ? static_cast<uint16_t>(kDefaultLegacyVibratoMaxRateStep * 0xff)
+      : static_cast<uint16_t>(0xff * lateEraRateStep(0xff));
+}
+
+// The tracked first-pass max only needs a minimum sensible range, not the full default export
+// range.
+inline constexpr uint16_t minMaxRateFactor(KonamiSnesVersion version) {
+  return usesLegacyVibrato(version)
+      ? static_cast<uint16_t>(kMinVibratoMaxRateStep * 0xff)
+      : kMinVibratoMaxRateStep;
+}
+
+// Both driver families export as "base Hz times a factor", but later vibrato runs on a 64-step
+// phase with overflow timing instead of a direct 256-step phase increment.
+inline double baseHz(KonamiSnesVersion version) {
+  return usesLegacyVibrato(version) ? (kTimerHz / 65536.0) : (kTimerHz / 16384.0);
+}
+
+inline uint16_t rateFactor(KonamiSnesVersion version, uint8_t rate, uint8_t tempo) {
+  if (usesLegacyVibrato(version)) {
+    const uint8_t safeTempo = (tempo == 0) ? 1 : tempo;
+    return static_cast<uint16_t>(legacyRateStep(rate) * safeTempo);
+  }
+
+  return (rate == 0) ? 0 : static_cast<uint16_t>(rate * lateEraRateStep(rate));
+}
+
+// Legacy delay is measured in music ticks, so it shrinks in real time as tempo rises. Later delay
+// is already measured against the fixed 250 Hz update rate.
+inline double delaySeconds(KonamiSnesVersion version, uint8_t delay, uint8_t tempo) {
+  if (usesLegacyVibrato(version)) {
+    const uint8_t safeTempo = (tempo == 0) ? 1 : tempo;
+    return ((256.0 / kTimerHz) * (delay + 1.0)) / safeTempo;
+  }
+
+  return (delay + 1.0) / kTimerHz;
+}
+
+inline double minDelaySeconds(KonamiSnesVersion version) {
+  return usesLegacyVibrato(version) ? delaySeconds(version, 0, 0xff) : delaySeconds(version, 0, 0);
+}
+
+inline double maxDelaySeconds(KonamiSnesVersion version) {
+  return usesLegacyVibrato(version) ? delaySeconds(version, 0xff, 1) : delaySeconds(version, 0xc7, 0);
+}
+
+// V3-V6 overload E4 arg1: 00-C7 is delay, C8-FF is an inline fade length with zero delay.
+inline constexpr uint8_t delayFromArg1(KonamiSnesVersion version, uint8_t arg1) {
+  return (!usesLegacyVibrato(version) && arg1 >= kLateEraVibratoFadeThreshold) ? 0 : arg1;
+}
+
+inline constexpr uint8_t inlineFadeLength(KonamiSnesVersion version, uint8_t arg1) {
+  return (!usesLegacyVibrato(version) && arg1 >= kLateEraVibratoFadeThreshold)
+      ? static_cast<uint8_t>(arg1 - (kLateEraVibratoFadeThreshold - 1))
+      : 0;
+}
+
+}  // namespace konami_snes::vibrato


### PR DESCRIPTION
This adds vibrato support to KonamiSnes, covering opcode 0xE4, which sets delay, depth, and rate (and optionally fade in V3-V6), and the vibrato fade opcode 0xF9 (identical across versions). This includes support for both versions of the 0xE4 event, which differ in several ways.

The driver supports a very wide range for vibrato depth and rate. Since modulators map these range across only 7-bits of resolution, we track the actual maxima used by each sequence and set modulator ranges accordingly. This is done in VGMInstr::useColl() with the new method `VGMInstr::updateModulatorAmount()`. We enforce minimum ranges in case the max-used values are tiny.

As before, this was made with assistance from @loveemu's [analysis of the Konami sound driver](https://github.com/loveemu/vgm-disasm/tree/master/snes/Konami). 

## How Has This Been Tested?
Testing by ear and by inspecting values in converted SF2 values. There are still conversion issues in later versions of the driver, but they don't seem to be related to vibrato.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
