### PR TITLE
NinSnes: pitch slide and pitch envelope support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@
 - Added Flatpak builds for Linux. From now on, stable releases will be automatically available on Flathub.
 - Added stitched export for collection chunks: drag collections into a stitch queue, reorder them, and export as a merged MIDI + SF2.
 - Added a search field to the Collections panel
-- Added Drum Kit support to the standard N-SPC driver (Nintendo's SNES SDK driver).
-- Added Drum Kit support to the SuzukiSnes driver (Seiken Densetsu 3, Super Mario RPG, etc)
-- Added many improvements to the KonamiSnes driver.
+- Added drum kit, vibrato, and pitch slide support to the standard N-SPC driver (Nintendo's SNES SDK driver).
+- Added drum kit, portamento, and slide support for volume/pan/pitch to the KonamiSnes driver.
 - Added vibrato, tremolo, more accurate portamento support, and fixed pan calculation in the CapcomSnes driver.
+- Added drum kit support to the SuzukiSnes driver (Seiken Densetsu 3, Super Mario RPG, etc)
 - Improved support for late-era Intelligent Systems SNES/SFC titles (Tetris Attack, Fire Emblem 4, Super Famicom Wars) 
 
 ### Changed

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -28,13 +28,13 @@ bool usesIntelliTempDrumKitExport(NinSnesProfileId profileId) {
   return intelliMode == NinSnesIntelliModeId::Ta || intelliMode == NinSnesIntelliModeId::Fe4;
 }
 
-void addVibratoHandling(VGMInstr* instr) {
+void addVibratoExportHandling(VGMInstr* instr) {
   // NinSnes drives vibrato from per-track controllers, so every exportable instrument shares the
   // same ModWheel/ChannelPressure/CC93 wiring and only the final ranges vary per sequence.
   instr->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
 }
 
-void applyVibratoScaling(NinSnesInstrSet* instrSet, const VibratoModulationSpec& spec) {
+void applyVibratoExportScaling(NinSnesInstrSet* instrSet, const VibratoModulationSpec& spec) {
   // Re-target the shared vibrato modulators to the maxima observed in the matched sequence.
   for (auto* instr : instrSet->exportInstrs()) {
     instr->updateStandardVibratoHandling(spec);
@@ -290,7 +290,7 @@ bool NinSnesInstrSet::parseInstrPointers() {
 void NinSnesInstrSet::useColl(const VGMColl* coll) {
   const auto* seq = dynamic_cast<const NinSnesSeq*>(coll != nullptr ? coll->seq() : nullptr);
   if (seq == nullptr || seq->rawFile() != rawFile() || seq->profileId != profileId) {
-    applyVibratoScaling(this, nin_snes::vibrato::modulationSpec());
+    applyVibratoExportScaling(this, nin_snes::vibrato::modulationSpec());
     return;
   }
 
@@ -303,7 +303,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
           overrideDef.progNum >> 7,
           overrideDef.progNum & 0x7f,
           fmt::format("Instrument {:d} (Overwrite)", overrideDef.logicalInstrIndex));
-      addVibratoHandling(overrideInstr);
+      addVibratoExportHandling(overrideInstr);
       auto* rgn =
           createRgnFromHeaderData(overrideInstr, rawFile(), profileId, spcDirAddr, overrideDef.regionData);
       if (rgn == nullptr) {
@@ -317,7 +317,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
     for (const auto& drumKitDef : seq->intelliTADrumKitDefs()) {
       auto* drumKit = new VGMInstr(
           this, 0, 0, 127, drumKitDef.program, fmt::format("Drum Kit {:d}", drumKitDef.program));
-      addVibratoHandling(drumKit);
+      addVibratoExportHandling(drumKit);
 
       for (size_t slot = 0; slot < drumKitDef.slots.size(); slot++) {
         const auto& slotDef = drumKitDef.slots[slot];
@@ -349,7 +349,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
     if (!percussionInstrNoteMap.empty()) {
       // Create the drumkit instrument for percussion note events.
       auto* drumKit = new VGMInstr(this, 0, 0, 127, 0, "Drum Kit");
-      addVibratoHandling(drumKit);
+      addVibratoExportHandling(drumKit);
       for (const auto& [instrIndex, percussionDef] : percussionInstrNoteMap) {
         VGMInstr* sourceInstr = nullptr;
         for (auto* instr : aInstrs) {
@@ -378,12 +378,12 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
     }
   }
 
-  applyVibratoScaling(this,
+  applyVibratoExportScaling(this,
                             nin_snes::vibrato::modulationSpec(seq->maxVibratoDepthCents, seq->maxVibratoRateHz));
 }
 
 void NinSnesInstrSet::unuseColl() {
-  applyVibratoScaling(this, nin_snes::vibrato::modulationSpec());
+  applyVibratoExportScaling(this, nin_snes::vibrato::modulationSpec());
 }
 
 // *************
@@ -414,7 +414,7 @@ bool NinSnesInstr::loadInstr() {
     return false;
   }
 
-  addVibratoHandling(this);
+  addVibratoExportHandling(this);
 
   uint16_t addrSampStart = readShort(offDirEnt);
 

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -28,13 +28,13 @@ bool usesIntelliTempDrumKitExport(NinSnesProfileId profileId) {
   return intelliMode == NinSnesIntelliModeId::Ta || intelliMode == NinSnesIntelliModeId::Fe4;
 }
 
-void addVibratoExportHandling(VGMInstr* instr) {
+void addVibratoHandling(VGMInstr* instr) {
   // NinSnes drives vibrato from per-track controllers, so every exportable instrument shares the
   // same ModWheel/ChannelPressure/CC93 wiring and only the final ranges vary per sequence.
   instr->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
 }
 
-void applyVibratoExportScaling(NinSnesInstrSet* instrSet, const VibratoModulationSpec& spec) {
+void applyVibratoScaling(NinSnesInstrSet* instrSet, const VibratoModulationSpec& spec) {
   // Re-target the shared vibrato modulators to the maxima observed in the matched sequence.
   for (auto* instr : instrSet->exportInstrs()) {
     instr->updateStandardVibratoHandling(spec);
@@ -290,7 +290,7 @@ bool NinSnesInstrSet::parseInstrPointers() {
 void NinSnesInstrSet::useColl(const VGMColl* coll) {
   const auto* seq = dynamic_cast<const NinSnesSeq*>(coll != nullptr ? coll->seq() : nullptr);
   if (seq == nullptr || seq->rawFile() != rawFile() || seq->profileId != profileId) {
-    applyVibratoExportScaling(this, nin_snes::vibrato::modulationSpec());
+    applyVibratoScaling(this, nin_snes::vibrato::modulationSpec());
     return;
   }
 
@@ -303,7 +303,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
           overrideDef.progNum >> 7,
           overrideDef.progNum & 0x7f,
           fmt::format("Instrument {:d} (Overwrite)", overrideDef.logicalInstrIndex));
-      addVibratoExportHandling(overrideInstr);
+      addVibratoHandling(overrideInstr);
       auto* rgn =
           createRgnFromHeaderData(overrideInstr, rawFile(), profileId, spcDirAddr, overrideDef.regionData);
       if (rgn == nullptr) {
@@ -317,7 +317,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
     for (const auto& drumKitDef : seq->intelliTADrumKitDefs()) {
       auto* drumKit = new VGMInstr(
           this, 0, 0, 127, drumKitDef.program, fmt::format("Drum Kit {:d}", drumKitDef.program));
-      addVibratoExportHandling(drumKit);
+      addVibratoHandling(drumKit);
 
       for (size_t slot = 0; slot < drumKitDef.slots.size(); slot++) {
         const auto& slotDef = drumKitDef.slots[slot];
@@ -349,7 +349,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
     if (!percussionInstrNoteMap.empty()) {
       // Create the drumkit instrument for percussion note events.
       auto* drumKit = new VGMInstr(this, 0, 0, 127, 0, "Drum Kit");
-      addVibratoExportHandling(drumKit);
+      addVibratoHandling(drumKit);
       for (const auto& [instrIndex, percussionDef] : percussionInstrNoteMap) {
         VGMInstr* sourceInstr = nullptr;
         for (auto* instr : aInstrs) {
@@ -378,12 +378,12 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
     }
   }
 
-  applyVibratoExportScaling(this,
+  applyVibratoScaling(this,
                             nin_snes::vibrato::modulationSpec(seq->maxVibratoDepthCents, seq->maxVibratoRateHz));
 }
 
 void NinSnesInstrSet::unuseColl() {
-  applyVibratoExportScaling(this, nin_snes::vibrato::modulationSpec());
+  applyVibratoScaling(this, nin_snes::vibrato::modulationSpec());
 }
 
 // *************
@@ -414,7 +414,7 @@ bool NinSnesInstr::loadInstr() {
     return false;
   }
 
-  addVibratoExportHandling(this);
+  addVibratoHandling(this);
 
   uint16_t addrSampStart = readShort(offDirEnt);
 

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -14,6 +14,8 @@ DECLARE_FORMAT(NinSnes);
 namespace {
 
 constexpr size_t MAX_TRACKS = kNinSnesTrackCount;
+constexpr uint16_t kNinSnesDefaultPitchBendRangeCents =
+    NinSnesTrackState::kDefaultPitchBendRangeCents;
 
 }  // namespace
 
@@ -34,6 +36,7 @@ NinSnesSeq::NinSnesSeq(RawFile* file, NinSnesProfileId profile, uint32_t offset,
 
   useReverb();
   setAlwaysWriteInitialReverb(0);
+  setAlwaysWriteInitialPitchBendRange(kNinSnesDefaultPitchBendRangeCents);
 
   loadEventMap();
 }

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -192,6 +192,14 @@ public:
 
 class NinSnesTrack : public SeqTrack {
 public:
+  struct PitchSlideEvent {
+    uint32_t offset = 0;
+    uint32_t eventLength = 0;
+    uint8_t delay = 0;
+    uint8_t length = 0;
+    uint8_t targetNote = 0;
+  };
+
   NinSnesTrack(NinSnesSeq* parentSeq, uint32_t offset = 0, uint32_t length = 0,
                const std::string& theName = "NinSnes Track");
 
@@ -229,11 +237,20 @@ private:
                           std::string& desc);
   bool handleIntelliEvent(NinSnesSeqEventType eventType, uint32_t beginOffset, uint8_t statusByte,
                           std::string& desc);
+  PitchSlideEvent readPitchSlide(uint32_t offset);
+  bool consumeQueuedPitchSlide();
+  void addPitchSlideEvent(const PitchSlideEvent& slide);
+  void beginPitchSlide(const PitchSlideEvent& slide);
+  void activatePitchMotion(uint8_t delay, uint8_t length, int32_t targetPitch);
+  void updatePitchSlide();
+  void beginNotePitch(uint8_t note);
+  void activateStoredPitchEnvelope();
   void beginNoteVibrato();
   void updateVibratoFade();
   void applyConfiguredVibrato();
   void clearVibratoRateAndDelay();
   void setVibratoDepth(uint8_t depth);
+  void resetPitchBendForNewNote();
   void addPendingEndEvent(uint8_t statusByte, const std::string& desc);
   void syncVibratoRateAndDelay();
 

--- a/src/main/formats/NinSnes/NinSnesSeqIntelli.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeqIntelli.cpp
@@ -287,10 +287,11 @@ bool NinSnesTrack::handleIntelliPercussionNote(uint32_t beginOffset, uint8_t slo
   const uint8_t drumKey = static_cast<uint8_t>(0x24 + slot);
 
   switchToPercussionProgramIfNeeded(drumProgram);
-  beginNoteVibrato();
+  beginNotePitch(static_cast<uint8_t>(drumKey - parentSeq.globalTranspose));
   addPercNoteByDur(beginOffset, curOffset - beginOffset,
                    static_cast<int8_t>(drumKey - cKeyCorrection - parentSeq.globalTranspose),
                    state.spcNoteVolume / 2, duration, "Percussion Note");
+  consumeQueuedPitchSlide();
   m_lastNoteWasPercussion = true;
   addTime(state.spcNoteDuration);
   return true;

--- a/src/main/formats/NinSnes/NinSnesSeqState.h
+++ b/src/main/formats/NinSnes/NinSnesSeqState.h
@@ -89,6 +89,8 @@ enum NinSnesSeqEventType {
 
 class NinSnesTrackState {
  public:
+  static constexpr uint16_t kDefaultPitchBendRangeCents = 200;
+
   NinSnesTrackState();
 
   virtual void resetVars();
@@ -105,7 +107,27 @@ class NinSnesTrackState {
   uint16_t konamiLoopStart;
   uint8_t konamiLoopCount;
 
+  // pitch envelope from/to define a reusable note-on envelope, while pitch slide instantiates the live motion directly.
+  struct StoredPitchEnvelope {
+    enum class Mode : uint8_t {
+      None,
+      To,
+      From,
+    };
+
+    Mode mode = Mode::None;
+    uint8_t delay = 0;
+    uint8_t length = 0;
+    int8_t semitones = 0;
+
+    bool enabled() const {
+      return mode != Mode::None && length != 0;
+    }
+  };
+
   SeqSynthLfoAutomation vibrato;
+  StoredPitchEnvelope pitchEnvelope;
+  SeqPitchBendAutomation<int32_t> pitch {100.0 / 256.0};
 };
 
 struct NinSnesPercussionDef {

--- a/src/main/formats/NinSnes/NinSnesTrack.cpp
+++ b/src/main/formats/NinSnes/NinSnesTrack.cpp
@@ -28,6 +28,8 @@ void NinSnesTrackState::resetVars() {
   konamiLoopCount = 0;
 
   vibrato.reset();
+  pitchEnvelope = {};
+  pitch.reset(kDefaultPitchBendRangeCents);
 }
 
 //  ************
@@ -130,6 +132,13 @@ void NinSnesTrack::resetVars() {
 
 void NinSnesTrack::onTickBegin() {
   updateVibratoFade();
+  updatePitchSlide();
+
+  // The SPC driver checks for queued EVENT_PITCH_SLIDE commands while a track is waiting before
+  // reading the next command, including after note, tie, and rest commands.
+  if (deltaTime > 1 && state.pitch.motionTicksRemaining() == 0) {
+    consumeQueuedPitchSlide();
+  }
 }
 
 uint8_t NinSnesTrack::getEffectiveNoteDuration() const {
@@ -327,9 +336,10 @@ bool NinSnesTrack::handleCoreEvent(NinSnesSeqEventType eventType, uint32_t begin
       const uint8_t noteNumber = statusByte - parentSeq.STATUS_NOTE_MIN;
       const uint8_t duration = getEffectiveNoteDuration();
       restoreNonPercussionProgramIfNeeded();
-      beginNoteVibrato();
+      beginNotePitch(noteNumber);
       addNoteByDur(beginOffset, curOffset - beginOffset, noteNumber, state.spcNoteVolume / 2,
                    duration, "Note");
+      consumeQueuedPitchSlide();
       m_lastNoteWasPercussion = false;
       addTime(state.spcNoteDuration);
       return true;
@@ -342,12 +352,14 @@ bool NinSnesTrack::handleCoreEvent(NinSnesSeqEventType eventType, uint32_t begin
       desc = fmt::format("Duration: {:d}", duration);
       makePrevDurNoteEnd(getTime() + duration);
       addTie(beginOffset, curOffset - beginOffset, duration, "Tie", desc);
+      consumeQueuedPitchSlide();
       addTime(state.spcNoteDuration);
       return true;
     }
 
     case EVENT_REST:
       addRest(beginOffset, curOffset - beginOffset, state.spcNoteDuration);
+      consumeQueuedPitchSlide();
       return true;
 
     case EVENT_PERCUSSION_NOTE: {
@@ -366,10 +378,11 @@ bool NinSnesTrack::handleCoreEvent(NinSnesSeqEventType eventType, uint32_t begin
       parentSeq.addPercussionInstrNoteMapping(instrIndex, noteIndex, parentSeq.globalTranspose);
 
       switchToPercussionProgramIfNeeded();
-      beginNoteVibrato();
+      beginNotePitch(static_cast<uint8_t>(noteIndex - parentSeq.globalTranspose));
       addPercNoteByDur(beginOffset, curOffset - beginOffset,
                        static_cast<int8_t>(noteIndex - cKeyCorrection - parentSeq.globalTranspose),
                        state.spcNoteVolume / 2, duration, "Percussion Note");
+      consumeQueuedPitchSlide();
       m_lastNoteWasPercussion = true;
       addTime(state.spcNoteDuration);
       return true;
@@ -545,6 +558,12 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
       const uint8_t pitchEnvDelay = readByte(curOffset++);
       const uint8_t pitchEnvLength = readByte(curOffset++);
       const int8_t pitchEnvSemitones = static_cast<int8_t>(readByte(curOffset++));
+      state.pitchEnvelope = {
+        NinSnesTrackState::StoredPitchEnvelope::Mode::To,
+        pitchEnvDelay,
+        pitchEnvLength,
+        pitchEnvSemitones,
+      };
       desc = fmt::format("Delay: {:d}  Length: {:d}  Semitones: {:d}", pitchEnvDelay,
                          pitchEnvLength, pitchEnvSemitones);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope (To)", desc,
@@ -556,6 +575,12 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
       const uint8_t pitchEnvDelay = readByte(curOffset++);
       const uint8_t pitchEnvLength = readByte(curOffset++);
       const int8_t pitchEnvSemitones = static_cast<int8_t>(readByte(curOffset++));
+      state.pitchEnvelope = {
+        NinSnesTrackState::StoredPitchEnvelope::Mode::From,
+        pitchEnvDelay,
+        pitchEnvLength,
+        pitchEnvSemitones,
+      };
       desc = fmt::format("Delay: {:d}  Length: {:d}  Semitones: {:d}", pitchEnvDelay,
                          pitchEnvLength, pitchEnvSemitones);
       addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope (From)", desc,
@@ -564,6 +589,7 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
     }
 
     case EVENT_PITCH_ENVELOPE_OFF:
+      state.pitchEnvelope = {};
       addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Envelope Off", desc,
                       Type::PitchEnvelope);
       return true;
@@ -621,13 +647,9 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, uint32_t
     }
 
     case EVENT_PITCH_SLIDE: {
-      const uint8_t pitchSlideDelay = readByte(curOffset++);
-      const uint8_t pitchSlideLength = readByte(curOffset++);
-      const uint8_t pitchSlideTargetNote = readByte(curOffset++);
-      desc = fmt::format("Delay: {:d}  Length: {:d}  Note: {:d}", pitchSlideDelay,
-                         pitchSlideLength, static_cast<int>(pitchSlideTargetNote - 0x80));
-      addGenericEvent(beginOffset, curOffset - beginOffset, "Pitch Slide", desc,
-                      Type::PitchBendSlide);
+      const auto slide = readPitchSlide(beginOffset);
+      addPitchSlideEvent(slide);
+      beginPitchSlide(slide);
       return true;
     }
 

--- a/src/main/formats/NinSnes/NinSnesTrackModulation.cpp
+++ b/src/main/formats/NinSnes/NinSnesTrackModulation.cpp
@@ -7,6 +7,9 @@
 
 namespace {
 
+constexpr uint16_t kNinSnesDefaultPitchBendRangeCents =
+    NinSnesTrackState::kDefaultPitchBendRangeCents;
+
 uint8_t convertVibratoDepthToMidi(uint8_t depth, double maxDepthCents) {
   if (depth == 0) {
     return 0;
@@ -31,7 +34,98 @@ uint8_t convertVibratoDelayToMidi(uint8_t delay, double tempo) {
                                     nin_snes::vibrato::kMaxDelaySeconds);
 }
 
+int32_t notePitch(uint8_t note) {
+  // NinSnes stores slide pitch in semitone units with an 8-bit fractional part.
+  return static_cast<int32_t>(note & 0x7f) << 8;
+}
+
 }  // namespace
+
+NinSnesTrack::PitchSlideEvent NinSnesTrack::readPitchSlide(uint32_t offset) {
+  return PitchSlideEvent {
+    offset,
+    4,
+    readByte(curOffset++),
+    readByte(curOffset++),
+    readByte(curOffset++),
+  };
+}
+
+bool NinSnesTrack::consumeQueuedPitchSlide() {
+  if (state.pitch.motionTicksRemaining() != 0) {
+    return false;
+  }
+
+  const auto statusByte = readByte(curOffset);
+  auto nextEvent = seq().EventMap.find(statusByte);
+  if (nextEvent == seq().EventMap.end() || nextEvent->second != EVENT_PITCH_SLIDE) {
+    return false;
+  }
+
+  const auto slideOffset = curOffset++;
+  auto slide = readPitchSlide(slideOffset);
+  addPitchSlideEvent(slide);
+  beginPitchSlide(slide);
+  return true;
+}
+
+void NinSnesTrack::addPitchSlideEvent(const PitchSlideEvent& slide) {
+  auto desc = fmt::format("Delay: {:d}  Length: {:d}  Target Note: {:d}",
+                          slide.delay,
+                          slide.length,
+                          slide.targetNote & 0x7f);
+  addGenericEvent(slide.offset, slide.eventLength, "Pitch Slide", desc, Type::PitchBendSlide);
+}
+
+void NinSnesTrack::beginPitchSlide(const PitchSlideEvent& slide) {
+  activatePitchMotion(slide.delay, slide.length, notePitch(slide.targetNote));
+}
+
+void NinSnesTrack::activatePitchMotion(uint8_t delay, uint8_t length, int32_t targetPitch) {
+  auto& pitch = state.pitch;
+  pitch.clearMotion();
+  if (!pitch.baseValid() || length == 0) {
+    return;
+  }
+
+  // F1/F2 and F9 all reduce to the same live pitch-motion state: wait for an optional delay,
+  // advance by a signed 8.8 delta each tick, then snap exactly to the stored target.
+  const int32_t currentPitch = pitch.currentPitch();
+  beginPitchBendAutomation(
+      pitch,
+      pitch.motionToTarget(targetPitch, length, delay),
+      pitch.rangeCentsForSlide(currentPitch, targetPitch, kNinSnesDefaultPitchBendRangeCents),
+      kNinSnesDefaultPitchBendRangeCents,
+      true);
+}
+
+void NinSnesTrack::updatePitchSlide() {
+  advancePitchBendAutomation(state.pitch);
+}
+
+void NinSnesTrack::beginNotePitch(uint8_t note) {
+  resetPitchBendForNewNote();
+  state.pitch.beginNote(notePitch(note));
+  activateStoredPitchEnvelope();
+  beginNoteVibrato();
+}
+
+void NinSnesTrack::activateStoredPitchEnvelope() {
+  const auto& pitchEnvelope = state.pitchEnvelope;
+  if (!pitchEnvelope.enabled()) {
+    return;
+  }
+
+  const int32_t semitoneOffset = static_cast<int32_t>(pitchEnvelope.semitones) * 256;
+  int32_t targetPitch = state.pitch.basePitch();
+  if (pitchEnvelope.mode == NinSnesTrackState::StoredPitchEnvelope::Mode::To) {
+    targetPitch += semitoneOffset;
+  } else {
+    state.pitch.setCurrentPitch(state.pitch.basePitch() - semitoneOffset);
+  }
+
+  activatePitchMotion(pitchEnvelope.delay, pitchEnvelope.length, targetPitch);
+}
 
 void NinSnesTrack::beginNoteVibrato() {
   // EVENT_VIBRATO_FADE is a reusable per-note fade-in for the configured E3 vibrato.
@@ -75,6 +169,22 @@ void NinSnesTrack::setVibratoDepth(uint8_t depth) {
 void NinSnesTrack::clearVibratoRateAndDelay() {
   addChannelPressureNoItem(0);
   addControllerEventNoItem(nin_snes::vibrato::kDelayController, 0);
+}
+
+void NinSnesTrack::resetPitchBendForNewNote() {
+  state.pitch.clearMotion();
+  state.pitch.invalidateBase();
+  if (state.pitch.atRest(kNinSnesDefaultPitchBendRangeCents)) {
+    return;
+  }
+
+  if (state.pitchEnvelope.enabled()) {
+    // Recurring pitch envelopes will set or reuse their needed range below.
+    setPitchBendAutomationBend(state.pitch, 0);
+    return;
+  }
+
+  resetPitchBendAutomation(state.pitch, kNinSnesDefaultPitchBendRangeCents);
 }
 
 void NinSnesTrack::syncVibratoRateAndDelay() {


### PR DESCRIPTION
## Purpose

This PR adds NinSnes pitch envelope and pitch slide support using the new automation classes.

## Summary

NinSnes has three pitch-motion events. All of them take a delay parameter in ticks, a duration parameter in ticks, and a parameter that indicates the change in pitch in semitones.

- `EVENT_PITCH_SLIDE` is a one-off slide. It specifies the new pitch in absolute semitones - like a note value. After the delay expires, the pitch is linearly shifted to the new pitch over the number of ticks specified.
- `EVENT_PITCH_ENVELOPE_FROM` sets a recurring slide that begins at note activation. The pitch amount is given in relative semitones. When a note is activated, the pitch is immediately bent, then, after the delay period, linearly slides toward the activated note over the duration period.
- `EVENT_PITCH_ENVELOPE_TO` is the same deal, except when the note is activated, it plays at the normal pitch and then bends toward the new pitch.
- `EVENT_PITCH_ENVELOPE_OFF` resets the pitch envelope setting. It does _not_ cancel currently running pitch slide.

Internally, the driver represents these pitch slide state using fixed point 8.8 semitone units. We construct a SeqPitchBendAutomation, specifying a `centsPerPitchUnit` of 100/255.0. From thereon, the automation handles the conversion from source-units to cents and ultimately to MIDI values. On every tick, we tell the automation to advance and output a bend if appropriate. When a slide is initiated, the SeqPitchBendAutomation also outputs a pitch bend range if needed.

We also handles queued pitch slides. If a pitch slide event appears after a note event while that note is still sounding, the track will initiate the new slide after the current pitch slide finishes without waiting for another note event. 

This implementation is based specifically on the Super Metroid SPC700 code [disassembled and analyzed](https://github.com/loveemu/vgm-disasm/tree/master/snes/NSPC/Nintendo) by @loveemu.

## Changes

- Implements `EVENT_PITCH_SLIDE`, `EVENT_PITCH_ENVELOPE_TO`, `EVENT_PITCH_ENVELOPE_FROM`, and `EVENT_PITCH_ENVELOPE_OFF`.
- Handles per-track pitch state and output with `SeqPitchBendAutomation`.
- Adds pitch helpers to `NinSnesTrackModulation.cpp` alongside the existing vibrato helpers.
- Initiates stored pitch envelope sides when notes begin.
- Handles queued pitch slides during a sustained note.
- Resets pitch bend/range on new notes when no recurring pitch envelope needs to keep using it.

## Audio demo

Queued pitch slides:

https://github.com/user-attachments/assets/2a21ed3c-ec32-4a3b-a45c-8ba2559e92c6

Envelope to slides

https://github.com/user-attachments/assets/d4e7d094-153c-483f-89f8-4c23b8e45169

Envelope from slides

https://github.com/user-attachments/assets/4333823f-b1ad-4eb9-aa5c-6c6720dd359e


## How Has This Been Tested?
Inspection of MIDI an lots of testing by ear.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.