### PR TITLE
PS1 VAB/SF2: correct attenuation export and ADPCM scan crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@
 
 * **Audio:** Fixed CPS3 volume and ADSR bugs.
 
+**PS1 (VAB)**
+
+* **Breath of Fire 3:** Fixed delay effects playing at too high volume.
+* **Stability:** Fixed a crash when loading certain PS1 music files
+
+
 ### User Interface & Tools
 
 * **Rendering:** The analysis panel was fully rewritten and now uses GPU rendering.
@@ -45,6 +51,7 @@
 
 ### General
 
+* **SF2:** Compensated SF2 attenuation to improve sound compatibility with most synths and players.
 * **Crash Fix:** Fixed a crash when removing a collection that was currently being played.
 * **Memory Leaks:** Fixed various memory leaks, most notably one which occurred during collection playback.
 

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -18,6 +18,10 @@
 
 namespace {
 
+constexpr double kEmu8000InitialAttenuationScale = 2.5;
+constexpr double kSoundFontCentibelsPerDecibel = 10.0;
+constexpr double kSoundFontMaxInitialAttenuationCentibels = 1440.0;
+
 std::optional<SFModulator> sf2SourceForModSource(ModSource source) {
   constexpr uint16_t midiContinuousController = 1u << 7;
   constexpr uint16_t bipolar = 1u << 9;
@@ -423,9 +427,14 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
 
       // initialAttenuation
       instGenList.sfGenOper = initialAttenuation;
+      // INFO.isng declares EMU8000. EMU-compatible SF2 synths apply a 0.4
+      // factor to generator 48, so store the reciprocal to preserve SynthFile's
+      // dB attenuation.
       u16 atten = static_cast<u16>(std::clamp(
-        std::round((rgn->attenDb + rgn->sampinfo->attenuation) * 10.0),
-        0.0, 1440.0));
+        std::round((rgn->attenDb + rgn->sampinfo->attenuation) *
+                   kSoundFontCentibelsPerDecibel *
+                   kEmu8000InitialAttenuationScale),
+        0.0, kSoundFontMaxInitialAttenuationCentibels));
       instGenList.genAmount.wAmount = atten;
       memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);

--- a/src/main/formats/PS1/Vab.cpp
+++ b/src/main/formats/PS1/Vab.cpp
@@ -204,12 +204,20 @@ VabRgn::VabRgn(VabInstr *instr, uint32_t offset)
 
 bool VabRgn::loadRgn() {
   VabInstr *instr = (VabInstr *) parInstr;
+  Vab *vab = static_cast<Vab *>(instr->parInstrSet);
   setLength(0x20);
   readBytes(offset(), 0x20, &attr);
 
   addGeneralItem(offset(), 1, "Priority");
   addGeneralItem(offset() + 1, 1, "Mode (use reverb?)");
-  addVolume((readByte(offset() + 2) * instr->masterVol) / (127.0 * 127.0), offset() + 2, 1);
+  const uint8_t toneVol = readByte(offset() + 2);
+  const double combinedVolume =
+    (static_cast<double>(vab->hdr.mvol) / 127.0) *
+    (static_cast<double>(instr->masterVol) / 127.0) *
+    (static_cast<double>(toneVol) / 127.0);
+  // libsnd squares the final left/right voice volume after applying VAB master,
+  // program, tone, and pan factors.
+  addVolume(combinedVolume * combinedVolume, offset() + 2, 1);
   addPan(readByte(offset() + 3), offset() + 3);
   addUnityKey(readByte(offset() + 4), offset() + 4);
   addGeneralItem(offset() + 5, 1, "Pitch Tune");
@@ -247,9 +255,9 @@ bool VabRgn::loadRgn() {
   // If it exceeds 127, driver clips the value and it will become 127. (In Hokuto no Ken, at least)
   // I am not sure if the interpretation of this value depends on a driver or VAB version.
   uint8_t ft = readByte(offset() + 5);
-  ft = std::min(ft, static_cast<u8>(127));
+  ft = std::min(ft, static_cast<uint8_t>(127));
   double cents = ft * 100.0 / 128.0;
-  setFineTune((int16_t) cents);
+  setFineTune(static_cast<int16_t>(cents));
 
   psxConvADSR<VabRgn>(this, ADSR1, ADSR2, false);
   return true;

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -216,9 +216,13 @@ constexpr u32 BACK_SCAN_LIMIT           = 0x5000;
 
 /// Check for a sequence of 16 null bytes - an empty ADPCM frame
 static inline bool isZero16(const RawFile* f, u32 ofs) {
-  if (!f->isValidOffset(ofs + 15)) return false;
-  const u64* blk = reinterpret_cast<const u64*>(f->data() + ofs);
-  return blk[0] == 0 && blk[1] == 0;
+  if (ofs > f->size() || f->size() - ofs < 16) return false;
+  for (u32 i = 0; i < 16; i++) {
+    if (f->readByte(ofs + i) != 0) {
+      return false;
+    }
+  }
+  return true;
 }
 
 static inline bool isValidFilterShiftByte(u8 b) {
@@ -351,7 +355,7 @@ std::vector<PSXSampColl*> PSXSampColl::searchForPSXADPCMs(RawFile* file, const s
     u32 origOffset = i;
     u32 start   = i;
     u32 scanned = 16;
-    while (start - scanned >= 16 && scanned < BACK_SCAN_LIMIT)
+    while (scanned < BACK_SCAN_LIMIT && i >= scanned + 16)
     {
       const u32 offset = i - scanned;
       scanned += 16;


### PR DESCRIPTION
## Description
- Apply PS1 VAB master volume, program volume, and tone volume together before converting to attenuation.
- Scale SF2 generator 48 `initialAttenuation` for EMU8000-compatible playback, matching the SF2 `isng` declaration.
- Fix a PSX ADPCM scanner crash caused by unsigned backscan underflow near offset 0.
- Avoid unaligned reads in the PSX ADPCM zero-frame check.

## Motivation and Context
- Fixes #877 (assumed from crash dump)
- Fixes #55

The SF2 export already writes `initialAttenuation`, but EMU8k/10k-compatible SF2 loaders apply a 0.4 factor to instrument/preset attenuation values. Since VGMTrans declares `isng` as `EMU8000`, the exported generator value needs to compensate for that behavior (or so I believe). FluidSynth applies this factor regardless of what `isng` is

This also fixes a related crash in PSX ADPCM scanning where backward scanning could underflow and attempt to read offset `0xfffffff0` and an unaligned read flagged by UBSAN.

## How Has This Been Tested?
Tested on macOS arm64.
- Verified delayed piano notes render at much lower level, about `0.33x` the dry/lead note level (#55)
- Ran synthetic PSX ADPCM offset-0 smoke test to confirm no crash

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
