### PR TITLE
AkaoSnes: vibrato fade-in support for V3 and V4

### DIFF
--- a/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
@@ -11,14 +11,6 @@
 #include "AkaoSnesModulation.h"
 #include "SNESDSP.h"
 
-namespace {
-
-void addAkaoSnesVibratoExportHandling(VGMInstr *instr, AkaoSnesVersion version) {
-  instr->addStandardVibratoHandling(akao_snes::modulation::vibratoSpec(version));
-}
-
-}  // namespace
-
 // ****************
 // AkaoSnesInstrSet
 // ****************
@@ -143,7 +135,7 @@ bool AkaoSnesInstr::loadInstr() {
     return false;
   }
 
-  addAkaoSnesVibratoExportHandling(this, version);
+  addStandardVibratoHandling(akao_snes::modulation::vibratoSpec(version));
 
   uint16_t addrSampStart = readShort(offDirEnt);
 
@@ -185,7 +177,7 @@ bool AkaoSnesDrumKit::loadInstr() {
     return false;
   }
 
-  addAkaoSnesVibratoExportHandling(this, version);
+  addStandardVibratoHandling(akao_snes::modulation::vibratoSpec(version));
 
   uint8_t NOTE_DUR_TABLE_SIZE;
   switch (version) {

--- a/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
@@ -14,10 +14,6 @@
 namespace {
 
 void addAkaoSnesVibratoExportHandling(VGMInstr *instr, AkaoSnesVersion version) {
-  if (!akao_snes::modulation::supportsLfoAutomation(version)) {
-    return;
-  }
-
   instr->addStandardVibratoHandling(akao_snes::modulation::vibratoSpec(version));
 }
 

--- a/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
@@ -315,6 +315,12 @@ uint8_t delayTicks(AkaoSnesVersion version, uint8_t delay) {
     return (delay == 0xff) ? 0 : delay;
   }
 
+  if (version == AKAOSNES_V4) {
+    // FF6-family drivers decrement delay during the same sequencer pass that
+    // initializes vibrato, so $01 enables fade-in with no audible pre-delay.
+    return (delay == 0) ? 0 : static_cast<uint8_t>(delay - 1);
+  }
+
   return delay;
 }
 
@@ -372,6 +378,13 @@ uint32_t v3VibratoRampTicks(uint8_t rate, uint8_t tempo) {
   // V3's delayed note-start ramp reaches the first full-depth sample after six
   // LFO update intervals; export that as one smooth SF2 depth fade.
   const double rampFrames = 6.0 * effectiveRateFrames(AKAOSNES_V3, rate, 0);
+  return driverFramesToMusicTicks(rampFrames, tempo);
+}
+
+uint32_t v4VibratoRampTicks(uint8_t rate, uint8_t tempo) {
+  // V4 starts delayed vibrato at quarter slope and reaches full depth after
+  // seven rate intervals. Approximate that slope ramp as one smooth depth fade.
+  const double rampFrames = 7.0 * effectiveRateFrames(AKAOSNES_V4, rate, 0);
   return driverFramesToMusicTicks(rampFrames, tempo);
 }
 

--- a/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
@@ -254,6 +254,7 @@ double delaySeconds(AkaoSnesVersion version, uint8_t delay, uint8_t tempo, uint8
 }
 
 uint32_t driverFramesToTicks(double frames, uint8_t tempo) {
+  // Tempo 0 stops music ticks; export automation still needs finite timing, so use the slowest nonzero tempo.
   const uint8_t safeTempo = (tempo == 0) ? 1 : tempo;
   return std::max<uint32_t>(1, static_cast<uint32_t>(std::lround(frames * safeTempo / 256.0)));
 }

--- a/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
@@ -253,7 +253,7 @@ double delaySeconds(AkaoSnesVersion version, uint8_t delay, uint8_t tempo, uint8
   return ticks * (256.0 / (frameRateHz(timer0Frequency) * safeTempo));
 }
 
-uint32_t driverFramesToMusicTicks(double frames, uint8_t tempo) {
+uint32_t driverFramesToTicks(double frames, uint8_t tempo) {
   const uint8_t safeTempo = (tempo == 0) ? 1 : tempo;
   return std::max<uint32_t>(1, static_cast<uint32_t>(std::lround(frames * safeTempo / 256.0)));
 }
@@ -371,21 +371,21 @@ uint32_t v1VibratoRampTicks(uint8_t rate, uint8_t tempo) {
   // FF4 derives the fade length from the vibrato rate counter in driver frames,
   // then the sequencer tempo determines how many music ticks those frames span.
   const double rampFrames = 14.0 * (counter + 1);
-  return driverFramesToMusicTicks(rampFrames, tempo);
+  return driverFramesToTicks(rampFrames, tempo);
 }
 
 uint32_t v3VibratoRampTicks(uint8_t rate, uint8_t tempo) {
   // V3's delayed note-start ramp reaches the first full-depth sample after six
   // LFO update intervals; export that as one smooth SF2 depth fade.
   const double rampFrames = 6.0 * effectiveRateFrames(AKAOSNES_V3, rate, 0);
-  return driverFramesToMusicTicks(rampFrames, tempo);
+  return driverFramesToTicks(rampFrames, tempo);
 }
 
 uint32_t v4VibratoRampTicks(uint8_t rate, uint8_t tempo) {
   // V4 starts delayed vibrato at quarter slope and reaches full depth after
   // seven rate intervals. Approximate that slope ramp as one smooth depth fade.
   const double rampFrames = 7.0 * effectiveRateFrames(AKAOSNES_V4, rate, 0);
-  return driverFramesToMusicTicks(rampFrames, tempo);
+  return driverFramesToTicks(rampFrames, tempo);
 }
 
 }  // namespace akao_snes::modulation

--- a/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
@@ -259,6 +259,7 @@ uint32_t driverFramesToTicks(double frames, uint8_t tempo) {
 }
 
 constexpr double kMaxV1DelaySeconds = 254.0 * 256.0 / (8000.0 / kMinTimer0Frequency);
+constexpr double kMaxV4DelaySeconds = 254.0 * 256.0 / ((8000.0 / kMaxTimer0Frequency) * 1.0);
 constexpr double kMaxDelaySeconds = 255.0 * 256.0 / ((8000.0 / kMaxTimer0Frequency) * 1.0);
 const double kMaxV1VibratoDepthCents = v1VibratoDepthCentsForHighByte(255);
 const double kMaxV2VibratoDepthCents = 1200.0 * std::log2(1.0 + (15.0 * 127.0 / 32768.0));
@@ -279,8 +280,13 @@ double maxVibratoDepthCents(AkaoSnesVersion version) {
 }
 
 double maxDelaySeconds(AkaoSnesVersion version) {
-  // Export range ceiling for the delay controller; V1 cannot represent literal $ff as a delay.
-  return (version == AKAOSNES_V1) ? kMaxV1DelaySeconds : kMaxDelaySeconds;
+  // Export range ceiling for the delay controller; V1 wraps $ff and V4 decrements
+  // the active delay during the setup tick, so neither uses the full 255 ticks.
+  if (version == AKAOSNES_V1) {
+    return kMaxV1DelaySeconds;
+  }
+
+  return (version == AKAOSNES_V4) ? kMaxV4DelaySeconds : kMaxDelaySeconds;
 }
 
 }  // namespace

