### PR TITLE
Improve MIDI Port event handling for compatibility in VGMSeqNoTrks

### DIFF
--- a/src/main/components/seq/VGMSeqNoTrks.cpp
+++ b/src/main/components/seq/VGMSeqNoTrks.cpp
@@ -139,7 +139,7 @@ void VGMSeqNoTrks::tryExpandMidiTracks(uint32_t numTracks) {
       auto* midiTrack = midi->addTrack();
       midiTracks.push_back(midiTrack);
 
-      if (numTracks < 10)
+      if (numTracks < 10 || ConversionOptions::the().skipChannel10() == false)
         continue;
 
       int chGroup = i == 9 && ConversionOptions::the().skipChannel10() ? 1 : 0;

--- a/src/main/components/seq/VGMSeqNoTrks.cpp
+++ b/src/main/components/seq/VGMSeqNoTrks.cpp
@@ -138,10 +138,13 @@ void VGMSeqNoTrks::tryExpandMidiTracks(uint32_t numTracks) {
     for (size_t i = initialTrackSize; i < numTracks; i++) {
       auto* midiTrack = midi->addTrack();
       midiTracks.push_back(midiTrack);
-      if (i == 9 && ConversionOptions::the().skipChannel10()) {
-        midiTrack->setChannelGroup(1);
-        midiTrack->addMidiPort(1);
-      }
+
+      if (numTracks < 10)
+        continue;
+
+      int chGroup = i == 9 && ConversionOptions::the().skipChannel10() ? 1 : 0;
+      midiTrack->setChannelGroup(chGroup);
+      midiTrack->addMidiPort(chGroup);
     }
   }
 }


### PR DESCRIPTION
We use the MIDI Port event to overcome the 16 channel limit of standard MIDI. We add the event to the beginning of a track to indicate that it should be considered part of a different channel group.

SpessaSynth only works with the MIDI Port event if we add it for every track - it doesn't seem to default a track's MIDI Port to 0.

We add the MIDI Port event for all tracks in a normal VGMSeq, but for VGMSeqNoTrks, it's only added for the 10th track when the option to skip MIDI channel 10 is enabled.

This changes that behavior: if a sequence has at least 10 tracks and the "Skip MIDI channel 10" option is enabled, we add the MIDI port event for all tracks.

This partially fixes #878

## How Has This Been Tested?
SpessaSynth plays as expected. Various other sequences tested with no deprecations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
