### PR TITLE
Add modulator source mappings, add abstracted SeqTrack vibrato/tremolo methods

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -104,6 +104,7 @@ add_library(vgmtranscore OBJECT)
 target_sources(vgmtranscore
   PRIVATE
     LogManager.cpp
+    ModSourceMap.cpp
     Options.cpp
     Root.cpp
     components/FileLoader.cpp
@@ -288,6 +289,7 @@ target_sources(vgmtranscore
       LogItem.h
       LogManager.h
       Loop.h
+      ModSourceMap.h
       Options.h
       Root.h
     FILE_SET headers_formats TYPE HEADERS BASE_DIRS formats

--- a/src/main/ModSourceMap.cpp
+++ b/src/main/ModSourceMap.cpp
@@ -1,0 +1,129 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#include "ModSourceMap.h"
+#include "Options.h"
+
+namespace {
+
+struct ModSourceSettingSpec {
+  ModDest destination;
+  const char* sf2Key;
+  ModSource sf2Default;
+  const char* dlsKey;
+  ModSource dlsDefault;
+};
+
+constexpr std::array<ModSourceSettingSpec, kModDests.size()> kModSourceSettings {{
+    {
+        ModDest::VibLfoToPitch,
+        "sf2ModSourceVibLfoToPitch",
+        ModSource::ModWheel,
+        "dlsModSourceVibLfoToPitch",
+        ModSource::ModWheel,
+    },
+    {
+        ModDest::VibLfoFreq,
+        "sf2ModSourceVibLfoFreq",
+        ModSource::VibratoRate,
+        "dlsModSourceVibLfoFreq",
+        ModSource::ChannelPressure,
+    },
+    {
+        ModDest::VibLfoDelay,
+        "sf2ModSourceVibLfoDelay",
+        ModSource::VibratoDelay,
+        "dlsModSourceVibLfoDelay",
+        ModSource::ChorusSend,
+    },
+    {
+        ModDest::ModLfoToVol,
+        "sf2ModSourceModLfoToVol",
+        ModSource::TremoloDepth,
+        "dlsModSourceModLfoToVol",
+        ModSource::ChorusSend,
+    },
+    {
+        ModDest::ModLfoFreq,
+        "sf2ModSourceModLfoFreq",
+        ModSource::SoundController6,
+        "dlsModSourceModLfoFreq",
+        ModSource::ChannelPressure,
+    },
+    {
+        ModDest::ModLfoDelay,
+        "sf2ModSourceModLfoDelay",
+        ModSource::SoundController10,
+        "dlsModSourceModLfoDelay",
+        ModSource::ReverbSend,
+    },
+    {
+        ModDest::InitialAtten,
+        "sf2ModSourceInitialAtten",
+        ModSource::TremoloDepth,
+        "dlsModSourceInitialAtten",
+        ModSource::ChorusSend,
+    },
+}};
+
+constexpr const char* settingKeyFor(const ModSourceSettingSpec& spec,
+                                    ModulationSourceTarget target) {
+  return target == ModulationSourceTarget::DLS ? spec.dlsKey : spec.sf2Key;
+}
+
+constexpr ModSource defaultSourceFor(const ModSourceSettingSpec& spec,
+                                     ModulationSourceTarget target) {
+  return target == ModulationSourceTarget::DLS ? spec.dlsDefault : spec.sf2Default;
+}
+
+constexpr int settingValueFor(ModSource source) {
+  return static_cast<int>(source);
+}
+
+constexpr ModSource sourceFromSettingValue(int value, ModSource fallback) {
+  if (value == static_cast<int>(ModSource::None) ||
+      (value >= 0 && value <= static_cast<int>(ModSource::PitchWheel))) {
+    return static_cast<ModSource>(value);
+  }
+  return fallback;
+}
+
+}  // namespace
+
+ModSourceMap::ModSourceMap(ModulationSourceTarget target) {
+  resetToDefaults(target);
+}
+
+void ModSourceMap::resetToDefaults(ModulationSourceTarget target) {
+  for (const auto& spec : kModSourceSettings) {
+    m_sources[modDestIndex(spec.destination)] = defaultSourceFor(spec, target);
+  }
+}
+
+void ModSourceMap::load(OptionStore& store, ModulationSourceTarget target) {
+  resetToDefaults(target);
+  for (const auto& spec : kModSourceSettings) {
+    const auto index = modDestIndex(spec.destination);
+    m_sources[index] = sourceFromSettingValue(
+        store.getInt(settingKeyFor(spec, target), settingValueFor(m_sources[index])),
+        m_sources[index]);
+  }
+}
+
+void ModSourceMap::save(OptionStore& store, ModulationSourceTarget target) const {
+  for (const auto& spec : kModSourceSettings) {
+    store.setInt(settingKeyFor(spec, target),
+                 settingValueFor(m_sources[modDestIndex(spec.destination)]));
+  }
+}
+
+ModSource ModSourceMap::sourceFor(ModDest destination) const {
+  return m_sources[modDestIndex(destination)];
+}
+
+void ModSourceMap::setSourceFor(ModDest destination, ModSource source) {
+  m_sources[modDestIndex(destination)] = source;
+}

--- a/src/main/ModSourceMap.h
+++ b/src/main/ModSourceMap.h
@@ -1,0 +1,28 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#pragma once
+
+#include <array>
+
+#include "Modulation.h"
+
+struct OptionStore;
+
+class ModSourceMap {
+public:
+  explicit ModSourceMap(ModulationSourceTarget target = ModulationSourceTarget::SoundFont);
+
+  void resetToDefaults(ModulationSourceTarget target);
+  void load(OptionStore& store, ModulationSourceTarget target);
+  void save(OptionStore& store, ModulationSourceTarget target) const;
+
+  [[nodiscard]] ModSource sourceFor(ModDest destination) const;
+  void setSourceFor(ModDest destination, ModSource source);
+
+private:
+  std::array<ModSource, kModDests.size()> m_sources{};
+};

--- a/src/main/Options.cpp
+++ b/src/main/Options.cpp
@@ -1,1 +1,40 @@
 #include "Options.h"
+
+#include <algorithm>
+
+void ConversionOptions::setNumSequenceLoops(int numLoops) {
+  m_sequence_loops = std::clamp(numLoops, 0, kMaxSequenceLoops);
+}
+
+ModSourceMap& ConversionOptions::modSourceMap(ModulationSourceTarget target) {
+  return target == ModulationSourceTarget::DLS ? m_dls_mod_sources : m_sf2_mod_sources;
+}
+
+ScopedMidiModulationSourceTarget::ScopedMidiModulationSourceTarget(ModulationSourceTarget target)
+    : m_previous(ConversionOptions::the().midiModulationSourceTarget()) {
+  ConversionOptions::the().setMidiModulationSourceTarget(target);
+}
+
+ScopedMidiModulationSourceTarget::~ScopedMidiModulationSourceTarget() {
+  ConversionOptions::the().setMidiModulationSourceTarget(m_previous);
+}
+
+void ConversionOptions::load(OptionStore& store) {
+  auto g = store.beginGroup("ConversionOptions");
+  const int bs = store.getInt("bankSelectStyle", static_cast<int>(BankSelectStyle::GS));
+  m_bs_style = (bs == static_cast<int>(BankSelectStyle::MMA)) ? BankSelectStyle::MMA
+                                                              : BankSelectStyle::GS;
+  m_sequence_loops = std::clamp(store.getInt("sequenceLoops", 1), 0, kMaxSequenceLoops);
+  m_skip_channel_10 = store.getBool("skipChannel10", true);
+  m_sf2_mod_sources.load(store, ModulationSourceTarget::SoundFont);
+  m_dls_mod_sources.load(store, ModulationSourceTarget::DLS);
+}
+
+void ConversionOptions::save(OptionStore& store) const {
+  auto g = store.beginGroup("ConversionOptions");
+  store.setInt("bankSelectStyle", static_cast<int>(m_bs_style));
+  store.setInt("sequenceLoops", m_sequence_loops);
+  store.setBool("skipChannel10", m_skip_channel_10);
+  m_sf2_mod_sources.save(store, ModulationSourceTarget::SoundFont);
+  m_dls_mod_sources.save(store, ModulationSourceTarget::DLS);
+}

--- a/src/main/Options.h
+++ b/src/main/Options.h
@@ -6,8 +6,12 @@
 
 #pragma once
 #include <algorithm>
+#include <array>
+#include <cstddef>
 #include <memory>
 #include <string_view>
+
+#include "Modulation.h"
 
 struct OptionStore {
   struct Group {
@@ -59,6 +63,40 @@ public:
   bool skipChannel10() const { return m_skip_channel_10; }
   void setSkipChannel10(bool should) { m_skip_channel_10 = should; }
 
+  [[nodiscard]] ModSource modSourceFor(ModulationSourceTarget target, ModDest destination) const {
+    return modSourcesForTarget(target)[modDestIndex(destination)];
+  }
+
+  void setModSourceFor(ModulationSourceTarget target, ModDest destination, ModSource source) {
+    modSourcesForTarget(target)[modDestIndex(destination)] = source;
+  }
+
+  [[nodiscard]] ModulationSourceTarget midiModulationSourceTarget() const {
+    return m_midi_modulation_source_target;
+  }
+
+  void setMidiModulationSourceTarget(ModulationSourceTarget target) {
+    m_midi_modulation_source_target = target;
+  }
+
+  class ScopedMidiModulationSourceTarget {
+  public:
+    explicit ScopedMidiModulationSourceTarget(ModulationSourceTarget target)
+        : m_previous(ConversionOptions::the().midiModulationSourceTarget()) {
+      ConversionOptions::the().setMidiModulationSourceTarget(target);
+    }
+
+    ~ScopedMidiModulationSourceTarget() {
+      ConversionOptions::the().setMidiModulationSourceTarget(m_previous);
+    }
+
+    ScopedMidiModulationSourceTarget(const ScopedMidiModulationSourceTarget&) = delete;
+    ScopedMidiModulationSourceTarget& operator=(const ScopedMidiModulationSourceTarget&) = delete;
+
+  private:
+    ModulationSourceTarget m_previous;
+  };
+
   void load(OptionStore& store) {
     auto g = store.beginGroup("ConversionOptions");
     const int bs = store.getInt("bankSelectStyle", static_cast<int>(BankSelectStyle::GS));
@@ -66,6 +104,20 @@ public:
                                                                 : BankSelectStyle::GS;
     m_sequence_loops = std::clamp(store.getInt("sequenceLoops", 1), 0, kMaxSequenceLoops);
     m_skip_channel_10 = store.getBool("skipChannel10", true);
+
+    m_sf2_mod_sources = defaultModSources(ModulationSourceTarget::SoundFont);
+    m_dls_mod_sources = defaultModSources(ModulationSourceTarget::DLS);
+    for (const ModDest destination : kModDests) {
+      const auto index = modDestIndex(destination);
+      m_sf2_mod_sources[index] = modSourceFromSettingValue(
+          store.getInt(modSourceSettingKey(ModulationSourceTarget::SoundFont, destination),
+                       modSourceSettingValue(m_sf2_mod_sources[index])),
+          m_sf2_mod_sources[index]);
+      m_dls_mod_sources[index] = modSourceFromSettingValue(
+          store.getInt(modSourceSettingKey(ModulationSourceTarget::DLS, destination),
+                       modSourceSettingValue(m_dls_mod_sources[index])),
+          m_dls_mod_sources[index]);
+    }
   }
 
   void save(OptionStore& store) const {
@@ -73,12 +125,109 @@ public:
     store.setInt("bankSelectStyle", static_cast<int>(m_bs_style));
     store.setInt("sequenceLoops",   m_sequence_loops);
     store.setBool("skipChannel10", m_skip_channel_10);
+    for (const ModDest destination : kModDests) {
+      store.setInt(modSourceSettingKey(ModulationSourceTarget::SoundFont, destination),
+                   modSourceSettingValue(modSourceFor(ModulationSourceTarget::SoundFont, destination)));
+      store.setInt(modSourceSettingKey(ModulationSourceTarget::DLS, destination),
+                   modSourceSettingValue(modSourceFor(ModulationSourceTarget::DLS, destination)));
+    }
   }
 
 private:
   ConversionOptions() = default;
 
+  using ModSourceMap = std::array<ModSource, kModDests.size()>;
+
+  static constexpr ModSourceMap defaultModSources(ModulationSourceTarget target) {
+    if (target == ModulationSourceTarget::DLS) {
+      return {
+          ModSource::ModWheel,
+          ModSource::ChannelPressure,
+          ModSource::ChorusSend,
+          ModSource::ChorusSend,
+          ModSource::ChannelPressure,
+          ModSource::ReverbSend,
+          ModSource::ChorusSend,
+      };
+    }
+
+    return {
+        ModSource::ModWheel,
+        ModSource::VibratoRate,
+        ModSource::VibratoDelay,
+        ModSource::TremoloDepth,
+        ModSource::SoundController6,
+        ModSource::SoundController10,
+        ModSource::TremoloDepth,
+    };
+  }
+
+  static constexpr const char* modSourceSettingKey(ModulationSourceTarget target, ModDest destination) {
+    switch (target) {
+      case ModulationSourceTarget::SoundFont:
+        switch (destination) {
+          case ModDest::VibLfoToPitch:
+            return "sf2ModSourceVibLfoToPitch";
+          case ModDest::VibLfoFreq:
+            return "sf2ModSourceVibLfoFreq";
+          case ModDest::VibLfoDelay:
+            return "sf2ModSourceVibLfoDelay";
+          case ModDest::ModLfoToVol:
+            return "sf2ModSourceModLfoToVol";
+          case ModDest::ModLfoFreq:
+            return "sf2ModSourceModLfoFreq";
+          case ModDest::ModLfoDelay:
+            return "sf2ModSourceModLfoDelay";
+          case ModDest::InitialAtten:
+            return "sf2ModSourceInitialAtten";
+        }
+        break;
+      case ModulationSourceTarget::DLS:
+        switch (destination) {
+          case ModDest::VibLfoToPitch:
+            return "dlsModSourceVibLfoToPitch";
+          case ModDest::VibLfoFreq:
+            return "dlsModSourceVibLfoFreq";
+          case ModDest::VibLfoDelay:
+            return "dlsModSourceVibLfoDelay";
+          case ModDest::ModLfoToVol:
+            return "dlsModSourceModLfoToVol";
+          case ModDest::ModLfoFreq:
+            return "dlsModSourceModLfoFreq";
+          case ModDest::ModLfoDelay:
+            return "dlsModSourceModLfoDelay";
+          case ModDest::InitialAtten:
+            return "dlsModSourceInitialAtten";
+        }
+        break;
+    }
+    return "";
+  }
+
+  static constexpr int modSourceSettingValue(ModSource source) {
+    return static_cast<int>(source);
+  }
+
+  static constexpr ModSource modSourceFromSettingValue(int value, ModSource fallback) {
+    if (value == static_cast<int>(ModSource::None) ||
+        (value >= 0 && value <= static_cast<int>(ModSource::PitchWheel))) {
+      return static_cast<ModSource>(value);
+    }
+    return fallback;
+  }
+
+  ModSourceMap& modSourcesForTarget(ModulationSourceTarget target) {
+    return target == ModulationSourceTarget::DLS ? m_dls_mod_sources : m_sf2_mod_sources;
+  }
+
+  [[nodiscard]] const ModSourceMap& modSourcesForTarget(ModulationSourceTarget target) const {
+    return target == ModulationSourceTarget::DLS ? m_dls_mod_sources : m_sf2_mod_sources;
+  }
+
   BankSelectStyle m_bs_style{BankSelectStyle::GS};
   int m_sequence_loops{0};
   bool m_skip_channel_10{true};
+  ModSourceMap m_sf2_mod_sources{defaultModSources(ModulationSourceTarget::SoundFont)};
+  ModSourceMap m_dls_mod_sources{defaultModSources(ModulationSourceTarget::DLS)};
+  ModulationSourceTarget m_midi_modulation_source_target{ModulationSourceTarget::SoundFont};
 };

--- a/src/main/Options.h
+++ b/src/main/Options.h
@@ -5,13 +5,10 @@
  */
 
 #pragma once
-#include <algorithm>
-#include <array>
-#include <cstddef>
 #include <memory>
 #include <string_view>
 
-#include "Modulation.h"
+#include "ModSourceMap.h"
 
 struct OptionStore {
   struct Group {
@@ -56,20 +53,12 @@ public:
   void setBankSelectStyle(BankSelectStyle style) { m_bs_style = style; }
 
   int numSequenceLoops() const { return m_sequence_loops; }
-  void setNumSequenceLoops(int numLoops) {
-    m_sequence_loops = std::clamp(numLoops, 0, kMaxSequenceLoops);
-  }
+  void setNumSequenceLoops(int numLoops);
 
   bool skipChannel10() const { return m_skip_channel_10; }
   void setSkipChannel10(bool should) { m_skip_channel_10 = should; }
 
-  [[nodiscard]] ModSource modSourceFor(ModulationSourceTarget target, ModDest destination) const {
-    return modSourcesForTarget(target)[modDestIndex(destination)];
-  }
-
-  void setModSourceFor(ModulationSourceTarget target, ModDest destination, ModSource source) {
-    modSourcesForTarget(target)[modDestIndex(destination)] = source;
-  }
+  [[nodiscard]] ModSourceMap& modSourceMap(ModulationSourceTarget target);
 
   [[nodiscard]] ModulationSourceTarget midiModulationSourceTarget() const {
     return m_midi_modulation_source_target;
@@ -79,155 +68,31 @@ public:
     m_midi_modulation_source_target = target;
   }
 
-  class ScopedMidiModulationSourceTarget {
-  public:
-    explicit ScopedMidiModulationSourceTarget(ModulationSourceTarget target)
-        : m_previous(ConversionOptions::the().midiModulationSourceTarget()) {
-      ConversionOptions::the().setMidiModulationSourceTarget(target);
-    }
-
-    ~ScopedMidiModulationSourceTarget() {
-      ConversionOptions::the().setMidiModulationSourceTarget(m_previous);
-    }
-
-    ScopedMidiModulationSourceTarget(const ScopedMidiModulationSourceTarget&) = delete;
-    ScopedMidiModulationSourceTarget& operator=(const ScopedMidiModulationSourceTarget&) = delete;
-
-  private:
-    ModulationSourceTarget m_previous;
-  };
-
-  void load(OptionStore& store) {
-    auto g = store.beginGroup("ConversionOptions");
-    const int bs = store.getInt("bankSelectStyle", static_cast<int>(BankSelectStyle::GS));
-    m_bs_style = (bs == static_cast<int>(BankSelectStyle::MMA)) ? BankSelectStyle::MMA
-                                                                : BankSelectStyle::GS;
-    m_sequence_loops = std::clamp(store.getInt("sequenceLoops", 1), 0, kMaxSequenceLoops);
-    m_skip_channel_10 = store.getBool("skipChannel10", true);
-
-    m_sf2_mod_sources = defaultModSources(ModulationSourceTarget::SoundFont);
-    m_dls_mod_sources = defaultModSources(ModulationSourceTarget::DLS);
-    for (const ModDest destination : kModDests) {
-      const auto index = modDestIndex(destination);
-      m_sf2_mod_sources[index] = modSourceFromSettingValue(
-          store.getInt(modSourceSettingKey(ModulationSourceTarget::SoundFont, destination),
-                       modSourceSettingValue(m_sf2_mod_sources[index])),
-          m_sf2_mod_sources[index]);
-      m_dls_mod_sources[index] = modSourceFromSettingValue(
-          store.getInt(modSourceSettingKey(ModulationSourceTarget::DLS, destination),
-                       modSourceSettingValue(m_dls_mod_sources[index])),
-          m_dls_mod_sources[index]);
-    }
-  }
-
-  void save(OptionStore& store) const {
-    auto g = store.beginGroup("ConversionOptions");
-    store.setInt("bankSelectStyle", static_cast<int>(m_bs_style));
-    store.setInt("sequenceLoops",   m_sequence_loops);
-    store.setBool("skipChannel10", m_skip_channel_10);
-    for (const ModDest destination : kModDests) {
-      store.setInt(modSourceSettingKey(ModulationSourceTarget::SoundFont, destination),
-                   modSourceSettingValue(modSourceFor(ModulationSourceTarget::SoundFont, destination)));
-      store.setInt(modSourceSettingKey(ModulationSourceTarget::DLS, destination),
-                   modSourceSettingValue(modSourceFor(ModulationSourceTarget::DLS, destination)));
-    }
-  }
+  void load(OptionStore& store);
+  void save(OptionStore& store) const;
 
 private:
   ConversionOptions() = default;
 
-  using ModSourceMap = std::array<ModSource, kModDests.size()>;
-
-  static constexpr ModSourceMap defaultModSources(ModulationSourceTarget target) {
-    if (target == ModulationSourceTarget::DLS) {
-      return {
-          ModSource::ModWheel,
-          ModSource::ChannelPressure,
-          ModSource::ChorusSend,
-          ModSource::ChorusSend,
-          ModSource::ChannelPressure,
-          ModSource::ReverbSend,
-          ModSource::ChorusSend,
-      };
-    }
-
-    return {
-        ModSource::ModWheel,
-        ModSource::VibratoRate,
-        ModSource::VibratoDelay,
-        ModSource::TremoloDepth,
-        ModSource::SoundController6,
-        ModSource::SoundController10,
-        ModSource::TremoloDepth,
-    };
-  }
-
-  static constexpr const char* modSourceSettingKey(ModulationSourceTarget target, ModDest destination) {
-    switch (target) {
-      case ModulationSourceTarget::SoundFont:
-        switch (destination) {
-          case ModDest::VibLfoToPitch:
-            return "sf2ModSourceVibLfoToPitch";
-          case ModDest::VibLfoFreq:
-            return "sf2ModSourceVibLfoFreq";
-          case ModDest::VibLfoDelay:
-            return "sf2ModSourceVibLfoDelay";
-          case ModDest::ModLfoToVol:
-            return "sf2ModSourceModLfoToVol";
-          case ModDest::ModLfoFreq:
-            return "sf2ModSourceModLfoFreq";
-          case ModDest::ModLfoDelay:
-            return "sf2ModSourceModLfoDelay";
-          case ModDest::InitialAtten:
-            return "sf2ModSourceInitialAtten";
-        }
-        break;
-      case ModulationSourceTarget::DLS:
-        switch (destination) {
-          case ModDest::VibLfoToPitch:
-            return "dlsModSourceVibLfoToPitch";
-          case ModDest::VibLfoFreq:
-            return "dlsModSourceVibLfoFreq";
-          case ModDest::VibLfoDelay:
-            return "dlsModSourceVibLfoDelay";
-          case ModDest::ModLfoToVol:
-            return "dlsModSourceModLfoToVol";
-          case ModDest::ModLfoFreq:
-            return "dlsModSourceModLfoFreq";
-          case ModDest::ModLfoDelay:
-            return "dlsModSourceModLfoDelay";
-          case ModDest::InitialAtten:
-            return "dlsModSourceInitialAtten";
-        }
-        break;
-    }
-    return "";
-  }
-
-  static constexpr int modSourceSettingValue(ModSource source) {
-    return static_cast<int>(source);
-  }
-
-  static constexpr ModSource modSourceFromSettingValue(int value, ModSource fallback) {
-    if (value == static_cast<int>(ModSource::None) ||
-        (value >= 0 && value <= static_cast<int>(ModSource::PitchWheel))) {
-      return static_cast<ModSource>(value);
-    }
-    return fallback;
-  }
-
-  ModSourceMap& modSourcesForTarget(ModulationSourceTarget target) {
-    return target == ModulationSourceTarget::DLS ? m_dls_mod_sources : m_sf2_mod_sources;
-  }
-
-  [[nodiscard]] const ModSourceMap& modSourcesForTarget(ModulationSourceTarget target) const {
-    return target == ModulationSourceTarget::DLS ? m_dls_mod_sources : m_sf2_mod_sources;
-  }
-
   BankSelectStyle m_bs_style{BankSelectStyle::GS};
   int m_sequence_loops{0};
   bool m_skip_channel_10{true};
-  ModSourceMap m_sf2_mod_sources{defaultModSources(ModulationSourceTarget::SoundFont)};
-  ModSourceMap m_dls_mod_sources{defaultModSources(ModulationSourceTarget::DLS)};
+  ModSourceMap m_sf2_mod_sources{ModulationSourceTarget::SoundFont};
+  ModSourceMap m_dls_mod_sources{ModulationSourceTarget::DLS};
   ModulationSourceTarget m_midi_modulation_source_target{ModulationSourceTarget::SoundFont};
+};
+
+// RAII helper which updates ConversionOptions::m_midi_modulation_source_target.
+// Sets the active MIDI modulation-source target for SeqTrack controller emission,
+// then restores the previous ConversionOptions value when the scope exits.
+class ScopedMidiModulationSourceTarget {
+public:
+  explicit ScopedMidiModulationSourceTarget(ModulationSourceTarget target);
+  ~ScopedMidiModulationSourceTarget();
+
+  ScopedMidiModulationSourceTarget(const ScopedMidiModulationSourceTarget&) = delete;
+  ScopedMidiModulationSourceTarget& operator=(const ScopedMidiModulationSourceTarget&) = delete;
+
+private:
+  ModulationSourceTarget m_previous;
 };

--- a/src/main/components/instr/Modulation.h
+++ b/src/main/components/instr/Modulation.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 
@@ -28,24 +30,47 @@ enum class TremoloGainMode {
   NoBoost,
 };
 
+enum class TremoloLfoMode {
+  Independent,
+  ShareVibratoLfo,
+};
+
 struct TremoloModulationSpec {
   double maxDepthDb;
   double minHertz;
   double maxHertz;
   TremoloGainMode gainMode = TremoloGainMode::BipolarAroundNominal;
+  std::optional<DelayRange> delayRange = std::nullopt;
+  TremoloLfoMode lfoMode = TremoloLfoMode::Independent;
 };
 
-enum class ModSource : uint8_t {
-  // Keep this list to controllers expressible by both SF2 and DLS2.
-  ModWheel,
-  ChannelPressure,
-  PolyPressure,
-  PitchWheel,
-  Volume,
-  Pan,
-  Expression,
-  ReverbSend,
-  ChorusSend,
+enum class ModulationSourceTarget : uint8_t {
+  SoundFont,
+  DLS,
+};
+
+enum class ModSource : int16_t {
+  None = -1,
+
+  // Values 0..127 represent MIDI continuous controllers. SF2 can use any CC;
+  // DLS2 only accepts a strict subset.
+  ModWheel = 1,
+  Breath = 2,
+  Volume = 7,
+  Pan = 10,
+  Expression = 11,
+  SoundController6 = 75,
+  VibratoRate = 76,
+  VibratoDepth = 77,
+  VibratoDelay = 78,
+  SoundController10 = 79,
+  ReverbSend = 91,
+  TremoloDepth = 92,
+  ChorusSend = 93,
+
+  ChannelPressure = 128,
+  PolyPressure = 129,
+  PitchWheel = 130,
 };
 
 enum class ModDest : uint8_t {
@@ -57,6 +82,35 @@ enum class ModDest : uint8_t {
   ModLfoDelay,
   InitialAtten,
 };
+
+inline constexpr std::array<ModDest, 7> kModDests {
+    ModDest::VibLfoToPitch,
+    ModDest::VibLfoFreq,
+    ModDest::VibLfoDelay,
+    ModDest::ModLfoToVol,
+    ModDest::ModLfoFreq,
+    ModDest::ModLfoDelay,
+    ModDest::InitialAtten,
+};
+
+constexpr size_t modDestIndex(ModDest destination) {
+  return static_cast<size_t>(destination);
+}
+
+constexpr ModSource modSourceForMidiController(uint8_t controller) {
+  return static_cast<ModSource>(controller);
+}
+
+constexpr bool isMidiControllerModSource(ModSource source) {
+  const int sourceValue = static_cast<int>(source);
+  return sourceValue >= 0 && sourceValue <= 127;
+}
+
+constexpr std::optional<uint8_t> midiControllerForModSource(ModSource source) {
+  return isMidiControllerModSource(source)
+      ? std::optional<uint8_t>(static_cast<uint8_t>(source))
+      : std::nullopt;
+}
 
 class ModAmount {
 public:
@@ -91,7 +145,29 @@ double clampSecondsRangeMinimum(double seconds);
 uint8_t midiValueForSecondsInRange(double seconds, double minSeconds, double maxSeconds);
 
 struct SynthModulator {
-  ModSource source;
+  SynthModulator(ModSource explicitSource, ModDest destination, int32_t amount)
+      : source(explicitSource),
+        sourceMappingKey(destination),
+        destination(destination),
+        amount(amount) {}
+
+  SynthModulator(ModDest destination, int32_t amount)
+      : source(std::nullopt),
+        sourceMappingKey(destination),
+        destination(destination),
+        amount(amount) {}
+
+  SynthModulator(ModDest sourceMappingKey, ModDest destination, int32_t amount)
+      : source(std::nullopt),
+        sourceMappingKey(sourceMappingKey),
+        destination(destination),
+        amount(amount) {}
+
+  // If source is empty, exporters resolve it from settings using sourceMappingKey.
+  // sourceMappingKey usually matches destination; it differs for shared controls, for example
+  // when ModLfoFreq uses VibLfoFreq because of TremoloLfoMode::ShareVibratoLfo.
+  std::optional<ModSource> source;
+  ModDest sourceMappingKey;
   ModDest destination;
 
   // Amount units are the shared SF2/DLS semantic units for the destination:

--- a/src/main/components/instr/Modulation.h
+++ b/src/main/components/instr/Modulation.h
@@ -30,18 +30,12 @@ enum class TremoloGainMode {
   NoBoost,
 };
 
-enum class TremoloLfoMode {
-  Independent,
-  ShareVibratoLfo,
-};
-
 struct TremoloModulationSpec {
   double maxDepthDb;
   double minHertz;
   double maxHertz;
   TremoloGainMode gainMode = TremoloGainMode::BipolarAroundNominal;
   std::optional<DelayRange> delayRange = std::nullopt;
-  TremoloLfoMode lfoMode = TremoloLfoMode::Independent;
 };
 
 enum class ModulationSourceTarget : uint8_t {
@@ -147,27 +141,16 @@ uint8_t midiValueForSecondsInRange(double seconds, double minSeconds, double max
 struct SynthModulator {
   SynthModulator(ModSource explicitSource, ModDest destination, int32_t amount)
       : source(explicitSource),
-        sourceMappingKey(destination),
         destination(destination),
         amount(amount) {}
 
   SynthModulator(ModDest destination, int32_t amount)
       : source(std::nullopt),
-        sourceMappingKey(destination),
         destination(destination),
         amount(amount) {}
 
-  SynthModulator(ModDest sourceMappingKey, ModDest destination, int32_t amount)
-      : source(std::nullopt),
-        sourceMappingKey(sourceMappingKey),
-        destination(destination),
-        amount(amount) {}
-
-  // If source is empty, exporters resolve it from settings using sourceMappingKey.
-  // sourceMappingKey usually matches destination; it differs for shared controls, for example
-  // when ModLfoFreq uses VibLfoFreq because of TremoloLfoMode::ShareVibratoLfo.
+  // If source is empty, exporters resolve it from settings using destination.
   std::optional<ModSource> source;
-  ModDest sourceMappingKey;
   ModDest destination;
 
   // Amount units are the shared SF2/DLS semantic units for the destination:

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -187,14 +187,6 @@ void VGMInstr::addModulator(ModDest destination, ModAmount amount) {
   m_modulators.emplace_back(destination, amount.value());
 }
 
-void VGMInstr::addModulator(ModDest sourceMappingKey, ModDest destination, ModAmount amount) {
-  if (!amount.valid()) {
-    return;
-  }
-
-  m_modulators.emplace_back(sourceMappingKey, destination, amount.value());
-}
-
 bool VGMInstr::updateModulatorAmount(ModSource source, ModDest destination, ModAmount amount) {
   if (!amount.valid()) {
     return false;
@@ -267,29 +259,19 @@ void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
 }
 
 void VGMInstr::addStandardTremoloHandling(const TremoloModulationSpec& spec) {
-  const ModDest lfoFreqSourceDestination = spec.lfoMode == TremoloLfoMode::ShareVibratoLfo
-      ? ModDest::VibLfoFreq
-      : ModDest::ModLfoFreq;
-  const ModDest lfoDelaySourceDestination = spec.lfoMode == TremoloLfoMode::ShareVibratoLfo
-      ? ModDest::VibLfoDelay
-      : ModDest::ModLfoDelay;
-
   addGenerator(ModDest::ModLfoFreq, ModAmount::fromHertz(spec.minHertz));
-  addModulator(lfoFreqSourceDestination,
-               ModDest::ModLfoFreq,
+  addModulator(ModDest::ModLfoFreq,
                ModAmount::fromHertzRange(spec.minHertz, spec.maxHertz));
   if (spec.delayRange.has_value()) {
     const double minDelaySeconds = clampSecondsRangeMinimum(spec.delayRange->minSeconds);
     addGenerator(ModDest::ModLfoDelay, ModAmount::fromSeconds(minDelaySeconds));
-    addModulator(lfoDelaySourceDestination,
-                 ModDest::ModLfoDelay,
+    addModulator(ModDest::ModLfoDelay,
                  ModAmount::fromSecondsRange(minDelaySeconds, spec.delayRange->maxSeconds));
   }
   addModulator(ModDest::ModLfoToVol,
                ModAmount::fromDecibels(spec.maxDepthDb));
   if (spec.gainMode == TremoloGainMode::NoBoost) {
-    addModulator(ModDest::ModLfoToVol,
-                 ModDest::InitialAtten,
+    addModulator(ModDest::InitialAtten,
                  ModAmount::fromDecibels(spec.maxDepthDb));
   }
 }

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -176,7 +176,23 @@ void VGMInstr::addModulator(ModSource source, ModDest destination, ModAmount amo
     return;
   }
 
-  m_modulators.push_back({source, destination, amount.value()});
+  m_modulators.emplace_back(source, destination, amount.value());
+}
+
+void VGMInstr::addModulator(ModDest destination, ModAmount amount) {
+  if (!amount.valid()) {
+    return;
+  }
+
+  m_modulators.emplace_back(destination, amount.value());
+}
+
+void VGMInstr::addModulator(ModDest sourceMappingKey, ModDest destination, ModAmount amount) {
+  if (!amount.valid()) {
+    return;
+  }
+
+  m_modulators.emplace_back(sourceMappingKey, destination, amount.value());
 }
 
 bool VGMInstr::updateModulatorAmount(ModSource source, ModDest destination, ModAmount amount) {
@@ -185,7 +201,22 @@ bool VGMInstr::updateModulatorAmount(ModSource source, ModDest destination, ModA
   }
 
   for (auto& modulator : m_modulators) {
-    if (modulator.source == source && modulator.destination == destination) {
+    if (modulator.source.has_value() && *modulator.source == source &&
+        modulator.destination == destination) {
+      modulator.amount = amount.value();
+      return true;
+    }
+  }
+  return false;
+}
+
+bool VGMInstr::updateModulatorAmount(ModDest destination, ModAmount amount) {
+  if (!amount.valid()) {
+    return false;
+  }
+
+  for (auto& modulator : m_modulators) {
+    if (!modulator.source.has_value() && modulator.destination == destination) {
       modulator.amount = amount.value();
       return true;
     }
@@ -201,18 +232,16 @@ void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
 }
 
 void VGMInstr::addStandardVibratoHandling(const VibratoModulationSpec& spec) {
-  addModulator(ModSource::ModWheel, ModDest::VibLfoToPitch, ModAmount::fromCents(spec.maxDepthCents));
+  addModulator(ModDest::VibLfoToPitch, ModAmount::fromCents(spec.maxDepthCents));
   // nullify default channel pressure to vib lfo pitch modulator
   addModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, ModAmount::fromCents(0));
   addGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(spec.minHertz));
-  addModulator(ModSource::ChannelPressure,
-               ModDest::VibLfoFreq,
+  addModulator(ModDest::VibLfoFreq,
                ModAmount::fromHertzRange(spec.minHertz, spec.maxHertz));
   if (spec.delayRange.has_value()) {
     const double minDelaySeconds = clampSecondsRangeMinimum(spec.delayRange->minSeconds);
     addGenerator(ModDest::VibLfoDelay, ModAmount::fromSeconds(minDelaySeconds));
-    addModulator(ModSource::ChorusSend,
-                 ModDest::VibLfoDelay,
+    addModulator(ModDest::VibLfoDelay,
                  ModAmount::fromSecondsRange(minDelaySeconds, spec.delayRange->maxSeconds));
   }
 }
@@ -224,11 +253,9 @@ void VGMInstr::updateStandardVibratoHandling(double maxDepthCents,
 }
 
 void VGMInstr::updateStandardVibratoHandling(const VibratoModulationSpec& spec) {
-  updateModulatorAmount(ModSource::ModWheel,
-                        ModDest::VibLfoToPitch,
+  updateModulatorAmount(ModDest::VibLfoToPitch,
                         ModAmount::fromCents(spec.maxDepthCents));
-  updateModulatorAmount(ModSource::ChannelPressure,
-                        ModDest::VibLfoFreq,
+  updateModulatorAmount(ModDest::VibLfoFreq,
                         ModAmount::fromHertzRange(spec.minHertz, spec.maxHertz));
 }
 
@@ -240,15 +267,28 @@ void VGMInstr::addStandardTremoloHandling(double maxDepthDb,
 }
 
 void VGMInstr::addStandardTremoloHandling(const TremoloModulationSpec& spec) {
+  const ModDest lfoFreqSourceDestination = spec.lfoMode == TremoloLfoMode::ShareVibratoLfo
+      ? ModDest::VibLfoFreq
+      : ModDest::ModLfoFreq;
+  const ModDest lfoDelaySourceDestination = spec.lfoMode == TremoloLfoMode::ShareVibratoLfo
+      ? ModDest::VibLfoDelay
+      : ModDest::ModLfoDelay;
+
   addGenerator(ModDest::ModLfoFreq, ModAmount::fromHertz(spec.minHertz));
-  addModulator(ModSource::ChannelPressure,
+  addModulator(lfoFreqSourceDestination,
                ModDest::ModLfoFreq,
                ModAmount::fromHertzRange(spec.minHertz, spec.maxHertz));
-  addModulator(ModSource::ChorusSend,
-               ModDest::ModLfoToVol,
+  if (spec.delayRange.has_value()) {
+    const double minDelaySeconds = clampSecondsRangeMinimum(spec.delayRange->minSeconds);
+    addGenerator(ModDest::ModLfoDelay, ModAmount::fromSeconds(minDelaySeconds));
+    addModulator(lfoDelaySourceDestination,
+                 ModDest::ModLfoDelay,
+                 ModAmount::fromSecondsRange(minDelaySeconds, spec.delayRange->maxSeconds));
+  }
+  addModulator(ModDest::ModLfoToVol,
                ModAmount::fromDecibels(spec.maxDepthDb));
   if (spec.gainMode == TremoloGainMode::NoBoost) {
-    addModulator(ModSource::ChorusSend,
+    addModulator(ModDest::ModLfoToVol,
                  ModDest::InitialAtten,
                  ModAmount::fromDecibels(spec.maxDepthDb));
   }

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -224,9 +224,9 @@ void VGMInstr::addStandardVibratoHandling(double maxDepthCents,
 }
 
 void VGMInstr::addStandardVibratoHandling(const VibratoModulationSpec& spec) {
-  addModulator(ModDest::VibLfoToPitch, ModAmount::fromCents(spec.maxDepthCents));
   // nullify default channel pressure to vib lfo pitch modulator
   addModulator(ModSource::ChannelPressure, ModDest::VibLfoToPitch, ModAmount::fromCents(0));
+  addModulator(ModDest::VibLfoToPitch, ModAmount::fromCents(spec.maxDepthCents));
   addGenerator(ModDest::VibLfoFreq, ModAmount::fromHertz(spec.minHertz));
   addModulator(ModDest::VibLfoFreq,
                ModAmount::fromHertzRange(spec.minHertz, spec.maxHertz));

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -75,7 +75,6 @@ public:
   // Modulator support
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
   void addModulator(ModDest destination, ModAmount amount);
-  void addModulator(ModDest sourceMappingKey, ModDest destination, ModAmount amount);
   bool updateModulatorAmount(ModSource source, ModDest destination, ModAmount amount);
   bool updateModulatorAmount(ModDest destination, ModAmount amount);
   void addStandardVibratoHandling(double maxDepthCents,

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -74,7 +74,10 @@ public:
 
   // Modulator support
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
+  void addModulator(ModDest destination, ModAmount amount);
+  void addModulator(ModDest sourceMappingKey, ModDest destination, ModAmount amount);
   bool updateModulatorAmount(ModSource source, ModDest destination, ModAmount amount);
+  bool updateModulatorAmount(ModDest destination, ModAmount amount);
   void addStandardVibratoHandling(double maxDepthCents,
                                   double minHertz,
                                   double maxHertz,

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -321,7 +321,9 @@ void SeqTrack::addForModSourceNoItem(ModSource source, uint8_t value) const {
       break;
     }
     case ModSource::None:
+      [[fallthrough]];
     case ModSource::PolyPressure:
+      [[fallthrough]];
     default:
       break;
   }

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -301,26 +301,72 @@ void SeqTrack::addControllerSlide(uint32_t dur,
   prevVal = targVal;
 }
 
-// Emit synth vibrato depth through CC1/modulation if it changed.
-bool SeqTrack::setSynthLfoModulationDepth(SeqSynthLfoAutomation& automation, uint8_t depth, bool force) {
+void SeqTrack::addModSourceNoItem(ModSource source, uint8_t value) const {
+  if (readMode != READMODE_CONVERT_TO_MIDI) {
+    return;
+  }
+
+  if (auto controller = midiControllerForModSource(source)) {
+    pMidiTrack->addControllerEvent(channel, *controller, value);
+    return;
+  }
+
+  switch (source) {
+    case ModSource::ChannelPressure:
+      pMidiTrack->addChannelPressure(channel, value);
+      break;
+    case ModSource::PitchWheel: {
+      const auto bend = static_cast<int16_t>(std::clamp<int>((static_cast<int>(value) * 128) - 8192,
+                                                             -8192,
+                                                             8191));
+      pMidiTrack->addPitchBend(channel, bend);
+      break;
+    }
+    case ModSource::None:
+    case ModSource::PolyPressure:
+    default:
+      break;
+  }
+}
+
+void SeqTrack::addModDestSourceNoItem(ModDest destination, uint8_t value) const {
+  const auto target = ConversionOptions::the().midiModulationSourceTarget();
+  addModSourceNoItem(ConversionOptions::the().modSourceFor(target, destination), value);
+}
+
+void SeqTrack::addLfoModulationEvent(ModDest destination,
+                                     uint32_t offset,
+                                     uint32_t length,
+                                     uint8_t value,
+                                     const std::string& eventName,
+                                     Type type) {
+  const bool isNewOffset = onEvent(offset, length);
+  recordSeqEvent<SeqEvent>(isNewOffset,
+                           getTime(),
+                           offset,
+                           length,
+                           eventName,
+                           type,
+                           fmt::format("Value: {:d}", value));
+  addModDestSourceNoItem(destination, value);
+}
+
+// Emit synth vibrato depth through the configured ModDest source if it changed.
+bool SeqTrack::emitVibratoDepth(SeqSynthLfoAutomation& automation, uint8_t depth, bool force) {
   return automation.emitDepth(depth,
                               [this](uint8_t outputDepth) {
-                                addModulationNoItem(outputDepth);
+                                addVibratoDepthNoItem(outputDepth);
                               },
                               force);
 }
 
-// Emit synth LFO depth through the given MIDI controller if it changed.
-bool SeqTrack::setSynthLfoControllerDepth(SeqSynthLfoAutomation& automation,
-                                          uint8_t controller, uint8_t depth,
-                                          bool force) {
+bool SeqTrack::emitTremoloDepth(SeqSynthLfoAutomation& automation, uint8_t depth, bool force) {
   return automation.emitDepth(depth,
-                              [this, controller](uint8_t outputDepth) {
-                                addControllerEventNoItem(controller, outputDepth);
+                              [this](uint8_t outputDepth) {
+                                addTremoloDepthNoItem(outputDepth);
                               },
                               force);
 }
-
 
 bool SeqTrack::isOffsetUsed(uint32_t offset) {
   if (offset <= visitedAddressMax) {
@@ -1410,6 +1456,74 @@ void SeqTrack::insertBreath(uint32_t offset,
 
   if (readMode == READMODE_CONVERT_TO_MIDI)
     pMidiTrack->insertBreath(channel, depth, absTime);
+}
+
+void SeqTrack::addVibratoDepth(uint32_t offset,
+                               uint32_t length,
+                               uint8_t depth,
+                               const std::string& sEventName) {
+  const bool isNewOffset = onEvent(offset, length);
+  recordSeqEvent<ModulationSeqEvent>(isNewOffset, getTime(), depth, offset, length, sEventName);
+  addVibratoDepthNoItem(depth);
+}
+
+void SeqTrack::addVibratoDepthNoItem(uint8_t depth) const {
+  addModDestSourceNoItem(ModDest::VibLfoToPitch, depth);
+}
+
+void SeqTrack::addVibratoFrequency(uint32_t offset,
+                                   uint32_t length,
+                                   uint8_t frequency,
+                                   const std::string& sEventName) {
+  addLfoModulationEvent(ModDest::VibLfoFreq, offset, length, frequency, sEventName, Type::Vibrato);
+}
+
+void SeqTrack::addVibratoFrequencyNoItem(uint8_t frequency) const {
+  addModDestSourceNoItem(ModDest::VibLfoFreq, frequency);
+}
+
+void SeqTrack::addVibratoDelay(uint32_t offset,
+                               uint32_t length,
+                               uint8_t delay,
+                               const std::string& sEventName) {
+  addLfoModulationEvent(ModDest::VibLfoDelay, offset, length, delay, sEventName, Type::Vibrato);
+}
+
+void SeqTrack::addVibratoDelayNoItem(uint8_t delay) const {
+  addModDestSourceNoItem(ModDest::VibLfoDelay, delay);
+}
+
+void SeqTrack::addTremoloDepth(uint32_t offset,
+                               uint32_t length,
+                               uint8_t depth,
+                               const std::string& sEventName) {
+  addLfoModulationEvent(ModDest::ModLfoToVol, offset, length, depth, sEventName, Type::Tremelo);
+}
+
+void SeqTrack::addTremoloDepthNoItem(uint8_t depth) const {
+  addModDestSourceNoItem(ModDest::ModLfoToVol, depth);
+}
+
+void SeqTrack::addTremoloFrequency(uint32_t offset,
+                                   uint32_t length,
+                                   uint8_t frequency,
+                                   const std::string& sEventName) {
+  addLfoModulationEvent(ModDest::ModLfoFreq, offset, length, frequency, sEventName, Type::Tremelo);
+}
+
+void SeqTrack::addTremoloFrequencyNoItem(uint8_t frequency) const {
+  addModDestSourceNoItem(ModDest::ModLfoFreq, frequency);
+}
+
+void SeqTrack::addTremoloDelay(uint32_t offset,
+                               uint32_t length,
+                               uint8_t delay,
+                               const std::string& sEventName) {
+  addLfoModulationEvent(ModDest::ModLfoDelay, offset, length, delay, sEventName, Type::Tremelo);
+}
+
+void SeqTrack::addTremoloDelayNoItem(uint8_t delay) const {
+  addModDestSourceNoItem(ModDest::ModLfoDelay, delay);
 }
 
 void SeqTrack::addSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName) {

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -301,7 +301,7 @@ void SeqTrack::addControllerSlide(uint32_t dur,
   prevVal = targVal;
 }
 
-void SeqTrack::addModSourceNoItem(ModSource source, uint8_t value) const {
+void SeqTrack::addForModSourceNoItem(ModSource source, uint8_t value) const {
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     return;
   }
@@ -316,9 +316,7 @@ void SeqTrack::addModSourceNoItem(ModSource source, uint8_t value) const {
       pMidiTrack->addChannelPressure(channel, value);
       break;
     case ModSource::PitchWheel: {
-      const auto bend = static_cast<int16_t>(std::clamp<int>((static_cast<int>(value) * 128) - 8192,
-                                                             -8192,
-                                                             8191));
+      const auto bend = static_cast<int16_t>(std::clamp<int>((static_cast<int>(value) * 128) - 8192, -8192, 8191));
       pMidiTrack->addPitchBend(channel, bend);
       break;
     }
@@ -329,9 +327,9 @@ void SeqTrack::addModSourceNoItem(ModSource source, uint8_t value) const {
   }
 }
 
-void SeqTrack::addModDestSourceNoItem(ModDest destination, uint8_t value) const {
+void SeqTrack::addForModDestNoItem(ModDest destination, uint8_t value) const {
   const auto target = ConversionOptions::the().midiModulationSourceTarget();
-  addModSourceNoItem(ConversionOptions::the().modSourceMap(target).sourceFor(destination), value);
+  addForModSourceNoItem(ConversionOptions::the().modSourceMap(target).sourceFor(destination), value);
 }
 
 void SeqTrack::addLfoModulationEvent(ModDest destination,
@@ -348,7 +346,7 @@ void SeqTrack::addLfoModulationEvent(ModDest destination,
                            eventName,
                            type,
                            fmt::format("Value: {:d}", value));
-  addModDestSourceNoItem(destination, value);
+  addForModDestNoItem(destination, value);
 }
 
 // Emit synth vibrato depth through the configured ModDest source if it changed.
@@ -1468,7 +1466,7 @@ void SeqTrack::addVibratoDepth(uint32_t offset,
 }
 
 void SeqTrack::addVibratoDepthNoItem(uint8_t depth) const {
-  addModDestSourceNoItem(ModDest::VibLfoToPitch, depth);
+  addForModDestNoItem(ModDest::VibLfoToPitch, depth);
 }
 
 void SeqTrack::addVibratoFrequency(uint32_t offset,
@@ -1479,7 +1477,7 @@ void SeqTrack::addVibratoFrequency(uint32_t offset,
 }
 
 void SeqTrack::addVibratoFrequencyNoItem(uint8_t frequency) const {
-  addModDestSourceNoItem(ModDest::VibLfoFreq, frequency);
+  addForModDestNoItem(ModDest::VibLfoFreq, frequency);
 }
 
 void SeqTrack::addVibratoDelay(uint32_t offset,
@@ -1490,7 +1488,7 @@ void SeqTrack::addVibratoDelay(uint32_t offset,
 }
 
 void SeqTrack::addVibratoDelayNoItem(uint8_t delay) const {
-  addModDestSourceNoItem(ModDest::VibLfoDelay, delay);
+  addForModDestNoItem(ModDest::VibLfoDelay, delay);
 }
 
 void SeqTrack::addTremoloDepth(uint32_t offset,
@@ -1501,7 +1499,7 @@ void SeqTrack::addTremoloDepth(uint32_t offset,
 }
 
 void SeqTrack::addTremoloDepthNoItem(uint8_t depth) const {
-  addModDestSourceNoItem(ModDest::ModLfoToVol, depth);
+  addForModDestNoItem(ModDest::ModLfoToVol, depth);
 }
 
 void SeqTrack::addTremoloFrequency(uint32_t offset,
@@ -1512,7 +1510,7 @@ void SeqTrack::addTremoloFrequency(uint32_t offset,
 }
 
 void SeqTrack::addTremoloFrequencyNoItem(uint8_t frequency) const {
-  addModDestSourceNoItem(ModDest::ModLfoFreq, frequency);
+  addForModDestNoItem(ModDest::ModLfoFreq, frequency);
 }
 
 void SeqTrack::addTremoloDelay(uint32_t offset,
@@ -1523,7 +1521,7 @@ void SeqTrack::addTremoloDelay(uint32_t offset,
 }
 
 void SeqTrack::addTremoloDelayNoItem(uint8_t delay) const {
-  addModDestSourceNoItem(ModDest::ModLfoDelay, delay);
+  addForModDestNoItem(ModDest::ModLfoDelay, delay);
 }
 
 void SeqTrack::addSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName) {

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -331,7 +331,7 @@ void SeqTrack::addModSourceNoItem(ModSource source, uint8_t value) const {
 
 void SeqTrack::addModDestSourceNoItem(ModDest destination, uint8_t value) const {
   const auto target = ConversionOptions::the().midiModulationSourceTarget();
-  addModSourceNoItem(ConversionOptions::the().modSourceFor(target, destination), value);
+  addModSourceNoItem(ConversionOptions::the().modSourceMap(target).sourceFor(destination), value);
 }
 
 void SeqTrack::addLfoModulationEvent(ModDest destination,

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -189,8 +189,8 @@ protected:
 
 private:
   void addControllerSlide(u32 dur, u16 &prevVal, u16 targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t)) const;
-  void addModSourceNoItem(ModSource source, uint8_t value) const;
-  void addModDestSourceNoItem(ModDest destination, uint8_t value) const;
+  void addForModSourceNoItem(ModSource source, uint8_t value) const;
+  void addForModDestNoItem(ModDest destination, uint8_t value) const;
   void addLfoModulationEvent(ModDest destination,
                              uint32_t offset,
                              uint32_t length,

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include "VGMItem.h"
 #include "VGMSeq.h"
+#include "Modulation.h"
 #include <spdlog/common.h>
 #include "LogManager.h"
 #include "SynthType.h"
@@ -175,16 +176,27 @@ protected:
   bool applyPitchBendAutomation(SeqPitchBendAutomation<PitchType>& automation);
   template <typename PitchType>
   void resetPitchBendAutomation(SeqPitchBendAutomation<PitchType>& automation, uint16_t defaultRangeCents);
-  bool setSynthLfoModulationDepth(SeqSynthLfoAutomation& automation, uint8_t depth, bool force = false);
-  bool setSynthLfoControllerDepth(SeqSynthLfoAutomation& automation, uint8_t controller, uint8_t depth,
-                                  bool force = false);
+  bool emitVibratoDepth(SeqSynthLfoAutomation& automation, uint8_t depth, bool force = false);
+  bool emitTremoloDepth(SeqSynthLfoAutomation& automation, uint8_t depth, bool force = false);
   template <typename ConvertDepth>
-  SeqMotionTick<int32_t> advanceSynthLfoFadeToModulation(SeqSynthLfoAutomation& automation,
-                                                         uint8_t fractionalBits,
-                                                         ConvertDepth&& convertDepth);
+  SeqMotionTick<int32_t> advanceVibratoDepthFade(SeqSynthLfoAutomation& automation,
+                                                 uint8_t fractionalBits,
+                                                 ConvertDepth&& convertDepth);
+  template <typename ConvertDepth>
+  SeqMotionTick<int32_t> advanceTremoloDepthFade(SeqSynthLfoAutomation& automation,
+                                                 uint8_t fractionalBits,
+                                                 ConvertDepth&& convertDepth);
 
 private:
   void addControllerSlide(u32 dur, u16 &prevVal, u16 targVal, uint8_t (*scalerFunc)(uint8_t), void (MidiTrack::*insertFunc)(uint8_t, uint8_t, uint32_t)) const;
+  void addModSourceNoItem(ModSource source, uint8_t value) const;
+  void addModDestSourceNoItem(ModDest destination, uint8_t value) const;
+  void addLfoModulationEvent(ModDest destination,
+                             uint32_t offset,
+                             uint32_t length,
+                             uint8_t value,
+                             const std::string& eventName,
+                             Type type);
   double applyPanVolumeCorrection(double level, LevelController controller) const;
   void addLevelNoItem(double level, LevelController controller, Resolution res, int absTime = -1);
   void reapplyStoredLevelNoItem(LevelController controller, int absTime = -1);
@@ -275,6 +287,18 @@ private:
   void addBreath(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName = "Breath Depth");
   void addBreathNoItem(uint8_t depth);
   void insertBreath(uint32_t offset, uint32_t length, uint8_t depth, uint32_t absTime, const std::string &sEventName = "Breath Depth");
+  void addVibratoDepth(uint32_t offset, uint32_t length, uint8_t depth, const std::string& sEventName = "Vibrato Depth");
+  void addVibratoDepthNoItem(uint8_t depth) const;
+  void addVibratoFrequency(uint32_t offset, uint32_t length, uint8_t frequency, const std::string& sEventName = "Vibrato Frequency");
+  void addVibratoFrequencyNoItem(uint8_t frequency) const;
+  void addVibratoDelay(uint32_t offset, uint32_t length, uint8_t delay, const std::string& sEventName = "Vibrato Delay");
+  void addVibratoDelayNoItem(uint8_t delay) const;
+  void addTremoloDepth(uint32_t offset, uint32_t length, uint8_t depth, const std::string& sEventName = "Tremolo Depth");
+  void addTremoloDepthNoItem(uint8_t depth) const;
+  void addTremoloFrequency(uint32_t offset, uint32_t length, uint8_t frequency, const std::string& sEventName = "Tremolo Frequency");
+  void addTremoloFrequencyNoItem(uint8_t frequency) const;
+  void addTremoloDelay(uint32_t offset, uint32_t length, uint8_t delay, const std::string& sEventName = "Tremolo Delay");
+  void addTremoloDelayNoItem(uint8_t delay) const;
 
   void addSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, const std::string &sEventName = "Sustain");
   void insertSustainEvent(uint32_t offset, uint32_t length, uint8_t depth, uint32_t absTime, const std::string &sEventName = "Sustain");

--- a/src/main/components/seq/automation/SeqTrackAutomation.h
+++ b/src/main/components/seq/automation/SeqTrackAutomation.h
@@ -67,14 +67,25 @@ void SeqTrack::resetPitchBendAutomation(SeqPitchBendAutomation<PitchType>& autom
 
 // Non-template helper implementations are defined in SeqTrack.cpp
 
-// Advance an LFO fade by one tick and emit converted CC1/modulation depth if it changed.
+// Advance an LFO fade by one tick and emit converted vibrato depth if it changed.
 template <typename ConvertDepth>
-SeqMotionTick<int32_t> SeqTrack::advanceSynthLfoFadeToModulation(SeqSynthLfoAutomation& automation,
-                                                                 uint8_t fractionalBits,
-                                                                 ConvertDepth&& convertDepth) {
+SeqMotionTick<int32_t> SeqTrack::advanceVibratoDepthFade(SeqSynthLfoAutomation& automation,
+                                                         uint8_t fractionalBits,
+                                                         ConvertDepth&& convertDepth) {
   return automation.tickFadeToDepth(fractionalBits,
                                     std::forward<ConvertDepth>(convertDepth),
                                     [this](uint8_t depth) {
-                                      addModulationNoItem(depth);
+                                      addVibratoDepthNoItem(depth);
+                                    });
+}
+
+template <typename ConvertDepth>
+SeqMotionTick<int32_t> SeqTrack::advanceTremoloDepthFade(SeqSynthLfoAutomation& automation,
+                                                         uint8_t fractionalBits,
+                                                         ConvertDepth&& convertDepth) {
+  return automation.tickFadeToDepth(fractionalBits,
+                                    std::forward<ConvertDepth>(convertDepth),
+                                    [this](uint8_t depth) {
+                                      addTremoloDepthNoItem(depth);
                                     });
 }

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -7,9 +7,11 @@
 #include <algorithm>
 #include <limits>
 #include <numeric>
+#include <optional>
 #include <ranges>
 #include <vector>
 #include "DLSFile.h"
+#include "Options.h"
 #include "ScaleConversion.h"
 #include "VGMInstrSet.h"
 #include "VGMSamp.h"
@@ -278,28 +280,44 @@ void DLSRgn::setWaveLinkInfo(uint16_t options, uint16_t phaseGroup, uint32_t the
 
 namespace {
 
-uint16_t dlsSourceForModSource(ModSource source) {
+std::optional<uint16_t> dlsSourceForModSource(ModSource source) {
+  if (auto controller = midiControllerForModSource(source)) {
+    switch (*controller) {
+      case 1:
+        return CONN_SRC_CC1;
+      case 7:
+        return CONN_SRC_CC7;
+      case 10:
+        return CONN_SRC_CC10;
+      case 11:
+        return CONN_SRC_CC11;
+      case 91:
+        return CONN_SRC_CC91;
+      case 93:
+        return CONN_SRC_CC93;
+      default:
+        return std::nullopt;
+    }
+  }
+
   switch (source) {
-    case ModSource::ModWheel:
-      return CONN_SRC_CC1;
+    case ModSource::None:
+      return CONN_SRC_NONE;
     case ModSource::ChannelPressure:
       return CONN_SRC_CHANNELPRESSURE;
     case ModSource::PolyPressure:
       return CONN_SRC_POLYPRESSURE;
     case ModSource::PitchWheel:
       return CONN_SRC_PITCHWHEEL;
-    case ModSource::Volume:
-      return CONN_SRC_CC7;
-    case ModSource::Pan:
-      return CONN_SRC_CC10;
-    case ModSource::Expression:
-      return CONN_SRC_CC11;
-    case ModSource::ReverbSend:
-      return CONN_SRC_CC91;
-    case ModSource::ChorusSend:
-      return CONN_SRC_CC93;
+    default:
+      break;
   }
-  return CONN_SRC_NONE;
+  return std::nullopt;
+}
+
+ModSource sourceForModulator(const SynthModulator& modulator) {
+  return modulator.source.value_or(
+      ConversionOptions::the().modSourceFor(ModulationSourceTarget::DLS, modulator.sourceMappingKey));
 }
 
 int32_t toDls16Dot16Scale(int32_t amount) {
@@ -407,17 +425,20 @@ void DLSArt::addGenerator(const SynthGenerator& generator) {
 }
 
 void DLSArt::addModulator(const SynthModulator& modulator) {
-  const uint16_t source = dlsSourceForModSource(modulator.source);
+  const auto source = dlsSourceForModSource(sourceForModulator(modulator));
+  if (!source.has_value()) {
+    return;
+  }
 
   switch (modulator.destination) {
     case ModDest::VibLfoToPitch:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
-          CONN_SRC_VIBRATO, source, CONN_DST_PITCH, CONN_TRN_NONE,
+          CONN_SRC_VIBRATO, *source, CONN_DST_PITCH, CONN_TRN_NONE,
           centsToDlsPitchScale(modulator.amount)));
       break;
     case ModDest::VibLfoFreq:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
-          source, CONN_SRC_NONE, CONN_DST_VIB_FREQUENCY, CONN_TRN_NONE,
+          *source, CONN_SRC_NONE, CONN_DST_VIB_FREQUENCY, CONN_TRN_NONE,
           centsToDlsPitchScale(modulator.amount)));
       break;
     case ModDest::VibLfoDelay:
@@ -426,22 +447,22 @@ void DLSArt::addModulator(const SynthModulator& modulator) {
       break;
     case ModDest::ModLfoFreq:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
-          source, CONN_SRC_NONE, CONN_DST_LFO_FREQUENCY, CONN_TRN_NONE,
+          *source, CONN_SRC_NONE, CONN_DST_LFO_FREQUENCY, CONN_TRN_NONE,
           centsToDlsPitchScale(modulator.amount)));
       break;
     case ModDest::ModLfoDelay:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
-          source, CONN_SRC_NONE, CONN_DST_LFO_STARTDELAY, CONN_TRN_NONE,
+          *source, CONN_SRC_NONE, CONN_DST_LFO_STARTDELAY, CONN_TRN_NONE,
           toDls16Dot16Scale(modulator.amount)));
       break;
     case ModDest::ModLfoToVol:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
-          CONN_SRC_LFO, source, CONN_DST_ATTENUATION, CONN_TRN_NONE,
+          CONN_SRC_LFO, *source, CONN_DST_ATTENUATION, CONN_TRN_NONE,
           toDls16Dot16Scale(modulator.amount)));
       break;
     case ModDest::InitialAtten:
       m_blocks.emplace_back(std::make_unique<ConnectionBlock>(
-          source, CONN_SRC_NONE, CONN_DST_ATTENUATION, CONN_TRN_NONE,
+          *source, CONN_SRC_NONE, CONN_DST_ATTENUATION, CONN_TRN_NONE,
           toDls16Dot16Scale(modulator.amount)));
       break;
   }

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -319,7 +319,7 @@ ModSource sourceForModulator(const SynthModulator& modulator) {
   return modulator.source.value_or(
       ConversionOptions::the()
           .modSourceMap(ModulationSourceTarget::DLS)
-          .sourceFor(modulator.sourceMappingKey));
+          .sourceFor(modulator.destination));
 }
 
 int32_t toDls16Dot16Scale(int32_t amount) {

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -302,7 +302,7 @@ std::optional<uint16_t> dlsSourceForModSource(ModSource source) {
 
   switch (source) {
     case ModSource::None:
-      return CONN_SRC_NONE;
+      return std::nullopt;
     case ModSource::ChannelPressure:
       return CONN_SRC_CHANNELPRESSURE;
     case ModSource::PolyPressure:

--- a/src/main/conversion/DLSFile.cpp
+++ b/src/main/conversion/DLSFile.cpp
@@ -317,7 +317,9 @@ std::optional<uint16_t> dlsSourceForModSource(ModSource source) {
 
 ModSource sourceForModulator(const SynthModulator& modulator) {
   return modulator.source.value_or(
-      ConversionOptions::the().modSourceFor(ModulationSourceTarget::DLS, modulator.sourceMappingKey));
+      ConversionOptions::the()
+          .modSourceMap(ModulationSourceTarget::DLS)
+          .sourceFor(modulator.sourceMappingKey));
 }
 
 int32_t toDls16Dot16Scale(int32_t amount) {

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -42,7 +42,9 @@ SFModulator sf2SourceForModSource(ModSource source) {
 
 ModSource sourceForModulator(const SynthModulator& modulator) {
   return modulator.source.value_or(
-      ConversionOptions::the().modSourceFor(ModulationSourceTarget::SoundFont, modulator.sourceMappingKey));
+      ConversionOptions::the()
+          .modSourceMap(ModulationSourceTarget::SoundFont)
+          .sourceFor(modulator.sourceMappingKey));
 }
 
 SFGenerator sf2GeneratorForModDestination(ModDest destination) {

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -41,6 +41,7 @@ SFModulator sf2SourceForModSource(ModSource source) {
 }
 
 ModSource sourceForModulator(const SynthModulator& modulator) {
+  // Use the explicitly set source if defined, otherwise use the dest->source mapping configured in ConversionOptions
   return modulator.source.value_or(
       ConversionOptions::the()
           .modSourceMap(ModulationSourceTarget::SoundFont)

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <optional>
 #include "SF2File.h"
 #include "version.h"
 #include "Options.h"
@@ -17,7 +18,7 @@
 
 namespace {
 
-SFModulator sf2SourceForModSource(ModSource source) {
+std::optional<SFModulator> sf2SourceForModSource(ModSource source) {
   constexpr uint16_t midiContinuousController = 1u << 7;
   constexpr uint16_t bipolar = 1u << 9;
 
@@ -33,19 +34,22 @@ SFModulator sf2SourceForModSource(ModSource source) {
     case ModSource::PitchWheel:
       return static_cast<SFModulator>(bipolar | 14);
     case ModSource::None:
-      return 0;
+      return std::nullopt;
     default:
       break;
   }
-  return 0;
+  return std::nullopt;
 }
 
 ModSource sourceForModulator(const SynthModulator& modulator) {
-  // Use the explicitly set source if defined, otherwise use the dest->source mapping configured in ConversionOptions
   return modulator.source.value_or(
       ConversionOptions::the()
           .modSourceMap(ModulationSourceTarget::SoundFont)
           .sourceFor(modulator.destination));
+}
+
+std::optional<SFModulator> sf2SourceForModulator(const SynthModulator& modulator) {
+  return sf2SourceForModSource(sourceForModulator(modulator));
 }
 
 SFGenerator sf2GeneratorForModDestination(ModDest destination) {
@@ -78,8 +82,14 @@ int16_t sf2AmountForGenerator(const SynthGenerator& generator) {
       generator.amount, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()));
 }
 
+size_t numSf2ModulatorsForInstr(const SynthInstr* instr) {
+  return std::ranges::count_if(instr->modulators(), [](const auto& modulator) {
+    return sf2SourceForModulator(modulator).has_value();
+  });
+}
+
 bool hasInstrumentGlobalZone(const SynthInstr* instr) {
-  return !instr->generators().empty() || !instr->modulators().empty();
+  return !instr->generators().empty() || numSf2ModulatorsForInstr(instr) != 0;
 }
 
 } // namespace
@@ -313,7 +323,7 @@ SF2File::SF2File(SynthFile *synthfile)
       globalInstBag.wInstGenNdx = static_cast<uint16_t>(instGenCounter);
       globalInstBag.wInstModNdx = static_cast<uint16_t>(instModCounter);
       instGenCounter += static_cast<int>(instr->generators().size());
-      instModCounter += static_cast<int>(instr->modulators().size());
+      instModCounter += static_cast<int>(numSf2ModulatorsForInstr(instr));
       memcpy(ibagCk->data + (instBagCounter++ * sizeof(sfInstBag)), &globalInstBag, sizeof(sfInstBag));
     }
 
@@ -340,7 +350,7 @@ SF2File::SF2File(SynthFile *synthfile)
   uint32_t numTotalMods = 1;
   for (const auto instr : synthfile->vInstrs) {
     if (hasInstrumentGlobalZone(instr)) {
-      numTotalMods += static_cast<uint32_t>(instr->modulators().size());
+      numTotalMods += static_cast<uint32_t>(numSf2ModulatorsForInstr(instr));
     }
   }
 
@@ -350,8 +360,13 @@ SF2File::SF2File(SynthFile *synthfile)
   dataPtr = 0;
   for (const auto instr : synthfile->vInstrs) {
     for (const auto& modulator : instr->modulators()) {
+      const auto source = sf2SourceForModulator(modulator);
+      if (!source.has_value()) {
+        continue;
+      }
+
       sfInstModList instModList{};
-      instModList.sfModSrcOper = sf2SourceForModSource(sourceForModulator(modulator));
+      instModList.sfModSrcOper = *source;
       instModList.sfModDestOper = sf2GeneratorForModDestination(modulator.destination);
       instModList.modAmount = sf2AmountForModulator(modulator);
       instModList.sfModAmtSrcOper = 0;

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include "SF2File.h"
 #include "version.h"
+#include "Options.h"
 #include "VGMInstrSet.h"
 #include "SynthFile.h"
 #include "ScaleConversion.h"
@@ -20,27 +21,28 @@ SFModulator sf2SourceForModSource(ModSource source) {
   constexpr uint16_t midiContinuousController = 1u << 7;
   constexpr uint16_t bipolar = 1u << 9;
 
+  if (auto controller = midiControllerForModSource(source)) {
+    return static_cast<SFModulator>(midiContinuousController | *controller);
+  }
+
   switch (source) {
-    case ModSource::ModWheel:
-      return static_cast<SFModulator>(midiContinuousController | 1);
     case ModSource::ChannelPressure:
       return 13;
     case ModSource::PolyPressure:
       return 10;
     case ModSource::PitchWheel:
       return static_cast<SFModulator>(bipolar | 14);
-    case ModSource::Volume:
-      return static_cast<SFModulator>(midiContinuousController | 7);
-    case ModSource::Pan:
-      return static_cast<SFModulator>(midiContinuousController | 10);
-    case ModSource::Expression:
-      return static_cast<SFModulator>(midiContinuousController | 11);
-    case ModSource::ReverbSend:
-      return static_cast<SFModulator>(midiContinuousController | 91);
-    case ModSource::ChorusSend:
-      return static_cast<SFModulator>(midiContinuousController | 93);
+    case ModSource::None:
+      return 0;
+    default:
+      break;
   }
   return 0;
+}
+
+ModSource sourceForModulator(const SynthModulator& modulator) {
+  return modulator.source.value_or(
+      ConversionOptions::the().modSourceFor(ModulationSourceTarget::SoundFont, modulator.sourceMappingKey));
 }
 
 SFGenerator sf2GeneratorForModDestination(ModDest destination) {
@@ -346,7 +348,7 @@ SF2File::SF2File(SynthFile *synthfile)
   for (const auto instr : synthfile->vInstrs) {
     for (const auto& modulator : instr->modulators()) {
       sfInstModList instModList{};
-      instModList.sfModSrcOper = sf2SourceForModSource(modulator.source);
+      instModList.sfModSrcOper = sf2SourceForModSource(sourceForModulator(modulator));
       instModList.sfModDestOper = sf2GeneratorForModDestination(modulator.destination);
       instModList.modAmount = sf2AmountForModulator(modulator);
       instModList.sfModAmtSrcOper = 0;

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -44,7 +44,7 @@ ModSource sourceForModulator(const SynthModulator& modulator) {
   return modulator.source.value_or(
       ConversionOptions::the()
           .modSourceMap(ModulationSourceTarget::SoundFont)
-          .sourceFor(modulator.sourceMappingKey));
+          .sourceFor(modulator.destination));
 }
 
 SFGenerator sf2GeneratorForModDestination(ModDest destination) {

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -98,8 +98,8 @@ void SynthInstr::addModulator(const SynthModulator& modulator) {
   m_modulators.push_back(modulator);
 }
 
-void SynthInstr::addModulator(ModSource source, ModDest destination,
-                              ModAmount amount) {
+// Add a modulator using a specific ModSource. This will bypass the ModDest->ModSource mapping in ConversionOptions
+void SynthInstr::addModulator(ModSource source, ModDest destination, ModAmount amount) {
   if (!amount.valid()) {
     return;
   }
@@ -107,6 +107,7 @@ void SynthInstr::addModulator(ModSource source, ModDest destination,
   m_modulators.emplace_back(source, destination, amount.value());
 }
 
+// Add a modulator without specifying the ModSource. The ModDest->ModSource mapping in ConversionOptions will be used
 void SynthInstr::addModulator(ModDest destination, ModAmount amount) {
   if (!amount.valid()) {
     return;

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -104,7 +104,24 @@ void SynthInstr::addModulator(ModSource source, ModDest destination,
     return;
   }
 
-  m_modulators.push_back({source, destination, amount.value()});
+  m_modulators.emplace_back(source, destination, amount.value());
+}
+
+void SynthInstr::addModulator(ModDest destination, ModAmount amount) {
+  if (!amount.valid()) {
+    return;
+  }
+
+  m_modulators.emplace_back(destination, amount.value());
+}
+
+void SynthInstr::addModulator(ModDest sourceMappingKey, ModDest destination,
+                              ModAmount amount) {
+  if (!amount.valid()) {
+    return;
+  }
+
+  m_modulators.emplace_back(sourceMappingKey, destination, amount.value());
 }
 
 void SynthInstr::addGenerator(const SynthGenerator& generator) {

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -115,15 +115,6 @@ void SynthInstr::addModulator(ModDest destination, ModAmount amount) {
   m_modulators.emplace_back(destination, amount.value());
 }
 
-void SynthInstr::addModulator(ModDest sourceMappingKey, ModDest destination,
-                              ModAmount amount) {
-  if (!amount.valid()) {
-    return;
-  }
-
-  m_modulators.emplace_back(sourceMappingKey, destination, amount.value());
-}
-
 void SynthInstr::addGenerator(const SynthGenerator& generator) {
   m_generators.push_back(generator);
 }

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -49,7 +49,6 @@ class SynthInstr {
   void addModulator(const SynthModulator& modulator);
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
   void addModulator(ModDest destination, ModAmount amount);
-  void addModulator(ModDest sourceMappingKey, ModDest destination, ModAmount amount);
   [[nodiscard]] const std::vector<SynthModulator>& modulators() const { return m_modulators; }
   void addGenerator(const SynthGenerator& generator);
   void addGenerator(ModDest destination, ModAmount amount);

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -48,6 +48,8 @@ class SynthInstr {
 
   void addModulator(const SynthModulator& modulator);
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
+  void addModulator(ModDest destination, ModAmount amount);
+  void addModulator(ModDest sourceMappingKey, ModDest destination, ModAmount amount);
   [[nodiscard]] const std::vector<SynthModulator>& modulators() const { return m_modulators; }
   void addGenerator(const SynthGenerator& generator);
   void addGenerator(ModDest destination, ModAmount amount);

--- a/src/main/conversion/VGMExport.h
+++ b/src/main/conversion/VGMExport.h
@@ -12,6 +12,7 @@
 #include "VGMSeq.h"
 #include "SF2Conversion.h"
 #include "DLSConversion.h"
+#include "Options.h"
 
 /*
  * The following free functions implement
@@ -40,6 +41,9 @@ bool saveAsOriginal(const RawFile& rawfile, const std::filesystem::path& filepat
 
 template <Target options>
 void saveAs(const VGMColl &coll, const std::filesystem::path &dir_path) {
+  const ConversionOptions::ScopedMidiModulationSourceTarget scopedModulationTarget(
+      (options & Target::DLS) != 0 ? ModulationSourceTarget::DLS : ModulationSourceTarget::SoundFont);
+
   auto filename = makeSafeFileName(coll.name());
   auto filepath = dir_path / filename;
 

--- a/src/main/conversion/VGMExport.h
+++ b/src/main/conversion/VGMExport.h
@@ -41,6 +41,7 @@ bool saveAsOriginal(const RawFile& rawfile, const std::filesystem::path& filepat
 
 template <Target options>
 void saveAs(const VGMColl &coll, const std::filesystem::path &dir_path) {
+  // ScopedMidiModulationSourceTarget uses RAII to set whether we're exporting for SF2 or DLS in ConversionOptions.
   const ScopedMidiModulationSourceTarget scopedModulationTarget(
       (options & Target::DLS) != 0 ? ModulationSourceTarget::DLS : ModulationSourceTarget::SoundFont);
 

--- a/src/main/conversion/VGMExport.h
+++ b/src/main/conversion/VGMExport.h
@@ -41,7 +41,7 @@ bool saveAsOriginal(const RawFile& rawfile, const std::filesystem::path& filepat
 
 template <Target options>
 void saveAs(const VGMColl &coll, const std::filesystem::path &dir_path) {
-  const ConversionOptions::ScopedMidiModulationSourceTarget scopedModulationTarget(
+  const ScopedMidiModulationSourceTarget scopedModulationTarget(
       (options & Target::DLS) != 0 ? ModulationSourceTarget::DLS : ModulationSourceTarget::SoundFont);
 
   auto filename = makeSafeFileName(coll.name());

--- a/src/main/conversion/VGMExport.h
+++ b/src/main/conversion/VGMExport.h
@@ -41,14 +41,15 @@ bool saveAsOriginal(const RawFile& rawfile, const std::filesystem::path& filepat
 
 template <Target options>
 void saveAs(const VGMColl &coll, const std::filesystem::path &dir_path) {
-  // ScopedMidiModulationSourceTarget uses RAII to set whether we're exporting for SF2 or DLS in ConversionOptions.
-  const ScopedMidiModulationSourceTarget scopedModulationTarget(
-      (options & Target::DLS) != 0 ? ModulationSourceTarget::DLS : ModulationSourceTarget::SoundFont);
-
   auto filename = makeSafeFileName(coll.name());
   auto filepath = dir_path / filename;
 
   if constexpr ((options & Target::MIDI) != 0) {
+    // ScopedMidiModulationSourceTarget uses RAII to set whether we're exporting for SF2 or DLS in ConversionOptions.
+    constexpr auto midiModulationTarget =
+        (options & Target::DLS) != 0 ? ModulationSourceTarget::DLS : ModulationSourceTarget::SoundFont;
+    const ScopedMidiModulationSourceTarget scopedModulationTarget(midiModulationTarget);
+
     auto midiPath = filepath;
     midiPath.replace_extension(".mid");
     coll.seq()->saveAsMidi(midiPath, &coll);

--- a/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesModulation.cpp
@@ -339,7 +339,7 @@ uint8_t vibratoDepthMidiValue(AkaoSnesVersion version, uint8_t rate, uint8_t dep
     return 0;
   }
 
-  // ModWheel drives depth, normalized against the largest depth this version can produce.
+  // The configured vibrato depth source is normalized against the largest depth this version can produce.
   const int midiValue =
       static_cast<int>(std::lround(128.0 * vibratoDepthCents(version, rate, depth) /
                                    maxVibratoDepthCents(version)));
@@ -353,7 +353,7 @@ uint8_t rateMidiValue(AkaoSnesVersion version, uint8_t rate, uint8_t depth, uint
 }
 
 uint8_t delayMidiValue(AkaoSnesVersion version, uint8_t delay, uint8_t tempo, uint8_t timer0Frequency) {
-  // CC93 drives LFO delay within the version's exported seconds range.
+  // The configured vibrato delay source drives LFO delay within the version's exported seconds range.
   return midiValueForSecondsInRange(delaySeconds(version, delay, tempo, timer0Frequency),
                                     0.0,
                                     maxDelaySeconds(version));

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
@@ -44,8 +44,8 @@ AkaoSnesTrack::LfoParams AkaoSnesTrack::readLfoParams() {
 }
 
 void AkaoSnesTrack::clearVibratoRateAndDelay() {
-  addChannelPressureNoItem(0);
-  addControllerEventNoItem(akao_snes::modulation::kVibratoDelayController, 0);
+  addVibratoFrequencyNoItem(0);
+  addVibratoDelayNoItem(0);
 }
 
 void AkaoSnesTrack::applyVibrato(uint32_t offset, uint32_t length, const LfoParams& params) {
@@ -70,7 +70,7 @@ void AkaoSnesTrack::applyVibrato(uint32_t offset, uint32_t length, const LfoPara
     vibrato.beginReusableFade(delay, vibrato.configuredDepth(8), initialDepth);
     midiDepth = (delay == 0) ? vibratoFadeDepthMidiValue(initialDepth) : 0;
   }
-  setSynthLfoModulationDepth(vibrato, midiDepth, true);
+  emitVibratoDepth(vibrato, midiDepth, true);
   if (active) {
     syncVibratoRateAndDelay();
   }
@@ -85,7 +85,7 @@ void AkaoSnesTrack::clearVibrato(uint32_t offset, uint32_t length) {
   vibrato.setDepth(0);
   // Turning vibrato off also prevents later notes from replaying the stored fade-in ramp.
   vibrato.clearReusableFade();
-  setSynthLfoModulationDepth(vibrato, 0, true);
+  emitVibratoDepth(vibrato, 0, true);
   clearVibratoRateAndDelay();
 }
 
@@ -138,9 +138,9 @@ void AkaoSnesTrack::beginVibratoForNote() {
       ? vibrato.configuredDepth(8) / 4
       : 0;
   vibrato.beginReusableFade(delay, vibrato.configuredDepth(8), initialDepth);
-  setSynthLfoModulationDepth(vibrato,
-                             (delay == 0) ? vibratoFadeDepthMidiValue(initialDepth) : 0,
-                             true);
+  emitVibratoDepth(vibrato,
+                   (delay == 0) ? vibratoFadeDepthMidiValue(initialDepth) : 0,
+                   true);
 }
 
 uint8_t AkaoSnesTrack::vibratoFadeDepthMidiValue(int32_t depth) const {
@@ -164,7 +164,7 @@ void AkaoSnesTrack::updateVibratoFade() {
     return;
   }
 
-  advanceSynthLfoFadeToModulation(vibrato, 8, [this](int32_t depth) {
+  advanceVibratoDepthFade(vibrato, 8, [this](int32_t depth) {
     return vibratoFadeDepthMidiValue(depth);
   });
 }
@@ -183,12 +183,11 @@ void AkaoSnesTrack::syncVibratoRateAndDelay() {
                                                                      vibrato.rate(),
                                                                      vibrato.depth(),
                                                                      parent->TIMER0_FREQUENCY);
-  addChannelPressureNoItem(rateMidiValue);
-  addControllerEventNoItem(akao_snes::modulation::kVibratoDelayController,
-                           akao_snes::modulation::delayMidiValue(parent->version,
-                                                                 vibrato.delay(),
-                                                                 parent->tempo,
-                                                                 parent->TIMER0_FREQUENCY));
+  addVibratoFrequencyNoItem(rateMidiValue);
+  addVibratoDelayNoItem(akao_snes::modulation::delayMidiValue(parent->version,
+                                                              vibrato.delay(),
+                                                              parent->tempo,
+                                                              parent->TIMER0_FREQUENCY));
 }
 
 void AkaoSnesTrack::syncTempoDependentLfos() {

--- a/src/main/formats/CapcomSnes/CapcomSnesDefinitions.h
+++ b/src/main/formats/CapcomSnes/CapcomSnesDefinitions.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "Modulation.h"
+#include <optional>
 
 namespace capcom_snes {
 
@@ -31,6 +32,8 @@ inline TremoloModulationSpec tremoloModulationSpec() {
       kTremoloBaseHz,
       kTremoloMaxHz,
       TremoloGainMode::NoBoost,
+      std::nullopt,
+      TremoloLfoMode::ShareVibratoLfo,
   };
 }
 

--- a/src/main/formats/CapcomSnes/CapcomSnesDefinitions.h
+++ b/src/main/formats/CapcomSnes/CapcomSnesDefinitions.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "Modulation.h"
-#include <optional>
 
 namespace capcom_snes {
 
@@ -32,8 +31,6 @@ inline TremoloModulationSpec tremoloModulationSpec() {
       kTremoloBaseHz,
       kTremoloMaxHz,
       TremoloGainMode::NoBoost,
-      std::nullopt,
-      TremoloLfoMode::ShareVibratoLfo,
   };
 }
 

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -102,7 +102,7 @@ bool CapcomSnesInstr::loadInstr() {
 
   // Vibrato has a full +/- octave range of 1200 cents (max depth value evaluates to 127/128 of range, just like SF2)
   // Vibrato frequency is a unipolar sweep from one Capcom LFO step up to 255 steps, so we use the
-  // step frequency as the global base and let channel pressure span the full range in Hz.
+  // step frequency as the global base and let the configured vibrato frequency source span the full range in Hz.
   // Tremolo runs at twice the base vibrato rate and only attenuates, never boosts.
 
   addStandardVibratoHandling(capcom_snes::vibratoModulationSpec());

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -18,7 +18,6 @@ DECLARE_FORMAT(CapcomSnes);
 #define MAX_TRACKS  8
 #define SEQ_PPQN    48
 #define SEQ_KEYOFS  0
-static constexpr uint8_t kTremoloDepthController = 93;
 
 // volume table
 const uint8_t CapcomSnesSeq::volTable[] = {
@@ -181,10 +180,10 @@ void CapcomSnesTrack::resetVars() {
 
 void CapcomSnesTrack::setLfoOutputsEnabled(bool enabled) {
   if (vibrato.depth() != 0) {
-    setSynthLfoModulationDepth(vibrato, vibrato.outputDepthWhen(enabled));
+    emitVibratoDepth(vibrato, vibrato.outputDepthWhen(enabled));
   }
   if (tremolo.depth() != 0) {
-    setSynthLfoControllerDepth(tremolo, kTremoloDepthController, tremolo.outputDepthWhen(enabled));
+    emitTremoloDepth(tremolo, tremolo.outputDepthWhen(enabled));
   }
 }
 
@@ -192,9 +191,9 @@ void CapcomSnesTrack::addVibratoDepthEvent(uint32_t offset, uint32_t length, uin
   bool isNewOffset = onEvent(offset, length);
   vibrato.setDepth(depth);
 
-  // Add the event to the UI, but, but don't emit the MIDI event while the driver has the LFO disabled.
+  // Record the stored depth, but emit zero while the driver has the LFO disabled.
   recordSeqEvent<ModulationSeqEvent>(isNewOffset, getTime(), depth, offset, length, "Vibrato Depth");
-  setSynthLfoModulationDepth(vibrato, vibrato.outputDepthWhen(areLfoOutputsEnabled()), true);
+  emitVibratoDepth(vibrato, vibrato.outputDepthWhen(areLfoOutputsEnabled()), true);
 }
 
 void CapcomSnesTrack::handleLfoRateChange(uint8_t lfoRateByte) {
@@ -818,20 +817,17 @@ bool CapcomSnesTrack::readEvent() {
           case 1:
             // Tremolo Depth
             tremolo.setDepth(convertTremoloDepthToMidiValue(lfoAmount, parentSeq->version));
-            setSynthLfoControllerDepth(tremolo,
-                                       kTremoloDepthController,
-                                       tremolo.outputDepthWhen(areLfoOutputsEnabled()),
-                                       true);
+            emitTremoloDepth(tremolo, tremolo.outputDepthWhen(areLfoOutputsEnabled()), true);
             desc = fmt::format("Amount: {:d}", lfoAmount);
             addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth", desc, Type::Lfo);
             break;
           case 2:
             // LFO Rate
             handleLfoRateChange(lfoAmount);
-            addChannelPressure(beginOffset,
-                               curOffset - beginOffset,
-                               convertLfoRateByteToMidiVal(lfoAmount),
-                               "LFO Rate");
+            addVibratoFrequency(beginOffset,
+                                curOffset - beginOffset,
+                                convertLfoRateByteToMidiVal(lfoAmount),
+                                "LFO Rate");
             break;
           case 3:
             // Flag to reset LFO phase on note activation. 1 enables. 0 disables. V1: off by default, V2+: on by default

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -384,7 +384,7 @@ int convertTremoloDepthToMidiValue(int sourceDepth, CapcomSnesVersion version) {
 
 uint8_t convertLfoRateByteToMidiVal(uint8_t freqByte) {
   if (freqByte == 0)
-    return 0; // this is a special-case that disables vibrato
+    return 0; // this is a special-case that disables the LFO
 
   // The driver stores rate as a multiple of a fixed LFO step; the shared helper
   // handles the Hz -> 7-bit MIDI mapping that matches the instrument modulator.
@@ -821,14 +821,17 @@ bool CapcomSnesTrack::readEvent() {
             desc = fmt::format("Amount: {:d}", lfoAmount);
             addGenericEvent(beginOffset, curOffset - beginOffset, "Tremolo Depth", desc, Type::Lfo);
             break;
-          case 2:
+          case 2: {
             // LFO Rate
             handleLfoRateChange(lfoAmount);
+            const uint8_t lfoRateMidiValue = convertLfoRateByteToMidiVal(lfoAmount);
             addVibratoFrequency(beginOffset,
                                 curOffset - beginOffset,
-                                convertLfoRateByteToMidiVal(lfoAmount),
+                                lfoRateMidiValue,
                                 "LFO Rate");
+            addTremoloFrequencyNoItem(lfoRateMidiValue);
             break;
+          }
           case 3:
             // Flag to reset LFO phase on note activation. 1 enables. 0 disables. V1: off by default, V2+: on by default
             // SoundFont 2 and DLS always reset LFO phase when a note is activated. This cannot be changed.

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -249,10 +249,7 @@ KonamiSnesInstr::~KonamiSnesInstr() {
 }
 
 bool KonamiSnesInstr::loadInstr() {
-  // Konami vibrato is driven per track from E4:
-  //   CC1  -> depth
-  //   ch. pressure -> final effective vibrato frequency
-  //   CC93 -> final effective vibrato delay
+  // Konami vibrato is driven per track from E4 through the configured vibrato MIDI sources.
   addStandardVibratoHandling(konami_snes::vibrato::modulationSpec(version));
 
   if (percussion) {

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -249,7 +249,6 @@ KonamiSnesInstr::~KonamiSnesInstr() {
 }
 
 bool KonamiSnesInstr::loadInstr() {
-  // Konami vibrato is driven per track from E4 through the configured vibrato MIDI sources.
   addStandardVibratoHandling(konami_snes::vibrato::modulationSpec(version));
 
   if (percussion) {

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -397,12 +397,11 @@ void KonamiSnesTrack::syncVibratoRateAndDelay() {
                                               konami_snes::vibrato::rateFactor(parentSeq.version, vibrato.rate(), parentSeq.tempo));
   }
 
-  addChannelPressureNoItem(convertVibratoRateToMidi(parentSeq.version,
-                                                    vibrato.rate(),
-                                                    parentSeq.tempo,
-                                                    parentSeq.maxVibratoRateFactor));
-  addControllerEventNoItem(konami_snes::kVibratoDelayController,
-                           convertVibratoDelayToMidi(parentSeq.version, vibrato.delay(), parentSeq.tempo));
+  addVibratoFrequencyNoItem(convertVibratoRateToMidi(parentSeq.version,
+                                                     vibrato.rate(),
+                                                     parentSeq.tempo,
+                                                     parentSeq.maxVibratoRateFactor));
+  addVibratoDelayNoItem(convertVibratoDelayToMidi(parentSeq.version, vibrato.delay(), parentSeq.tempo));
 }
 
 
@@ -430,7 +429,7 @@ void KonamiSnesTrack::onTickBegin() {
   panFade.tickRaw([this](int32_t) { applyCurrentPan(); });
   volumeFade.tickRaw([this](int32_t) { applyCurrentVolume(); });
 
-  advanceSynthLfoFadeToModulation(vibrato, 8, [this](int32_t depth) {
+  advanceVibratoDepthFade(vibrato, 8, [this](int32_t depth) {
     return convertVibratoDepthToMidi(seq().version,
                                      vibrato.depth(),
                                      static_cast<uint16_t>(depth),
@@ -835,7 +834,7 @@ bool KonamiSnesTrack::readEvent() {
       if (!isTiedNote && vibrato.hasReusableFade() &&
           konami_snes::vibrato::isActive(seq().version, vibrato.rate(), vibrato.depth())) {
         vibrato.beginReusableFadeToConfiguredDepth(8);
-        setSynthLfoModulationDepth(vibrato, 0);
+        emitVibratoDepth(vibrato, 0);
       }
 
       if (isTiedNote) {
@@ -1034,13 +1033,13 @@ bool KonamiSnesTrack::readEvent() {
                                                 parentSeq.maxVibratoDepth)
                     : 0);
       vibrato.setCurrentDepthPreservingMotion(deferDepthForFade ? 0 : vibrato.configuredDepth(8));
-      setSynthLfoModulationDepth(vibrato, midiDepth, true);
+      emitVibratoDepth(vibrato, midiDepth, true);
       if (active) {
         syncVibratoRateAndDelay();
       }
       else {
-        addChannelPressureNoItem(0);
-        addControllerEventNoItem(konami_snes::kVibratoDelayController, 0);
+        addVibratoFrequencyNoItem(0);
+        addVibratoDelayNoItem(0);
       }
       break;
     }

--- a/src/main/formats/MP2k/MP2kSeq.cpp
+++ b/src/main/formats/MP2k/MP2kSeq.cpp
@@ -23,7 +23,6 @@ DECLARE_FORMAT(MP2k);
 constexpr uint8_t kMp2kModTypeVibrato = 0;
 constexpr uint8_t kMp2kModTypeTremolo = 1;
 constexpr uint8_t kMp2kModTypePan = 2;
-constexpr uint8_t kMp2kTremoloDepthController = 93;
 
 const char* mp2kModTypeName(uint8_t type) {
   switch (type) {
@@ -478,8 +477,8 @@ bool MP2kTrack::lfoOutputsEnabled() const {
 }
 
 void MP2kTrack::clearLfoOutputs() {
-  setSynthLfoModulationDepth(vibratoLfo, 0, true);
-  setSynthLfoControllerDepth(tremoloLfo, kMp2kTremoloDepthController, 0, true);
+  emitVibratoDepth(vibratoLfo, 0, true);
+  emitTremoloDepth(tremoloLfo, 0, true);
 }
 
 void MP2kTrack::applyLfoDepth(bool force) {
@@ -490,13 +489,12 @@ void MP2kTrack::applyLfoDepth(bool force) {
 
   switch (modType) {
     case kMp2kModTypeVibrato:
-      setSynthLfoModulationDepth(vibratoLfo, vibratoLfo.depth(), force);
-      setSynthLfoControllerDepth(tremoloLfo, kMp2kTremoloDepthController, 0, true);
+      emitVibratoDepth(vibratoLfo, vibratoLfo.depth(), force);
+      emitTremoloDepth(tremoloLfo, 0, true);
       break;
     case kMp2kModTypeTremolo:
-      setSynthLfoControllerDepth(tremoloLfo, kMp2kTremoloDepthController, tremoloLfo.depth(),
-                                 force);
-      setSynthLfoModulationDepth(vibratoLfo, 0, true);
+      emitTremoloDepth(tremoloLfo, tremoloLfo.depth(), force);
+      emitVibratoDepth(vibratoLfo, 0, true);
       break;
     default:
       clearLfoOutputs();
@@ -553,11 +551,11 @@ void MP2kTrack::beginNoteLfo() {
   }
 
   if (modType == kMp2kModTypeVibrato) {
-    setSynthLfoModulationDepth(vibratoLfo, 0, false);
+    emitVibratoDepth(vibratoLfo, 0, false);
     vibratoLfo.setReusableFadeToConfiguredDepth(1);
     vibratoLfo.beginReusableFadeToConfiguredDepth();
   } else if (modType == kMp2kModTypeTremolo) {
-    setSynthLfoControllerDepth(tremoloLfo, kMp2kTremoloDepthController, 0, false);
+    emitTremoloDepth(tremoloLfo, 0, false);
     tremoloLfo.setReusableFadeToConfiguredDepth(1);
     tremoloLfo.beginReusableFadeToConfiguredDepth();
   }
@@ -578,7 +576,7 @@ void MP2kTrack::updateLfoFade() {
         0,
         [](int32_t depth) { return depth; },
         [this](uint8_t depth) {
-          addControllerEventNoItem(kMp2kTremoloDepthController, depth);
+          addTremoloDepthNoItem(depth);
         });
   }
 }

--- a/src/main/formats/MP2k/MP2kSeq.cpp
+++ b/src/main/formats/MP2k/MP2kSeq.cpp
@@ -568,12 +568,8 @@ void MP2kTrack::updateLfoFade() {
   }
 
   if (modType == kMp2kModTypeVibrato) {
-    advanceVibratoDepthFade(vibratoLfo, 0, [](int32_t depth) {
-      return depth;
-    });
+    advanceVibratoDepthFade(vibratoLfo, 0, [](int32_t depth) { return depth; });
   } else if (modType == kMp2kModTypeTremolo) {
-    advanceTremoloDepthFade(tremoloLfo, 0, [](int32_t depth) {
-      return depth;
-    });
+    advanceTremoloDepthFade(tremoloLfo, 0, [](int32_t depth) { return depth; });
   }
 }

--- a/src/main/formats/MP2k/MP2kSeq.cpp
+++ b/src/main/formats/MP2k/MP2kSeq.cpp
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <spdlog/fmt/fmt.h>
+#include "automation/SeqTrackAutomation.h"
 #include "MidiFile.h"
 #include "MP2kFormat.h"
 
@@ -567,16 +568,12 @@ void MP2kTrack::updateLfoFade() {
   }
 
   if (modType == kMp2kModTypeVibrato) {
-    vibratoLfo.tickFadeToDepth(
-        0,
-        [](int32_t depth) { return depth; },
-        [this](uint8_t depth) { addModulationNoItem(depth); });
+    advanceVibratoDepthFade(vibratoLfo, 0, [](int32_t depth) {
+      return depth;
+    });
   } else if (modType == kMp2kModTypeTremolo) {
-    tremoloLfo.tickFadeToDepth(
-        0,
-        [](int32_t depth) { return depth; },
-        [this](uint8_t depth) {
-          addTremoloDepthNoItem(depth);
-        });
+    advanceTremoloDepthFade(tremoloLfo, 0, [](int32_t depth) {
+      return depth;
+    });
   }
 }

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -30,7 +30,7 @@ bool usesIntelliTempDrumKitExport(NinSnesProfileId profileId) {
 
 void addVibratoHandling(VGMInstr* instr) {
   // NinSnes drives vibrato from per-track controllers, so every exportable instrument shares the
-  // same ModWheel/ChannelPressure/CC93 wiring and only the final ranges vary per sequence.
+  // same settings-backed controller wiring and only the final ranges vary per sequence.
   instr->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
 }
 

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -28,12 +28,6 @@ bool usesIntelliTempDrumKitExport(NinSnesProfileId profileId) {
   return intelliMode == NinSnesIntelliModeId::Ta || intelliMode == NinSnesIntelliModeId::Fe4;
 }
 
-void addVibratoHandling(VGMInstr* instr) {
-  // NinSnes drives vibrato from per-track controllers, so every exportable instrument shares the
-  // same settings-backed controller wiring and only the final ranges vary per sequence.
-  instr->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
-}
-
 void applyVibratoScaling(NinSnesInstrSet* instrSet, const VibratoModulationSpec& spec) {
   // Re-target the shared vibrato modulators to the maxima observed in the matched sequence.
   for (auto* instr : instrSet->exportInstrs()) {
@@ -303,7 +297,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
           overrideDef.progNum >> 7,
           overrideDef.progNum & 0x7f,
           fmt::format("Instrument {:d} (Overwrite)", overrideDef.logicalInstrIndex));
-      addVibratoHandling(overrideInstr);
+      overrideInstr->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
       auto* rgn =
           createRgnFromHeaderData(overrideInstr, rawFile(), profileId, spcDirAddr, overrideDef.regionData);
       if (rgn == nullptr) {
@@ -317,7 +311,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
     for (const auto& drumKitDef : seq->intelliTADrumKitDefs()) {
       auto* drumKit = new VGMInstr(
           this, 0, 0, 127, drumKitDef.program, fmt::format("Drum Kit {:d}", drumKitDef.program));
-      addVibratoHandling(drumKit);
+      drumKit->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
 
       for (size_t slot = 0; slot < drumKitDef.slots.size(); slot++) {
         const auto& slotDef = drumKitDef.slots[slot];
@@ -349,7 +343,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
     if (!percussionInstrNoteMap.empty()) {
       // Create the drumkit instrument for percussion note events.
       auto* drumKit = new VGMInstr(this, 0, 0, 127, 0, "Drum Kit");
-      addVibratoHandling(drumKit);
+      drumKit->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
       for (const auto& [instrIndex, percussionDef] : percussionInstrNoteMap) {
         VGMInstr* sourceInstr = nullptr;
         for (auto* instr : aInstrs) {
@@ -414,7 +408,7 @@ bool NinSnesInstr::loadInstr() {
     return false;
   }
 
-  addVibratoHandling(this);
+  addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
 
   uint16_t addrSampStart = readShort(offDirEnt);
 

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -249,7 +249,7 @@ private:
   void updateVibratoFade();
   void applyConfiguredVibrato();
   void clearVibratoRateAndDelay();
-  void setVibratoDepth(uint8_t depth);
+  void setConfiguredVibratoDepth(uint8_t depth);
   void resetPitchBendForNewNote();
   void addPendingEndEvent(uint8_t statusByte, const std::string& desc);
   void syncVibratoRateAndDelay();

--- a/src/main/formats/NinSnes/NinSnesTrackModulation.cpp
+++ b/src/main/formats/NinSnes/NinSnesTrackModulation.cpp
@@ -130,7 +130,7 @@ void NinSnesTrack::activateStoredPitchEnvelope() {
 void NinSnesTrack::beginNoteVibrato() {
   // EVENT_VIBRATO_FADE is a reusable per-note fade-in for the configured E3 vibrato.
   if (state.vibrato.active() && state.vibrato.beginReusableFadeToConfiguredDepth()) {
-    setVibratoDepth(0);
+    setConfiguredVibratoDepth(0);
   }
 }
 
@@ -145,7 +145,7 @@ void NinSnesTrack::applyConfiguredVibrato() {
     }
   }
 
-  setVibratoDepth(vibrato.outputDepthWhen(active));
+  setConfiguredVibratoDepth(vibrato.outputDepthWhen(active));
   if (active) {
     syncVibratoRateAndDelay();
   } else {
@@ -154,21 +154,21 @@ void NinSnesTrack::applyConfiguredVibrato() {
 }
 
 void NinSnesTrack::updateVibratoFade() {
-  advanceSynthLfoFadeToModulation(state.vibrato, 0, [this](int32_t depth) {
+  advanceVibratoDepthFade(state.vibrato, 0, [this](int32_t depth) {
     return convertVibratoDepthToMidi(static_cast<uint8_t>(depth), seq().maxVibratoDepthCents);
   });
 }
 
-void NinSnesTrack::setVibratoDepth(uint8_t depth) {
+void NinSnesTrack::setConfiguredVibratoDepth(uint8_t depth) {
   auto& vibrato = state.vibrato;
   vibrato.setCurrentDepthPreservingMotion(depth);
   const uint8_t midiDepth = convertVibratoDepthToMidi(depth, seq().maxVibratoDepthCents);
-  setSynthLfoModulationDepth(vibrato, midiDepth);
+  emitVibratoDepth(vibrato, midiDepth);
 }
 
 void NinSnesTrack::clearVibratoRateAndDelay() {
-  addChannelPressureNoItem(0);
-  addControllerEventNoItem(nin_snes::vibrato::kDelayController, 0);
+  addVibratoFrequencyNoItem(0);
+  addVibratoDelayNoItem(0);
 }
 
 void NinSnesTrack::resetPitchBendForNewNote() {
@@ -202,7 +202,6 @@ void NinSnesTrack::syncVibratoRateAndDelay() {
         std::max(parentSeq.maxVibratoRateHz, nin_snes::vibrato::rateHz(vibrato.rate(), currentTempo));
   }
 
-  addChannelPressureNoItem(convertVibratoRateToMidi(vibrato.rate(), currentTempo, parentSeq.maxVibratoRateHz));
-  addControllerEventNoItem(nin_snes::vibrato::kDelayController,
-                           convertVibratoDelayToMidi(vibrato.delay(), currentTempo));
+  addVibratoFrequencyNoItem(convertVibratoRateToMidi(vibrato.rate(), currentTempo, parentSeq.maxVibratoRateHz));
+  addVibratoDelayNoItem(convertVibratoDelayToMidi(vibrato.delay(), currentTempo));
 }


### PR DESCRIPTION
This adds ModDest -> ModSource mappings for SF2 and DLS (separately) in ConversionOptions, laying the groundwork that will allow users to specify which controllers or events to use for vibrato and tremolo modulators. This PR doesn't include an UI to change these mappings - that will have to come down the road. But this does establish sensible defaults, and it means that SF2 can utilize more appropriate CC sources instead of being constrained by DLS.

Of course, the mappings grant us a convenient layer of abstraction: SeqTrack can now provide methods for adding vibrato and tremolo events which resolve the configured MIDI output under the hood. Those new methods are:
- addVibratoDepth()
- addVibratoFrequency()
- addVibratoDelay()
- addTremoloDepth()
- addTremoloFrequency()
- addTremoloDelay()

There are also *NoItem() variants for each of these methods. I have updated all of the format call sites to utilize these methods instead of hard-coded controller / channel pressure events.

Separately, I've updated addStandardTremoloHandling() so that it uses a unique controller for LFO frequency instead of sharing the same source as vibLfoFreq. CapcomSnes, which shares a single LFO for vibrato and tremolo, has been updated to write MIDI events for both vibrato and tremolo frequency.

I've also renamed a number of methods for clarity.
- SeqTrack::setSynthLfoModulationDepth() -> emitVibratoDepth()
- SeqTrack::setSynthLfoControllerDepth() -> emitTremoloDepth()
- SeqTrack::advanceSynthLfoFadeToModulation() ->advanceVibratoDepthFade()

## Motivation and Context
Hardcoding modulator sources and their sequence-side event outputs was a bad scene. This simplifies modulator handling, makes the code easier to read, allows exported SF2s to use the full range of CCs, and will eventually give users more flexibility.

## How Has This Been Tested?
Tested a few of the formats utilizing modulators for deprecation by listening for vibrato and tremolo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
