### PR TITLE
SegSat: improve decay2 substitution

### DIFF
--- a/src/main/formats/SegSat/SegSatInstrSet.cpp
+++ b/src/main/formats/SegSat/SegSatInstrSet.cpp
@@ -312,8 +312,12 @@ SegSatRgn::SegSatRgn(SegSatInstr* instr, uint32_t offset, const std::string& nam
   release_time = DRTimes[m_releaseRate * 2] / 1000.0;
   double decay2Time = DRTimes[m_decayRate2 * 2] / 1000.0;
 
-  if (((decay_time < 0.5 && sustain_level > 0.7) || sustain_level == 1.0) && decay2Time < 88600) {
+  if (sustain_level == 1.0 && decay2Time < 1000) {
     decay_time = decay2Time;
+    sustain_level = 0;
+  }
+  else if (decay2Time < 2.0) {
+    decay_time += decay2Time;
     sustain_level = 0;
   }
 


### PR DESCRIPTION
This improves the condition and manner in which we approximate the Saturn SCSP decay 2 curve (ie sustain rate) into the SF2/DLS ADSR which lacks such a curve.

Previously, we would entirely replace decay 1 time with decay 2 if the decay 1 time was less than half a second, the sustain level was greater than 70%, and the decay 2 time was anything but the maximum length.

The new logic only replaces the decay 1 curve if the sustain level is 100% (meaning decay does nothing) and the decay 2 time is less than 1000 seconds.

Otherwise, if the decay 2 time is less than 2 seconds, it is instead added to the decay 1 time.

In both cases, the sustain level is set to 0, since decay 2 fades the amplitude down to 0 like a release curve.

We do similar substitutions for the ADSR envelopes of SNES, PSX, and CPS2 QSound, though I believe the latter two could be improved in a similar manner.

This partially fixes #878.

## How Has This Been Tested?
The track in question is fixed by this. I tested several other titles for deprecation and found no problems.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
