### PR TITLE
NDS: Improvements in conversion of modulation and pitch-bending commands

### DIFF
--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -802,8 +802,9 @@ double SeqTrack::applyPanVolumeCorrection(double level, LevelController controll
     PanVolumeCorrectionMode relevantCorrectionMode = controller == LevelController::Volume ?
       PanVolumeCorrectionMode::kAdjustVolumeController :
       PanVolumeCorrectionMode::kAdjustExpressionController;
-    if (parentSeq->panVolumeCorrectionMode == relevantCorrectionMode)
-      level *= panVolumeCorrectionRate;
+    if (parentSeq->panVolumeCorrectionMode == relevantCorrectionMode) {
+      level *= usesLinearAmplitudeScale() ? panVolumeCorrectionRate : std::sqrt(panVolumeCorrectionRate);
+    }
   }
   return level;
 }
@@ -1078,7 +1079,7 @@ void SeqTrack::addPan(uint32_t offset, uint32_t length, uint8_t pan, const std::
 
 void SeqTrack::addPanNoItem(uint8_t pan) {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
-    const uint8_t midiPan = usesLinearAmplitudeScale()
+    const uint8_t midiPan = usesLinearPanAmplitudeScale()
       ? convert7bitLinearPercentPanValToStdMidiVal(pan, &panVolumeCorrectionRate)
       : pan;
     pMidiTrack->addPan(channel, midiPan);
@@ -1123,7 +1124,7 @@ void SeqTrack::insertPan(uint32_t offset,
   recordSeqEvent<PanSeqEvent>(isNewOffset, absTime, pan, offset, length, sEventName);
 
   if (readMode == READMODE_CONVERT_TO_MIDI) {
-    const uint8_t midiPan = usesLinearAmplitudeScale()
+    const uint8_t midiPan = usesLinearPanAmplitudeScale()
       ? convert7bitLinearPercentPanValToStdMidiVal(pan, &panVolumeCorrectionRate)
       : pan;
     pMidiTrack->insertPan(channel, midiPan, absTime);

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -84,6 +84,11 @@ class SeqTrack : public VGMItem {
   }
   void setUseLinearAmplitudeScale(bool set) { m_useLinearAmpScale = set; }
 
+  [[nodiscard]] bool usesLinearPanAmplitudeScale() const {
+    return m_useLinearPanAmpScale || parentSeq->usesLinearPanAmplitudeScale();
+  }
+  void setUseLinearPanAmplitudeScale(bool set) { m_useLinearPanAmpScale = set; }
+
   virtual bool loadTrackInit(int trackNum, MidiTrack *preparedMidiTrack);
   virtual void loadTrackMainLoop(uint32_t stopOffset, int32_t stopTime);
 
@@ -325,6 +330,7 @@ private:
   bool bDetermineTrackLengthEventByEvent;
   bool bWriteGenericEventAsTextEvent;
   bool m_useLinearAmpScale = false;
+  bool m_useLinearPanAmpScale = false;
 
   std::unordered_set<uint32_t> visitedAddresses;
   uint32_t visitedAddressMax;

--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -513,9 +513,11 @@ void MidiTrack::addModulationDepthRange(uint8_t channel, double semitones) {
 }
 
 void MidiTrack::insertModulationDepthRange(uint8_t channel, double semitones, uint32_t absTime) {
-  semitones = std::max(-64.0, std::min(64.0, semitones));
-  int16_t midiTuning = std::min(static_cast<int>(lround(128 * semitones)), 8191) + 8192;
-  insertFineTuning(channel, midiTuning >> 7, midiTuning & 0x7f, absTime);
+  semitones = std::max(0.0, std::min(24.0, semitones));
+  const int totalCents = static_cast<int>(lround(semitones * 100.0));
+  const uint8_t msb = static_cast<uint8_t>(std::min(totalCents / 100, 127));
+  const uint8_t lsb = static_cast<uint8_t>(std::min(totalCents % 100, 127));
+  insertModulationDepthRange(channel, msb, lsb, absTime);
 }
 
 void MidiTrack::addProgramChange(uint8_t channel, uint8_t progNum) {

--- a/src/main/formats/Akao/AkaoSeq.cpp
+++ b/src/main/formats/Akao/AkaoSeq.cpp
@@ -23,6 +23,7 @@ AkaoSeq::AkaoSeq(RawFile *file, uint32_t offset, AkaoPs1Version version, std::st
   setAlwaysWriteInitialVol(127);
   setAlwaysWriteInitialPitchBendRange(12 * 100);
   setUseLinearAmplitudeScale(true);        //I think this applies, but not certain, see FF9 320, track 3 for example of problem
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
   //UseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kAdjustVolumeController); // disabled, it only changes the volume and the pan slightly, and also its output becomes undefined if pan and volume slides are used at the same time
   bUsesIndividualArts = false;
   useReverb();

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -33,6 +33,7 @@ AkaoSnesSeq::AkaoSnesSeq(RawFile *file,
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
@@ -32,6 +32,7 @@ AsciiShuichiSnesSeq::AsciiShuichiSnesSeq(RawFile *file, uint32_t seqHeaderOffset
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/CPS/CPS2Seq.cpp
+++ b/src/main/formats/CPS/CPS2Seq.cpp
@@ -26,6 +26,7 @@ CPS2Seq::CPS2Seq(RawFile *file, uint32_t offset, CPS2FormatVer fmtVersion, std::
   setAlwaysWriteInitialVol(127);
   setAlwaysWriteInitialMonoMode(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
   if (fmt_version >= CPS2_V200)
     setAlwaysWriteInitialPitchBendRange(12 * 100);
 }

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -42,6 +42,7 @@ CapcomSnesSeq::CapcomSnesSeq(RawFile *file,
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/ChunSnes/ChunSnesSeq.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesSeq.cpp
@@ -30,6 +30,7 @@ ChunSnesSeq::ChunSnesSeq(RawFile *file,
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/FFT/FFTSeq.cpp
+++ b/src/main/formats/FFT/FFTSeq.cpp
@@ -19,6 +19,7 @@ FFTSeq::FFTSeq(RawFile *file, uint32_t offset)
     : VGMSeq(FFTFormat::name, file, offset) {
   setAlwaysWriteInitialVol(127);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
   useReverb();
 }
 

--- a/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
@@ -41,6 +41,7 @@ FalcomSnesSeq::FalcomSnesSeq(RawFile *file,
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/GraphResSnes/GraphResSnesSeq.cpp
+++ b/src/main/formats/GraphResSnes/GraphResSnesSeq.cpp
@@ -24,6 +24,7 @@ GraphResSnesSeq::GraphResSnesSeq(RawFile *file, GraphResSnesVersion ver, uint32_
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   setAlwaysWriteInitialTempo(60000000.0 / ((125 * 0x85) * SEQ_PPQN)); // good ol' frame-based sequence!
 

--- a/src/main/formats/HOSA/HOSASeq.cpp
+++ b/src/main/formats/HOSA/HOSASeq.cpp
@@ -14,6 +14,7 @@ HOSASeq::HOSASeq(RawFile *file, uint32_t offset, const std::string &name)
     : VGMSeq(HOSAFormat::name, file, offset, 0, name) {
   useReverb();
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 }
 
 //==============================================================

--- a/src/main/formats/HudsonSnes/HudsonSnesSeq.cpp
+++ b/src/main/formats/HudsonSnes/HudsonSnesSeq.cpp
@@ -28,6 +28,7 @@ HudsonSnesSeq::HudsonSnesSeq(RawFile *file, HudsonSnesVersion ver, uint32_t seqd
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
@@ -20,6 +20,7 @@ ItikitiSnesSeq::ItikitiSnesSeq(RawFile *file, uint32_t offset, std::string new_n
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
@@ -22,6 +22,7 @@ KonamiArcadeSeq::KonamiArcadeSeq(
       fmtVer(fmtVer), m_memOffset(ramOffset), m_drums(drums), m_nmiRate(nmiRate) {
   bLoadTickByTick = true;
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
   setAllowDiscontinuousTrackData(true);
   setAlwaysWriteInitialVol(127);
   setAlwaysWriteInitialExpression(127);

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2Seq.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2Seq.cpp
@@ -181,6 +181,7 @@ KonamiTMNT2Track::KonamiTMNT2Track(
       m_isFmTrack(isFmTrack) {
   synthType = isFmTrack ? SynthType::YM2151 : SynthType::SoundFont;
   setUseLinearAmplitudeScale(!isFmTrack);
+  setUseLinearPanAmplitudeScale(!isFmTrack);
 }
 
 void KonamiTMNT2Track::resetVars() {

--- a/src/main/formats/MoriSnes/MoriSnesSeq.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesSeq.cpp
@@ -20,6 +20,7 @@ MoriSnesSeq::MoriSnesSeq(RawFile *file, MoriSnesVersion ver, uint32_t seqdataOff
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/NDS/NDSFormat.h
+++ b/src/main/formats/NDS/NDSFormat.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstdint>
+
 #include "Format.h"
 #include "NDSScanner.h"
 #include "VGMColl.h"
@@ -18,5 +20,6 @@ inline constexpr double kLfoSpeedToHz = kPeriodicUpdateHz / 512.0;
 inline constexpr double kVibratoBaseHz = 0.375;
 inline constexpr double kVibratoMaxHz = 48.0;
 inline constexpr double kVibratoDepthCents = 1200.0;
+inline constexpr uint32_t kBaseTempo = 240;
 
 } // namespace nds

--- a/src/main/formats/NDS/NDSFormat.h
+++ b/src/main/formats/NDS/NDSFormat.h
@@ -11,4 +11,12 @@ BEGIN_FORMAT(NDS)
   USING_SCANNER(NDSScanner)
 END_FORMAT()
 
+namespace nds {
 
+inline constexpr double kPeriodicUpdateHz = 192.0;
+inline constexpr double kLfoSpeedToHz = kPeriodicUpdateHz / 512.0;
+inline constexpr double kVibratoBaseHz = 0.375;
+inline constexpr double kVibratoMaxHz = 48.0;
+inline constexpr double kVibratoDepthCents = 1200.0;
+
+} // namespace nds

--- a/src/main/formats/NDS/NDSInstrSet.cpp
+++ b/src/main/formats/NDS/NDSInstrSet.cpp
@@ -81,6 +81,8 @@ NDSInstr::NDSInstr(NDSInstrSet* instrSet, uint32_t offset, uint32_t length, uint
 }
 
 bool NDSInstr::loadInstr() {
+  addStandardVibratoHandling(nds::kVibratoDepthCents, nds::kVibratoBaseHz, nds::kVibratoMaxHz);
+
   // All of the undefined case values below are used for tone or noise channels
   switch (instrType) {
     case 0x01: {

--- a/src/main/formats/NDS/NDSSeq.cpp
+++ b/src/main/formats/NDS/NDSSeq.cpp
@@ -205,6 +205,10 @@ void NDSTrack::resetModState() {
   portamentoControlKey = clampMidi7Bit(static_cast<int>(kNdsDefaultPortamentoKey) +
                                        static_cast<int>(cKeyCorrection) + static_cast<int>(transpose));
   portamentoTime = 0;
+  tieModeEnabled = false;
+  tieNoteActive = false;
+  tieNoteKey = 0;
+  tieNoteEndTick = 0;
 }
 
 void NDSTrack::addTime(uint32_t delta) {
@@ -452,7 +456,32 @@ bool NDSTrack::readEvent(void) {
     uint8_t vel = readByte(curOffset++);
     dur = readVarLen(curOffset);//GetByte(curOffset++);
     onNoteStart(noteStartTick, status_byte);
-    addNoteByDur(beginOffset, curOffset - beginOffset, status_byte, vel, dur);
+
+    if (tieNoteActive && tieNoteEndTick <= noteStartTick) {
+      tieNoteActive = false;
+    }
+
+    if (tieModeEnabled && tieNoteActive && tieNoteKey == status_byte) {
+      // Tie keeps the voice alive; same-key notes just extend the existing note length.
+      makePrevDurNoteEnd(noteStartTick + dur);
+      tieNoteEndTick = noteStartTick + dur;
+      addTie(beginOffset, curOffset - beginOffset, dur, "Tie");
+    }
+    else {
+      if (tieModeEnabled && tieNoteActive) {
+        // Approximation: key changes in tie mode restart at this tick in MIDI.
+        makePrevDurNoteEnd(noteStartTick);
+        tieNoteActive = false;
+      }
+
+      addNoteByDur(beginOffset, curOffset - beginOffset, status_byte, vel, dur);
+      if (tieModeEnabled) {
+        tieNoteActive = true;
+        tieNoteKey = status_byte;
+        tieNoteEndTick = noteStartTick + dur;
+      }
+    }
+
     applySweepPitchForNote(noteStartTick, dur);
     if (noteWithDelta) {
       addTime(dur);
@@ -607,10 +636,17 @@ bool NDSTrack::readEvent(void) {
       }
 
       // [loveemu] (ex: Hanjuku Hero DS: NSE_42)
-      case 0xC8:
-        curOffset++;
-        addUnknown(beginOffset, curOffset - beginOffset, "Tie");
+      case 0xC8: {
+        tieModeEnabled = (readByte(curOffset++) != 0);
+        if (readMode == READMODE_CONVERT_TO_MIDI) {
+          makePrevDurNoteEnd(getTime());
+        }
+        tieNoteActive = false;
+        tieNoteEndTick = getTime();
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Tie",
+                        tieModeEnabled ? "On" : "Off", Type::Tie);
         break;
+      }
 
       // [loveemu] (ex: Hanjuku Hero DS: NSE_50)
       case 0xC9: {

--- a/src/main/formats/NDS/NDSSeq.cpp
+++ b/src/main/formats/NDS/NDSSeq.cpp
@@ -201,6 +201,10 @@ void NDSTrack::resetModState() {
   lastPanCc = -1;
   sweepPitch = 0;
   basePitchBend = 0;
+  portamentoEnabled = false;
+  portamentoControlKey = clampMidi7Bit(static_cast<int>(kNdsDefaultPortamentoKey) +
+                                       static_cast<int>(cKeyCorrection) + static_cast<int>(transpose));
+  portamentoTime = 0;
 }
 
 void NDSTrack::addTime(uint32_t delta) {
@@ -261,7 +265,13 @@ uint32_t NDSTrack::modDelayToMidiTicks(uint16_t delay, uint32_t atTick) const {
   return std::max<uint32_t>(1, static_cast<uint32_t>(std::lround(ticks)));
 }
 
-void NDSTrack::onNoteStart(uint32_t noteStartTick) {
+void NDSTrack::onNoteStart(uint32_t noteStartTick, uint8_t noteKey) {
+  if (readMode == READMODE_CONVERT_TO_MIDI && portamentoEnabled) {
+    addPortamentoControlNoItem(portamentoControlKey);
+  }
+  portamentoControlKey = clampMidi7Bit(static_cast<int>(noteKey) + static_cast<int>(cKeyCorrection) +
+                                       static_cast<int>(transpose));
+
   modPhaseCounter = 0;
   modDelayCounter = 0;
 
@@ -309,12 +319,38 @@ void NDSTrack::applySweepPitchForNote(uint32_t startTick, uint32_t duration) {
     return;
   }
 
-  // As far as I can tell, sweep starts with note-on and decays linearly to 0 over note length.
-  const int startBend = std::clamp(static_cast<int>(basePitchBend) + static_cast<int>(sweepPitch), -8192, 8191);
-  const int endBend = std::clamp(static_cast<int>(basePitchBend), -8192, 8191);
+  uint32_t sweepLength = duration;
+  if (portamentoTime != 0) {
+    const uint64_t absSweep = static_cast<uint64_t>(std::abs(static_cast<int32_t>(sweepPitch)));
+    const uint64_t t = static_cast<uint64_t>(portamentoTime);
+    // Not 100% confident about this, but I think it's exact!
+    sweepLength = static_cast<uint32_t>((t * t * absSweep) >> 11);
+  }
 
-  pMidiTrack->insertPitchBend(channel, static_cast<int16_t>(startBend), startTick);
-  pMidiTrack->insertPitchBend(channel, static_cast<int16_t>(endBend), startTick + duration);
+  const int endBend = std::clamp(static_cast<int>(basePitchBend), -8192, 8191);
+  bool haveLast = false;
+  int lastBend = 0;
+
+  if (sweepLength == 0) {
+    pMidiTrack->insertPitchBend(channel, static_cast<int16_t>(endBend), startTick);
+    return;
+  }
+
+  const uint32_t rampTicks = std::min(duration, sweepLength);
+  for (uint32_t i = 0; i <= rampTicks; i++) {
+    const int64_t scaled = static_cast<int64_t>(sweepPitch) * static_cast<int64_t>(sweepLength - i);
+    const int sweepAtTick = static_cast<int>(scaled / static_cast<int64_t>(sweepLength));
+    const int bend = std::clamp(static_cast<int>(basePitchBend) + sweepAtTick, -8192, 8191);
+    if (!haveLast || bend != lastBend) {
+      pMidiTrack->insertPitchBend(channel, static_cast<int16_t>(bend), startTick + i);
+      lastBend = bend;
+      haveLast = true;
+    }
+  }
+
+  if (!haveLast || lastBend != endBend) {
+    pMidiTrack->insertPitchBend(channel, static_cast<int16_t>(endBend), startTick + duration);
+  }
 }
 
 void NDSTrack::renderModPoint(uint32_t tick) {
@@ -415,7 +451,7 @@ bool NDSTrack::readEvent(void) {
     const uint32_t noteStartTick = getTime();
     uint8_t vel = readByte(curOffset++);
     dur = readVarLen(curOffset);//GetByte(curOffset++);
-    onNoteStart(noteStartTick);
+    onNoteStart(noteStartTick, status_byte);
     addNoteByDur(beginOffset, curOffset - beginOffset, status_byte, vel, dur);
     applySweepPitchForNote(noteStartTick, dur);
     if (noteWithDelta) {
@@ -577,10 +613,19 @@ bool NDSTrack::readEvent(void) {
         break;
 
       // [loveemu] (ex: Hanjuku Hero DS: NSE_50)
-      case 0xC9:
-        curOffset++;
-        addUnknown(beginOffset, curOffset - beginOffset, "Portamento Control");
+      case 0xC9: {
+        uint8_t portKey = readByte(curOffset++);
+        portamentoEnabled = true;
+        portamentoControlKey = clampMidi7Bit(static_cast<int>(portKey) + static_cast<int>(cKeyCorrection) +
+                                             static_cast<int>(transpose));
+        if (readMode == READMODE_CONVERT_TO_MIDI) {
+          addPortamentoNoItem(true);
+          addPortamentoControlNoItem(portamentoControlKey);
+        }
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Portamento Control",
+                        "Key=" + std::to_string(portKey), Type::Portamento);
         break;
+      }
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_ARR1_)
       case 0xCA: {
@@ -633,14 +678,15 @@ bool NDSTrack::readEvent(void) {
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_ARR1_)
       case 0xCE: {
         bool bPortOn = (readByte(curOffset++) != 0);
+        portamentoEnabled = bPortOn;
         addPortamento(beginOffset, curOffset - beginOffset, bPortOn);
         break;
       }
 
       // [loveemu] (ex: Bomberman: SEQ_AREA04)
       case 0xCF: {
-        uint8_t portTime = readByte(curOffset++);
-        addPortamentoTime(beginOffset, curOffset - beginOffset, portTime);
+        portamentoTime = readByte(curOffset++);
+        addPortamentoTime(beginOffset, curOffset - beginOffset, portamentoTime);
         break;
       }
 

--- a/src/main/formats/NDS/NDSSeq.cpp
+++ b/src/main/formats/NDS/NDSSeq.cpp
@@ -3,9 +3,10 @@
 #include <array>
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
-#include "Modulation.h"
 #include "NDSFormat.h"
+#include "ScaleConversion.h"
 
 DECLARE_FORMAT(NDS);
 
@@ -14,6 +15,10 @@ using namespace std;
 namespace {
 uint8_t clampMidi7Bit(int value) {
   return static_cast<uint8_t>(std::clamp(value, 0, 127));
+}
+
+int16_t clampMidiPitchBend(int value) {
+  return static_cast<int16_t>(std::clamp(value, -8192, 8191));
 }
 
 int8_t sineSampleAt(int index) {
@@ -42,21 +47,46 @@ int8_t sineSampleAt(int index) {
 }
 
 constexpr uint8_t kNdsDefaultPortamentoKey = 60;
+constexpr uint8_t kNdsDefaultPitchBendRangeSemitones = 2;
 
-uint8_t speedToVibratoRatePressure(uint8_t speed) {
-  if (speed == 0) {
-    return 0;
+uint16_t maxLevelForResolution(Resolution res) {
+  return res == Resolution::FourteenBit ? 16383 : 127;
+}
+
+uint8_t expressionCcForAmplitudeScale(uint16_t rawExpression,
+                                      Resolution resolution,
+                                      double volumeScale,
+                                      bool usesLinearAmplitudeScale) {
+  const double expressionLevel = rawExpression / static_cast<double>(maxLevelForResolution(resolution));
+  const double correction = usesLinearAmplitudeScale ? volumeScale : std::sqrt(volumeScale);
+  return clampMidi7Bit(static_cast<int>(std::lround(expressionLevel * correction * 127.0)));
+}
+
+int32_t ndsVolumeLfoDbTenths(int32_t raw) {
+  return static_cast<int32_t>((static_cast<int64_t>(raw) * 60) >> 14);
+}
+
+double amplitudeScaleFromDbTenths(int32_t dbTenths) {
+  return std::pow(10.0, static_cast<double>(dbTenths) / 200.0);
+}
+
+uint32_t tempoToNdsCounterStep(double tempoBpm, double fallbackTempoBpm) {
+  double tempo = tempoBpm > 0.0 ? tempoBpm : fallbackTempoBpm;
+  if (tempo <= 0.0) {
+    tempo = 120.0;
   }
-
-  return midiValueForHertzInRange(static_cast<double>(speed) * nds::kLfoSpeedToHz,
-                                  nds::kVibratoBaseHz,
-                                  nds::kVibratoMaxHz);
+  return std::max<uint32_t>(1, static_cast<uint32_t>(std::lround(tempo)));
 }
 } // namespace
 
 NDSSeq::NDSSeq(RawFile *file, uint32_t offset, uint32_t length, string name)
     : VGMSeq(NDSFormat::name, file, offset, length, name) {
   setShouldTrackControlFlowState(true);
+  // NDS pan values are linear balance values. Map the left/right ratio onto
+  // MIDI's equal-power pan curve, then compensate expression so the exported
+  // MIDI keeps NDS's constant-sum pan loudness.
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kAdjustExpressionController);
+  setAlwaysWriteInitialPitchBendRange(kNdsDefaultPitchBendRangeSemitones * 100);
 }
 
 void NDSSeq::resetVars() {
@@ -190,21 +220,21 @@ void NDSTrack::resetModState() {
   modLastRenderTick = getTime();
   modPhaseCounter = 0;
   modDelayCounter = 0;
-  modPeriodicRemainder = 0.0;
-  modRangeSent = false;
-  pitchModEnableTick = getTime();
+  modTempoCounter = nds::kBaseTempo;
   currentTempoBpm = static_cast<const NDSSeq*>(parentSeq)->tempoAtTick(getTime());
 
-  lastPitchModCc = -1;
-  lastPitchVibratoRatePressure = -1;
   lastExprCc = -1;
   lastPanCc = -1;
+  lastPanExprCc = -1;
+  lastPitchLfoBend = std::numeric_limits<int>::min();
   sweepPitch = 0;
   basePitchBend = 0;
+  pitchBendRangeSemitones = kNdsDefaultPitchBendRangeSemitones;
   portamentoEnabled = false;
   portamentoControlKey = clampMidi7Bit(static_cast<int>(kNdsDefaultPortamentoKey) +
                                        static_cast<int>(cKeyCorrection) + static_cast<int>(transpose));
   portamentoTime = 0;
+  prevNoteKey = kNdsDefaultPortamentoKey;
   tieModeEnabled = false;
   tieNoteActive = false;
   tieNoteKey = 0;
@@ -255,20 +285,6 @@ std::string NDSTrack::to_string(ModTarget target) {
   }
 }
 
-uint32_t NDSTrack::modDelayToMidiTicks(uint16_t delay, uint32_t atTick) const {
-  if (delay == 0) {
-    return 0;
-  }
-
-  const double tempoAtTick = static_cast<const NDSSeq*>(parentSeq)->tempoAtTick(atTick);
-  const double effectiveTempo = (tempoAtTick > 0.0) ? tempoAtTick : currentTempoBpm;
-
-  const double ticks = (static_cast<double>(delay) * effectiveTempo *
-                        static_cast<double>(parentSeq->ppqn())) /
-                       (60.0 * nds::kPeriodicUpdateHz);
-  return std::max<uint32_t>(1, static_cast<uint32_t>(std::lround(ticks)));
-}
-
 void NDSTrack::onNoteStart(uint32_t noteStartTick, uint8_t noteKey) {
   if (readMode == READMODE_CONVERT_TO_MIDI && portamentoEnabled) {
     addPortamentoControlNoItem(portamentoControlKey);
@@ -279,55 +295,85 @@ void NDSTrack::onNoteStart(uint32_t noteStartTick, uint8_t noteKey) {
   modPhaseCounter = 0;
   modDelayCounter = 0;
 
-  if (toModTarget(modType) != ModTarget::Pitch) {
-    return;
+  switch (toModTarget(modType)) {
+    case ModTarget::Pitch:
+      lastPitchLfoBend = std::numeric_limits<int>::min();
+      break;
+    case ModTarget::Volume:
+      lastExprCc = -1;
+      break;
+    case ModTarget::Pan:
+      lastPanCc = -1;
+      lastPanExprCc = -1;
+      break;
+    case ModTarget::Unknown:
+      return;
   }
 
-  pitchModEnableTick = noteStartTick + modDelayToMidiTicks(modDelay, noteStartTick);
-  if (lastPitchModCc != 0) {
-    lastPitchModCc = -1;
-  }
-  emitPitchVibratoParamsAt(noteStartTick);
+  renderModPoint(noteStartTick);
 }
 
-void NDSTrack::emitPitchModRangeAt(uint32_t tick) {
+int32_t NDSTrack::currentModRawValue() const {
+  if (modDepth == 0 || modDelayCounter < modDelay) {
+    return 0;
+  }
+
+  const int index = (modPhaseCounter >> 8) & 0x7F;
+  return static_cast<int32_t>(sineSampleAt(index)) * static_cast<int32_t>(modDepth) *
+         static_cast<int32_t>(modRange);
+}
+
+int16_t NDSTrack::pitchBendWithLfo(int32_t raw) const {
+  const uint8_t range = std::max<uint8_t>(1, pitchBendRangeSemitones);
+  const int32_t pitchUnits = static_cast<int32_t>((static_cast<int64_t>(raw) * (1 << 6)) >> 14);
+  const int lfoBend = static_cast<int>(std::lround(static_cast<double>(pitchUnits) * 128.0 /
+                                                   static_cast<double>(range)));
+  return clampMidiPitchBend(static_cast<int>(basePitchBend) + lfoBend);
+}
+
+void NDSTrack::emitPitchLfoBendAt(uint32_t tick, int32_t raw) {
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     return;
   }
-  const double semitones = static_cast<double>(modRange);
-  pMidiTrack->insertModulationDepthRange(channel, semitones, tick);
-}
 
-void NDSTrack::emitPitchVibratoParamsAt(uint32_t tick) {
-  if (readMode != READMODE_CONVERT_TO_MIDI) {
-    return;
-  }
-
-  const bool depthEnabled = (tick >= pitchModEnableTick) && (modDepth != 0) && (modSpeed != 0);
-  const int depthCc = depthEnabled ? static_cast<int>(modDepth) : 0;
-  const int ratePressure = static_cast<int>(speedToVibratoRatePressure(modSpeed));
-
-  if (depthCc != lastPitchModCc) {
-    pMidiTrack->insertModulation(channel, static_cast<uint8_t>(depthCc), tick); // CC1
-    lastPitchModCc = depthCc;
-  }
-
-  if (ratePressure != lastPitchVibratoRatePressure) {
-    pMidiTrack->insertChannelPressure(channel, static_cast<uint8_t>(ratePressure), tick);
-    lastPitchVibratoRatePressure = ratePressure;
+  const int16_t bend = pitchBendWithLfo(raw);
+  if (bend != lastPitchLfoBend) {
+    pMidiTrack->insertPitchBend(channel, bend, tick);
+    lastPitchLfoBend = bend;
   }
 }
 
-void NDSTrack::applySweepPitchForNote(uint32_t startTick, uint32_t duration) {
-  if (readMode != READMODE_CONVERT_TO_MIDI || duration == 0 || sweepPitch == 0) {
+void NDSTrack::applySweepPitchForNote(uint32_t startTick, uint32_t duration, uint8_t noteKey) {
+  if (readMode != READMODE_CONVERT_TO_MIDI || duration == 0) {
     return;
   }
 
+  // Calculate effective sweep pitch in pitch units.
+  // It seems that 1 semitone = 64 units.
+  int32_t effectiveSweep = sweepPitch;
+  if (portamentoEnabled) {
+    effectiveSweep += (static_cast<int32_t>(prevNoteKey) - static_cast<int32_t>(noteKey))
+                      << 6;
+  }
+
+  if (effectiveSweep == 0) {
+    return;
+  }
+
+  // Convert from NDS pitch units to MIDI pitch bend units.
+  // NDS: 1 semitone = 64 units
+  // MIDI: pitch bend range (8192 units) = pitchBendRangeSemitones semitones
+  // midiUnits = ndsUnits * 8192 / (range * 64) = ndsUnits * 128 / range
+  const uint8_t range = std::max<uint8_t>(1, pitchBendRangeSemitones);
+  const int32_t sweepMidi = static_cast<int32_t>(
+      std::lround(static_cast<double>(effectiveSweep) * 128.0 / static_cast<double>(range)));
+
+  // Calculate sweep length
+  // When portamentoTime == 0, the sweep lasts the entire note duration.
   uint32_t sweepLength = duration;
   if (portamentoTime != 0) {
-    const uint64_t absSweep = static_cast<uint64_t>(std::abs(static_cast<int32_t>(sweepPitch)));
+    const uint64_t absSweep = static_cast<uint64_t>(std::abs(static_cast<int64_t>(effectiveSweep)));
     const uint64_t t = static_cast<uint64_t>(portamentoTime);
-    // Not 100% confident about this, but I think it's exact!
     sweepLength = static_cast<uint32_t>((t * t * absSweep) >> 11);
   }
 
@@ -340,9 +386,10 @@ void NDSTrack::applySweepPitchForNote(uint32_t startTick, uint32_t duration) {
     return;
   }
 
+  // Emit pitch bend events ramping from (basePitchBend + sweepMidi) down to basePitchBend.
   const uint32_t rampTicks = std::min(duration, sweepLength);
   for (uint32_t i = 0; i <= rampTicks; i++) {
-    const int64_t scaled = static_cast<int64_t>(sweepPitch) * static_cast<int64_t>(sweepLength - i);
+    const int64_t scaled = static_cast<int64_t>(sweepMidi) * static_cast<int64_t>(sweepLength - i);
     const int sweepAtTick = static_cast<int>(scaled / static_cast<int64_t>(sweepLength));
     const int bend = std::clamp(static_cast<int>(basePitchBend) + sweepAtTick, -8192, 8191);
     if (!haveLast || bend != lastBend) {
@@ -363,11 +410,7 @@ void NDSTrack::renderModPoint(uint32_t tick) {
     return;
   }
 
-  int32_t raw = 0;
-  if (modDepth != 0 && modDelayCounter >= modDelay) {
-    const int index = (modPhaseCounter >> 8) & 0x7F;
-    raw = static_cast<int32_t>(sineSampleAt(index)) * static_cast<int32_t>(modDepth) * static_cast<int32_t>(modRange);
-  }
+  const int32_t raw = currentModRawValue();
 
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     return;
@@ -375,16 +418,20 @@ void NDSTrack::renderModPoint(uint32_t tick) {
 
   switch (target) {
     case ModTarget::Pitch: {
-      if (!modRangeSent) {
-        emitPitchModRangeAt(tick);
-        modRangeSent = true;
-      }
-      emitPitchVibratoParamsAt(tick);
+      emitPitchLfoBendAt(tick, raw);
       break;
     }
     case ModTarget::Volume: {
-      const int32_t lfo = (raw * 60) >> 14;
-      const uint8_t cc = clampMidi7Bit(static_cast<int>(expression) + static_cast<int>(lfo));
+      const int32_t lfoDbTenths = ndsVolumeLfoDbTenths(raw);
+      const int32_t maxLfoDbTenths =
+          ndsVolumeLfoDbTenths(static_cast<int32_t>(127) * static_cast<int32_t>(modDepth) *
+                               static_cast<int32_t>(modRange));
+      double amplitudeScale = amplitudeScaleFromDbTenths(lfoDbTenths - maxLfoDbTenths);
+      if (parentSeq->panVolumeCorrectionMode == PanVolumeCorrectionMode::kAdjustExpressionController) {
+        amplitudeScale *= panVolumeCorrectionRate;
+      }
+      const uint8_t cc = expressionCcForAmplitudeScale(
+          expression, expressionResolution, amplitudeScale, usesLinearAmplitudeScale());
       if (cc != lastExprCc) {
         pMidiTrack->insertExpression(channel, cc, tick);
         lastExprCc = cc;
@@ -393,10 +440,22 @@ void NDSTrack::renderModPoint(uint32_t tick) {
     }
     case ModTarget::Pan: {
       const int32_t lfo = (raw * 64) >> 14;
-      const uint8_t cc = clampMidi7Bit(static_cast<int>(prevPan) + static_cast<int>(lfo));
+      const uint8_t pan = clampMidi7Bit(static_cast<int>(prevPan) + static_cast<int>(lfo));
+      double volumeScale = 1.0;
+      const uint8_t cc = usesLinearPanAmplitudeScale()
+                             ? convert7bitLinearPercentPanValToStdMidiVal(pan, &volumeScale)
+                             : pan;
       if (cc != lastPanCc) {
         pMidiTrack->insertPan(channel, cc, tick);
         lastPanCc = cc;
+      }
+      if (parentSeq->panVolumeCorrectionMode == PanVolumeCorrectionMode::kAdjustExpressionController) {
+        const uint8_t exprCc = expressionCcForAmplitudeScale(
+            expression, expressionResolution, volumeScale, usesLinearAmplitudeScale());
+        if (exprCc != lastPanExprCc) {
+          pMidiTrack->insertExpression(channel, exprCc, tick);
+          lastPanExprCc = exprCc;
+        }
       }
       break;
     }
@@ -412,18 +471,23 @@ void NDSTrack::advanceModStateByMidiTicks(uint32_t midiTicks, uint32_t startTick
 
   const auto* ndsSeq = static_cast<const NDSSeq*>(parentSeq);
   for (uint32_t i = 0; i < midiTicks; i++) {
-    const double tempoAtTick = ndsSeq->tempoAtTick(startTick + i);
-    const double effectiveTempo = (tempoAtTick > 0.0) ? tempoAtTick : currentTempoBpm;
-    const double periodicPerMidiTick = (nds::kPeriodicUpdateHz * 60.0) /
-                                       (effectiveTempo * static_cast<double>(parentSeq->ppqn()));
-
-    const double stepsWithRemainder = modPeriodicRemainder + periodicPerMidiTick;
-    const uint32_t wholeSteps = static_cast<uint32_t>(stepsWithRemainder);
-    modPeriodicRemainder = stepsWithRemainder - static_cast<double>(wholeSteps);
-
-    for (uint32_t j = 0; j < wholeSteps; j++) {
-      advanceModStateOnePeriodicTick();
+    // Consume the current sequence tick, then count the
+    // periodic sound updates needed before the next sequence tick becomes due.
+    if (modTempoCounter >= nds::kBaseTempo) {
+      modTempoCounter -= nds::kBaseTempo;
+    } else {
+      modTempoCounter = 0;
     }
+
+    if (modTempoCounter >= nds::kBaseTempo) {
+      continue;
+    }
+
+    const uint32_t tempoStep = tempoToNdsCounterStep(ndsSeq->tempoAtTick(startTick + i), currentTempoBpm);
+    do {
+      modTempoCounter += tempoStep;
+      advanceModStateOnePeriodicTick();
+    } while (modTempoCounter < nds::kBaseTempo);
   }
 }
 
@@ -482,7 +546,8 @@ bool NDSTrack::readEvent(void) {
       }
     }
 
-    applySweepPitchForNote(noteStartTick, dur);
+    applySweepPitchForNote(noteStartTick, dur, status_byte);
+    prevNoteKey = status_byte;
     if (noteWithDelta) {
       addTime(dur);
     }
@@ -608,16 +673,19 @@ bool NDSTrack::readEvent(void) {
 
       // [loveemu] pitch bend (ex: Castlevania Dawn of Sorrow: BGM_BOSS2)
       case 0xC4: {
-        int16_t bend = (signed) readByte(curOffset++) * 64;
+        int16_t bend = static_cast<int16_t>(static_cast<int8_t>(readByte(curOffset++))) * 64;
         basePitchBend = bend;
         addPitchBend(beginOffset, curOffset - beginOffset, bend);
+        lastPitchLfoBend = bend;
         break;
       }
 
       // [loveemu] pitch bend range (ex: Castlevania Dawn of Sorrow: BGM_BOSS2)
       case 0xC5: {
         uint8_t semitones = readByte(curOffset++);
+        pitchBendRangeSemitones = semitones;
         addPitchBendRange(beginOffset, curOffset - beginOffset, semitones * 100);
+        lastPitchLfoBend = std::numeric_limits<int>::min();
         break;
       }
 
@@ -652,6 +720,7 @@ bool NDSTrack::readEvent(void) {
       case 0xC9: {
         uint8_t portKey = readByte(curOffset++);
         portamentoEnabled = true;
+        prevNoteKey = portKey;
         portamentoControlKey = clampMidi7Bit(static_cast<int>(portKey) + static_cast<int>(cKeyCorrection) +
                                              static_cast<int>(transpose));
         if (readMode == READMODE_CONVERT_TO_MIDI) {
@@ -669,10 +738,17 @@ bool NDSTrack::readEvent(void) {
         modDepth = readByte(curOffset++);
         addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation Depth",
                         "Depth=" + std::to_string(modDepth), Type::Lfo);
-        if (modDepth == 0) {
-          lastPitchModCc = -1;
+        const ModTarget target = toModTarget(modType);
+        if (target == ModTarget::Pitch) {
+          lastPitchLfoBend = std::numeric_limits<int>::min();
+          renderModPoint(getTime());
+        } else if (target == ModTarget::Volume) {
           lastExprCc = -1;
+          renderModPoint(getTime());
+        } else if (target == ModTarget::Pan) {
           lastPanCc = -1;
+          lastPanExprCc = -1;
+          renderModPoint(getTime());
         }
         break;
       }
@@ -689,13 +765,22 @@ bool NDSTrack::readEvent(void) {
       // [loveemu] (ex: Children of Mana: SEQ_BGM001)
       case 0xCC: {
         renderModUntil(getTime());
+        const ModTarget oldTarget = toModTarget(modType);
         modType = readByte(curOffset++);
-        modRangeSent = false;
-        lastPitchModCc = -1;
-        lastPitchVibratoRatePressure = -1;
         lastExprCc = -1;
         lastPanCc = -1;
+        lastPanExprCc = -1;
         const ModTarget target = toModTarget(modType);
+        if (oldTarget == ModTarget::Pitch && target != ModTarget::Pitch) {
+          lastPitchLfoBend = std::numeric_limits<int>::min();
+          emitPitchLfoBendAt(getTime(), 0);
+        }
+        if (target == ModTarget::Pitch) {
+          lastPitchLfoBend = std::numeric_limits<int>::min();
+          renderModPoint(getTime());
+        } else if (target == ModTarget::Volume || target == ModTarget::Pan) {
+          renderModPoint(getTime());
+        }
         addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation Type",
                         "Target=" + to_string(target), Type::Lfo);
         break;
@@ -705,7 +790,18 @@ bool NDSTrack::readEvent(void) {
       case 0xCD: {
         renderModUntil(getTime());
         modRange = readByte(curOffset++);
-        modRangeSent = false;
+        const ModTarget target = toModTarget(modType);
+        if (target == ModTarget::Pitch) {
+          lastPitchLfoBend = std::numeric_limits<int>::min();
+          renderModPoint(getTime());
+        } else if (target == ModTarget::Volume) {
+          lastExprCc = -1;
+          renderModPoint(getTime());
+        } else if (target == ModTarget::Pan) {
+          lastPanCc = -1;
+          lastPanExprCc = -1;
+          renderModPoint(getTime());
+        }
         addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation Range",
                         "Range=" + std::to_string(modRange), Type::Lfo);
         break;
@@ -774,10 +870,17 @@ bool NDSTrack::readEvent(void) {
         modDelay = readShort(curOffset);
         curOffset += 2;
         modDelayCounter = 0;
-        if (toModTarget(modType) == ModTarget::Pitch) {
-          pitchModEnableTick = getTime() + modDelayToMidiTicks(modDelay, getTime());
-          lastPitchModCc = -1;
-          emitPitchVibratoParamsAt(getTime());
+        const ModTarget target = toModTarget(modType);
+        if (target == ModTarget::Pitch) {
+          lastPitchLfoBend = std::numeric_limits<int>::min();
+          renderModPoint(getTime());
+        } else if (target == ModTarget::Volume) {
+          lastExprCc = -1;
+          renderModPoint(getTime());
+        } else if (target == ModTarget::Pan) {
+          lastPanCc = -1;
+          lastPanExprCc = -1;
+          renderModPoint(getTime());
         }
         addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation Delay",
                         "Delay=" + std::to_string(modDelay), Type::Lfo);

--- a/src/main/formats/NDS/NDSSeq.cpp
+++ b/src/main/formats/NDS/NDSSeq.cpp
@@ -1,12 +1,99 @@
 #include "NDSSeq.h"
 
+#include <array>
+#include <algorithm>
+#include <cmath>
+
+#include "Modulation.h"
+#include "NDSFormat.h"
+
 DECLARE_FORMAT(NDS);
 
 using namespace std;
 
+namespace {
+uint8_t clampMidi7Bit(int value) {
+  return static_cast<uint8_t>(std::clamp(value, 0, 127));
+}
+
+int8_t sineSampleAt(int index) {
+  static constexpr std::array<int8_t, 33> SINE_LOOKUP_TABLE{
+      0, 6, 12, 19, 25, 31, 37, 43, 49, 54, 60,
+      65, 71, 76, 81, 85, 90, 94, 98, 102, 106, 109,
+      112, 115, 117, 120, 122, 123, 125, 126, 126, 127, 127,
+  };
+
+  if (index < 0) {
+    index = 0;
+  } else if (index > 127) {
+    index = 127;
+  }
+
+  if (index < 32) {
+    return SINE_LOOKUP_TABLE[index];
+  }
+  if (index < 64) {
+    return SINE_LOOKUP_TABLE[32 - (index - 32)];
+  }
+  if (index < 96) {
+    return static_cast<int8_t>(-SINE_LOOKUP_TABLE[index - 64]);
+  }
+  return static_cast<int8_t>(-SINE_LOOKUP_TABLE[32 - (index - 96)]);
+}
+
+constexpr uint8_t kNdsDefaultPortamentoKey = 60;
+
+uint8_t speedToVibratoRatePressure(uint8_t speed) {
+  if (speed == 0) {
+    return 0;
+  }
+
+  return midiValueForHertzInRange(static_cast<double>(speed) * nds::kLfoSpeedToHz,
+                                  nds::kVibratoBaseHz,
+                                  nds::kVibratoMaxHz);
+}
+} // namespace
+
 NDSSeq::NDSSeq(RawFile *file, uint32_t offset, uint32_t length, string name)
     : VGMSeq(NDSFormat::name, file, offset, length, name) {
   setShouldTrackControlFlowState(true);
+}
+
+void NDSSeq::resetVars() {
+  VGMSeq::resetVars();
+
+  if (readMode == READMODE_ADD_TO_UI) {
+    m_tempoMap.clear();
+  }
+
+  if (m_tempoMap.empty()) {
+    m_tempoMap.emplace(0, TempoPoint{initialTempoBPM, -1});
+  }
+}
+
+void NDSSeq::registerTempoChange(uint32_t tick, double bpm, int trackIndex) {
+  if (bpm <= 0.0) {
+    return;
+  }
+
+  const TempoPoint point{bpm, trackIndex};
+  auto [it, inserted] = m_tempoMap.emplace(tick, point);
+  if (!inserted && trackIndex >= it->second.trackIndex) {
+    it->second = point;
+  }
+}
+
+double NDSSeq::tempoAtTick(uint32_t tick) const {
+  if (m_tempoMap.empty()) {
+    return (initialTempoBPM > 0.0) ? initialTempoBPM : 120.0;
+  }
+
+  auto it = m_tempoMap.upper_bound(tick);
+  if (it == m_tempoMap.begin()) {
+    return it->second.bpm;
+  }
+  --it;
+  return it->second.bpm;
 }
 
 bool NDSSeq::parseHeader(void) {
@@ -15,10 +102,11 @@ bool NDSSeq::parseHeader(void) {
   SSEQHdr->addChild(offset() + 8, 4, "Size");
   SSEQHdr->addChild(offset() + 12, 2, "Header Size");
   SSEQHdr->addUnknownChild(offset() + 14, 2);
-  //SeqChunkHdr->addSimpleChild(offset(), 4, "Blah");
+
   setLength(readWord(offset() + 8));
   setPPQN(0x30);
-  return true;        //successful
+
+  return true;
 }
 
 bool NDSSeq::parseTrackPointers(void) {
@@ -65,7 +153,6 @@ bool NDSSeq::parseTrackPointers(void) {
           (readByte(off + 4) << 16) + offset() + 0x1C;
       NDSTrack *newTrack = new NDSTrack(this, trkOffset);
       aTracks.push_back(newTrack);
-      //newTrack->
       off += 5;
       b = readByte(off);
     }
@@ -73,6 +160,7 @@ bool NDSSeq::parseTrackPointers(void) {
   }
   aTracks[0]->setOffset(off);
   aTracks[0]->dwStartOffset = off;
+  
   return true;
 }
 
@@ -89,6 +177,233 @@ NDSTrack::NDSTrack(NDSSeq *parentFile, uint32_t offset, uint32_t length)
 void NDSTrack::resetVars() {
   SeqTrack::resetVars();
   noteWithDelta = false;
+  resetModState();
+}
+
+void NDSTrack::resetModState() {
+  modDepth = 0;
+  modSpeed = 16;
+  modType = static_cast<uint8_t>(ModTarget::Pitch);
+  modRange = 1;
+  modDelay = 0;
+
+  modLastRenderTick = getTime();
+  modPhaseCounter = 0;
+  modDelayCounter = 0;
+  modPeriodicRemainder = 0.0;
+  modRangeSent = false;
+  pitchModEnableTick = getTime();
+  currentTempoBpm = static_cast<const NDSSeq*>(parentSeq)->tempoAtTick(getTime());
+
+  lastPitchModCc = -1;
+  lastPitchVibratoRatePressure = -1;
+  lastExprCc = -1;
+  lastPanCc = -1;
+  sweepPitch = 0;
+  basePitchBend = 0;
+}
+
+void NDSTrack::addTime(uint32_t delta) {
+  renderModUntil(getTime() + delta);
+  SeqTrack::addTime(delta);
+}
+
+void NDSTrack::renderModUntil(uint32_t endTick) {
+  if (endTick <= modLastRenderTick) {
+    return;
+  }
+
+  for (uint32_t tick = modLastRenderTick; tick < endTick; tick++) {
+    renderModPoint(tick);
+    advanceModStateByMidiTicks(1, tick);
+  }
+  modLastRenderTick = endTick;
+}
+
+NDSTrack::ModTarget NDSTrack::toModTarget(uint8_t value) {
+  switch (value) {
+    case 0:
+      return ModTarget::Pitch;
+    case 1:
+      return ModTarget::Volume;
+    case 2:
+      return ModTarget::Pan;
+    default:
+      return ModTarget::Unknown;
+  }
+}
+
+std::string NDSTrack::to_string(ModTarget target) {
+  switch (target) {
+    case ModTarget::Pitch:
+      return "Pitch";
+    case ModTarget::Volume:
+      return "Volume";
+    case ModTarget::Pan:
+      return "Pan";
+    case ModTarget::Unknown:
+    default:
+      return "Unknown";
+  }
+}
+
+uint32_t NDSTrack::modDelayToMidiTicks(uint16_t delay, uint32_t atTick) const {
+  if (delay == 0) {
+    return 0;
+  }
+
+  const double tempoAtTick = static_cast<const NDSSeq*>(parentSeq)->tempoAtTick(atTick);
+  const double effectiveTempo = (tempoAtTick > 0.0) ? tempoAtTick : currentTempoBpm;
+
+  const double ticks = (static_cast<double>(delay) * effectiveTempo *
+                        static_cast<double>(parentSeq->ppqn())) /
+                       (60.0 * nds::kPeriodicUpdateHz);
+  return std::max<uint32_t>(1, static_cast<uint32_t>(std::lround(ticks)));
+}
+
+void NDSTrack::onNoteStart(uint32_t noteStartTick) {
+  modPhaseCounter = 0;
+  modDelayCounter = 0;
+
+  if (toModTarget(modType) != ModTarget::Pitch) {
+    return;
+  }
+
+  pitchModEnableTick = noteStartTick + modDelayToMidiTicks(modDelay, noteStartTick);
+  if (lastPitchModCc != 0) {
+    lastPitchModCc = -1;
+  }
+  emitPitchVibratoParamsAt(noteStartTick);
+}
+
+void NDSTrack::emitPitchModRangeAt(uint32_t tick) {
+  if (readMode != READMODE_CONVERT_TO_MIDI) {
+    return;
+  }
+  const double semitones = static_cast<double>(modRange);
+  pMidiTrack->insertModulationDepthRange(channel, semitones, tick);
+}
+
+void NDSTrack::emitPitchVibratoParamsAt(uint32_t tick) {
+  if (readMode != READMODE_CONVERT_TO_MIDI) {
+    return;
+  }
+
+  const bool depthEnabled = (tick >= pitchModEnableTick) && (modDepth != 0) && (modSpeed != 0);
+  const int depthCc = depthEnabled ? static_cast<int>(modDepth) : 0;
+  const int ratePressure = static_cast<int>(speedToVibratoRatePressure(modSpeed));
+
+  if (depthCc != lastPitchModCc) {
+    pMidiTrack->insertModulation(channel, static_cast<uint8_t>(depthCc), tick); // CC1
+    lastPitchModCc = depthCc;
+  }
+
+  if (ratePressure != lastPitchVibratoRatePressure) {
+    pMidiTrack->insertChannelPressure(channel, static_cast<uint8_t>(ratePressure), tick);
+    lastPitchVibratoRatePressure = ratePressure;
+  }
+}
+
+void NDSTrack::applySweepPitchForNote(uint32_t startTick, uint32_t duration) {
+  if (readMode != READMODE_CONVERT_TO_MIDI || duration == 0 || sweepPitch == 0) {
+    return;
+  }
+
+  // As far as I can tell, sweep starts with note-on and decays linearly to 0 over note length.
+  const int startBend = std::clamp(static_cast<int>(basePitchBend) + static_cast<int>(sweepPitch), -8192, 8191);
+  const int endBend = std::clamp(static_cast<int>(basePitchBend), -8192, 8191);
+
+  pMidiTrack->insertPitchBend(channel, static_cast<int16_t>(startBend), startTick);
+  pMidiTrack->insertPitchBend(channel, static_cast<int16_t>(endBend), startTick + duration);
+}
+
+void NDSTrack::renderModPoint(uint32_t tick) {
+  const ModTarget target = toModTarget(modType);
+  if (target == ModTarget::Unknown) {
+    return;
+  }
+
+  int32_t raw = 0;
+  if (modDepth != 0 && modDelayCounter >= modDelay) {
+    const int index = (modPhaseCounter >> 8) & 0x7F;
+    raw = static_cast<int32_t>(sineSampleAt(index)) * static_cast<int32_t>(modDepth) * static_cast<int32_t>(modRange);
+  }
+
+  if (readMode != READMODE_CONVERT_TO_MIDI) {
+    return;
+  }
+
+  switch (target) {
+    case ModTarget::Pitch: {
+      if (!modRangeSent) {
+        emitPitchModRangeAt(tick);
+        modRangeSent = true;
+      }
+      emitPitchVibratoParamsAt(tick);
+      break;
+    }
+    case ModTarget::Volume: {
+      const int32_t lfo = (raw * 60) >> 14;
+      const uint8_t cc = clampMidi7Bit(static_cast<int>(expression) + static_cast<int>(lfo));
+      if (cc != lastExprCc) {
+        pMidiTrack->insertExpression(channel, cc, tick);
+        lastExprCc = cc;
+      }
+      break;
+    }
+    case ModTarget::Pan: {
+      const int32_t lfo = (raw * 64) >> 14;
+      const uint8_t cc = clampMidi7Bit(static_cast<int>(prevPan) + static_cast<int>(lfo));
+      if (cc != lastPanCc) {
+        pMidiTrack->insertPan(channel, cc, tick);
+        lastPanCc = cc;
+      }
+      break;
+    }
+    case ModTarget::Unknown:
+      break;
+  }
+}
+
+void NDSTrack::advanceModStateByMidiTicks(uint32_t midiTicks, uint32_t startTick) {
+  if (midiTicks == 0) {
+    return;
+  }
+
+  const auto* ndsSeq = static_cast<const NDSSeq*>(parentSeq);
+  for (uint32_t i = 0; i < midiTicks; i++) {
+    const double tempoAtTick = ndsSeq->tempoAtTick(startTick + i);
+    const double effectiveTempo = (tempoAtTick > 0.0) ? tempoAtTick : currentTempoBpm;
+    const double periodicPerMidiTick = (nds::kPeriodicUpdateHz * 60.0) /
+                                       (effectiveTempo * static_cast<double>(parentSeq->ppqn()));
+
+    const double stepsWithRemainder = modPeriodicRemainder + periodicPerMidiTick;
+    const uint32_t wholeSteps = static_cast<uint32_t>(stepsWithRemainder);
+    modPeriodicRemainder = stepsWithRemainder - static_cast<double>(wholeSteps);
+
+    for (uint32_t j = 0; j < wholeSteps; j++) {
+      advanceModStateOnePeriodicTick();
+    }
+  }
+}
+
+void NDSTrack::advanceModStateOnePeriodicTick() {
+  if (modDelayCounter < modDelay) {
+    modDelayCounter++;
+    return;
+  }
+
+  uint32_t offset = modPhaseCounter;
+  offset += static_cast<uint32_t>(modSpeed) << 6;
+  offset >>= 8;
+  while (offset >= 128) {
+    offset -= 128;
+  }
+  offset <<= 8;
+
+  modPhaseCounter += static_cast<uint16_t>(static_cast<uint32_t>(modSpeed) << 6);
+  modPhaseCounter &= 0xFF;
+  modPhaseCounter |= static_cast<uint16_t>(offset);
 }
 
 bool NDSTrack::readEvent(void) {
@@ -97,9 +412,12 @@ bool NDSTrack::readEvent(void) {
 
   if (status_byte < 0x80) //then it's a note on event
   {
+    const uint32_t noteStartTick = getTime();
     uint8_t vel = readByte(curOffset++);
     dur = readVarLen(curOffset);//GetByte(curOffset++);
+    onNoteStart(noteStartTick);
     addNoteByDur(beginOffset, curOffset - beginOffset, status_byte, vel, dur);
+    applySweepPitchForNote(noteStartTick, dur);
     if (noteWithDelta) {
       addTime(dur);
     }
@@ -212,21 +530,21 @@ bool NDSTrack::readEvent(void) {
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_BOSS1_)
       case 0xC2: {
         uint8_t mvol = readByte(curOffset++);
-        addUnknown(beginOffset, curOffset - beginOffset, "Master Volume");
+        addMasterVol(beginOffset, curOffset - beginOffset, mvol);
         break;
       }
 
       // [loveemu] (ex: Puyo Pop Fever 2: BGM00)
       case 0xC3: {
-        int8_t transpose = (signed) readByte(curOffset++);
+        int8_t transpose = static_cast<int8_t>(readByte(curOffset++));
         addTranspose(beginOffset, curOffset - beginOffset, transpose);
-//			AddGenericEvent(beginOffset, curOffset-beginOffset, "Transpose", NULL, BG_CLR_GREEN);
         break;
       }
 
       // [loveemu] pitch bend (ex: Castlevania Dawn of Sorrow: BGM_BOSS2)
       case 0xC4: {
         int16_t bend = (signed) readByte(curOffset++) * 64;
+        basePitchBend = bend;
         addPitchBend(beginOffset, curOffset - beginOffset, bend);
         break;
       }
@@ -266,28 +584,51 @@ bool NDSTrack::readEvent(void) {
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_ARR1_)
       case 0xCA: {
-        uint8_t amount = readByte(curOffset++);
-        addModulation(beginOffset, curOffset - beginOffset, amount, "Modulation Depth");
+        renderModUntil(getTime());
+        modDepth = readByte(curOffset++);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation Depth",
+                        "Depth=" + std::to_string(modDepth), Type::Lfo);
+        if (modDepth == 0) {
+          lastPitchModCc = -1;
+          lastExprCc = -1;
+          lastPanCc = -1;
+        }
         break;
       }
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_ARR1_)
-      case 0xCB:
-        curOffset++;
-        addUnknown(beginOffset, curOffset - beginOffset, "Modulation Speed");
+      case 0xCB: {
+        renderModUntil(getTime());
+        modSpeed = readByte(curOffset++);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation Speed",
+                        "Speed=" + std::to_string(modSpeed), Type::Lfo);
         break;
+      }
 
       // [loveemu] (ex: Children of Mana: SEQ_BGM001)
-      case 0xCC:
-        curOffset++;
-        addUnknown(beginOffset, curOffset - beginOffset, "Modulation Type");
+      case 0xCC: {
+        renderModUntil(getTime());
+        modType = readByte(curOffset++);
+        modRangeSent = false;
+        lastPitchModCc = -1;
+        lastPitchVibratoRatePressure = -1;
+        lastExprCc = -1;
+        lastPanCc = -1;
+        const ModTarget target = toModTarget(modType);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation Type",
+                        "Target=" + to_string(target), Type::Lfo);
         break;
+      }
 
       // [loveemu] (ex: Phoenix Wright - Ace Attorney: BGM021)
-      case 0xCD:
-        curOffset++;
-        addUnknown(beginOffset, curOffset - beginOffset, "Modulation Range");
+      case 0xCD: {
+        renderModUntil(getTime());
+        modRange = readByte(curOffset++);
+        modRangeSent = false;
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation Range",
+                        "Range=" + std::to_string(modRange), Type::Lfo);
         break;
+      }
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_ARR1_)
       case 0xCE: {
@@ -346,23 +687,39 @@ bool NDSTrack::readEvent(void) {
         break;
 
       // [loveemu] (ex: Children of Mana: SEQ_BGM001)
-      case 0xE0:
+      case 0xE0: {
+        renderModUntil(getTime());
+        modDelay = readShort(curOffset);
         curOffset += 2;
-        addUnknown(beginOffset, curOffset - beginOffset, "Modulation Delay");
+        modDelayCounter = 0;
+        if (toModTarget(modType) == ModTarget::Pitch) {
+          pitchModEnableTick = getTime() + modDelayToMidiTicks(modDelay, getTime());
+          lastPitchModCc = -1;
+          emitPitchVibratoParamsAt(getTime());
+        }
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Modulation Delay",
+                        "Delay=" + std::to_string(modDelay), Type::Lfo);
         break;
+      }
 
       case 0xE1: {
         uint16_t bpm = readShort(curOffset);
         curOffset += 2;
+        currentTempoBpm = static_cast<double>(bpm);
         addTempoBPM(beginOffset, curOffset - beginOffset, bpm);
+        static_cast<NDSSeq*>(parentSeq)->registerTempoChange(
+            getTime(), currentTempoBpm, channelGroup * 16 + channel);
         break;
       }
 
       // [loveemu] (ex: Hippatte! Puzzle Bobble: SEQ_1pbgm03)
-      case 0xE3:
+      case 0xE3: {
+        sweepPitch = readShort(curOffset);
         curOffset += 2;
-        addUnknown(beginOffset, curOffset - beginOffset, "Sweep Pitch");
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Sweep Pitch",
+                        "Sweep=" + std::to_string(sweepPitch), Type::Lfo);
         break;
+      }
 
       // [loveemu] (ex: Castlevania Dawn of Sorrow: SDL_BGM_WIND_)
       case 0xFC:
@@ -380,6 +737,7 @@ bool NDSTrack::readEvent(void) {
         break;
 
       case 0xFF:
+        renderModUntil(getTime());
         addEndOfTrack(beginOffset, curOffset - beginOffset);
         return false;
 

--- a/src/main/formats/NDS/NDSSeq.h
+++ b/src/main/formats/NDS/NDSSeq.h
@@ -52,7 +52,7 @@ class NDSTrack
   void renderModPoint(uint32_t tick);
   void advanceModStateByMidiTicks(uint32_t midiTicks, uint32_t startTick);
   void advanceModStateOnePeriodicTick();
-  void onNoteStart(uint32_t noteStartTick);
+  void onNoteStart(uint32_t noteStartTick, uint8_t noteKey);
   static ModTarget toModTarget(uint8_t value);
   static std::string to_string(ModTarget target);
   void applySweepPitchForNote(uint32_t startTick, uint32_t duration);
@@ -80,4 +80,7 @@ class NDSTrack
   int16_t basePitchBend;
   uint32_t pitchModEnableTick;
   double currentTempoBpm;
+  bool portamentoEnabled;
+  uint8_t portamentoControlKey;
+  uint8_t portamentoTime;
 };

--- a/src/main/formats/NDS/NDSSeq.h
+++ b/src/main/formats/NDS/NDSSeq.h
@@ -83,4 +83,8 @@ class NDSTrack
   bool portamentoEnabled;
   uint8_t portamentoControlKey;
   uint8_t portamentoTime;
+  bool tieModeEnabled;
+  bool tieNoteActive;
+  uint8_t tieNoteKey;
+  uint32_t tieNoteEndTick;
 };

--- a/src/main/formats/NDS/NDSSeq.h
+++ b/src/main/formats/NDS/NDSSeq.h
@@ -1,15 +1,29 @@
 #pragma once
+#include <map>
+#include <string>
+
 #include "VGMSeq.h"
 #include "SeqTrack.h"
-#include "NDSFormat.h"
 
 class NDSSeq:
     public VGMSeq {
  public:
   NDSSeq(RawFile *file, uint32_t offset, uint32_t length = 0, std::string theName = "NDSSeq");
 
-  virtual bool parseHeader();
-  virtual bool parseTrackPointers();
+  bool parseHeader() override;
+  bool parseTrackPointers() override;
+  void resetVars() override;
+
+  void registerTempoChange(uint32_t tick, double bpm, int trackIndex);
+  [[nodiscard]] double tempoAtTick(uint32_t tick) const;
+
+ private:
+  struct TempoPoint {
+    double bpm;
+    int trackIndex;
+  };
+
+  std::map<uint32_t, TempoPoint> m_tempoMap;
 
 };
 
@@ -18,9 +32,52 @@ class NDSTrack
     : public SeqTrack {
  public:
   NDSTrack(NDSSeq *parentFile, uint32_t offset = 0, uint32_t length = 0);
-  void resetVars();
-  virtual bool readEvent();
+  void resetVars() override;
+  bool readEvent() override;
+  void addTime(uint32_t delta) override;
 
   uint32_t dur;
   bool noteWithDelta;
+
+ private:
+  enum class ModTarget : uint8_t {
+    Pitch = 0,
+    Volume = 1,
+    Pan = 2,
+    Unknown = 0xFF,
+  };
+
+  void resetModState();
+  void renderModUntil(uint32_t endTick);
+  void renderModPoint(uint32_t tick);
+  void advanceModStateByMidiTicks(uint32_t midiTicks, uint32_t startTick);
+  void advanceModStateOnePeriodicTick();
+  void onNoteStart(uint32_t noteStartTick);
+  static ModTarget toModTarget(uint8_t value);
+  static std::string to_string(ModTarget target);
+  void applySweepPitchForNote(uint32_t startTick, uint32_t duration);
+  void emitPitchModRangeAt(uint32_t tick);
+  void emitPitchVibratoParamsAt(uint32_t tick);
+  uint32_t modDelayToMidiTicks(uint16_t delay, uint32_t atTick) const;
+
+  uint8_t modDepth;
+  uint8_t modSpeed;
+  uint8_t modType;
+  uint8_t modRange;
+  uint16_t modDelay;
+
+  uint32_t modLastRenderTick;
+  uint16_t modPhaseCounter;
+  uint16_t modDelayCounter;
+  double modPeriodicRemainder;
+  bool modRangeSent;
+
+  int lastPitchModCc;
+  int lastPitchVibratoRatePressure;
+  int lastExprCc;
+  int lastPanCc;
+  int16_t sweepPitch;
+  int16_t basePitchBend;
+  uint32_t pitchModEnableTick;
+  double currentTempoBpm;
 };

--- a/src/main/formats/NDS/NDSSeq.h
+++ b/src/main/formats/NDS/NDSSeq.h
@@ -55,10 +55,10 @@ class NDSTrack
   void onNoteStart(uint32_t noteStartTick, uint8_t noteKey);
   static ModTarget toModTarget(uint8_t value);
   static std::string to_string(ModTarget target);
-  void applySweepPitchForNote(uint32_t startTick, uint32_t duration);
-  void emitPitchModRangeAt(uint32_t tick);
-  void emitPitchVibratoParamsAt(uint32_t tick);
-  uint32_t modDelayToMidiTicks(uint16_t delay, uint32_t atTick) const;
+  void applySweepPitchForNote(uint32_t startTick, uint32_t duration, uint8_t noteKey);
+  int32_t currentModRawValue() const;
+  int16_t pitchBendWithLfo(int32_t raw) const;
+  void emitPitchLfoBendAt(uint32_t tick, int32_t raw);
 
   uint8_t modDepth;
   uint8_t modSpeed;
@@ -69,20 +69,20 @@ class NDSTrack
   uint32_t modLastRenderTick;
   uint16_t modPhaseCounter;
   uint16_t modDelayCounter;
-  double modPeriodicRemainder;
-  bool modRangeSent;
+  uint32_t modTempoCounter;
 
-  int lastPitchModCc;
-  int lastPitchVibratoRatePressure;
   int lastExprCc;
   int lastPanCc;
+  int lastPanExprCc;
+  int lastPitchLfoBend;
   int16_t sweepPitch;
   int16_t basePitchBend;
-  uint32_t pitchModEnableTick;
+  uint8_t pitchBendRangeSemitones;
   double currentTempoBpm;
   bool portamentoEnabled;
   uint8_t portamentoControlKey;
   uint8_t portamentoTime;
+  uint8_t prevNoteKey;
   bool tieModeEnabled;
   bool tieNoteActive;
   uint8_t tieNoteKey;

--- a/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesSeq.cpp
@@ -17,6 +17,7 @@ NamcoSnesSeq::NamcoSnesSeq(RawFile *file, NamcoSnesVersion ver, uint32_t seqdata
       version(ver) {
   setAllowDiscontinuousTrackData(true);
   VGMSeq::setUseLinearAmplitudeScale(true);
+  VGMSeq::setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   setAlwaysWriteInitialTempo(60000000.0 / (SEQ_PPQN * (125 * 0x86)));
 

--- a/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
+++ b/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
@@ -14,6 +14,7 @@ NeverlandSnesSeq::NeverlandSnesSeq(RawFile *file, NeverlandSnesVersion ver, uint
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesSeq.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesSeq.cpp
@@ -24,6 +24,7 @@ PandoraBoxSnesSeq::PandoraBoxSnesSeq(RawFile *file,
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/PrismSnes/PrismSnesSeq.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesSeq.cpp
@@ -32,6 +32,7 @@ PrismSnesSeq::PrismSnesSeq(RawFile *file, PrismSnesVersion ver, uint32_t seqdata
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/SoftCreatSnes/SoftCreatSnesSeq.cpp
+++ b/src/main/formats/SoftCreatSnes/SoftCreatSnesSeq.cpp
@@ -19,6 +19,7 @@ SoftCreatSnesSeq::SoftCreatSnesSeq(RawFile *file,
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/SonyPS2/SonyPS2Seq.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Seq.cpp
@@ -13,6 +13,7 @@ SonyPS2Seq::SonyPS2Seq(RawFile *file, uint32_t offset, std::string name)
       compOption(0),
       bSkipDeltaTime(0) {
   VGMSeq::setUseLinearAmplitudeScale(true);        // Onimusha: Kaede Theme track 2 for example of linear vol scale.
+  VGMSeq::setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
   useReverb();
 }
 

--- a/src/main/formats/SquarePS2/SquarePS2Seq.cpp
+++ b/src/main/formats/SquarePS2/SquarePS2Seq.cpp
@@ -11,6 +11,7 @@ using namespace std;
 BGMSeq::BGMSeq(RawFile *file, uint32_t offset)
     : VGMSeq(SquarePS2Format::name, file, offset) {
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
   useReverb();
   setAlwaysWriteInitialVol(127);
 }

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
@@ -23,6 +23,7 @@ SuzukiSnesSeq::SuzukiSnesSeq(RawFile *file, SuzukiSnesVersion ver, uint32_t seqd
   bLoadTickByTick = true;
   setAllowDiscontinuousTrackData(true);
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   useReverb();
   setAlwaysWriteInitialReverb(0);

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
@@ -40,6 +40,7 @@ TamSoftPS1Seq::TamSoftPS1Seq(RawFile *file, uint32_t offset, uint8_t theSong, co
     : VGMSeq(TamSoftPS1Format::name, file, offset, 0, name), song(theSong), ps2(false), type(0) {
   bLoadTickByTick = true;
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
 
   const double PSX_NTSC_FRAMERATE = 53222400.0 / 263.0 / 3413.0;
   setAlwaysWriteInitialTempo(60.0 / (SEQ_PPQN / PSX_NTSC_FRAMERATE));

--- a/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
@@ -14,6 +14,7 @@ DECLARE_FORMAT(TriAcePS1);
 TriAcePS1Seq::TriAcePS1Seq(RawFile *file, uint32_t offset, const std::string &name)
     : VGMSeq(TriAcePS1Format::name, file, offset, 0, name) {
   setUseLinearAmplitudeScale(true);
+  setUseLinearPanAmplitudeScale(PanVolumeCorrectionMode::kNoVolumeAdjust);
   useReverb();
   setAlwaysWriteInitialPitchBendRange(12 * 100);
 }


### PR DESCRIPTION
> [!WARNING]
> Pretty close, but still WIP. Making a PR for the sake of CI, it's easier to get testing builds for other OSes this way.
> Will provide audio samples!

## Description

This PR introduces NDS format enhancements.

- Adds modulator support (vibrato/tremolo via LFO), pitch sweep events, and master volume handling
- Implements portamento/glide events
- Adds tie mode support where notes can be tied across consecutive events
- Fixed bend range units for accurate pitch bend conversion
- Introduces a separate `linearPanAmplitudeScale` flag (`m_useLinearPanAmpScale`) distinct from the existing `usesLinearAmplitudeScale`
- `insertModulationDepthRange` now properly inserts modulation depth range using RPN/NRPN with the correct semitone bounds (0-24) and splits into MSB/LSB.

## Motivation and Context

Increase NDS conversion accuracy. After this PR, the only two items left for complete support are dynamic ADSR and the SSEQ VM instructions (in the whole commercial NDS library, those aren't actually used that much!)

## How Has This Been Tested

Tried many games, constructed a test SDAT with a lot of pain and suffering to compare our output to real hardware and emulators. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.