### PR TITLE
Remove common.h macros and harden filename logging

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -549,6 +549,16 @@ target_link_libraries(
 )
 target_compile_features(vgmtranscore PUBLIC cxx_std_20)
 
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles(
+  "int main() { const char *file_name = __FILE_NAME__; return file_name[0]; }"
+  HAS__FILE_NAME__)
+target_compile_definitions(vgmtranscore PUBLIC HAS__FILE_NAME__=$<BOOL:${HAS__FILE_NAME__}>)
+
+if(NOT HAS__FILE_NAME__ AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(vgmtranscore PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:-fmacro-prefix-map=${PROJECT_SOURCE_DIR}/=>")
+endif()
+
 configure_file(${PROJECT_SOURCE_DIR}/bin/mame_roms.json mame_roms.json COPYONLY)
 target_compile_definitions(vgmtranscore PUBLIC "DEV_ENV_BUILD_TREE=\"${CMAKE_CURRENT_BINARY_DIR}\"")
 

--- a/src/main/LogManager.h
+++ b/src/main/LogManager.h
@@ -66,6 +66,20 @@ private:
 };
 
 // Logging Macros
+#ifndef HAS__FILE_NAME__
+#ifdef __FILE_NAME__
+#define HAS__FILE_NAME__ 1
+#else
+#define HAS__FILE_NAME__ 0
+#endif
+#endif
+
+#if HAS__FILE_NAME__
+#define THIS_FILE_NAME __FILE_NAME__
+#else
+#define THIS_FILE_NAME __FILE__
+#endif
+
 #define L_LOG(level, ...) LogManager::the().log(level, THIS_FILE_NAME, __LINE__, __VA_ARGS__)
 #define L_ERROR(...) L_LOG(spdlog::level::err, __VA_ARGS__)
 #define L_WARN(...) L_LOG(spdlog::level::warn, __VA_ARGS__)

--- a/src/main/formats/SonyPS2/SonyPS2InstrSet.h
+++ b/src/main/formats/SonyPS2/SonyPS2InstrSet.h
@@ -5,9 +5,6 @@
 #include "VGMRgn.h"
 #include "SonyPS2Format.h"
 
-//FORWARD_DECLARE_TYPEDEF_STRUCT(ProgParam);
-
-
 #define SCEHD_LFO_NON        0
 #define SCEHD_LFO_SAWUP      1
 #define SCEHD_LFO_SAWDOWN    2

--- a/src/main/util/common.h
+++ b/src/main/util/common.h
@@ -21,7 +21,6 @@
 
 
 #define KILOBYTE 1024
-#define MEGABYTE (KILOBYTE*1024)
 
 /* Type aliases to save some typing */
 using size_t = std::size_t;

--- a/src/main/util/common.h
+++ b/src/main/util/common.h
@@ -19,9 +19,6 @@
 #define THIS_FILE_NAME ""
 #endif
 
-
-#define KILOBYTE 1024
-
 /* Type aliases to save some typing */
 using size_t = std::size_t;
 

--- a/src/main/util/common.h
+++ b/src/main/util/common.h
@@ -24,8 +24,6 @@
 #define MEGABYTE (KILOBYTE*1024)
 #define GIGABYTE (MEGABYTE*1024)
 
-#define F_EPSILON 0.00001
-
 /* Type aliases to save some typing */
 using size_t = std::size_t;
 

--- a/src/main/util/common.h
+++ b/src/main/util/common.h
@@ -22,7 +22,6 @@
 
 #define KILOBYTE 1024
 #define MEGABYTE (KILOBYTE*1024)
-#define GIGABYTE (MEGABYTE*1024)
 
 /* Type aliases to save some typing */
 using size_t = std::size_t;

--- a/src/main/util/common.h
+++ b/src/main/util/common.h
@@ -13,12 +13,6 @@
 #include <variant>
 #include <filesystem>
 
-#ifdef __FILE_NAME__
-#define THIS_FILE_NAME __FILE_NAME__
-#else
-#define THIS_FILE_NAME ""
-#endif
-
 /* Type aliases to save some typing */
 using size_t = std::size_t;
 

--- a/src/main/util/common.h
+++ b/src/main/util/common.h
@@ -26,10 +26,6 @@
 
 #define F_EPSILON 0.00001
 
-#define FORWARD_DECLARE_TYPEDEF_STRUCT(type) \
-    struct _##type;    \
-    typedef _##type type
-
 /* Type aliases to save some typing */
 using size_t = std::size_t;
 


### PR DESCRIPTION
## Description
Removes the remaining macro definitions from `common.h`:
- `FORWARD_DECLARE_TYPEDEF_STRUCT`
- `F_EPSILON`
- `KILOBYTE`
- `MEGABYTE`
- `GIGABYTE`
- `THIS_FILE_NAME`

Adds a `vgmtranscore` CMake check for `HAS__FILE_NAME__`, and keeps filename logging local to `LogManager.h` by aliasing `THIS_FILE_NAME` to:
- `__FILE_NAME__` when supported
- `__FILE__` otherwise

For GCC without `__FILE_NAME__`, CMake uses `-fmacro-prefix-map=${PROJECT_SOURCE_DIR}/=` to keep fallback log filenames from including the full source-root path. MSVC keeps using `__FILE__`.

## Motivation and Context
This is part of the code hygiene series aimed at killing `common.h`, improving header includes, reducing unnecessary global definitions, and making the dependency tree nicer.

## How Has This Been Tested?
Tested locally on macOS

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code cleanup

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.