--- a/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
@@ -253,6 +253,11 @@ double delaySeconds(AkaoSnesVersion version, uint8_t delay, uint8_t tempo, uint8
   return ticks * (256.0 / (frameRateHz(timer0Frequency) * safeTempo));
 }
 
+uint32_t driverFramesToMusicTicks(double frames, uint8_t tempo) {
+  const uint8_t safeTempo = (tempo == 0) ? 1 : tempo;
+  return std::max<uint32_t>(1, static_cast<uint32_t>(std::lround(frames * safeTempo / 256.0)));
+}
+
 constexpr double kMaxV1DelaySeconds = 254.0 * 256.0 / (8000.0 / kMinTimer0Frequency);
 constexpr double kMaxDelaySeconds = 255.0 * 256.0 / ((8000.0 / kMaxTimer0Frequency) * 1.0);
 const double kMaxV1VibratoDepthCents = v1VibratoDepthCentsForHighByte(255);
@@ -357,11 +362,17 @@ uint32_t v1VibratoRampTicks(uint8_t rate, uint8_t tempo) {
     return 0;
   }
 
-  const uint8_t safeTempo = (tempo == 0) ? 1 : tempo;
   // FF4 derives the fade length from the vibrato rate counter in driver frames,
   // then the sequencer tempo determines how many music ticks those frames span.
   const double rampFrames = 14.0 * (counter + 1);
