### PR TITLE
NinSnes: add vibrato support

### DIFF
--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -216,6 +216,10 @@ void VGMSeq::loadTracksMain(uint32_t stopTime) {
         itrSlider = itrNextSlider;
       }
 
+      if (hasActiveTracks()) {
+        onTickEnd();
+      }
+
       if (bIncTickAfterProcessingTracks == true) {
         time++;
       }

--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -39,6 +39,7 @@ class VGMSeq : public VGMFile {
   virtual bool parseHeader();
   virtual bool parseTrackPointers();  // Function to find all of the track pointers.   Returns number of total tracks.
   virtual void resetVars();
+  virtual void onTickEnd() {}
   virtual void useColl(const VGMColl* coll) {}
   virtual MidiFile *convertToMidi(const VGMColl* coll = nullptr);
   virtual MidiTrack *firstMidiTrack();

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -5,6 +5,7 @@
  */
 #include "NinSnesInstr.h"
 #include "NinSnesSeq.h"
+#include "NinSnesVibrato.h"
 #include "SNESDSP.h"
 #include "VGMColl.h"
 #include <spdlog/fmt/fmt.h>
@@ -25,6 +26,34 @@ uint32_t getProgramNumber(const VGMInstr* instr) {
 bool usesIntelliTempDrumKitExport(NinSnesProfileId profileId) {
   const auto intelliMode = getNinSnesProfile(profileId).intelliMode;
   return intelliMode == NinSnesIntelliModeId::Ta || intelliMode == NinSnesIntelliModeId::Fe4;
+}
+
+void addVibratoExportHandling(VGMInstr* instr) {
+  // NinSnes drives vibrato from per-track controllers, so every exportable instrument shares the
+  // same ModWheel/ChannelPressure/CC93 wiring and only the final ranges vary per sequence.
+  instr->addStandardVibratoHandling(nin_snes::vibrato::defaultMaxDepthCents(),
+                                    nin_snes::vibrato::minRateHz(),
+                                    nin_snes::vibrato::defaultMaxRateHz(),
+                                    VGMInstr::DelayRange{
+                                        nin_snes::vibrato::minDelaySeconds(),
+                                        nin_snes::vibrato::maxDelaySeconds(),
+                                    });
+}
+
+void applyVibratoExportScaling(NinSnesInstrSet* instrSet, double maxDepthCents, double maxRateHz) {
+  const double effectiveMaxDepthCents =
+      (maxDepthCents > 0.0) ? maxDepthCents : nin_snes::vibrato::defaultMaxDepthCents();
+  const double effectiveMaxRateHz =
+      (maxRateHz > 0.0) ? maxRateHz : nin_snes::vibrato::defaultMaxRateHz();
+
+  for (auto* instr : instrSet->exportInstrs()) {
+    instr->updateModulatorAmount(ModSource::ModWheel,
+                                 ModDest::VibLfoToPitch,
+                                 ModAmount::fromCents(effectiveMaxDepthCents));
+    instr->updateModulatorAmount(ModSource::ChannelPressure,
+                                 ModDest::VibLfoFreq,
+                                 ModAmount::fromHertzRange(nin_snes::vibrato::minRateHz(), effectiveMaxRateHz));
+  }
 }
 
 VGMInstr* findInstrByProgram(const std::vector<VGMInstr*>& instrs, uint32_t progNum) {
@@ -273,13 +302,19 @@ bool NinSnesInstrSet::parseInstrPointers() {
 }
 
 void NinSnesInstrSet::useColl(const VGMColl* coll) {
-  if (coll->seq() == nullptr) {
+  double maxVibratoDepthCents = nin_snes::vibrato::defaultMaxDepthCents();
+  double maxVibratoRateHz = nin_snes::vibrato::defaultMaxRateHz();
+  const auto* seq = dynamic_cast<const NinSnesSeq*>(coll != nullptr ? coll->seq() : nullptr);
+  if (seq == nullptr || seq->rawFile() != rawFile() || seq->profileId != profileId) {
+    applyVibratoExportScaling(this, maxVibratoDepthCents, maxVibratoRateHz);
     return;
   }
 
-  const auto* seq = dynamic_cast<const NinSnesSeq*>(coll->seq());
-  if (seq == nullptr || seq->rawFile() != rawFile() || seq->profileId != profileId) {
-    return;
+  if (seq->maxVibratoDepthCents > 0.0) {
+    maxVibratoDepthCents = seq->maxVibratoDepthCents;
+  }
+  if (seq->maxVibratoRateHz > 0.0) {
+    maxVibratoRateHz = seq->maxVibratoRateHz;
   }
 
   if (usesIntelliTempDrumKitExport(seq->profileId)) {
@@ -291,6 +326,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
           overrideDef.progNum >> 7,
           overrideDef.progNum & 0x7f,
           fmt::format("Instrument {:d} (Overwrite)", overrideDef.logicalInstrIndex));
+      addVibratoExportHandling(overrideInstr);
       auto* rgn =
           createRgnFromHeaderData(overrideInstr, rawFile(), profileId, spcDirAddr, overrideDef.regionData);
       if (rgn == nullptr) {
@@ -304,6 +340,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
     for (const auto& drumKitDef : seq->intelliTADrumKitDefs()) {
       auto* drumKit = new VGMInstr(
           this, 0, 0, 127, drumKitDef.program, fmt::format("Drum Kit {:d}", drumKitDef.program));
+      addVibratoExportHandling(drumKit);
 
       for (size_t slot = 0; slot < drumKitDef.slots.size(); slot++) {
         const auto& slotDef = drumKitDef.slots[slot];
@@ -330,42 +367,46 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
 
       addTempInstr(drumKit);
     }
+  } else {
+    const auto& percussionInstrNoteMap = seq->percussionInstrNoteMap();
+    if (!percussionInstrNoteMap.empty()) {
+      auto* drumKit = new VGMInstr(this, 0, 0, 127, 0, "Drum Kit");
+      addVibratoExportHandling(drumKit);
+      for (const auto& [instrIndex, percussionDef] : percussionInstrNoteMap) {
+        VGMInstr* sourceInstr = nullptr;
+        for (auto* instr : aInstrs) {
+          if (instr->instrNum == instrIndex) {
+            sourceInstr = instr;
+            break;
+          }
+        }
+        if (sourceInstr == nullptr) {
+          continue;
+        }
 
-    return;
-  }
+        for (auto* sourceRgn : sourceInstr->regions()) {
+          drumKit->addRgn(cloneLegacyRgnForDrumKit(drumKit,
+                                                   sourceRgn,
+                                                   percussionDef.noteIndex,
+                                                   percussionDef.globalTranspose));
+        }
+      }
 
-  const auto& percussionInstrNoteMap = seq->percussionInstrNoteMap();
-  if (percussionInstrNoteMap.empty()) {
-    return;
-  }
-
-  // Create the drumkit instrument for percussion note events
-  auto* drumKit = new VGMInstr(this, 0, 0, 127, 0, "Drum Kit");
-  for (const auto& [instrIndex, percussionDef] : percussionInstrNoteMap) {
-    // Get the referenced instrument by checking its instrument number
-    VGMInstr* sourceInstr = nullptr;
-    for (auto* instr : aInstrs) {
-      if (instr->instrNum == instrIndex) {
-        sourceInstr = instr;
-        break;
+      if (drumKit->regions().empty()) {
+        delete drumKit;
+      } else {
+        addTempInstr(drumKit);
       }
     }
-    if (sourceInstr == nullptr) {
-      continue;
-    }
-
-    for (auto* sourceRgn : sourceInstr->regions()) {
-      drumKit->addRgn(
-          cloneLegacyRgnForDrumKit(drumKit, sourceRgn, percussionDef.noteIndex, percussionDef.globalTranspose));
-    }
   }
 
-  if (drumKit->regions().empty()) {
-    delete drumKit;
-    return;
-  }
+  applyVibratoExportScaling(this, maxVibratoDepthCents, maxVibratoRateHz);
+}
 
-  addTempInstr(drumKit);
+void NinSnesInstrSet::unuseColl() {
+  applyVibratoExportScaling(this,
+                            nin_snes::vibrato::defaultMaxDepthCents(),
+                            nin_snes::vibrato::defaultMaxRateHz());
 }
 
 // *************
@@ -394,6 +435,8 @@ bool NinSnesInstr::loadInstr() {
   if (offDirEnt + 4 > 0x10000) {
     return false;
   }
+
+  addVibratoExportHandling(this);
 
   uint16_t addrSampStart = readShort(offDirEnt);
 

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -19,6 +19,12 @@ struct NinSnesPitchTuning {
   int16_t fineTune = 0;
 };
 
+struct VibratoExportSettings {
+  const NinSnesSeq* seq = nullptr;
+  double maxDepthCents = nin_snes::vibrato::defaultMaxDepthCents();
+  double maxRateHz = nin_snes::vibrato::defaultMaxRateHz();
+};
+
 uint32_t getProgramNumber(const VGMInstr* instr) {
   return (instr->bank << 7) | (instr->instrNum & 0x7f);
 }
@@ -54,6 +60,25 @@ void applyVibratoExportScaling(NinSnesInstrSet* instrSet, double maxDepthCents, 
                                  ModDest::VibLfoFreq,
                                  ModAmount::fromHertzRange(nin_snes::vibrato::minRateHz(), effectiveMaxRateHz));
   }
+}
+
+VibratoExportSettings resolveVibratoExportSettings(const NinSnesInstrSet& instrSet,
+                                                   const VGMColl* coll) {
+  VibratoExportSettings settings;
+
+  const auto* seq = dynamic_cast<const NinSnesSeq*>(coll != nullptr ? coll->seq() : nullptr);
+  if (seq == nullptr || seq->rawFile() != instrSet.rawFile() || seq->profileId != instrSet.profileId) {
+    return settings;
+  }
+
+  settings.seq = seq;
+  if (seq->maxVibratoDepthCents > 0.0) {
+    settings.maxDepthCents = seq->maxVibratoDepthCents;
+  }
+  if (seq->maxVibratoRateHz > 0.0) {
+    settings.maxRateHz = seq->maxVibratoRateHz;
+  }
+  return settings;
 }
 
 VGMInstr* findInstrByProgram(const std::vector<VGMInstr*>& instrs, uint32_t progNum) {
@@ -99,10 +124,10 @@ NinSnesPitchTuning calculatePitchTuning(uint16_t pitchScale) {
   };
 }
 
-VGMRgn* cloneLegacyRgnForDrumKit(VGMInstr* instr,
-                                 VGMRgn* sourceRgn,
-                                 uint8_t noteIndex,
-                                 int8_t globalTranspose) {
+VGMRgn* cloneStandardRgnForDrumKit(VGMInstr* instr,
+                                   VGMRgn* sourceRgn,
+                                   uint8_t noteIndex,
+                                   int8_t globalTranspose) {
   auto* newRgn = new VGMRgn(instr,
                             sourceRgn->offset(),
                             sourceRgn->length(),
@@ -302,111 +327,112 @@ bool NinSnesInstrSet::parseInstrPointers() {
 }
 
 void NinSnesInstrSet::useColl(const VGMColl* coll) {
-  double maxVibratoDepthCents = nin_snes::vibrato::defaultMaxDepthCents();
-  double maxVibratoRateHz = nin_snes::vibrato::defaultMaxRateHz();
-  const auto* seq = dynamic_cast<const NinSnesSeq*>(coll != nullptr ? coll->seq() : nullptr);
-  if (seq == nullptr || seq->rawFile() != rawFile() || seq->profileId != profileId) {
-    applyVibratoExportScaling(this, maxVibratoDepthCents, maxVibratoRateHz);
-    return;
-  }
-
-  if (seq->maxVibratoDepthCents > 0.0) {
-    maxVibratoDepthCents = seq->maxVibratoDepthCents;
-  }
-  if (seq->maxVibratoRateHz > 0.0) {
-    maxVibratoRateHz = seq->maxVibratoRateHz;
-  }
-
-  if (usesIntelliTempDrumKitExport(seq->profileId)) {
-    for (const auto& overrideDef : seq->intelliTAInstrumentOverrides()) {
-      auto* overrideInstr = new VGMInstr(
-          this,
-          0,
-          NinSnesInstr::expectedSize(profileId),
-          overrideDef.progNum >> 7,
-          overrideDef.progNum & 0x7f,
-          fmt::format("Instrument {:d} (Overwrite)", overrideDef.logicalInstrIndex));
-      addVibratoExportHandling(overrideInstr);
-      auto* rgn =
-          createRgnFromHeaderData(overrideInstr, rawFile(), profileId, spcDirAddr, overrideDef.regionData);
-      if (rgn == nullptr) {
-        delete overrideInstr;
-        continue;
-      }
-      overrideInstr->addRgn(rgn);
-      addTempInstr(overrideInstr);
-    }
-
-    for (const auto& drumKitDef : seq->intelliTADrumKitDefs()) {
-      auto* drumKit = new VGMInstr(
-          this, 0, 0, 127, drumKitDef.program, fmt::format("Drum Kit {:d}", drumKitDef.program));
-      addVibratoExportHandling(drumKit);
-
-      for (size_t slot = 0; slot < drumKitDef.slots.size(); slot++) {
-        const auto& slotDef = drumKitDef.slots[slot];
-        if (!slotDef.active) {
-          continue;
-        }
-
-        VGMInstr* sourceInstr = findInstrByProgram(exportInstrs(), slotDef.sourceProgNum);
-        if (sourceInstr == nullptr) {
-          continue;
-        }
-
-        const uint8_t drumKey = static_cast<uint8_t>(0x24 + slot);
-        for (auto* sourceRgn : sourceInstr->regions()) {
-          drumKit->addRgn(
-              cloneIntelliTARgnForDrumKit(drumKit, sourceRgn, drumKey, slotDef.playedNoteByte));
-        }
-      }
-
-      if (drumKit->regions().empty()) {
-        delete drumKit;
-        continue;
-      }
-
-      addTempInstr(drumKit);
-    }
-  } else {
-    const auto& percussionInstrNoteMap = seq->percussionInstrNoteMap();
-    if (!percussionInstrNoteMap.empty()) {
-      auto* drumKit = new VGMInstr(this, 0, 0, 127, 0, "Drum Kit");
-      addVibratoExportHandling(drumKit);
-      for (const auto& [instrIndex, percussionDef] : percussionInstrNoteMap) {
-        VGMInstr* sourceInstr = nullptr;
-        for (auto* instr : aInstrs) {
-          if (instr->instrNum == instrIndex) {
-            sourceInstr = instr;
-            break;
-          }
-        }
-        if (sourceInstr == nullptr) {
-          continue;
-        }
-
-        for (auto* sourceRgn : sourceInstr->regions()) {
-          drumKit->addRgn(cloneLegacyRgnForDrumKit(drumKit,
-                                                   sourceRgn,
-                                                   percussionDef.noteIndex,
-                                                   percussionDef.globalTranspose));
-        }
-      }
-
-      if (drumKit->regions().empty()) {
-        delete drumKit;
-      } else {
-        addTempInstr(drumKit);
-      }
+  const auto exportSettings = resolveVibratoExportSettings(*this, coll);
+  if (exportSettings.seq != nullptr) {
+    if (usesIntelliTempDrumKitExport(exportSettings.seq->profileId)) {
+      addIntelliOverrideInstrs(*exportSettings.seq);
+      addIntelliDrumKits(*exportSettings.seq);
+    } else {
+      addStandardPercussionDrumKit(*exportSettings.seq);
     }
   }
 
-  applyVibratoExportScaling(this, maxVibratoDepthCents, maxVibratoRateHz);
+  applyVibratoExportScaling(this, exportSettings.maxDepthCents, exportSettings.maxRateHz);
 }
 
 void NinSnesInstrSet::unuseColl() {
   applyVibratoExportScaling(this,
                             nin_snes::vibrato::defaultMaxDepthCents(),
                             nin_snes::vibrato::defaultMaxRateHz());
+}
+
+void NinSnesInstrSet::addStandardPercussionDrumKit(const NinSnesSeq& seq) {
+  const auto& percussionInstrNoteMap = seq.percussionInstrNoteMap();
+  if (percussionInstrNoteMap.empty()) {
+    return;
+  }
+
+  auto* drumKit = new VGMInstr(this, 0, 0, 127, 0, "Drum Kit");
+  addVibratoExportHandling(drumKit);
+  for (const auto& [instrIndex, percussionDef] : percussionInstrNoteMap) {
+    VGMInstr* sourceInstr = nullptr;
+    for (auto* instr : aInstrs) {
+      if (instr->instrNum == instrIndex) {
+        sourceInstr = instr;
+        break;
+      }
+    }
+    if (sourceInstr == nullptr) {
+      continue;
+    }
+
+    for (auto* sourceRgn : sourceInstr->regions()) {
+      drumKit->addRgn(cloneStandardRgnForDrumKit(drumKit,
+                                                 sourceRgn,
+                                                 percussionDef.noteIndex,
+                                                 percussionDef.globalTranspose));
+    }
+  }
+
+  if (drumKit->regions().empty()) {
+    delete drumKit;
+  } else {
+    addTempInstr(drumKit);
+  }
+}
+
+void NinSnesInstrSet::addIntelliOverrideInstrs(const NinSnesSeq& seq) {
+  for (const auto& overrideDef : seq.intelliTAInstrumentOverrides()) {
+    auto* overrideInstr = new VGMInstr(this,
+                                       0,
+                                       NinSnesInstr::expectedSize(profileId),
+                                       overrideDef.progNum >> 7,
+                                       overrideDef.progNum & 0x7f,
+                                       fmt::format("Instrument {:d} (Overwrite)",
+                                                   overrideDef.logicalInstrIndex));
+    addVibratoExportHandling(overrideInstr);
+    auto* rgn =
+        createRgnFromHeaderData(overrideInstr, rawFile(), profileId, spcDirAddr, overrideDef.regionData);
+    if (rgn == nullptr) {
+      delete overrideInstr;
+      continue;
+    }
+    overrideInstr->addRgn(rgn);
+    addTempInstr(overrideInstr);
+  }
+}
+
+void NinSnesInstrSet::addIntelliDrumKits(const NinSnesSeq& seq) {
+  for (const auto& drumKitDef : seq.intelliTADrumKitDefs()) {
+    auto* drumKit =
+        new VGMInstr(this, 0, 0, 127, drumKitDef.program, fmt::format("Drum Kit {:d}", drumKitDef.program));
+    addVibratoExportHandling(drumKit);
+
+    for (size_t slot = 0; slot < drumKitDef.slots.size(); slot++) {
+      const auto& slotDef = drumKitDef.slots[slot];
+      if (!slotDef.active) {
+        continue;
+      }
+
+      VGMInstr* sourceInstr = findInstrByProgram(exportInstrs(), slotDef.sourceProgNum);
+      if (sourceInstr == nullptr) {
+        continue;
+      }
+
+      const uint8_t drumKey = static_cast<uint8_t>(0x24 + slot);
+      for (auto* sourceRgn : sourceInstr->regions()) {
+        drumKit->addRgn(
+            cloneIntelliTARgnForDrumKit(drumKit, sourceRgn, drumKey, slotDef.playedNoteByte));
+      }
+    }
+
+    if (drumKit->regions().empty()) {
+      delete drumKit;
+      continue;
+    }
+
+    addTempInstr(drumKit);
+  }
 }
 
 // *************

--- a/src/main/formats/NinSnes/NinSnesInstr.h
+++ b/src/main/formats/NinSnes/NinSnesInstr.h
@@ -5,6 +5,8 @@
 #include "NinSnesFormat.h"
 #include "NinSnesScanResult.h"
 
+class NinSnesSeq;
+
 // ****************
 // NinSnesInstrSet
 // ****************
@@ -34,6 +36,11 @@ class NinSnesInstrSet:
  protected:
   uint32_t spcDirAddr;
   std::vector<uint8_t> usedSRCNs;
+
+ private:
+  void addStandardPercussionDrumKit(const NinSnesSeq& seq);
+  void addIntelliOverrideInstrs(const NinSnesSeq& seq);
+  void addIntelliDrumKits(const NinSnesSeq& seq);
 };
 
 // *************

--- a/src/main/formats/NinSnes/NinSnesInstr.h
+++ b/src/main/formats/NinSnes/NinSnesInstr.h
@@ -23,6 +23,7 @@ class NinSnesInstrSet:
   bool parseHeader() override;
   bool parseInstrPointers() override;
   void useColl(const VGMColl* coll) override;
+  void unuseColl() override;
 
   NinSnesSignatureId signature;
   NinSnesProfileId profileId;

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -599,7 +599,7 @@ void NinSnesTrack::beginNoteVibrato() {
     return;
   }
 
-  // F0 is a reusable per-note fade-in for the currently configured E3 vibrato, so a real note-on
+  // EVENT_VIBRATO_FADE is a reusable per-note fade-in for the currently configured E3 vibrato, so a real note-on
   // either restarts that fade from zero depth or restores the steady-state depth immediately.
   if (vibrato.fade.length == 0) {
     vibrato.fade.delayRemaining = 0;

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -117,10 +117,7 @@ void NinSnesSeq::resetVars() {
   spcPercussionBase = spcPercussionBaseInit;
   sectionRepeatCount = 0;
   globalTranspose = 0;
-  tempo = nin_snes::vibrato::kDefaultTempo;
-  tempoFade = {};
-  tempoFade.currentTempo = tempo << 8;
-  tempoFade.targetTempo = tempoFade.currentTempo;
+  resetTempoState(nin_snes::vibrato::kDefaultTempo);
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     maxVibratoDepthCents = nin_snes::vibrato::minMaxDepthCents();
     maxVibratoRateHz = nin_snes::vibrato::minMaxRateHz();
@@ -350,10 +347,53 @@ double NinSnesSeq::getTempoInBPM(uint8_t tempoValue) {
   }
 }
 
-void NinSnesSeq::onTickEnd() {
-  if (advanceTempoFade(tempoFade) != FadeStepResult::Inactive && !aTracks.empty()) {
-    static_cast<NinSnesTrack*>(aTracks[0])->applyCurrentTempo();
+void NinSnesSeq::resetTempoState(uint8_t newTempo) {
+  tempo = newTempo;
+  tempoFade = {};
+  tempoFade.currentTempo = newTempo << 8;
+  tempoFade.targetTempo = tempoFade.currentTempo;
+}
+
+void NinSnesSeq::setTempoImmediate(uint8_t newTempo) {
+  resetTempoState(newTempo);
+  syncTrackVibratoToTempo();
+}
+
+void NinSnesSeq::beginTempoFade(uint8_t targetTempo, uint8_t fadeLength) {
+  if (fadeLength == 0) {
+    setTempoImmediate(targetTempo);
+    return;
   }
+
+  tempoFade.currentTempo = tempo << 8;
+  tempoFade.targetTempo = targetTempo << 8;
+  tempoFade.delta =
+      static_cast<int16_t>((tempoFade.targetTempo - tempoFade.currentTempo) / fadeLength);
+  tempoFade.length = fadeLength;
+}
+
+void NinSnesSeq::syncTrackVibratoToTempo() {
+  for (auto* track : aTracks) {
+    static_cast<NinSnesTrack*>(track)->syncVibratoRateAndDelay();
+  }
+}
+
+void NinSnesSeq::applyTempoFadeStep() {
+  if (advanceTempoFade(tempoFade) == FadeStepResult::Inactive) {
+    return;
+  }
+
+  const uint8_t newTempo = static_cast<uint8_t>(std::clamp(tempoFade.currentTempo >> 8, 0, 0xff));
+  if (newTempo == tempo) {
+    return;
+  }
+
+  tempo = newTempo;
+  syncTrackVibratoToTempo();
+}
+
+void NinSnesSeq::onTickEnd() {
+  applyTempoFadeStep();
 }
 
 uint16_t NinSnesSeq::convertToAPUAddress(uint16_t offset) {
@@ -626,20 +666,6 @@ void NinSnesTrack::syncVibratoRateAndDelay() {
                                                     parentSeq.maxVibratoRateHz));
   addControllerEventNoItem(nin_snes::vibrato::kDelayController,
                            convertVibratoDelayToMidi(vibrato.delay, currentTempo));
-}
-
-void NinSnesTrack::applyCurrentTempo() {
-  auto& parentSeq = seq();
-  const uint8_t newTempo =
-      static_cast<uint8_t>(std::clamp(parentSeq.tempoFade.currentTempo >> 8, 0, 0xff));
-  if (newTempo == parentSeq.tempo) {
-    return;
-  }
-
-  parentSeq.tempo = newTempo;
-  for (auto* track : parentSeq.aTracks) {
-    static_cast<NinSnesTrack*>(track)->syncVibratoRateAndDelay();
-  }
 }
 
 void NinSnesTrack::onTickBegin() {
@@ -930,14 +956,8 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
 
     case EVENT_TEMPO: {
       const uint8_t newTempo = readByte(curOffset++);
-      parentSeq.tempo = newTempo;
-      parentSeq.tempoFade = {};
-      parentSeq.tempoFade.currentTempo = newTempo << 8;
-      parentSeq.tempoFade.targetTempo = parentSeq.tempoFade.currentTempo;
+      parentSeq.setTempoImmediate(newTempo);
       addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
-      for (auto* track : parentSeq.aTracks) {
-        static_cast<NinSnesTrack*>(track)->syncVibratoRateAndDelay();
-      }
       return true;
     }
 
@@ -946,21 +966,7 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
       const uint8_t newTempo = readByte(curOffset++);
       addTempoSlide(beginOffset, curOffset - beginOffset, fadeLength,
                     static_cast<int>(60000000 / parentSeq.getTempoInBPM(newTempo)));
-      if (fadeLength == 0) {
-        parentSeq.tempo = newTempo;
-        parentSeq.tempoFade = {};
-        parentSeq.tempoFade.currentTempo = newTempo << 8;
-        parentSeq.tempoFade.targetTempo = parentSeq.tempoFade.currentTempo;
-        for (auto* track : parentSeq.aTracks) {
-          static_cast<NinSnesTrack*>(track)->syncVibratoRateAndDelay();
-        }
-      } else {
-        parentSeq.tempoFade.currentTempo = parentSeq.tempo << 8;
-        parentSeq.tempoFade.targetTempo = newTempo << 8;
-        parentSeq.tempoFade.delta = static_cast<int16_t>(
-            (parentSeq.tempoFade.targetTempo - parentSeq.tempoFade.currentTempo) / fadeLength);
-        parentSeq.tempoFade.length = fadeLength;
-      }
+      parentSeq.beginTempoFade(newTempo, fadeLength);
       return true;
     }
 

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -1,7 +1,11 @@
 #include "NinSnesSeq.h"
+#include "NinSnesVibrato.h"
+#include "Modulation.h"
 #include "SeqEvent.h"
 #include "ScaleConversion.h"
 #include "spdlog/fmt/fmt.h"
+#include <algorithm>
+#include <cmath>
 
 DECLARE_FORMAT(NinSnes);
 
@@ -12,12 +16,72 @@ DECLARE_FORMAT(NinSnes);
 #define SEQ_PPQN 48
 #define SEQ_KEYOFS 24
 
+namespace {
+
+enum class FadeStepResult {
+  Inactive,
+  Running,
+  Finished,
+};
+
+FadeStepResult advanceTempoFade(NinSnesSeq::ActiveTempoFade& fade) {
+  if (fade.length == 0) {
+    return FadeStepResult::Inactive;
+  }
+
+  // NinSnes advances the 8.8 tempo first, then decrements the remaining step count, and finally
+  // snaps exactly to the target on the last update.
+  fade.currentTempo += fade.delta;
+  fade.length -= 1;
+  if (fade.length == 0) {
+    fade.currentTempo = fade.targetTempo;
+    return FadeStepResult::Finished;
+  }
+  return FadeStepResult::Running;
+}
+
+uint8_t convertVibratoDepthToMidi(uint8_t depth, double maxDepthCents) {
+  if (depth == 0) {
+    return 0;
+  }
+
+  const double effectiveMaxDepthCents =
+      (maxDepthCents > 0.0) ? maxDepthCents : nin_snes::vibrato::defaultMaxDepthCents();
+  const int midiValue = static_cast<int>(
+      std::lround(128.0 * nin_snes::vibrato::depthCents(depth) / effectiveMaxDepthCents));
+  return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
+}
+
+uint8_t convertVibratoRateToMidi(uint8_t rate, double tempo, double maxRateHz) {
+  const double currentRateHz = nin_snes::vibrato::rateHz(rate, tempo);
+  if (currentRateHz <= 0.0) {
+    return 0;
+  }
+
+  const double effectiveMaxRateHz =
+      (maxRateHz > 0.0) ? maxRateHz : nin_snes::vibrato::defaultMaxRateHz();
+  return midiValueForHertzInRange(currentRateHz,
+                                  nin_snes::vibrato::minRateHz(),
+                                  effectiveMaxRateHz);
+}
+
+uint8_t convertVibratoDelayToMidi(uint8_t delay, double tempo) {
+  return midiValueForSecondsInRange(nin_snes::vibrato::delaySeconds(delay, tempo),
+                                    nin_snes::vibrato::minDelaySeconds(),
+                                    nin_snes::vibrato::maxDelaySeconds());
+}
+
+}  // namespace
+
 NinSnesSeq::NinSnesSeq(RawFile* file, NinSnesProfileId profile, uint32_t offset,
                        uint8_t percussion_base, const std::vector<uint8_t>& theVolumeTable,
                        const std::vector<uint8_t>& theDurRateTable, std::string theName)
     : VGMMultiSectionSeq(NinSnesFormat::name, file, offset, 0, theName),
       signature(NinSnesSignatureId::None), profileId(profile), header(NULL),
       volumeTable(theVolumeTable), durRateTable(theDurRateTable),
+      tempo(nin_snes::vibrato::kDefaultTempo),
+      maxVibratoDepthCents(nin_snes::vibrato::minMaxDepthCents()),
+      maxVibratoRateHz(nin_snes::vibrato::minMaxRateHz()),
       spcPercussionBaseInit(percussion_base), konamiBaseAddress(0), quintetBGMInstrBase(0),
       falcomBaseOffset(0), m_nextIntelliTAOverrideProgram(0x80) {
   bLoadTickByTick = true;
@@ -53,6 +117,14 @@ void NinSnesSeq::resetVars() {
   spcPercussionBase = spcPercussionBaseInit;
   sectionRepeatCount = 0;
   globalTranspose = 0;
+  tempo = nin_snes::vibrato::kDefaultTempo;
+  tempoFade = {};
+  tempoFade.currentTempo = tempo << 8;
+  tempoFade.targetTempo = tempoFade.currentTempo;
+  if (readMode != READMODE_CONVERT_TO_MIDI) {
+    maxVibratoDepthCents = nin_snes::vibrato::minMaxDepthCents();
+    maxVibratoRateHz = nin_snes::vibrato::minMaxRateHz();
+  }
   m_percussionInstrNoteMap.clear();
 
   // Intelligent Systems:
@@ -265,11 +337,22 @@ void NinSnesSeq::loadEventMap() {
   intelliDurVolTable = definition.intelliDurVolTable;
 }
 
-double NinSnesSeq::getTempoInBPM(uint8_t tempo) {
-  if (tempo != 0) {
-    return (double)60000000 / (SEQ_PPQN * 2000) * ((double)tempo / 256);
+double NinSnesSeq::getTempoInBPM() {
+  return getTempoInBPM(tempo);
+}
+
+double NinSnesSeq::getTempoInBPM(uint8_t tempoValue) {
+  if (tempoValue != 0) {
+    return static_cast<double>(60000000) / (SEQ_PPQN * 2000) *
+           (static_cast<double>(tempoValue) / 256);
   } else {
     return 1.0;  // since tempo 0 cannot be expressed, this function returns a very small value.
+  }
+}
+
+void NinSnesSeq::onTickEnd() {
+  if (advanceTempoFade(tempoFade) != FadeStepResult::Inactive && !aTracks.empty()) {
+    static_cast<NinSnesTrack*>(aTracks[0])->applyCurrentTempo();
   }
 }
 
@@ -376,6 +459,7 @@ void NinSnesTrackSharedData::resetVars(void) {
   // Konami:
   konamiLoopStart = 0;
   konamiLoopCount = 0;
+  vibrato = {};
 }
 
 //  ************
@@ -395,6 +479,9 @@ void NinSnesTrack::resetVars() {
   cKeyCorrection = SEQ_KEYOFS;
   if (shared != NULL) {
     transpose = shared->spcTranspose;
+    vibrato = shared->vibrato;
+  } else {
+    vibrato = {};
   }
   m_lastNoteWasPercussion = false;
   nonPercussionProgram = 0;
@@ -465,6 +552,98 @@ NinSnesSeq& NinSnesTrack::seq() const {
 
 NinSnesIntelliModeId NinSnesTrack::intelliMode() const {
   return seq().profile().intelliMode;
+}
+
+void NinSnesTrack::beginNoteVibrato() {
+  if (!vibrato.active()) {
+    return;
+  }
+
+  // F0 is a reusable per-note fade-in for the currently configured E3 vibrato, so a real note-on
+  // either restarts that fade from zero depth or restores the steady-state depth immediately.
+  if (vibrato.fade.length == 0) {
+    vibrato.fade.delayRemaining = 0;
+    vibrato.fade.ticksRemaining = 0;
+    setVibratoDepth(vibrato.depth);
+  } else {
+    vibrato.fade.delayRemaining = vibrato.delay;
+    vibrato.fade.ticksRemaining = vibrato.fade.length;
+    setVibratoDepth(0);
+  }
+}
+
+void NinSnesTrack::updateVibratoFade() {
+  if (vibrato.fade.ticksRemaining == 0) {
+    return;
+  }
+
+  if (vibrato.fade.delayRemaining > 0) {
+    vibrato.fade.delayRemaining -= 1;
+    syncSharedVibratoState();
+    return;
+  }
+
+  vibrato.fade.ticksRemaining -= 1;
+  const uint8_t depth = (vibrato.fade.ticksRemaining == 0)
+      ? vibrato.depth
+      : std::min<uint8_t>(vibrato.depth, vibrato.fade.currentDepth + vibrato.fade.step);
+  setVibratoDepth(depth);
+}
+
+void NinSnesTrack::setVibratoDepth(uint8_t depth) {
+  vibrato.fade.currentDepth = depth;
+  const uint8_t midiDepth = convertVibratoDepthToMidi(depth, seq().maxVibratoDepthCents);
+  if (midiDepth != vibrato.fade.midiDepth) {
+    addModulationNoItem(midiDepth);
+  }
+  vibrato.fade.midiDepth = midiDepth;
+  syncSharedVibratoState();
+}
+
+void NinSnesTrack::syncSharedVibratoState() {
+  if (shared == nullptr) {
+    return;
+  }
+
+  shared->vibrato = vibrato;
+}
+
+void NinSnesTrack::syncVibratoRateAndDelay() {
+  if (!vibrato.active()) {
+    return;
+  }
+
+  auto& parentSeq = seq();
+  const double currentTempo = parentSeq.tempo;
+  if (readMode != READMODE_CONVERT_TO_MIDI) {
+    // Rate and delay are both tempo-relative, so a sequence-specific max only makes sense once the
+    // current tempo has been folded into the exported Hz value.
+    parentSeq.maxVibratoRateHz =
+        std::max(parentSeq.maxVibratoRateHz, nin_snes::vibrato::rateHz(vibrato.rate, currentTempo));
+  }
+
+  addChannelPressureNoItem(convertVibratoRateToMidi(vibrato.rate, currentTempo,
+                                                    parentSeq.maxVibratoRateHz));
+  addControllerEventNoItem(nin_snes::vibrato::kDelayController,
+                           convertVibratoDelayToMidi(vibrato.delay, currentTempo));
+}
+
+void NinSnesTrack::applyCurrentTempo() {
+  auto& parentSeq = seq();
+  const uint8_t newTempo =
+      static_cast<uint8_t>(std::clamp(parentSeq.tempoFade.currentTempo >> 8, 0, 0xff));
+  if (newTempo == parentSeq.tempo) {
+    return;
+  }
+
+  parentSeq.tempo = newTempo;
+  for (auto* track : parentSeq.aTracks) {
+    static_cast<NinSnesTrack*>(track)->syncVibratoRateAndDelay();
+  }
+}
+
+void NinSnesTrack::onTickBegin() {
+  updateVibratoFade();
 }
 
 void NinSnesTrack::readStandardNoteParam(uint32_t beginOffset, uint8_t statusByte,
@@ -597,6 +776,7 @@ bool NinSnesTrack::handleCoreEvent(NinSnesSeqEventType eventType, uint32_t begin
       const uint8_t noteNumber = statusByte - parentSeq.STATUS_NOTE_MIN;
       const uint8_t duration = getEffectiveNoteDuration();
       restoreNonPercussionProgramIfNeeded();
+      beginNoteVibrato();
       addNoteByDur(beginOffset, curOffset - beginOffset, noteNumber, shared->spcNoteVolume / 2,
                    duration, "Note");
       m_lastNoteWasPercussion = false;
@@ -635,6 +815,7 @@ bool NinSnesTrack::handleCoreEvent(NinSnesSeqEventType eventType, uint32_t begin
       parentSeq.addPercussionInstrNoteMapping(instrIndex, noteIndex, parentSeq.globalTranspose);
 
       switchToPercussionProgramIfNeeded();
+      beginNoteVibrato();
       addPercNoteByDur(beginOffset, curOffset - beginOffset,
                        static_cast<int8_t>(noteIndex - cKeyCorrection - parentSeq.globalTranspose),
                        shared->spcNoteVolume / 2, duration, "Percussion Note");
@@ -702,17 +883,35 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
     }
 
     case EVENT_VIBRATO_ON: {
-      const uint8_t vibratoDelay = readByte(curOffset++);
-      const uint8_t vibratoRate = readByte(curOffset++);
-      const uint8_t vibratoDepth = readByte(curOffset++);
-      desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}", vibratoDelay, vibratoRate,
-                         vibratoDepth);
+      vibrato.delay = readByte(curOffset++);
+      vibrato.rate = readByte(curOffset++);
+      vibrato.depth = readByte(curOffset++);
+      vibrato.fade = {};
+      desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}", vibrato.delay, vibrato.rate,
+                         vibrato.depth);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, Type::Vibrato);
+      if (vibrato.active()) {
+        if (readMode != READMODE_CONVERT_TO_MIDI) {
+          parentSeq.maxVibratoDepthCents =
+              std::max(parentSeq.maxVibratoDepthCents, nin_snes::vibrato::depthCents(vibrato.depth));
+        }
+        setVibratoDepth(vibrato.depth);
+        syncVibratoRateAndDelay();
+      } else {
+        setVibratoDepth(0);
+        addChannelPressureNoItem(0);
+        addControllerEventNoItem(nin_snes::vibrato::kDelayController, 0);
+      }
       return true;
     }
 
     case EVENT_VIBRATO_OFF:
+      vibrato = {};
+      syncSharedVibratoState();
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Off", desc, Type::Vibrato);
+      addModulationNoItem(0);
+      addChannelPressureNoItem(0);
+      addControllerEventNoItem(nin_snes::vibrato::kDelayController, 0);
       return true;
 
     case EVENT_MASTER_VOLUME: {
@@ -731,7 +930,14 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
 
     case EVENT_TEMPO: {
       const uint8_t newTempo = readByte(curOffset++);
+      parentSeq.tempo = newTempo;
+      parentSeq.tempoFade = {};
+      parentSeq.tempoFade.currentTempo = newTempo << 8;
+      parentSeq.tempoFade.targetTempo = parentSeq.tempoFade.currentTempo;
       addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
+      for (auto* track : parentSeq.aTracks) {
+        static_cast<NinSnesTrack*>(track)->syncVibratoRateAndDelay();
+      }
       return true;
     }
 
@@ -740,6 +946,21 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
       const uint8_t newTempo = readByte(curOffset++);
       addTempoSlide(beginOffset, curOffset - beginOffset, fadeLength,
                     static_cast<int>(60000000 / parentSeq.getTempoInBPM(newTempo)));
+      if (fadeLength == 0) {
+        parentSeq.tempo = newTempo;
+        parentSeq.tempoFade = {};
+        parentSeq.tempoFade.currentTempo = newTempo << 8;
+        parentSeq.tempoFade.targetTempo = parentSeq.tempoFade.currentTempo;
+        for (auto* track : parentSeq.aTracks) {
+          static_cast<NinSnesTrack*>(track)->syncVibratoRateAndDelay();
+        }
+      } else {
+        parentSeq.tempoFade.currentTempo = parentSeq.tempo << 8;
+        parentSeq.tempoFade.targetTempo = newTempo << 8;
+        parentSeq.tempoFade.delta = static_cast<int16_t>(
+            (parentSeq.tempoFade.targetTempo - parentSeq.tempoFade.currentTempo) / fadeLength);
+        parentSeq.tempoFade.length = fadeLength;
+      }
       return true;
     }
 
@@ -788,6 +1009,14 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
       const uint8_t fadeLength = readByte(curOffset++);
       desc = fmt::format("Length: {:d}", fadeLength);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Fade", desc, Type::Vibrato);
+      if (fadeLength == 0) {
+        vibrato.fade.length = 0;
+        vibrato.fade.step = 0;
+      } else {
+        vibrato.fade.length = fadeLength;
+        vibrato.fade.step = vibrato.depth / fadeLength;
+      }
+      syncSharedVibratoState();
       return true;
     }
 

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -117,7 +117,8 @@ void NinSnesSeq::resetVars() {
   spcPercussionBase = spcPercussionBaseInit;
   sectionRepeatCount = 0;
   globalTranspose = 0;
-  resetTempoState(nin_snes::vibrato::kDefaultTempo);
+  setImmediateTempo(nin_snes::vibrato::kDefaultTempo);
+
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     maxVibratoDepthCents = nin_snes::vibrato::minMaxDepthCents();
     maxVibratoRateHz = nin_snes::vibrato::minMaxRateHz();
@@ -347,53 +348,31 @@ double NinSnesSeq::getTempoInBPM(uint8_t tempoValue) {
   }
 }
 
-void NinSnesSeq::resetTempoState(uint8_t newTempo) {
+void NinSnesSeq::setImmediateTempo(uint8_t newTempo) {
   tempo = newTempo;
   tempoFade = {};
   tempoFade.currentTempo = newTempo << 8;
   tempoFade.targetTempo = tempoFade.currentTempo;
 }
 
-void NinSnesSeq::setTempoImmediate(uint8_t newTempo) {
-  resetTempoState(newTempo);
-  syncTrackVibratoToTempo();
-}
-
-void NinSnesSeq::beginTempoFade(uint8_t targetTempo, uint8_t fadeLength) {
-  if (fadeLength == 0) {
-    setTempoImmediate(targetTempo);
-    return;
-  }
-
+void NinSnesSeq::startTempoFade(uint8_t fadeLength, uint8_t targetTempo) {
   tempoFade.currentTempo = tempo << 8;
   tempoFade.targetTempo = targetTempo << 8;
-  tempoFade.delta =
-      static_cast<int16_t>((tempoFade.targetTempo - tempoFade.currentTempo) / fadeLength);
+  tempoFade.delta = static_cast<int16_t>((tempoFade.targetTempo - tempoFade.currentTempo) / fadeLength);
   tempoFade.length = fadeLength;
 }
 
-void NinSnesSeq::syncTrackVibratoToTempo() {
+void NinSnesSeq::syncTempoDependentTracks() {
   for (auto* track : aTracks) {
     static_cast<NinSnesTrack*>(track)->syncVibratoRateAndDelay();
   }
 }
 
-void NinSnesSeq::applyTempoFadeStep() {
-  if (advanceTempoFade(tempoFade) == FadeStepResult::Inactive) {
-    return;
-  }
-
-  const uint8_t newTempo = static_cast<uint8_t>(std::clamp(tempoFade.currentTempo >> 8, 0, 0xff));
-  if (newTempo == tempo) {
-    return;
-  }
-
-  tempo = newTempo;
-  syncTrackVibratoToTempo();
-}
-
 void NinSnesSeq::onTickEnd() {
-  applyTempoFadeStep();
+  // EVENT_TEMPO_FADE applies its first tempo step at the end of the tick that parsed the command.
+  if (advanceTempoFade(tempoFade) != FadeStepResult::Inactive && !aTracks.empty()) {
+    static_cast<NinSnesTrack*>(aTracks[0])->applyCurrentTempo();
+  }
 }
 
 uint16_t NinSnesSeq::convertToAPUAddress(uint16_t offset) {
@@ -517,7 +496,7 @@ void NinSnesTrack::resetVars() {
   SeqTrack::resetVars();
 
   cKeyCorrection = SEQ_KEYOFS;
-  if (shared != NULL) {
+  if (shared != nullptr) {
     transpose = shared->spcTranspose;
     vibrato = shared->vibrato;
   } else {
@@ -528,6 +507,10 @@ void NinSnesTrack::resetVars() {
   currentPercussionProgram = 0;
   currentLogicalProgram.reset();
   intelliLegato = false;
+}
+
+void NinSnesTrack::onTickBegin() {
+  updateVibratoFade();
 }
 
 uint8_t NinSnesTrack::getEffectiveNoteDuration() const {
@@ -604,12 +587,27 @@ void NinSnesTrack::beginNoteVibrato() {
   if (vibrato.fade.length == 0) {
     vibrato.fade.delayRemaining = 0;
     vibrato.fade.ticksRemaining = 0;
-    setVibratoDepth(vibrato.depth);
   } else {
     vibrato.fade.delayRemaining = vibrato.delay;
     vibrato.fade.ticksRemaining = vibrato.fade.length;
-    setVibratoDepth(0);
   }
+  setVibratoDepth(vibrato.fade.length == 0 ? vibrato.depth : 0);
+}
+
+void NinSnesTrack::applyConfiguredVibrato() {
+  if (vibrato.active()) {
+    auto& parentSeq = seq();
+    if (readMode != READMODE_CONVERT_TO_MIDI) {
+      parentSeq.maxVibratoDepthCents =
+          std::max(parentSeq.maxVibratoDepthCents, nin_snes::vibrato::depthCents(vibrato.depth));
+    }
+    setVibratoDepth(vibrato.depth);
+    syncVibratoRateAndDelay();
+    return;
+  }
+
+  setVibratoDepth(0);
+  clearVibratoRateAndDelay();
 }
 
 void NinSnesTrack::updateVibratoFade() {
@@ -624,6 +622,7 @@ void NinSnesTrack::updateVibratoFade() {
   }
 
   vibrato.fade.ticksRemaining -= 1;
+  // NinSnes increments the raw depth byte each tick and snaps exactly to the target at the end.
   const uint8_t depth = (vibrato.fade.ticksRemaining == 0)
       ? vibrato.depth
       : std::min<uint8_t>(vibrato.depth, vibrato.fade.currentDepth + vibrato.fade.step);
@@ -638,6 +637,11 @@ void NinSnesTrack::setVibratoDepth(uint8_t depth) {
   }
   vibrato.fade.midiDepth = midiDepth;
   syncSharedVibratoState();
+}
+
+void NinSnesTrack::clearVibratoRateAndDelay() {
+  addChannelPressureNoItem(0);
+  addControllerEventNoItem(nin_snes::vibrato::kDelayController, 0);
 }
 
 void NinSnesTrack::syncSharedVibratoState() {
@@ -662,14 +666,21 @@ void NinSnesTrack::syncVibratoRateAndDelay() {
         std::max(parentSeq.maxVibratoRateHz, nin_snes::vibrato::rateHz(vibrato.rate, currentTempo));
   }
 
-  addChannelPressureNoItem(convertVibratoRateToMidi(vibrato.rate, currentTempo,
-                                                    parentSeq.maxVibratoRateHz));
+  addChannelPressureNoItem(convertVibratoRateToMidi(vibrato.rate, currentTempo, parentSeq.maxVibratoRateHz));
   addControllerEventNoItem(nin_snes::vibrato::kDelayController,
                            convertVibratoDelayToMidi(vibrato.delay, currentTempo));
 }
 
-void NinSnesTrack::onTickBegin() {
-  updateVibratoFade();
+void NinSnesTrack::applyCurrentTempo() {
+  auto& parentSeq = seq();
+  const uint8_t newTempo = static_cast<uint8_t>(std::clamp(parentSeq.tempoFade.currentTempo >> 8, 0, 0xff));
+  if (newTempo == parentSeq.tempo) {
+    return;
+  }
+
+  parentSeq.tempo = newTempo;
+  addTempoBPMNoItem(parentSeq.getTempoInBPM(newTempo));
+  parentSeq.syncTempoDependentTracks();
 }
 
 void NinSnesTrack::readStandardNoteParam(uint32_t beginOffset, uint8_t statusByte,
@@ -916,18 +927,7 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
       desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}", vibrato.delay, vibrato.rate,
                          vibrato.depth);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, Type::Vibrato);
-      if (vibrato.active()) {
-        if (readMode != READMODE_CONVERT_TO_MIDI) {
-          parentSeq.maxVibratoDepthCents =
-              std::max(parentSeq.maxVibratoDepthCents, nin_snes::vibrato::depthCents(vibrato.depth));
-        }
-        setVibratoDepth(vibrato.depth);
-        syncVibratoRateAndDelay();
-      } else {
-        setVibratoDepth(0);
-        addChannelPressureNoItem(0);
-        addControllerEventNoItem(nin_snes::vibrato::kDelayController, 0);
-      }
+      applyConfiguredVibrato();
       return true;
     }
 
@@ -936,8 +936,7 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
       syncSharedVibratoState();
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Off", desc, Type::Vibrato);
       addModulationNoItem(0);
-      addChannelPressureNoItem(0);
-      addControllerEventNoItem(nin_snes::vibrato::kDelayController, 0);
+      clearVibratoRateAndDelay();
       return true;
 
     case EVENT_MASTER_VOLUME: {
@@ -956,17 +955,26 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
 
     case EVENT_TEMPO: {
       const uint8_t newTempo = readByte(curOffset++);
-      parentSeq.setTempoImmediate(newTempo);
+      parentSeq.setImmediateTempo(newTempo);
       addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
+      parentSeq.syncTempoDependentTracks();
       return true;
     }
 
     case EVENT_TEMPO_FADE: {
       const uint8_t fadeLength = readByte(curOffset++);
       const uint8_t newTempo = readByte(curOffset++);
-      addTempoSlide(beginOffset, curOffset - beginOffset, fadeLength,
-                    static_cast<int>(60000000 / parentSeq.getTempoInBPM(newTempo)));
-      parentSeq.beginTempoFade(newTempo, fadeLength);
+      if (fadeLength == 0) {
+        parentSeq.setImmediateTempo(newTempo);
+        addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
+        parentSeq.syncTempoDependentTracks();
+      } else {
+        const bool isNewOffset = onEvent(beginOffset, curOffset - beginOffset);
+        recordDurSeqEvent<TempoSlideSeqEvent>(isNewOffset, getTime(), fadeLength,
+                                              parentSeq.getTempoInBPM(newTempo), fadeLength,
+                                              beginOffset, curOffset - beginOffset, "Tempo Slide");
+        parentSeq.startTempoFade(fadeLength, newTempo);
+      }
       return true;
     }
 

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -11,6 +11,13 @@ struct NinSnesProfile;
 
 class NinSnesSeq : public VGMMultiSectionSeq {
 public:
+  struct ActiveTempoFade {
+    int32_t currentTempo = 0;
+    int32_t targetTempo = 0;
+    int16_t delta = 0;
+    uint8_t length = 0;
+  };
+
   NinSnesSeq(RawFile* file, NinSnesProfileId profile, uint32_t offset, uint8_t percussion_base = 0,
              const std::vector<uint8_t>& theVolumeTable = std::vector<uint8_t>(),
              const std::vector<uint8_t>& theDurRateTable = std::vector<uint8_t>(),
@@ -20,6 +27,7 @@ public:
 
   virtual bool parseHeader();
   virtual void resetVars();
+  void onTickEnd() override;
   virtual bool readEvent(long stopTime);
 
   const NinSnesProfile& profile() const;
@@ -53,6 +61,10 @@ public:
   uint8_t spcPercussionBase;
   uint8_t sectionRepeatCount;
   int8_t globalTranspose;
+  uint8_t tempo;
+  ActiveTempoFade tempoFade;
+  double maxVibratoDepthCents;
+  double maxVibratoRateHz;
 
   // Konami:
   uint16_t konamiBaseAddress;
@@ -115,8 +127,9 @@ public:
   NinSnesTrack(NinSnesSection* parentSection, uint32_t offset = 0, uint32_t length = 0,
                const std::string& theName = "NinSnes Track");
 
-  virtual void resetVars();
-  virtual bool readEvent();
+  void resetVars() override;
+  void onTickBegin() override;
+  bool readEvent() override;
 
   uint16_t convertToApuAddress(uint16_t offset);
   uint16_t getShortAddress(uint32_t offset);
@@ -129,6 +142,7 @@ public:
   bool available = true;
 
 private:
+  friend class NinSnesSeq;
   NinSnesSeq& seq() const;
   NinSnesIntelliModeId intelliMode() const;
   bool handleIntelliPercussionNote(uint32_t beginOffset, uint8_t slot, uint8_t duration);
@@ -144,6 +158,12 @@ private:
   bool handleIntelliEvent(NinSnesSeqEventType eventType, uint32_t beginOffset, uint8_t statusByte,
                           std::string& desc);
   void addPendingEndEvent(uint8_t statusByte, const std::string& desc);
+  void beginNoteVibrato();
+  void updateVibratoFade();
+  void setVibratoDepth(uint8_t depth);
+  void syncSharedVibratoState();
+  void syncVibratoRateAndDelay();
+  void applyCurrentTempo();
 
   uint8_t getEffectiveNoteDuration() const;
   void rememberMelodicProgram(uint32_t progNum,
@@ -162,4 +182,5 @@ private:
   uint8_t currentPercussionProgram = 0;
   std::optional<uint8_t> currentLogicalProgram;
   bool intelliLegato = false;
+  NinSnesTrackSharedData::VibratoState vibrato;
 };

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -102,7 +102,13 @@ protected:
   VGMHeader* header;
 
 private:
+  friend class NinSnesTrack;
   void loadEventMap();
+  void resetTempoState(uint8_t newTempo);
+  void setTempoImmediate(uint8_t newTempo);
+  void beginTempoFade(uint8_t targetTempo, uint8_t fadeLength);
+  void syncTrackVibratoToTempo();
+  void applyTempoFadeStep();
   NinSnesIntelliTADrumKitDef buildIntelliTADrumKitDef() const;
 
   uint8_t spcPercussionBaseInit;
@@ -163,7 +169,6 @@ private:
   void setVibratoDepth(uint8_t depth);
   void syncSharedVibratoState();
   void syncVibratoRateAndDelay();
-  void applyCurrentTempo();
 
   uint8_t getEffectiveNoteDuration() const;
   void rememberMelodicProgram(uint32_t progNum,

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -25,10 +25,10 @@ public:
   NinSnesSeq(RawFile* file, const NinSnesScanResult& scanResult);
   virtual ~NinSnesSeq();
 
-  virtual bool parseHeader();
-  virtual void resetVars();
+  bool parseHeader() override;
+  void resetVars() override;
   void onTickEnd() override;
-  virtual bool readEvent(long stopTime);
+  bool readEvent(long stopTime) override;
 
   const NinSnesProfile& profile() const;
   double getTempoInBPM();
@@ -104,11 +104,9 @@ protected:
 private:
   friend class NinSnesTrack;
   void loadEventMap();
-  void resetTempoState(uint8_t newTempo);
-  void setTempoImmediate(uint8_t newTempo);
-  void beginTempoFade(uint8_t targetTempo, uint8_t fadeLength);
-  void syncTrackVibratoToTempo();
-  void applyTempoFadeStep();
+  void setImmediateTempo(uint8_t newTempo);
+  void startTempoFade(uint8_t fadeLength, uint8_t targetTempo);
+  void syncTempoDependentTracks();
   NinSnesIntelliTADrumKitDef buildIntelliTADrumKitDef() const;
 
   uint8_t spcPercussionBaseInit;
@@ -166,8 +164,11 @@ private:
   void addPendingEndEvent(uint8_t statusByte, const std::string& desc);
   void beginNoteVibrato();
   void updateVibratoFade();
+  void applyConfiguredVibrato();
+  void clearVibratoRateAndDelay();
   void setVibratoDepth(uint8_t depth);
   void syncSharedVibratoState();
+  void applyCurrentTempo();
   void syncVibratoRateAndDelay();
 
   uint8_t getEffectiveNoteDuration() const;

--- a/src/main/formats/NinSnes/NinSnesSeqState.h
+++ b/src/main/formats/NinSnes/NinSnesSeqState.h
@@ -103,6 +103,28 @@ class NinSnesTrackSharedData {
   // Konami:
   uint16_t konamiLoopStart;
   uint8_t konamiLoopCount;
+
+  struct VibratoState {
+    struct Fade {
+      uint8_t length = 0;
+      uint8_t step = 0;
+      uint8_t delayRemaining = 0;
+      uint8_t ticksRemaining = 0;
+      uint8_t currentDepth = 0;
+      uint8_t midiDepth = 0;
+    };
+
+    uint8_t delay = 0;
+    uint8_t rate = 0;
+    uint8_t depth = 0;
+    Fade fade;
+
+    bool active() const {
+      return rate != 0 && depth != 0;
+    }
+  };
+
+  VibratoState vibrato;
 };
 
 struct NinSnesPercussionDef {

--- a/src/main/formats/NinSnes/NinSnesVibrato.h
+++ b/src/main/formats/NinSnes/NinSnesVibrato.h
@@ -1,0 +1,75 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace nin_snes::vibrato {
+
+constexpr double kTimerHz = 500.0;
+constexpr uint8_t kDefaultTempo = 0x20;
+constexpr uint8_t kDelayController = 93;
+constexpr uint8_t kMinVibratoMaxDepth = 0x80;
+constexpr uint8_t kMinVibratoMaxRate = 0x20;
+
+inline constexpr bool isActive(uint8_t rate, uint8_t depth) {
+  return rate != 0 && depth != 0;
+}
+
+inline constexpr double sanitizedTempo(double tempo) {
+  return (tempo > 0.0) ? tempo : 1.0;
+}
+
+// Depth 00-F0 uses the regular 1/256-semitone path. F1-FF switches to the large-depth mode that
+// reuses the low nibble as a 1-15 semitone multiplier.
+inline constexpr double depthCents(uint8_t depth) {
+  const double centsPerPitchUnit = 100.0 / 256.0;
+  if (depth <= 0xf0) {
+    return ((0xffu * depth) >> 8) * centsPerPitchUnit;
+  }
+  return (0xffu * (depth & 0x0fu)) * centsPerPitchUnit;
+}
+
+inline constexpr double rateHz(uint8_t rate, double tempo) {
+  return (kTimerHz * sanitizedTempo(tempo) * rate) / 65536.0;
+}
+
+inline constexpr double delaySeconds(uint8_t delay, double tempo) {
+  return (256.0 * delay) / (kTimerHz * sanitizedTempo(tempo));
+}
+
+inline constexpr double minRateHz() {
+  return rateHz(1, 1);
+}
+
+inline constexpr double defaultMaxRateHz() {
+  return rateHz(0xff, 0xff);
+}
+
+inline constexpr double defaultMaxDepthCents() {
+  return depthCents(0xff);
+}
+
+// The tracked sequence max only needs a minimum sensible range, not the full format maximum.
+inline constexpr double minMaxDepthCents() {
+  return depthCents(kMinVibratoMaxDepth);
+}
+
+inline constexpr double minMaxRateHz() {
+  return rateHz(kMinVibratoMaxRate, kDefaultTempo);
+}
+
+// Delay 00 is "start immediately". The SF2 export helper clamps that to the smallest normal
+// positive delay it can represent.
+inline constexpr double minDelaySeconds() {
+  return 0.0;
+}
+
+inline constexpr double maxDelaySeconds() {
+  return delaySeconds(0xff, 1);
+}
+
+}  // namespace nin_snes::vibrato


### PR DESCRIPTION
Vibrato on NinSnes is extremely similar to the KonamiSnes driver (I expect Konami took inspiration). EVENT_VIBRATO_ON takes three parameters: delay, rate, and depth. Both delay and rate are relative to the current tempo. There is also EVENT_VIBRATO_FADE, which just like the Konami driver, initiates a linear fade to the depth specified in the VIBRATO_ON event. The fade begins after note activation when the delay ticks have elapsed.

I've added a new callback in VGMSeq for tick-by-tick parsing: `onTickEnd()`. Tempo slide no longer uses addTempoBPMSlide, but instead sets the tempo iteratively at the end of a tick. This was changed primarily because the vibrato delay and rate should update when the tempo changes, but it also allows us to quantize the tempo per tick more accurately.

This implementation is based specifically on the Super Metroid SPC700 code [disassembled and analyzed](https://github.com/loveemu/vgm-disasm/tree/master/snes/NSPC/Nintendo) by @loveemu. I haven't compared this with other versions.

I ran into a complication having to do with the fact VGMMultiSectionSeq calls loadTrackInit on each track in `loadSection()`. This in turn calls `SeqTrack::resetVars()`. NinSnes needs to persist state across sections. This is especially true for the fade/slide events. To fix this, we define a struct for shared state to persist across section loads: `NinSnesTrackSharedData`. The next PR will simplify how we work with this data - effectively making it the single source instead of having sync() calls to update it.

## How Has This Been Tested?
A lot of testing by ear. I have yet to encounter a game that doesn't sound correct, though given how many variants of the driver exist, I wouldn't rule it out.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
