### PR TITLE
NinSnes: add vibrato support

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -226,6 +226,7 @@ target_sources(vgmtranscore
     formats/NinSnes/NinSnesSeq.cpp
     formats/NinSnes/NinSnesSeqIntelli.cpp
     formats/NinSnes/NinSnesTrack.cpp
+    formats/NinSnes/NinSnesTrackModulation.cpp
     formats/Org/OrgScanner.cpp
     formats/Org/OrgSeq.cpp
     formats/PS1/PS1Seq.cpp

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -5,6 +5,7 @@
  */
 #include "NinSnesInstr.h"
 #include "NinSnesSeq.h"
+#include "NinSnesVibrato.h"
 #include "SNESDSP.h"
 #include "VGMColl.h"
 #include <spdlog/fmt/fmt.h>
@@ -25,6 +26,19 @@ uint32_t getProgramNumber(const VGMInstr* instr) {
 bool usesIntelliTempDrumKitExport(NinSnesProfileId profileId) {
   const auto intelliMode = getNinSnesProfile(profileId).intelliMode;
   return intelliMode == NinSnesIntelliModeId::Ta || intelliMode == NinSnesIntelliModeId::Fe4;
+}
+
+void addVibratoHandling(VGMInstr* instr) {
+  // NinSnes drives vibrato from per-track controllers, so every exportable instrument shares the
+  // same ModWheel/ChannelPressure/CC93 wiring and only the final ranges vary per sequence.
+  instr->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
+}
+
+void applyVibratoScaling(NinSnesInstrSet* instrSet, const VibratoModulationSpec& spec) {
+  // Re-target the shared vibrato modulators to the maxima observed in the matched sequence.
+  for (auto* instr : instrSet->exportInstrs()) {
+    instr->updateStandardVibratoHandling(spec);
+  }
 }
 
 VGMInstr* findInstrByProgram(const std::vector<VGMInstr*>& instrs, uint32_t progNum) {
@@ -276,6 +290,7 @@ bool NinSnesInstrSet::parseInstrPointers() {
 void NinSnesInstrSet::useColl(const VGMColl* coll) {
   const auto* seq = dynamic_cast<const NinSnesSeq*>(coll != nullptr ? coll->seq() : nullptr);
   if (seq == nullptr || seq->rawFile() != rawFile() || seq->profileId != profileId) {
+    applyVibratoScaling(this, nin_snes::vibrato::modulationSpec());
     return;
   }
 
@@ -288,6 +303,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
           overrideDef.progNum >> 7,
           overrideDef.progNum & 0x7f,
           fmt::format("Instrument {:d} (Overwrite)", overrideDef.logicalInstrIndex));
+      addVibratoHandling(overrideInstr);
       auto* rgn =
           createRgnFromHeaderData(overrideInstr, rawFile(), profileId, spcDirAddr, overrideDef.regionData);
       if (rgn == nullptr) {
@@ -301,6 +317,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
     for (const auto& drumKitDef : seq->intelliTADrumKitDefs()) {
       auto* drumKit = new VGMInstr(
           this, 0, 0, 127, drumKitDef.program, fmt::format("Drum Kit {:d}", drumKitDef.program));
+      addVibratoHandling(drumKit);
 
       for (size_t slot = 0; slot < drumKitDef.slots.size(); slot++) {
         const auto& slotDef = drumKitDef.slots[slot];
@@ -332,6 +349,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
     if (!percussionInstrNoteMap.empty()) {
       // Create the drumkit instrument for percussion note events.
       auto* drumKit = new VGMInstr(this, 0, 0, 127, 0, "Drum Kit");
+      addVibratoHandling(drumKit);
       for (const auto& [instrIndex, percussionDef] : percussionInstrNoteMap) {
         VGMInstr* sourceInstr = nullptr;
         for (auto* instr : aInstrs) {
@@ -359,9 +377,13 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
       }
     }
   }
+
+  applyVibratoScaling(this,
+                            nin_snes::vibrato::modulationSpec(seq->maxVibratoDepthCents, seq->maxVibratoRateHz));
 }
 
 void NinSnesInstrSet::unuseColl() {
+  applyVibratoScaling(this, nin_snes::vibrato::modulationSpec());
 }
 
 // *************
@@ -391,6 +413,8 @@ bool NinSnesInstr::loadInstr() {
   if (offDirEnt + 4 > 0x10000) {
     return false;
   }
+
+  addVibratoHandling(this);
 
   uint16_t addrSampStart = readShort(offDirEnt);
 

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -1,4 +1,5 @@
 #include "NinSnesSeq.h"
+#include "NinSnesVibrato.h"
 #include "Options.h"
 #include "spdlog/fmt/fmt.h"
 #include <algorithm>
@@ -13,7 +14,6 @@ DECLARE_FORMAT(NinSnes);
 namespace {
 
 constexpr size_t MAX_TRACKS = kNinSnesTrackCount;
-constexpr uint8_t kNinSnesDefaultTempo = 0x20;
 
 }  // namespace
 
@@ -23,7 +23,9 @@ NinSnesSeq::NinSnesSeq(RawFile* file, NinSnesProfileId profile, uint32_t offset,
     : VGMSeq(NinSnesFormat::name, file, offset, 0, theName),
       signature(NinSnesSignatureId::None), profileId(profile),
       volumeTable(theVolumeTable), durRateTable(theDurRateTable),
-      tempo(kNinSnesDefaultTempo),
+      tempo(nin_snes::vibrato::kDefaultTempo),
+      maxVibratoDepthCents(nin_snes::vibrato::kMinMaxDepthCents),
+      maxVibratoRateHz(nin_snes::vibrato::kMinMaxRateHz),
       dwStartOffset(offset), curOffset(offset),
       konamiBaseAddress(0), quintetBGMInstrBase(0), falcomBaseOffset(0),
       header(NULL), spcPercussionBaseInit(percussion_base), m_nextIntelliTAOverrideProgram(0x80) {
@@ -80,8 +82,12 @@ void NinSnesSeq::resetVars() {
   sectionRepeatCount = 0;
   m_sectionForeverLoops = 0;
   globalTranspose = 0;
-  setImmediateTempo(kNinSnesDefaultTempo);
+  setImmediateTempo(nin_snes::vibrato::kDefaultTempo);
 
+  if (readMode != READMODE_CONVERT_TO_MIDI) {
+    maxVibratoDepthCents = nin_snes::vibrato::kMinMaxDepthCents;
+    maxVibratoRateHz = nin_snes::vibrato::kMinMaxRateHz;
+  }
   m_percussionInstrNoteMap.clear();
 
   // Intelligent Systems:
@@ -415,6 +421,28 @@ double NinSnesSeq::getTempoInBPM(uint8_t tempoValue) {
 
 void NinSnesSeq::setImmediateTempo(uint8_t newTempo) {
   tempo = newTempo;
+  tempoFade.setCurrentRaw(newTempo);
+}
+
+void NinSnesSeq::startTempoFade(uint8_t fadeLength, uint8_t targetTempo) {
+  tempoFade.begin(SeqFixedPointMotion<int32_t>::toRawTarget(targetTempo, fadeLength));
+}
+
+void NinSnesSeq::syncTempoDependentTracks() {
+  for (auto* track : aTracks) {
+    static_cast<NinSnesTrack*>(track)->syncVibratoRateAndDelay();
+  }
+}
+
+void NinSnesSeq::onTickEnd() {
+  // EVENT_TEMPO_FADE applies its first tempo step at the end of the tick that parsed the command.
+  tempoFade.tickRaw([this](int32_t tempoValue) {
+    tempo = static_cast<uint8_t>(std::clamp(tempoValue, 0, 0xff));
+    if (!aTracks.empty()) {
+      aTracks[0]->addTempoBPMNoItem(getTempoInBPM(tempo));
+    }
+    syncTempoDependentTracks();
+  });
 }
 
 uint16_t NinSnesSeq::convertToAPUAddress(uint16_t offset) {

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <optional>
 #include "VGMSeq.h"
+#include "automation/SeqAutomation.h"
 #include "SeqTrack.h"
 #include "NinSnesFormat.h"
 #include "NinSnesScanResult.h"
@@ -26,6 +27,7 @@ public:
   bool load() override;
   bool parseHeader() override;
   void resetVars() override;
+  void onTickEnd() override;
   bool readPlaylistEvent(long stopTime);
 
   const NinSnesProfile& profile() const;
@@ -58,6 +60,9 @@ public:
   uint8_t sectionRepeatCount;
   int8_t globalTranspose;
   uint8_t tempo;
+  SeqFixedPointAutomation<> tempoFade;
+  double maxVibratoDepthCents;
+  double maxVibratoRateHz;
   uint32_t dwStartOffset;
   uint32_t curOffset;
   std::vector<NinSnesSection *> aSections;
@@ -109,6 +114,8 @@ private:
   NinSnesSection *getSectionAtOffset(uint32_t offset);
   bool addLoopForeverNoItem();
   void setImmediateTempo(uint8_t newTempo);
+  void startTempoFade(uint8_t fadeLength, uint8_t targetTempo);
+  void syncTempoDependentTracks();
   NinSnesIntelliTADrumKitDef buildIntelliTADrumKitDef() const;
 
   uint8_t spcPercussionBaseInit;
@@ -189,6 +196,7 @@ public:
                const std::string& theName = "NinSnes Track");
 
   void resetVars() override;
+  void onTickBegin() override;
   bool readEvent() override;
 
   uint16_t convertToApuAddress(uint16_t offset);
@@ -221,7 +229,13 @@ private:
                           std::string& desc);
   bool handleIntelliEvent(NinSnesSeqEventType eventType, uint32_t beginOffset, uint8_t statusByte,
                           std::string& desc);
+  void beginNoteVibrato();
+  void updateVibratoFade();
+  void applyConfiguredVibrato();
+  void clearVibratoRateAndDelay();
+  void setVibratoDepth(uint8_t depth);
   void addPendingEndEvent(uint8_t statusByte, const std::string& desc);
+  void syncVibratoRateAndDelay();
 
   uint8_t getEffectiveNoteDuration() const;
   void rememberMelodicProgram(uint32_t progNum,

--- a/src/main/formats/NinSnes/NinSnesSeqIntelli.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeqIntelli.cpp
@@ -287,6 +287,7 @@ bool NinSnesTrack::handleIntelliPercussionNote(uint32_t beginOffset, uint8_t slo
   const uint8_t drumKey = static_cast<uint8_t>(0x24 + slot);
 
   switchToPercussionProgramIfNeeded(drumProgram);
+  beginNoteVibrato();
   addPercNoteByDur(beginOffset, curOffset - beginOffset,
                    static_cast<int8_t>(drumKey - cKeyCorrection - parentSeq.globalTranspose),
                    state.spcNoteVolume / 2, duration, "Percussion Note");

--- a/src/main/formats/NinSnes/NinSnesSeqState.h
+++ b/src/main/formats/NinSnes/NinSnesSeqState.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include "automation/SeqMidiAutomation.h"
 
 enum NinSnesSeqEventType {
   // start enum at 1 because if map[] look up fails, it returns 0, and we don't want that to get
@@ -103,6 +104,8 @@ class NinSnesTrackState {
   // Konami:
   uint16_t konamiLoopStart;
   uint8_t konamiLoopCount;
+
+  SeqSynthLfoAutomation vibrato;
 };
 
 struct NinSnesPercussionDef {

--- a/src/main/formats/NinSnes/NinSnesTrack.cpp
+++ b/src/main/formats/NinSnes/NinSnesTrack.cpp
@@ -26,6 +26,8 @@ void NinSnesTrackState::resetVars() {
   // Konami:
   konamiLoopStart = 0;
   konamiLoopCount = 0;
+
+  vibrato.reset();
 }
 
 //  ************
@@ -124,6 +126,10 @@ void NinSnesTrack::resetVars() {
 
   state.resetVars();
   resetTransientPlaybackState();
+}
+
+void NinSnesTrack::onTickBegin() {
+  updateVibratoFade();
 }
 
 uint8_t NinSnesTrack::getEffectiveNoteDuration() const {
@@ -321,6 +327,7 @@ bool NinSnesTrack::handleCoreEvent(NinSnesSeqEventType eventType, uint32_t begin
       const uint8_t noteNumber = statusByte - parentSeq.STATUS_NOTE_MIN;
       const uint8_t duration = getEffectiveNoteDuration();
       restoreNonPercussionProgramIfNeeded();
+      beginNoteVibrato();
       addNoteByDur(beginOffset, curOffset - beginOffset, noteNumber, state.spcNoteVolume / 2,
                    duration, "Note");
       m_lastNoteWasPercussion = false;
@@ -359,6 +366,7 @@ bool NinSnesTrack::handleCoreEvent(NinSnesSeqEventType eventType, uint32_t begin
       parentSeq.addPercussionInstrNoteMapping(instrIndex, noteIndex, parentSeq.globalTranspose);
 
       switchToPercussionProgramIfNeeded();
+      beginNoteVibrato();
       addPercNoteByDur(beginOffset, curOffset - beginOffset,
                        static_cast<int8_t>(noteIndex - cKeyCorrection - parentSeq.globalTranspose),
                        state.spcNoteVolume / 2, duration, "Percussion Note");
@@ -426,17 +434,22 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
     }
 
     case EVENT_VIBRATO_ON: {
+      auto& vibrato = state.vibrato;
       const uint8_t vibratoDelay = readByte(curOffset++);
       const uint8_t vibratoRate = readByte(curOffset++);
       const uint8_t vibratoDepth = readByte(curOffset++);
-      desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}", vibratoDelay, vibratoRate,
-                         vibratoDepth);
+      vibrato.configure(vibratoDelay, vibratoRate, vibratoDepth);
+      desc = fmt::format("Delay: {:d}  Rate: {:d}  Depth: {:d}", vibrato.delay(), vibrato.rate(),
+                         vibrato.depth());
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato", desc, Type::Vibrato);
+      applyConfiguredVibrato();
       return true;
     }
 
     case EVENT_VIBRATO_OFF:
+      state.vibrato.clearConfig();
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Off", desc, Type::Vibrato);
+      applyConfiguredVibrato();
       return true;
 
     case EVENT_MASTER_VOLUME: {
@@ -457,14 +470,24 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
       const uint8_t newTempo = readByte(curOffset++);
       parentSeq.setImmediateTempo(newTempo);
       addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
+      parentSeq.syncTempoDependentTracks();
       return true;
     }
 
     case EVENT_TEMPO_FADE: {
       const uint8_t fadeLength = readByte(curOffset++);
       const uint8_t newTempo = readByte(curOffset++);
-      addTempoSlide(beginOffset, curOffset - beginOffset, fadeLength,
-                    static_cast<int>(60000000 / parentSeq.getTempoInBPM(newTempo)));
+      if (fadeLength == 0) {
+        parentSeq.setImmediateTempo(newTempo);
+        addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
+        parentSeq.syncTempoDependentTracks();
+      } else {
+        const bool isNewOffset = onEvent(beginOffset, curOffset - beginOffset);
+        recordDurSeqEvent<TempoSlideSeqEvent>(isNewOffset, getTime(), fadeLength,
+                                              parentSeq.getTempoInBPM(newTempo), fadeLength,
+                                              beginOffset, curOffset - beginOffset, "Tempo Slide");
+        parentSeq.startTempoFade(fadeLength, newTempo);
+      }
       return true;
     }
 
@@ -510,9 +533,11 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
     }
 
     case EVENT_VIBRATO_FADE: {
+      auto& vibrato = state.vibrato;
       const uint8_t fadeLength = readByte(curOffset++);
       desc = fmt::format("Length: {:d}", fadeLength);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Vibrato Fade", desc, Type::Vibrato);
+      vibrato.setReusableFadeToConfiguredDepth(fadeLength);
       return true;
     }
 

--- a/src/main/formats/NinSnes/NinSnesTrackModulation.cpp
+++ b/src/main/formats/NinSnes/NinSnesTrackModulation.cpp
@@ -1,0 +1,98 @@
+#include "NinSnesSeq.h"
+#include "NinSnesVibrato.h"
+#include "Modulation.h"
+#include "automation/SeqTrackAutomation.h"
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+uint8_t convertVibratoDepthToMidi(uint8_t depth, double maxDepthCents) {
+  if (depth == 0) {
+    return 0;
+  }
+
+  const int midiValue = static_cast<int>(std::lround(128.0 * nin_snes::vibrato::depthCents(depth) / maxDepthCents));
+  return static_cast<uint8_t>(std::clamp(midiValue, 0, 127));
+}
+
+uint8_t convertVibratoRateToMidi(uint8_t rate, double tempo, double maxRateHz) {
+  const double currentRateHz = nin_snes::vibrato::rateHz(rate, tempo);
+  if (currentRateHz <= 0.0) {
+    return 0;
+  }
+
+  return midiValueForHertzInRange(currentRateHz, nin_snes::vibrato::kMinRateHz, maxRateHz);
+}
+
+uint8_t convertVibratoDelayToMidi(uint8_t delay, double tempo) {
+  return midiValueForSecondsInRange(nin_snes::vibrato::delaySeconds(delay, tempo),
+                                    nin_snes::vibrato::kMinDelaySeconds,
+                                    nin_snes::vibrato::kMaxDelaySeconds);
+}
+
+}  // namespace
+
+void NinSnesTrack::beginNoteVibrato() {
+  // EVENT_VIBRATO_FADE is a reusable per-note fade-in for the configured E3 vibrato.
+  if (state.vibrato.active() && state.vibrato.beginReusableFadeToConfiguredDepth()) {
+    setVibratoDepth(0);
+  }
+}
+
+void NinSnesTrack::applyConfiguredVibrato() {
+  auto& vibrato = state.vibrato;
+  const bool active = vibrato.active();
+  if (active) {
+    auto& parentSeq = seq();
+    if (readMode != READMODE_CONVERT_TO_MIDI) {
+      parentSeq.maxVibratoDepthCents =
+          std::max(parentSeq.maxVibratoDepthCents, nin_snes::vibrato::depthCents(vibrato.depth()));
+    }
+  }
+
+  setVibratoDepth(vibrato.outputDepthWhen(active));
+  if (active) {
+    syncVibratoRateAndDelay();
+  } else {
+    clearVibratoRateAndDelay();
+  }
+}
+
+void NinSnesTrack::updateVibratoFade() {
+  advanceSynthLfoFadeToModulation(state.vibrato, 0, [this](int32_t depth) {
+    return convertVibratoDepthToMidi(static_cast<uint8_t>(depth), seq().maxVibratoDepthCents);
+  });
+}
+
+void NinSnesTrack::setVibratoDepth(uint8_t depth) {
+  auto& vibrato = state.vibrato;
+  vibrato.setCurrentDepthPreservingMotion(depth);
+  const uint8_t midiDepth = convertVibratoDepthToMidi(depth, seq().maxVibratoDepthCents);
+  setSynthLfoModulationDepth(vibrato, midiDepth);
+}
+
+void NinSnesTrack::clearVibratoRateAndDelay() {
+  addChannelPressureNoItem(0);
+  addControllerEventNoItem(nin_snes::vibrato::kDelayController, 0);
+}
+
+void NinSnesTrack::syncVibratoRateAndDelay() {
+  const auto& vibrato = state.vibrato;
+  if (!vibrato.active()) {
+    return;
+  }
+
+  auto& parentSeq = seq();
+  const double currentTempo = parentSeq.tempo;
+  if (readMode != READMODE_CONVERT_TO_MIDI) {
+    // Rate and delay are both tempo-relative, so a sequence-specific max only makes sense once the
+    // current tempo has been folded into the exported Hz value.
+    parentSeq.maxVibratoRateHz =
+        std::max(parentSeq.maxVibratoRateHz, nin_snes::vibrato::rateHz(vibrato.rate(), currentTempo));
+  }
+
+  addChannelPressureNoItem(convertVibratoRateToMidi(vibrato.rate(), currentTempo, parentSeq.maxVibratoRateHz));
+  addControllerEventNoItem(nin_snes::vibrato::kDelayController,
+                           convertVibratoDelayToMidi(vibrato.delay(), currentTempo));
+}

--- a/src/main/formats/NinSnes/NinSnesVibrato.h
+++ b/src/main/formats/NinSnes/NinSnesVibrato.h
@@ -1,0 +1,63 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+#pragma once
+
+#include <cstdint>
+#include "Modulation.h"
+
+namespace nin_snes::vibrato {
+
+constexpr double kTimerHz = 500.0;
+constexpr uint8_t kDefaultTempo = 0x20;
+constexpr uint8_t kDelayController = 93;
+constexpr uint8_t kMinVibratoMaxDepth = 0x80;
+constexpr uint8_t kMinVibratoMaxRate = 0x20;
+
+// Depth 00-F0 uses the regular 1/256-semitone path. F1-FF switches to the large-depth mode that
+// reuses the low nibble as a 1-15 semitone multiplier.
+inline constexpr double depthCents(uint8_t depth) {
+  const double centsPerPitchUnit = 100.0 / 256.0;
+  if (depth <= 0xf0) {
+    return ((0xffu * depth) >> 8) * centsPerPitchUnit;
+  }
+  return (0xffu * (depth & 0x0fu)) * centsPerPitchUnit;
+}
+
+inline constexpr double rateHz(uint8_t rate, double tempo) {
+  const double safeTempo = (tempo > 0.0) ? tempo : 1.0;
+  return (kTimerHz * safeTempo * rate) / 65536.0;
+}
+
+inline constexpr double delaySeconds(uint8_t delay, double tempo) {
+  const double safeTempo = (tempo > 0.0) ? tempo : 1.0;
+  return (256.0 * delay) / (kTimerHz * safeTempo);
+}
+
+inline constexpr double kMinRateHz = rateHz(1, 1);
+inline constexpr double kDefaultMaxRateHz = rateHz(0xff, 0xff);
+inline constexpr double kDefaultMaxDepthCents = depthCents(0xff);
+// The tracked sequence max only needs a minimum sensible range, not the full format maximum.
+inline constexpr double kMinMaxDepthCents = depthCents(kMinVibratoMaxDepth);
+inline constexpr double kMinMaxRateHz = rateHz(kMinVibratoMaxRate, kDefaultTempo);
+// Delay 00 is "start immediately". The SF2 export helper clamps that to the smallest normal
+// positive delay it can represent.
+inline constexpr double kMinDelaySeconds = 0.0;
+inline constexpr double kMaxDelaySeconds = delaySeconds(0xff, 1);
+
+inline VibratoModulationSpec modulationSpec(double maxDepthCents = kDefaultMaxDepthCents,
+                                            double maxRateHz = kDefaultMaxRateHz) {
+  return {
+      (maxDepthCents > 0.0) ? maxDepthCents : kDefaultMaxDepthCents,
+      kMinRateHz,
+      (maxRateHz > 0.0) ? maxRateHz : kDefaultMaxRateHz,
+      DelayRange {
+          kMinDelaySeconds,
+          kMaxDelaySeconds,
+      },
+  };
+}
+
+}  // namespace nin_snes::vibrato


### PR DESCRIPTION
## Purpose

This PR adds vibrato support to the NinSnes driver using the new automation classes.

## Summary

Vibrato on NinSnes is extremely similar to the KonamiSnes driver (I expect Konami took inspiration). EVENT_VIBRATO_ON takes three parameters: delay, rate, and depth. Both delay and rate are relative to the current tempo. There is also EVENT_VIBRATO_FADE, which just like the Konami driver, initiates a linear fade to the depth specified in the VIBRATO_ON event. The fade begins after note activation when the delay ticks have elapsed.

Tempo slide no longer uses addTempoBPMSlide, but instead sets the tempo iteratively at the end of a tick using VGMSeq::onTickEnd(). This was changed primarily because the vibrato delay and rate are determined by tempo and should therefore update when the tempo changes, but it also allows us to quantize the tempo per tick more accurately.

This implementation is based specifically on the Super Metroid SPC700 code [disassembled and analyzed](https://github.com/loveemu/vgm-disasm/tree/master/snes/NSPC/Nintendo) by @loveemu. I haven't compared this with other versions.

## Changes

- Implements `EVENT_VIBRATO_ON`, `EVENT_VIBRATO_OFF`, and `EVENT_VIBRATO_FADE` using modulators.
- Implements `EVENT_TEMPO_FADE` with `SeqFixedPointAutomation`.
- Adds "standard" vibrato modulators/generators to NinSnes instruments.
- Stores per-track vibrato state with `SeqSynthLfoAutomation`.
- Starts reusable per-note vibrato fade-ins when notes begin.
- Resyncs active vibrato rate/delay when tempo changes.
- Adds `NinSnesVibrato.h`, which defines vibrato-related constants,  source-unit to real-unit conversion helpers, and the VibratoModulationSpec.
- Adds `NinSnesTrackModulation.cpp`, which contains helpers that update track automations and write to tracks, and source-unit to MIDI-unit conversion helpers.

## How Has This Been Tested?
Testing by ear a across many NinSnes variants. Inspecting outputted MIDI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