-  return std::max<uint32_t>(1, static_cast<uint32_t>(std::lround(rampFrames * safeTempo / 256.0)));
+  return driverFramesToMusicTicks(rampFrames, tempo);
+}
+
+uint32_t v3VibratoRampTicks(uint8_t rate, uint8_t tempo) {
+  // V3's delayed note-start ramp reaches the first full-depth sample after six
+  // LFO update intervals; export that as one smooth SF2 depth fade.
+  const double rampFrames = 6.0 * effectiveRateFrames(AKAOSNES_V3, rate, 0);
+  return driverFramesToMusicTicks(rampFrames, tempo);
 }
 
 }  // namespace akao_snes::modulation

--- a/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
@@ -285,17 +285,7 @@ double maxDelaySeconds(AkaoSnesVersion version) {
 
 }  // namespace
 
-bool supportsLfoAutomation(AkaoSnesVersion version) {
-  // Only the SNES AKAO versions modeled above have enough known LFO behavior to automate.
-  return version == AKAOSNES_V1 || version == AKAOSNES_V2 ||
-         version == AKAOSNES_V3 || version == AKAOSNES_V4;
-}
-
 bool isLfoActive(AkaoSnesVersion version, uint8_t rate, uint8_t depth) {
-  if (!supportsLfoAutomation(version)) {
-    return false;
-  }
-
   if (version == AKAOSNES_V2) {
     // V2 can be active with a zero depth byte because the low six bits are
     // interpreted as magnitude + 1; only a zero rate counter disables it.

--- a/src/main/formats/AkaoSnes/AkaoSnesModulation.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesModulation.h
@@ -25,5 +25,6 @@ uint8_t rateMidiValue(AkaoSnesVersion version, uint8_t rate, uint8_t depth, uint
 uint8_t delayMidiValue(AkaoSnesVersion version, uint8_t delay, uint8_t tempo, uint8_t timer0Frequency);
 uint32_t v1VibratoRampTicks(uint8_t rate, uint8_t tempo);
 uint32_t v3VibratoRampTicks(uint8_t rate, uint8_t tempo);
+uint32_t v4VibratoRampTicks(uint8_t rate, uint8_t tempo);
 
 }  // namespace akao_snes::modulation

--- a/src/main/formats/AkaoSnes/AkaoSnesModulation.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesModulation.h
@@ -24,5 +24,6 @@ uint8_t vibratoDepthMidiValue(AkaoSnesVersion version, uint8_t rate, uint8_t dep
 uint8_t rateMidiValue(AkaoSnesVersion version, uint8_t rate, uint8_t depth, uint8_t timer0Frequency);
 uint8_t delayMidiValue(AkaoSnesVersion version, uint8_t delay, uint8_t tempo, uint8_t timer0Frequency);
 uint32_t v1VibratoRampTicks(uint8_t rate, uint8_t tempo);
+uint32_t v3VibratoRampTicks(uint8_t rate, uint8_t tempo);
 
 }  // namespace akao_snes::modulation

--- a/src/main/formats/AkaoSnes/AkaoSnesModulation.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesModulation.h
@@ -14,7 +14,6 @@ namespace akao_snes::modulation {
 inline constexpr uint8_t kDefaultTempo = 0x20;
 inline constexpr uint8_t kVibratoDelayController = 93;
 
-bool supportsLfoAutomation(AkaoSnesVersion version);
 bool isLfoActive(AkaoSnesVersion version, uint8_t rate, uint8_t depth);
 uint8_t delayTicks(AkaoSnesVersion version, uint8_t delay);
 

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.h
@@ -157,6 +157,7 @@ public:
   void syncVibratoRateAndDelay();
   void configureVibratoFade();
   void beginVibratoForNote();
+  uint8_t vibratoFadeDepthMidiValue(int32_t depth) const;
   void updateVibratoFade();
 
   uint8_t onetimeDuration;

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
@@ -7,6 +7,7 @@
 #include "AkaoSnesSeq.h"
 #include "AkaoSnesModulation.h"
 #include "automation/SeqTrackAutomation.h"
+#include <algorithm>
 #include <spdlog/fmt/fmt.h>
 
 /*
@@ -14,10 +15,10 @@
  * handlers here keep only the live per-track state; the version-specific math
  * lives in AkaoSnesModulation.h.
  *
- * V1/FF4 and V3 have per-note fade-in behavior that restarts on normal keyed
- * notes and is not restarted by ties/slur/legato. V2 uses a different operand
- * order for the three-byte LFO setup command. V3/V4 share the later command
- * shape, with V4's rate byte treating zero as 256 frames.
+ * V1/FF4, V3, and V4 have per-note fade-in behavior that restarts on normal
+ * keyed notes and is not restarted by ties/slur/legato. V2 uses a different
+ * operand order for the three-byte LFO setup command. V3/V4 share the later
+ * command shape, with V4's rate byte treating zero as 256 frames.
  */
 
 void AkaoSnesSeq::syncTempoDependentTracks() {
@@ -66,13 +67,17 @@ void AkaoSnesTrack::applyVibrato(uint32_t offset, uint32_t length, const LfoPara
   }
 
   vibrato.configure(params.delay, params.rate, params.depth);
-  // Only V1 creates reusable note-start vibrato fade state. Later versions
-  // apply the configured vibrato depth directly after the setup command.
   configureVibratoFade();
 
-  const uint8_t midiDepth = active
+  uint8_t midiDepth = active
       ? akao_snes::modulation::vibratoDepthMidiValue(parent->version, params.rate, params.depth)
       : 0;
+  if (parent->version == AKAOSNES_V4 && active && vibrato.hasReusableFade()) {
+    const uint32_t delay = akao_snes::modulation::delayTicks(parent->version, vibrato.delay());
+    const int32_t initialDepth = vibrato.configuredDepth(8) / 4;
+    vibrato.beginReusableFade(delay, vibrato.configuredDepth(8), initialDepth);
+    midiDepth = (delay == 0) ? vibratoFadeDepthMidiValue(initialDepth) : 0;
+  }
   setSynthLfoModulationDepth(vibrato, midiDepth, true);
   if (active) {
     syncVibratoRateAndDelay();
@@ -92,7 +97,7 @@ void AkaoSnesTrack::clearVibrato(uint32_t offset, uint32_t length) {
   }
 
   vibrato.setDepth(0);
-  // Turning V1 vibrato off also prevents later notes from replaying the stored fade-in ramp.
+  // Turning vibrato off also prevents later notes from replaying the stored fade-in ramp.
   vibrato.clearReusableFade();
   setSynthLfoModulationDepth(vibrato, 0, true);
   clearVibratoRateAndDelay();
@@ -120,42 +125,65 @@ void AkaoSnesTrack::configureVibratoFade() {
     return;
   }
 
+  if (parent->version == AKAOSNES_V4 && vibrato.delay() != 0) {
+    const uint32_t ticks = akao_snes::modulation::v4VibratoRampTicks(vibrato.rate(), parent->tempo);
+    const int32_t targetDepth = vibrato.configuredDepth(8);
+    const int32_t initialDepth = targetDepth / 4;
+    const int32_t step = ticks == 0 ? 0 : (targetDepth - initialDepth) / static_cast<int32_t>(ticks);
+    vibrato.setReusableFade(ticks, step);
+    return;
+  }
+
   vibrato.clearReusableFade();
 }
 
 void AkaoSnesTrack::beginVibratoForNote() {
   const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
   const bool supportsNoteStartFade =
-      parent->version == AKAOSNES_V1 || parent->version == AKAOSNES_V3;
+      parent->version == AKAOSNES_V1 || parent->version == AKAOSNES_V3 ||
+      parent->version == AKAOSNES_V4;
   if (!supportsNoteStartFade || !vibrato.hasReusableFade() ||
       !akao_snes::modulation::isLfoActive(parent->version, vibrato.rate(), vibrato.depth())) {
     return;
   }
 
-  // Normal notes with a reusable fade start at zero vibrato depth, then
-  // updateVibratoFade() advances them on sequencer ticks. Ties and legato notes
-  // skip this call.
-  vibrato.beginReusableFade(akao_snes::modulation::delayTicks(parent->version, vibrato.delay()),
-                            vibrato.configuredDepth(8));
-  setSynthLfoModulationDepth(vibrato, 0, true);
+  // Normal notes with a reusable fade restart the exported depth ramp. V4 begins
+  // at quarter depth when there is no effective pre-delay; the others begin at
+  // zero. Ties and legato notes skip this call.
+  const uint32_t delay = akao_snes::modulation::delayTicks(parent->version, vibrato.delay());
+  const int32_t initialDepth = (parent->version == AKAOSNES_V4)
+      ? vibrato.configuredDepth(8) / 4
+      : 0;
+  vibrato.beginReusableFade(delay, vibrato.configuredDepth(8), initialDepth);
+  setSynthLfoModulationDepth(vibrato,
+                             (delay == 0) ? vibratoFadeDepthMidiValue(initialDepth) : 0,
+                             true);
+}
+
+uint8_t AkaoSnesTrack::vibratoFadeDepthMidiValue(int32_t depth) const {
+  const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
+  const int32_t targetDepth = vibrato.configuredDepth(8);
+  if (targetDepth <= 0) {
+    return 0;
+  }
+
+  const int fullDepth = akao_snes::modulation::vibratoDepthMidiValue(parent->version,
+                                                                     vibrato.rate(),
+                                                                     vibrato.depth());
+  return static_cast<uint8_t>(std::clamp<int>((fullDepth * depth + (targetDepth / 2)) / targetDepth,
+                                              0,
+                                              127));
 }
 
 void AkaoSnesTrack::updateVibratoFade() {
   const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
-  if (parent->version != AKAOSNES_V1 && parent->version != AKAOSNES_V3) {
+  if (parent->version != AKAOSNES_V1 && parent->version != AKAOSNES_V3 &&
+      parent->version != AKAOSNES_V4) {
     return;
   }
 
-  advanceSynthLfoFadeToModulation(vibrato, 8, [this, parent](int32_t depth) {
-    const int32_t targetDepth = vibrato.configuredDepth(8);
-    if (targetDepth <= 0) {
-      return 0;
-    }
-
-    const int fullDepth = akao_snes::modulation::vibratoDepthMidiValue(parent->version,
-                                                                       vibrato.rate(),
-                                                                       vibrato.depth());
-    return static_cast<int>((fullDepth * depth + (targetDepth / 2)) / targetDepth);
+  advanceSynthLfoFadeToModulation(vibrato, 8, [this](int32_t depth) {
+    return vibratoFadeDepthMidiValue(depth);
   });
 }
 
@@ -166,7 +194,7 @@ void AkaoSnesTrack::syncVibratoRateAndDelay() {
     return;
   }
 
-  // Tempo changes can alter V1's reusable fade duration, so refresh it when
+  // Tempo changes can alter reusable fade duration, so refresh it when
   // resending tempo-dependent LFO controller values.
   configureVibratoFade();
 

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
@@ -16,9 +16,9 @@
  * lives in AkaoSnesModulation.h.
  *
  * V1/FF4, V3, and V4 have per-note fade-in behavior that restarts on normal
- * keyed notes and is not restarted by ties/slur/legato. V2 uses a different
- * operand order for the three-byte LFO setup command. V3/V4 share the later
- * command shape, with V4's rate byte treating zero as 256 frames.
+ * keyed notes and is not restarted by ties/slur/legato. V2 is the only
+ * supported version that orders the three-byte LFO setup as depth, delay, rate;
+ * the others use delay, rate, depth.
  */
 
 void AkaoSnesSeq::syncTempoDependentTracks() {
@@ -80,8 +80,6 @@ void AkaoSnesTrack::applyVibrato(uint32_t offset, uint32_t length, const LfoPara
 }
 
 void AkaoSnesTrack::clearVibrato(uint32_t offset, uint32_t length) {
-  const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
-
   addGenericEvent(offset, length, "Vibrato Off", "", Type::Vibrato);
 
   vibrato.setDepth(0);

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
@@ -14,10 +14,10 @@
  * handlers here keep only the live per-track state; the version-specific math
  * lives in AkaoSnesModulation.h.
  *
- * V1/FF4 is the outlier: vibrato has a per-note fade-in behavior that restarts
- * on normal keyed notes and is not restarted by ties/slur/legato. V2 also uses
- * a different operand order for the three-byte LFO setup command. V3/V4 share
- * the later command shape, with V4's rate byte treating zero as 256 frames.
+ * V1/FF4 and V3 have per-note fade-in behavior that restarts on normal keyed
+ * notes and is not restarted by ties/slur/legato. V2 uses a different operand
+ * order for the three-byte LFO setup command. V3/V4 share the later command
+ * shape, with V4's rate byte treating zero as 256 frames.
  */
 
 void AkaoSnesSeq::syncTempoDependentTracks() {
@@ -100,28 +100,41 @@ void AkaoSnesTrack::clearVibrato(uint32_t offset, uint32_t length) {
 
 void AkaoSnesTrack::configureVibratoFade() {
   const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
-  if (parent->version != AKAOSNES_V1 ||
-      !akao_snes::modulation::isLfoActive(parent->version, vibrato.rate(), vibrato.depth())) {
+  if (!akao_snes::modulation::isLfoActive(parent->version, vibrato.rate(), vibrato.depth())) {
     vibrato.clearReusableFade();
     return;
   }
 
-  // V1/FF4 ramps from zero to the configured vibrato depth over a driver-derived
-  // number of sequencer ticks. The actual MIDI depth is computed during the
-  // fade so tempo changes can keep the reusable shape synchronized.
-  vibrato.setReusableFadeToConfiguredDepth(
-      akao_snes::modulation::v1VibratoRampTicks(vibrato.rate(), parent->tempo), 8);
+  if (parent->version == AKAOSNES_V1) {
+    // V1/FF4 ramps from zero to the configured vibrato depth over a driver-derived
+    // number of sequencer ticks. The actual MIDI depth is computed during the
+    // fade so tempo changes can keep the reusable shape synchronized.
+    vibrato.setReusableFadeToConfiguredDepth(
+        akao_snes::modulation::v1VibratoRampTicks(vibrato.rate(), parent->tempo), 8);
+    return;
+  }
+
+  if (parent->version == AKAOSNES_V3 && vibrato.delay() != 0) {
+    vibrato.setReusableFadeToConfiguredDepth(
+        akao_snes::modulation::v3VibratoRampTicks(vibrato.rate(), parent->tempo), 8);
+    return;
+  }
+
+  vibrato.clearReusableFade();
 }
 
 void AkaoSnesTrack::beginVibratoForNote() {
   const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
-  if (parent->version != AKAOSNES_V1 || !vibrato.hasReusableFade() ||
+  const bool supportsNoteStartFade =
+      parent->version == AKAOSNES_V1 || parent->version == AKAOSNES_V3;
+  if (!supportsNoteStartFade || !vibrato.hasReusableFade() ||
       !akao_snes::modulation::isLfoActive(parent->version, vibrato.rate(), vibrato.depth())) {
     return;
   }
 
-  // A normal V1 note starts with zero vibrato depth, then updateVibratoFade()
-  // advances it on sequencer ticks. Ties and legato notes skip this call.
+  // Normal notes with a reusable fade start at zero vibrato depth, then
+  // updateVibratoFade() advances them on sequencer ticks. Ties and legato notes
+  // skip this call.
   vibrato.beginReusableFade(akao_snes::modulation::delayTicks(parent->version, vibrato.delay()),
                             vibrato.configuredDepth(8));
   setSynthLfoModulationDepth(vibrato, 0, true);
@@ -129,7 +142,7 @@ void AkaoSnesTrack::beginVibratoForNote() {
 
 void AkaoSnesTrack::updateVibratoFade() {
   const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
-  if (parent->version != AKAOSNES_V1) {
+  if (parent->version != AKAOSNES_V1 && parent->version != AKAOSNES_V3) {
     return;
   }
 

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
@@ -127,9 +127,7 @@ void AkaoSnesTrack::configureVibratoFade() {
 
 void AkaoSnesTrack::beginVibratoForNote() {
   const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
-  const bool supportsNoteStartFade =
-      parent->version == AKAOSNES_V1 || parent->version == AKAOSNES_V3 || parent->version == AKAOSNES_V4;
-  if (!supportsNoteStartFade || !vibrato.hasReusableFade() ||
+  if (parent->version == AKAOSNES_V2 || !vibrato.hasReusableFade() ||
       !akao_snes::modulation::isLfoActive(parent->version, vibrato.rate(), vibrato.depth())) {
     return;
   }
@@ -164,8 +162,7 @@ uint8_t AkaoSnesTrack::vibratoFadeDepthMidiValue(int32_t depth) const {
 
 void AkaoSnesTrack::updateVibratoFade() {
   const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
-  if (parent->version != AKAOSNES_V1 && parent->version != AKAOSNES_V3 &&
-      parent->version != AKAOSNES_V4) {
+  if (parent->version == AKAOSNES_V2) {
     return;
   }
 

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
@@ -140,8 +140,7 @@ void AkaoSnesTrack::configureVibratoFade() {
 void AkaoSnesTrack::beginVibratoForNote() {
   const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
   const bool supportsNoteStartFade =
-      parent->version == AKAOSNES_V1 || parent->version == AKAOSNES_V3 ||
-      parent->version == AKAOSNES_V4;
+      parent->version == AKAOSNES_V1 || parent->version == AKAOSNES_V3 || parent->version == AKAOSNES_V4;
   if (!supportsNoteStartFade || !vibrato.hasReusableFade() ||
       !akao_snes::modulation::isLfoActive(parent->version, vibrato.rate(), vibrato.depth())) {
     return;

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
@@ -22,10 +22,6 @@
  */
 
 void AkaoSnesSeq::syncTempoDependentTracks() {
-  if (!akao_snes::modulation::supportsLfoAutomation(version)) {
-    return;
-  }
-
   for (auto *track : aTracks) {
     static_cast<AkaoSnesTrack*>(track)->syncTempoDependentLfos();
   }
@@ -62,10 +58,6 @@ void AkaoSnesTrack::applyVibrato(uint32_t offset, uint32_t length, const LfoPara
                   fmt::format("Delay: {}  Rate: {}  Depth: {}", params.delay, params.rate, params.depth),
                   Type::Vibrato);
 
-  if (!akao_snes::modulation::supportsLfoAutomation(parent->version)) {
-    return;
-  }
-
   vibrato.configure(params.delay, params.rate, params.depth);
   configureVibratoFade();
 
@@ -91,10 +83,6 @@ void AkaoSnesTrack::clearVibrato(uint32_t offset, uint32_t length) {
   const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
 
   addGenericEvent(offset, length, "Vibrato Off", "", Type::Vibrato);
-
-  if (!akao_snes::modulation::supportsLfoAutomation(parent->version)) {
-    return;
-  }
 
   vibrato.setDepth(0);
   // Turning vibrato off also prevents later notes from replaying the stored fade-in ramp.
@@ -188,8 +176,7 @@ void AkaoSnesTrack::updateVibratoFade() {
 
 void AkaoSnesTrack::syncVibratoRateAndDelay() {
   const auto *parent = static_cast<AkaoSnesSeq*>(parentSeq);
-  if (!akao_snes::modulation::supportsLfoAutomation(parent->version) ||
-      !akao_snes::modulation::isLfoActive(parent->version, vibrato.rate(), vibrato.depth())) {
+  if (!akao_snes::modulation::isLfoActive(parent->version, vibrato.rate(), vibrato.depth())) {
     return;
   }
 


### PR DESCRIPTION
This adds per-note vibrato fade-in for AkaoSnes V3 and V4 using the automation classes. We already support V1's fade-in, and V2 doesn't have this as a feature.

For V3 drivers such as FF5 and Secret of Mana, the fade is delay-triggered and only starts when the vibrato delay is non-zero. V4 / FF6-family drivers have related but different timing, including the important case where a delay of 1 enables fade-in but has effectively no audible pre-delay.

New non-tied notes restart the fade, while ties and legato notes do not. I also cleaned up some surrounding code by removing the redundant `supportsLfoAutomation()` helper, simplifying V2-exclusion checks, and trimming a couple of now-unnecessary wrappers/comments.

## How Has This Been Tested?
Verified modwheel ramps look correct in exported MIDI and compared by ear.

## Audio Demo

The difference is subtle.

Old

https://github.com/user-attachments/assets/ee781acc-7d9e-4705-9823-18567ea6d863

New

https://github.com/user-attachments/assets/cfdf9089-3783-458a-a5ab-eb005ecfbcf3



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.