### PR TITLE
AkaoSnes: pitch slides and pitch envelopes

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -150,6 +150,7 @@ target_sources(vgmtranscore
     formats/AkaoSnes/AkaoSnesScanner.cpp
     formats/AkaoSnes/AkaoSnesSeq.cpp
     formats/AkaoSnes/AkaoSnesTrackLfo.cpp
+    formats/AkaoSnes/AkaoSnesTrackPitch.cpp
     formats/AsciiShuichiSnes/AsciiShuichiSnesInstr.cpp
     formats/AsciiShuichiSnes/AsciiShuichiSnesScanner.cpp
     formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp

--- a/src/main/components/seq/automation/SeqMidiAutomation.h
+++ b/src/main/components/seq/automation/SeqMidiAutomation.h
@@ -15,7 +15,7 @@
 template <typename PitchType>
 class SeqPitchBendAutomation {
  public:
-  using PitchToCents = double (*)(PitchType pitch, PitchType basePitch);
+  using PitchToCents = std::function<double(PitchType, PitchType)>;
 
   explicit SeqPitchBendAutomation(double centsPerPitchUnit = 100.0)
       : m_centsPerPitchUnit(centsPerPitchUnit) {}

--- a/src/main/components/seq/automation/SeqMidiAutomation.h
+++ b/src/main/components/seq/automation/SeqMidiAutomation.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <functional>
 #include <utility>
 
 // Stores source-space pitch and converts it to MIDI pitch bend when emitting.
@@ -85,7 +86,7 @@ class SeqPitchBendAutomation {
   [[nodiscard]] uint16_t rangeCentsForSlide(PitchType startPitch,
                                             PitchType targetPitch,
                                             uint16_t minimumRangeCents) const {
-    if (m_pitchToCents != nullptr) {
+    if (m_pitchToCents) {
       const double startDeviation = std::abs(centsForPitch(startPitch));
       const double targetDeviation = std::abs(centsForPitch(targetPitch));
       return std::max<uint16_t>(
@@ -208,7 +209,7 @@ class SeqPitchBendAutomation {
   static constexpr int32_t kMaxMidiPitchBend = 8191;
 
   [[nodiscard]] double centsForPitch(PitchType pitch) const {
-    if (m_pitchToCents != nullptr) {
+    if (m_pitchToCents) {
       return m_pitchToCents(pitch, m_basePitch);
     }
 
@@ -221,7 +222,7 @@ class SeqPitchBendAutomation {
   uint16_t m_pitchBendRangeCents = 200;
   int16_t m_currentPitchBend = 0;
   double m_centsPerPitchUnit = 100.0;
-  PitchToCents m_pitchToCents = nullptr;
+  PitchToCents m_pitchToCents {};
 };
 
 // Manages synth LFO state: stored delay/rate/depth and optional per-note fade-ins.

--- a/src/main/components/seq/automation/SeqMidiAutomation.h
+++ b/src/main/components/seq/automation/SeqMidiAutomation.h
@@ -15,6 +15,8 @@
 template <typename PitchType>
 class SeqPitchBendAutomation {
  public:
+  using PitchToCents = double (*)(PitchType pitch, PitchType basePitch);
+
   explicit SeqPitchBendAutomation(double centsPerPitchUnit = 100.0)
       : m_centsPerPitchUnit(centsPerPitchUnit) {}
 
@@ -28,6 +30,10 @@ class SeqPitchBendAutomation {
 
   void setCentsPerPitchUnit(double centsPerPitchUnit) {
     m_centsPerPitchUnit = centsPerPitchUnit;
+  }
+
+  void setPitchToCents(PitchToCents pitchToCents) {
+    m_pitchToCents = pitchToCents;
   }
 
   // Set the note-relative base pitch and reset current pitch to that base.
@@ -67,6 +73,14 @@ class SeqPitchBendAutomation {
     return SeqMotionPlan<PitchType>::targetOverTicks(targetPitch, ticks, delay);
   }
 
+  // Build a target-over-ticks motion that applies the supplied step on the final tick instead of snapping.
+  [[nodiscard]] SeqMotionPlan<PitchType> motionToTargetWithStepNoSnap(PitchType targetPitch,
+                                                                      PitchType step,
+                                                                      uint32_t ticks,
+                                                                      uint32_t delay = 0) const {
+    return SeqMotionPlan<PitchType>::targetOverTicksWithStepNoSnap(targetPitch, step, ticks, delay);
+  }
+
   // Return a MIDI bend range large enough for pitchUnits, but not below minimumRangeCents.
   [[nodiscard]] uint16_t rangeCentsForPitchSpan(double pitchUnits,
                                                 uint16_t minimumRangeCents) const {
@@ -79,6 +93,14 @@ class SeqPitchBendAutomation {
   [[nodiscard]] uint16_t rangeCentsForSlide(PitchType startPitch,
                                             PitchType targetPitch,
                                             uint16_t minimumRangeCents) const {
+    if (m_pitchToCents != nullptr) {
+      const double startDeviation = std::abs(centsForPitch(startPitch));
+      const double targetDeviation = std::abs(centsForPitch(targetPitch));
+      return std::max<uint16_t>(
+          minimumRangeCents,
+          static_cast<uint16_t>(std::ceil(std::max(startDeviation, targetDeviation))));
+    }
+
     const double startDeviation = std::abs(static_cast<double>(startPitch - m_basePitch));
     const double targetDeviation = std::abs(static_cast<double>(targetPitch - m_basePitch));
     return rangeCentsForPitchSpan(std::max(startDeviation, targetDeviation), minimumRangeCents);
@@ -91,8 +113,7 @@ class SeqPitchBendAutomation {
   // Convert source-space pitch to MIDI bend using the current bend range.
   [[nodiscard]] int16_t bendForPitch(PitchType pitch) const {
     const auto bend = static_cast<int32_t>(
-        std::lround((((static_cast<double>(pitch - m_basePitch) * m_centsPerPitchUnit) /
-                      m_pitchBendRangeCents) * 8192.0)));
+        std::lround(((centsForPitch(pitch) / m_pitchBendRangeCents) * 8192.0)));
     return static_cast<int16_t>(std::clamp(bend, kMinMidiPitchBend, kMaxMidiPitchBend));
   }
 
@@ -194,12 +215,21 @@ class SeqPitchBendAutomation {
   static constexpr int32_t kMinMidiPitchBend = -8192;
   static constexpr int32_t kMaxMidiPitchBend = 8191;
 
+  [[nodiscard]] double centsForPitch(PitchType pitch) const {
+    if (m_pitchToCents != nullptr) {
+      return m_pitchToCents(pitch, m_basePitch);
+    }
+
+    return static_cast<double>(pitch - m_basePitch) * m_centsPerPitchUnit;
+  }
+
   bool m_baseValid = false;
   PitchType m_basePitch {};
   SeqAutomatedValue<PitchType> m_pitch;
   uint16_t m_pitchBendRangeCents = 200;
   int16_t m_currentPitchBend = 0;
   double m_centsPerPitchUnit = 100.0;
+  PitchToCents m_pitchToCents = nullptr;
 };
 
 // Manages synth LFO state: stored delay/rate/depth and optional per-note fade-ins.

--- a/src/main/components/seq/automation/SeqMidiAutomation.h
+++ b/src/main/components/seq/automation/SeqMidiAutomation.h
@@ -73,14 +73,6 @@ class SeqPitchBendAutomation {
     return SeqMotionPlan<PitchType>::targetOverTicks(targetPitch, ticks, delay);
   }
 
-  // Build a target-over-ticks motion that applies the supplied step on the final tick instead of snapping.
-  [[nodiscard]] SeqMotionPlan<PitchType> motionToTargetWithStepNoSnap(PitchType targetPitch,
-                                                                      PitchType step,
-                                                                      uint32_t ticks,
-                                                                      uint32_t delay = 0) const {
-    return SeqMotionPlan<PitchType>::targetOverTicksWithStepNoSnap(targetPitch, step, ticks, delay);
-  }
-
   // Return a MIDI bend range large enough for pitchUnits, but not below minimumRangeCents.
   [[nodiscard]] uint16_t rangeCentsForPitchSpan(double pitchUnits,
                                                 uint16_t minimumRangeCents) const {

--- a/src/main/components/seq/automation/SeqMotion.h
+++ b/src/main/components/seq/automation/SeqMotion.h
@@ -47,12 +47,13 @@ struct SeqMotionPlan {
   uint32_t ticks = 0;
   uint32_t delay = 0;
   SeqMotionMode mode = SeqMotionMode::TargetOverTicks;
+  bool snapToTarget = true;
 
   // Compute the per-tick step from the current value when begin() is called.
   static SeqMotionPlan targetOverTicks(ValueType targetValue,
                                        uint32_t tickCount,
                                        uint32_t delayTicks = 0) {
-    return {targetValue, {}, tickCount, delayTicks, SeqMotionMode::TargetOverTicks};
+    return {targetValue, {}, tickCount, delayTicks, SeqMotionMode::TargetOverTicks, true};
   }
 
   // Use the supplied step for tickCount ticks, then snap to target.
@@ -60,14 +61,22 @@ struct SeqMotionPlan {
                                                ValueType stepValue,
                                                uint32_t tickCount,
                                                uint32_t delayTicks = 0) {
-    return {targetValue, stepValue, tickCount, delayTicks, SeqMotionMode::TargetOverTicksWithStep};
+    return {targetValue, stepValue, tickCount, delayTicks, SeqMotionMode::TargetOverTicksWithStep, true};
+  }
+
+  // Use the supplied step for tickCount ticks and leave the final stepped value as-is.
+  static SeqMotionPlan targetOverTicksWithStepNoSnap(ValueType targetValue,
+                                                     ValueType stepValue,
+                                                     uint32_t tickCount,
+                                                     uint32_t delayTicks = 0) {
+    return {targetValue, stepValue, tickCount, delayTicks, SeqMotionMode::TargetOverTicksWithStep, false};
   }
 
   // Use the supplied step as-is until the value reaches or crosses target.
   static SeqMotionPlan targetByStep(ValueType targetValue,
                                     ValueType stepValue,
                                     uint32_t delayTicks = 0) {
-    return {targetValue, stepValue, 0, delayTicks, SeqMotionMode::TargetByStep};
+    return {targetValue, stepValue, 0, delayTicks, SeqMotionMode::TargetByStep, true};
   }
 
   [[nodiscard]] bool usesTicks() const {
@@ -114,6 +123,7 @@ class SeqLinearMotion {
     m_delay = plan.delay;
     m_ticksRemaining = plan.ticks;
     m_mode = plan.mode;
+    m_snapToTarget = plan.snapToTarget;
 
     if (plan.mode == SeqMotionMode::TargetOverTicks) {
       if (plan.ticks == 0) {
@@ -188,7 +198,12 @@ class SeqLinearMotion {
 
       m_ticksRemaining -= 1;
       if (m_ticksRemaining == 0) {
-        m_current = m_target;
+        if (m_snapToTarget) {
+          m_current = m_target;
+        }
+        else {
+          m_current = static_cast<ValueType>(m_current + m_step);
+        }
         return {SeqMotionStatus::Finished, previous, m_current, m_current != previous};
       }
 
@@ -217,4 +232,5 @@ class SeqLinearMotion {
   uint32_t m_delay = 0;
   uint32_t m_ticksRemaining = 0;
   SeqMotionMode m_mode = SeqMotionMode::TargetOverTicks;
+  bool m_snapToTarget = true;
 };

--- a/src/main/components/seq/automation/SeqMotion.h
+++ b/src/main/components/seq/automation/SeqMotion.h
@@ -47,13 +47,12 @@ struct SeqMotionPlan {
   uint32_t ticks = 0;
   uint32_t delay = 0;
   SeqMotionMode mode = SeqMotionMode::TargetOverTicks;
-  bool snapToTarget = true;
 
   // Compute the per-tick step from the current value when begin() is called.
   static SeqMotionPlan targetOverTicks(ValueType targetValue,
                                        uint32_t tickCount,
                                        uint32_t delayTicks = 0) {
-    return {targetValue, {}, tickCount, delayTicks, SeqMotionMode::TargetOverTicks, true};
+    return {targetValue, {}, tickCount, delayTicks, SeqMotionMode::TargetOverTicks};
   }
 
   // Use the supplied step for tickCount ticks, then snap to target.
@@ -61,22 +60,14 @@ struct SeqMotionPlan {
                                                ValueType stepValue,
                                                uint32_t tickCount,
                                                uint32_t delayTicks = 0) {
-    return {targetValue, stepValue, tickCount, delayTicks, SeqMotionMode::TargetOverTicksWithStep, true};
-  }
-
-  // Use the supplied step for tickCount ticks and leave the final stepped value as-is.
-  static SeqMotionPlan targetOverTicksWithStepNoSnap(ValueType targetValue,
-                                                     ValueType stepValue,
-                                                     uint32_t tickCount,
-                                                     uint32_t delayTicks = 0) {
-    return {targetValue, stepValue, tickCount, delayTicks, SeqMotionMode::TargetOverTicksWithStep, false};
+    return {targetValue, stepValue, tickCount, delayTicks, SeqMotionMode::TargetOverTicksWithStep};
   }
 
   // Use the supplied step as-is until the value reaches or crosses target.
   static SeqMotionPlan targetByStep(ValueType targetValue,
                                     ValueType stepValue,
                                     uint32_t delayTicks = 0) {
-    return {targetValue, stepValue, 0, delayTicks, SeqMotionMode::TargetByStep, true};
+    return {targetValue, stepValue, 0, delayTicks, SeqMotionMode::TargetByStep};
   }
 
   [[nodiscard]] bool usesTicks() const {
@@ -123,7 +114,6 @@ class SeqLinearMotion {
     m_delay = plan.delay;
     m_ticksRemaining = plan.ticks;
     m_mode = plan.mode;
-    m_snapToTarget = plan.snapToTarget;
 
     if (plan.mode == SeqMotionMode::TargetOverTicks) {
       if (plan.ticks == 0) {
@@ -198,12 +188,7 @@ class SeqLinearMotion {
 
       m_ticksRemaining -= 1;
       if (m_ticksRemaining == 0) {
-        if (m_snapToTarget) {
-          m_current = m_target;
-        }
-        else {
-          m_current = static_cast<ValueType>(m_current + m_step);
-        }
+        m_current = m_target;
         return {SeqMotionStatus::Finished, previous, m_current, m_current != previous};
       }
 
@@ -232,5 +217,4 @@ class SeqLinearMotion {
   uint32_t m_delay = 0;
   uint32_t m_ticksRemaining = 0;
   SeqMotionMode m_mode = SeqMotionMode::TargetOverTicks;
-  bool m_snapToTarget = true;
 };

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -793,6 +793,9 @@ bool AkaoSnesTrack::readEvent(void) {
         pitchEnvelopeDelay = readByte(curOffset++);
         pitchEnvelopeLength = readByte(curOffset++);
         pitchEnvelopeSemitones = static_cast<int8_t>(readByte(curOffset++));
+        setPitchEnvelope(pitchEnvelopeSemitones,
+                         static_cast<uint8_t>(pitchEnvelopeDelay + 1),
+                         pitchEnvelopeLength);
         desc = fmt::format("Delay: {}  Length: {}  Key: {} semitones",
                            pitchEnvelopeDelay,
                            pitchEnvelopeLength,
@@ -818,7 +821,7 @@ bool AkaoSnesTrack::readEvent(void) {
     }
 
     case EVENT_PITCH_ENVELOPE_OFF: {
-      if (parentSeq->version == AKAOSNES_V2) {
+      if (parentSeq->version == AKAOSNES_V1 || parentSeq->version == AKAOSNES_V2) {
         clearPitchEnvelope();
       }
       addGenericEvent(beginOffset,

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -49,6 +49,10 @@ int32_t akaoSnesPitchSlideStep(AkaoSnesVersion version,
   return diff / static_cast<int32_t>(steps);
 }
 
+uint16_t akaoSnesV2PitchEnvelopeProgressStep(uint8_t length) {
+  return length == 0 ? 0 : static_cast<uint16_t>(0xff00 / length);
+}
+
 double akaoSnesPitchCents(int32_t pitch, int32_t basePitch) {
   if (pitch <= 0 || basePitch <= 0) {
     return 0.0;
@@ -268,7 +272,7 @@ void AkaoSnesSeq::LoadEventMap() {
     EventMap[0xd3] = EVENT_NOP1;
     EventMap[0xd4] = EVENT_ECHO_VOLUME;
     EventMap[0xd5] = EVENT_ECHO_FEEDBACK_FIR;
-    EventMap[0xd6] = EVENT_PITCH_SLIDE_ON;
+    EventMap[0xd6] = EVENT_PITCH_ENVELOPE_ON;
     EventMap[0xd7] = EVENT_TREMOLO_ON;
     EventMap[0xd8] = EVENT_VIBRATO_ON;
     EventMap[0xd9] = EVENT_PAN_LFO_ON_WITH_DELAY;
@@ -284,7 +288,7 @@ void AkaoSnesSeq::LoadEventMap() {
     EventMap[0xe3] = EVENT_NOP;
     EventMap[0xe4] = EVENT_NOP;
     EventMap[0xe5] = EVENT_NOP;
-    EventMap[0xe6] = EVENT_PITCH_SLIDE_OFF;
+    EventMap[0xe6] = EVENT_PITCH_ENVELOPE_OFF;
     EventMap[0xe7] = EVENT_TREMOLO_OFF;
     EventMap[0xe8] = EVENT_VIBRATO_OFF;
     EventMap[0xe9] = EVENT_PAN_LFO_OFF;
@@ -321,8 +325,8 @@ void AkaoSnesSeq::LoadEventMap() {
     EventMap[0xd8] = EVENT_ECHO_VOLUME;
     EventMap[0xd9] = EVENT_ECHO_VOLUME_FADE;
     EventMap[0xda] = EVENT_TRANSPOSE_ABS;
-    EventMap[0xdb] = EVENT_PITCH_SLIDE_ON;
-    EventMap[0xdc] = EVENT_PITCH_SLIDE_OFF;
+    EventMap[0xdb] = EVENT_PITCH_ENVELOPE_ON;
+    EventMap[0xdc] = EVENT_PITCH_ENVELOPE_OFF;
     EventMap[0xdd] = EVENT_VIBRATO_ON;
     EventMap[0xde] = EVENT_VIBRATO_OFF;
     EventMap[0xdf] = EVENT_TREMOLO_ON;
@@ -634,6 +638,7 @@ void AkaoSnesTrack::resetVars() {
   jumpActivatedByMainCpu = true; // it should be false in the actual driver, but for convenience
 
   ignoreMasterVolumeProgNum = 0xff;
+  pitchEnvelope = {};
   pendingPitchSlideSteps = 0;
   pendingPitchSlideSemitones = 0;
   pitchSlide.setPitchToCents(akaoSnesPitchCents);
@@ -646,17 +651,59 @@ void AkaoSnesTrack::onTickBegin() {
   updateVibratoFade();
   updateTremoloFade();
   updatePitchSlide();
+  updatePitchEnvelope();
 }
 
 void AkaoSnesTrack::updatePitchSlide() {
   advancePitchBendAutomation(pitchSlide);
 }
 
+void AkaoSnesTrack::updatePitchEnvelope() {
+  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
+  if (parentSeq->version != AKAOSNES_V2 || !pitchEnvelope.active || !pitchSlide.baseValid()) {
+    return;
+  }
+
+  if (pitchEnvelope.activeDelay > 1) {
+    pitchEnvelope.activeDelay--;
+    return;
+  }
+  if (pitchEnvelope.activeDelay == 1) {
+    pitchEnvelope.activeDelay = 0;
+  }
+
+  pitchEnvelope.progress += pitchEnvelope.progressStep;
+
+  int32_t currentOffset;
+  if (pitchEnvelope.progress > 0xffff) {
+    currentOffset = pitchEnvelope.targetOffset;
+    pitchEnvelope.progress = 0x10000;
+    pitchEnvelope.active = false;
+  }
+  else {
+    const uint8_t progressHigh = static_cast<uint8_t>(pitchEnvelope.progress >> 8);
+    const int32_t targetMagnitude =
+        pitchEnvelope.targetOffset < 0 ? -pitchEnvelope.targetOffset : pitchEnvelope.targetOffset;
+    int32_t currentMagnitude =
+        (targetMagnitude / AKAOSNES_PITCH_FRACTION_SCALE) * progressHigh / 256;
+    currentMagnitude *= AKAOSNES_PITCH_FRACTION_SCALE;
+    currentOffset = pitchEnvelope.targetOffset < 0 ? -currentMagnitude : currentMagnitude;
+  }
+
+  pitchSlide.setCurrentPitch(pitchSlide.basePitch() + currentOffset);
+  applyPitchBendAutomation(pitchSlide);
+}
+
 void AkaoSnesTrack::resetPitchBendForNewNote() {
+  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
   pitchSlide.clearMotion();
   pitchSlide.invalidateBase();
 
   if (!pitchSlide.atRest(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS)) {
+    if (parentSeq->version == AKAOSNES_V2 && pitchEnvelope.enabled) {
+      setPitchBendAutomationBend(pitchSlide, 0);
+      return;
+    }
     resetPitchBendAutomation(pitchSlide, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS);
   }
 }
@@ -665,6 +712,59 @@ void AkaoSnesTrack::beginNotePitch(uint8_t, bool validForPitchBend) {
   resetPitchBendForNewNote();
   if (validForPitchBend) {
     pitchSlide.beginNote(akaoSnesBasePitch());
+    beginPitchEnvelopeForNote();
+  }
+}
+
+void AkaoSnesTrack::setPitchEnvelope(int8_t semitones, uint8_t delay, uint8_t length) {
+  if (semitones == 0 || length == 0) {
+    clearPitchEnvelope();
+    return;
+  }
+
+  pitchEnvelope.enabled = true;
+  pitchEnvelope.semitones = semitones;
+  pitchEnvelope.delay = delay;
+  pitchEnvelope.length = length;
+  pitchEnvelope.progressStep = akaoSnesV2PitchEnvelopeProgressStep(length);
+}
+
+void AkaoSnesTrack::clearPitchEnvelope() {
+  pitchEnvelope.enabled = false;
+  pitchEnvelope.active = false;
+  pitchEnvelope.semitones = 0;
+  pitchEnvelope.delay = 0;
+  pitchEnvelope.length = 0;
+  pitchEnvelope.progressStep = 0;
+  pitchEnvelope.activeDelay = 0;
+  pitchEnvelope.progress = 0;
+  pitchEnvelope.targetOffset = 0;
+}
+
+void AkaoSnesTrack::beginPitchEnvelopeForNote() {
+  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
+  if (parentSeq->version != AKAOSNES_V2 || !pitchEnvelope.enabled || !pitchSlide.baseValid()) {
+    return;
+  }
+
+  const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(pitchEnvelope.semitones);
+  const int32_t rawDiff =
+      (targetPitch - pitchSlide.basePitch()) / AKAOSNES_PITCH_FRACTION_SCALE;
+  const int32_t rawMagnitude = rawDiff < 0 ? -rawDiff : rawDiff;
+  const int32_t signedMagnitude =
+      pitchEnvelope.semitones < 0 ? -rawMagnitude : rawMagnitude;
+  pitchEnvelope.targetOffset = signedMagnitude * AKAOSNES_PITCH_FRACTION_SCALE;
+  pitchEnvelope.activeDelay = pitchEnvelope.delay;
+  pitchEnvelope.progress = 0;
+  pitchEnvelope.active = pitchEnvelope.targetOffset != 0 && pitchEnvelope.progressStep != 0;
+  pitchSlide.setCurrentPitch(pitchSlide.basePitch());
+
+  if (pitchEnvelope.active) {
+    setPitchBendAutomationRange(
+        pitchSlide,
+        pitchSlide.rangeCentsForSlide(pitchSlide.basePitch(),
+                                      pitchSlide.basePitch() + pitchEnvelope.targetOffset,
+                                      AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS));
   }
 }
 
@@ -896,40 +996,48 @@ bool AkaoSnesTrack::readEvent(void) {
       break;
     }
 
-    case EVENT_PITCH_SLIDE_ON: {
-      int8_t pitchSlideSemitones;
-      uint8_t pitchSlideDelay;
-      uint8_t pitchSlideLength;
+    case EVENT_PITCH_ENVELOPE_ON: {
+      int8_t pitchEnvelopeSemitones;
+      uint8_t pitchEnvelopeDelay;
+      uint8_t pitchEnvelopeLength;
 
       if (parentSeq->version == AKAOSNES_V1) {
-        pitchSlideDelay = readByte(curOffset++);
-        pitchSlideLength = readByte(curOffset++);
-        pitchSlideSemitones = readByte(curOffset++);
-        desc = fmt::format("Delay: {}  Length: {}  Key: {} semitones", pitchSlideDelay,
-          pitchSlideLength, pitchSlideSemitones);
+        pitchEnvelopeDelay = readByte(curOffset++);
+        pitchEnvelopeLength = readByte(curOffset++);
+        pitchEnvelopeSemitones = static_cast<int8_t>(readByte(curOffset++));
+        desc = fmt::format("Delay: {}  Length: {}  Key: {} semitones",
+                           pitchEnvelopeDelay,
+                           pitchEnvelopeLength,
+                           static_cast<int>(pitchEnvelopeSemitones));
       }
       else { // AKAOSNES_V2
-        pitchSlideSemitones = readByte(curOffset++);
-        pitchSlideDelay = readByte(curOffset++);
-        pitchSlideLength = readByte(curOffset++);
-        desc = fmt::format("Key: {} semitones  Delay: {}  Length: {}", pitchSlideSemitones,
-          pitchSlideDelay, pitchSlideLength);
+        pitchEnvelopeSemitones = static_cast<int8_t>(readByte(curOffset++));
+        pitchEnvelopeDelay = readByte(curOffset++);
+        pitchEnvelopeLength = readByte(curOffset++);
+        setPitchEnvelope(pitchEnvelopeSemitones, pitchEnvelopeDelay, pitchEnvelopeLength);
+        desc = fmt::format("Key: {} semitones  Delay: {}  Length: {}",
+                           static_cast<int>(pitchEnvelopeSemitones),
+                           pitchEnvelopeDelay,
+                           pitchEnvelopeLength);
       }
 
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      "Pitch Slide On",
+                      "Pitch Envelope On",
                       desc,
-                      Type::PitchBendSlide);
+                      Type::PitchEnvelope);
       break;
     }
 
-    case EVENT_PITCH_SLIDE_OFF: {
+    case EVENT_PITCH_ENVELOPE_OFF: {
+      if (parentSeq->version == AKAOSNES_V2) {
+        clearPitchEnvelope();
+      }
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
-                      "Pitch Slide Off",
+                      "Pitch Envelope Off",
                       desc,
-                      Type::PitchBendSlide);
+                      Type::PitchEnvelope);
       break;
     }
 

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -677,7 +677,7 @@ bool AkaoSnesTrack::readEvent(void) {
 
       if (noteIndex < 12) {
         uint8_t note = octave * 12 + noteIndex;
-        beginNotePitch(note, !percussion);
+        beginNotePitch(!percussion);
         beginPendingPitchSlide();
 
         if (!slur && !legato) {
@@ -837,21 +837,14 @@ bool AkaoSnesTrack::readEvent(void) {
     case EVENT_PITCH_SLIDE: {
       uint8_t pitchSlideTime = readByte(curOffset++);
       int8_t pitchSlideSemitones = static_cast<int8_t>(readByte(curOffset++));
-      if (parentSeq->version == AKAOSNES_V3 || parentSeq->version == AKAOSNES_V4) {
-        // V3 D6 and V4 C8 are one-shot pitch-slide setup commands:
-        // tt stores as tt + 1, wrapping $ff to the 256-step case.
-        const uint16_t pitchSlideSteps = static_cast<uint16_t>(pitchSlideTime) + 1;
-        setPendingPitchSlide(pitchSlideSteps, pitchSlideSemitones);
-        desc = fmt::format("Time: {}  Steps: {}  Key: {} semitones",
-                           pitchSlideTime,
-                           pitchSlideSteps,
-                           static_cast<int>(pitchSlideSemitones));
-      }
-      else {
-        desc = fmt::format("Length: {}  Key: {} semitones",
-                           pitchSlideTime,
-                           static_cast<int>(pitchSlideSemitones));
-      }
+      // V3 D6 and V4 C8 are one-shot pitch-slide setup commands:
+      // tt stores as tt + 1, wrapping $ff to the 256-step case.
+      const uint16_t pitchSlideSteps = static_cast<uint16_t>(pitchSlideTime) + 1;
+      setPendingPitchSlide(pitchSlideSteps, pitchSlideSemitones);
+      desc = fmt::format("Time: {}  Steps: {}  Key: {} semitones",
+                         pitchSlideTime,
+                         pitchSlideSteps,
+                         static_cast<int>(pitchSlideSemitones));
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Slide",

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -15,6 +15,35 @@ DECLARE_FORMAT(AkaoSnes);
 static constexpr uint16_t SEQ_PPQN = 48;
 static constexpr int MAX_TRACKS = 8;
 static constexpr uint8_t NOTE_VELOCITY = 100;
+static constexpr uint16_t AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS = 200;
+static constexpr int32_t AKAOSNES_NOMINAL_DSP_PITCH = 0x1000;
+static constexpr int32_t AKAOSNES_PITCH_FRACTION_SCALE = 0x100;
+
+namespace {
+// For MIDI bend output, only target/base ratios matter, so normalize every new note to DSP pitch $1000.
+int32_t akaoSnesBasePitch() {
+  return AKAOSNES_NOMINAL_DSP_PITCH * AKAOSNES_PITCH_FRACTION_SCALE;
+}
+
+int32_t akaoSnesPitchForSemitoneOffset(int8_t semitones) {
+  const double pitch =
+      static_cast<double>(AKAOSNES_NOMINAL_DSP_PITCH) *
+      std::pow(2.0, static_cast<double>(semitones) / 12.0);
+  return static_cast<int32_t>(std::lround(pitch)) * AKAOSNES_PITCH_FRACTION_SCALE;
+}
+
+double akaoSnesPitchCents(int32_t pitch, int32_t basePitch) {
+  if (pitch <= 0 || basePitch <= 0) {
+    return 0.0;
+  }
+
+  return 1200.0 * std::log2(static_cast<double>(pitch) / static_cast<double>(basePitch));
+}
+
+uint16_t akaoSnesPitchSlideSteps(uint8_t timeParam) {
+  return static_cast<uint16_t>(timeParam) + 1;
+}
+}
 
 //  **********
 //  AkaoSnesSeq
@@ -588,6 +617,10 @@ void AkaoSnesTrack::resetVars() {
   jumpActivatedByMainCpu = true; // it should be false in the actual driver, but for convenience
 
   ignoreMasterVolumeProgNum = 0xff;
+  pendingPitchSlideSteps = 0;
+  pendingPitchSlideSemitones = 0;
+  pitchSlide.setPitchToCents(akaoSnesPitchCents);
+  pitchSlide.reset(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS);
   vibrato.reset();
   tremolo.reset();
 }
@@ -595,6 +628,69 @@ void AkaoSnesTrack::resetVars() {
 void AkaoSnesTrack::onTickBegin() {
   updateVibratoFade();
   updateTremoloFade();
+  updatePitchSlide();
+}
+
+void AkaoSnesTrack::updatePitchSlide() {
+  advancePitchBendAutomation(pitchSlide);
+}
+
+void AkaoSnesTrack::resetPitchBendForNewNote() {
+  pitchSlide.clearMotion();
+  pitchSlide.invalidateBase();
+
+  if (!pitchSlide.atRest(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS)) {
+    resetPitchBendAutomation(pitchSlide, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS);
+  }
+}
+
+void AkaoSnesTrack::beginNotePitch(uint8_t, bool validForPitchBend) {
+  resetPitchBendForNewNote();
+  if (validForPitchBend) {
+    pitchSlide.beginNote(akaoSnesBasePitch());
+  }
+}
+
+void AkaoSnesTrack::setPendingPitchSlide(uint16_t steps, int8_t semitones) {
+  pendingPitchSlideSteps = steps;
+  pendingPitchSlideSemitones = semitones;
+  if (pendingPitchSlideSemitones == 0) {
+    clearPendingPitchSlide();
+  }
+}
+
+void AkaoSnesTrack::clearPendingPitchSlide() {
+  pendingPitchSlideSteps = 0;
+  pendingPitchSlideSemitones = 0;
+}
+
+void AkaoSnesTrack::beginPendingPitchSlide() {
+  if (pendingPitchSlideSteps == 0 || pendingPitchSlideSemitones == 0) {
+    clearPendingPitchSlide();
+    return;
+  }
+
+  const uint16_t steps = pendingPitchSlideSteps;
+  const int8_t semitones = pendingPitchSlideSemitones;
+  clearPendingPitchSlide();
+
+  if (!pitchSlide.baseValid()) {
+    return;
+  }
+
+  const int32_t currentPitch = pitchSlide.currentPitch();
+  const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(semitones);
+  const int32_t step = (targetPitch - currentPitch) / static_cast<int32_t>(steps);
+
+  beginPitchBendAutomation(
+      pitchSlide,
+      pitchSlide.motionToTargetWithStepNoSnap(targetPitch, step, steps),
+      pitchSlide.rangeCentsForSlide(currentPitch, targetPitch, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS),
+      AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS,
+      true);
+
+  // FF6 applies the first slide increment on the same sequencer tick that consumes C8.
+  updatePitchSlide();
 }
 
 bool AkaoSnesTrack::readEvent(void) {
@@ -674,6 +770,8 @@ bool AkaoSnesTrack::readEvent(void) {
 
       if (noteIndex < 12) {
         uint8_t note = octave * 12 + noteIndex;
+        beginNotePitch(note, !percussion);
+        beginPendingPitchSlide();
 
         if (!slur && !legato) {
           beginVibratoForNote();
@@ -690,6 +788,7 @@ bool AkaoSnesTrack::readEvent(void) {
         addTime(len);
       }
       else if (noteIndex == parentSeq->STATUS_NOTEINDEX_TIE) {
+        beginPendingPitchSlide();
         makePrevDurNoteEnd(getTime() + dur);
         addTie(beginOffset, curOffset - beginOffset, dur, "Tie", desc);
         addTime(len);
@@ -816,12 +915,25 @@ bool AkaoSnesTrack::readEvent(void) {
     }
 
     case EVENT_PITCH_SLIDE: {
-      uint8_t pitchSlideLength = readByte(curOffset++);
-      int8_t pitchSlideSemitones = readByte(curOffset++);
+      uint8_t pitchSlideTime = readByte(curOffset++);
+      int8_t pitchSlideSemitones = static_cast<int8_t>(readByte(curOffset++));
+      if (parentSeq->version == AKAOSNES_V4) {
+        const uint16_t pitchSlideSteps = akaoSnesPitchSlideSteps(pitchSlideTime);
+        setPendingPitchSlide(pitchSlideSteps, pitchSlideSemitones);
+        desc = fmt::format("Time: {}  Steps: {}  Key: {} semitones",
+                           pitchSlideTime,
+                           pitchSlideSteps,
+                           static_cast<int>(pitchSlideSemitones));
+      }
+      else {
+        desc = fmt::format("Length: {}  Key: {} semitones",
+                           pitchSlideTime,
+                           static_cast<int>(pitchSlideSemitones));
+      }
       addGenericEvent(beginOffset,
                       curOffset - beginOffset,
                       "Pitch Slide",
-                      fmt::format("Length: {}  Key: {} semitones", pitchSlideLength, pitchSlideSemitones),
+                      desc,
                       Type::PitchBendSlide);
       break;
     }

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -15,56 +15,6 @@ DECLARE_FORMAT(AkaoSnes);
 static constexpr uint16_t SEQ_PPQN = 48;
 static constexpr int MAX_TRACKS = 8;
 static constexpr uint8_t NOTE_VELOCITY = 100;
-static constexpr uint16_t AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS = 200;
-static constexpr int32_t AKAOSNES_NOMINAL_DSP_PITCH = 0x1000;
-static constexpr int32_t AKAOSNES_PITCH_FRACTION_SCALE = 0x100;
-
-namespace {
-// For MIDI bend output, only target/base ratios matter, so normalize every new note to DSP pitch $1000.
-int32_t akaoSnesBasePitch() {
-  return AKAOSNES_NOMINAL_DSP_PITCH * AKAOSNES_PITCH_FRACTION_SCALE;
-}
-
-int32_t akaoSnesPitchForSemitoneOffset(int8_t semitones) {
-  const double pitch =
-      static_cast<double>(AKAOSNES_NOMINAL_DSP_PITCH) *
-      std::pow(2.0, static_cast<double>(semitones) / 12.0);
-  return static_cast<int32_t>(std::lround(pitch)) * AKAOSNES_PITCH_FRACTION_SCALE;
-}
-
-int32_t akaoSnesPitchSlideStep(AkaoSnesVersion version,
-                               int32_t currentPitch,
-                               int32_t targetPitch,
-                               uint16_t steps) {
-  const int32_t diff = targetPitch - currentPitch;
-  if (version == AKAOSNES_V3) {
-    const int32_t rawDiff = diff / AKAOSNES_PITCH_FRACTION_SCALE;
-    int32_t rawStep = rawDiff / static_cast<int32_t>(steps);
-    if (rawStep == 0 && rawDiff != 0) {
-      rawStep = (rawDiff > 0) ? 1 : -1;
-    }
-    return rawStep * AKAOSNES_PITCH_FRACTION_SCALE;
-  }
-
-  return diff / static_cast<int32_t>(steps);
-}
-
-uint16_t akaoSnesV2PitchEnvelopeProgressStep(uint8_t length) {
-  return length == 0 ? 0 : static_cast<uint16_t>(0xff00 / length);
-}
-
-double akaoSnesPitchCents(int32_t pitch, int32_t basePitch) {
-  if (pitch <= 0 || basePitch <= 0) {
-    return 0.0;
-  }
-
-  return 1200.0 * std::log2(static_cast<double>(pitch) / static_cast<double>(basePitch));
-}
-
-uint16_t akaoSnesPitchSlideSteps(uint8_t timeParam) {
-  return static_cast<uint16_t>(timeParam) + 1;
-}
-}
 
 //  **********
 //  AkaoSnesSeq
@@ -638,11 +588,7 @@ void AkaoSnesTrack::resetVars() {
   jumpActivatedByMainCpu = true; // it should be false in the actual driver, but for convenience
 
   ignoreMasterVolumeProgNum = 0xff;
-  pitchEnvelope = {};
-  pendingPitchSlideSteps = 0;
-  pendingPitchSlideSemitones = 0;
-  pitchSlide.setPitchToCents(akaoSnesPitchCents);
-  pitchSlide.reset(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS);
+  resetPitchState();
   vibrato.reset();
   tremolo.reset();
 }
@@ -652,164 +598,6 @@ void AkaoSnesTrack::onTickBegin() {
   updateTremoloFade();
   updatePitchSlide();
   updatePitchEnvelope();
-}
-
-void AkaoSnesTrack::updatePitchSlide() {
-  advancePitchBendAutomation(pitchSlide);
-}
-
-void AkaoSnesTrack::updatePitchEnvelope() {
-  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
-  if (parentSeq->version != AKAOSNES_V2 || !pitchEnvelope.active || !pitchSlide.baseValid()) {
-    return;
-  }
-
-  if (pitchEnvelope.activeDelay > 1) {
-    pitchEnvelope.activeDelay--;
-    return;
-  }
-  if (pitchEnvelope.activeDelay == 1) {
-    pitchEnvelope.activeDelay = 0;
-  }
-
-  pitchEnvelope.progress += pitchEnvelope.progressStep;
-
-  int32_t currentOffset;
-  if (pitchEnvelope.progress > 0xffff) {
-    currentOffset = pitchEnvelope.targetOffset;
-    pitchEnvelope.progress = 0x10000;
-    pitchEnvelope.active = false;
-  }
-  else {
-    const uint8_t progressHigh = static_cast<uint8_t>(pitchEnvelope.progress >> 8);
-    const int32_t targetMagnitude =
-        pitchEnvelope.targetOffset < 0 ? -pitchEnvelope.targetOffset : pitchEnvelope.targetOffset;
-    int32_t currentMagnitude =
-        (targetMagnitude / AKAOSNES_PITCH_FRACTION_SCALE) * progressHigh / 256;
-    currentMagnitude *= AKAOSNES_PITCH_FRACTION_SCALE;
-    currentOffset = pitchEnvelope.targetOffset < 0 ? -currentMagnitude : currentMagnitude;
-  }
-
-  pitchSlide.setCurrentPitch(pitchSlide.basePitch() + currentOffset);
-  applyPitchBendAutomation(pitchSlide);
-}
-
-void AkaoSnesTrack::resetPitchBendForNewNote() {
-  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
-  pitchSlide.clearMotion();
-  pitchSlide.invalidateBase();
-
-  if (!pitchSlide.atRest(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS)) {
-    if (parentSeq->version == AKAOSNES_V2 && pitchEnvelope.enabled) {
-      setPitchBendAutomationBend(pitchSlide, 0);
-      return;
-    }
-    resetPitchBendAutomation(pitchSlide, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS);
-  }
-}
-
-void AkaoSnesTrack::beginNotePitch(uint8_t, bool validForPitchBend) {
-  resetPitchBendForNewNote();
-  if (validForPitchBend) {
-    pitchSlide.beginNote(akaoSnesBasePitch());
-    beginPitchEnvelopeForNote();
-  }
-}
-
-void AkaoSnesTrack::setPitchEnvelope(int8_t semitones, uint8_t delay, uint8_t length) {
-  if (semitones == 0 || length == 0) {
-    clearPitchEnvelope();
-    return;
-  }
-
-  pitchEnvelope.enabled = true;
-  pitchEnvelope.semitones = semitones;
-  pitchEnvelope.delay = delay;
-  pitchEnvelope.length = length;
-  pitchEnvelope.progressStep = akaoSnesV2PitchEnvelopeProgressStep(length);
-}
-
-void AkaoSnesTrack::clearPitchEnvelope() {
-  pitchEnvelope.enabled = false;
-  pitchEnvelope.active = false;
-  pitchEnvelope.semitones = 0;
-  pitchEnvelope.delay = 0;
-  pitchEnvelope.length = 0;
-  pitchEnvelope.progressStep = 0;
-  pitchEnvelope.activeDelay = 0;
-  pitchEnvelope.progress = 0;
-  pitchEnvelope.targetOffset = 0;
-}
-
-void AkaoSnesTrack::beginPitchEnvelopeForNote() {
-  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
-  if (parentSeq->version != AKAOSNES_V2 || !pitchEnvelope.enabled || !pitchSlide.baseValid()) {
-    return;
-  }
-
-  const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(pitchEnvelope.semitones);
-  const int32_t rawDiff =
-      (targetPitch - pitchSlide.basePitch()) / AKAOSNES_PITCH_FRACTION_SCALE;
-  const int32_t rawMagnitude = rawDiff < 0 ? -rawDiff : rawDiff;
-  const int32_t signedMagnitude =
-      pitchEnvelope.semitones < 0 ? -rawMagnitude : rawMagnitude;
-  pitchEnvelope.targetOffset = signedMagnitude * AKAOSNES_PITCH_FRACTION_SCALE;
-  pitchEnvelope.activeDelay = pitchEnvelope.delay;
-  pitchEnvelope.progress = 0;
-  pitchEnvelope.active = pitchEnvelope.targetOffset != 0 && pitchEnvelope.progressStep != 0;
-  pitchSlide.setCurrentPitch(pitchSlide.basePitch());
-
-  if (pitchEnvelope.active) {
-    setPitchBendAutomationRange(
-        pitchSlide,
-        pitchSlide.rangeCentsForSlide(pitchSlide.basePitch(),
-                                      pitchSlide.basePitch() + pitchEnvelope.targetOffset,
-                                      AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS));
-  }
-}
-
-void AkaoSnesTrack::setPendingPitchSlide(uint16_t steps, int8_t semitones) {
-  pendingPitchSlideSteps = steps;
-  pendingPitchSlideSemitones = semitones;
-  if (pendingPitchSlideSemitones == 0) {
-    clearPendingPitchSlide();
-  }
-}
-
-void AkaoSnesTrack::clearPendingPitchSlide() {
-  pendingPitchSlideSteps = 0;
-  pendingPitchSlideSemitones = 0;
-}
-
-void AkaoSnesTrack::beginPendingPitchSlide() {
-  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
-  if (pendingPitchSlideSteps == 0 || pendingPitchSlideSemitones == 0) {
-    clearPendingPitchSlide();
-    return;
-  }
-
-  const uint16_t steps = pendingPitchSlideSteps;
-  const int8_t semitones = pendingPitchSlideSemitones;
-  clearPendingPitchSlide();
-
-  if (!pitchSlide.baseValid()) {
-    return;
-  }
-
-  const int32_t currentPitch = pitchSlide.currentPitch();
-  const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(semitones);
-  const int32_t step =
-      akaoSnesPitchSlideStep(parentSeq->version, currentPitch, targetPitch, steps);
-
-  beginPitchBendAutomation(
-      pitchSlide,
-      pitchSlide.motionToTargetWithStepNoSnap(targetPitch, step, steps),
-      pitchSlide.rangeCentsForSlide(currentPitch, targetPitch, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS),
-      AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS,
-      true);
-
-  // Apply the first update on the same sequencer tick that consumes the setup command.
-  updatePitchSlide();
 }
 
 bool AkaoSnesTrack::readEvent(void) {
@@ -1045,7 +833,7 @@ bool AkaoSnesTrack::readEvent(void) {
       uint8_t pitchSlideTime = readByte(curOffset++);
       int8_t pitchSlideSemitones = static_cast<int8_t>(readByte(curOffset++));
       if (parentSeq->version == AKAOSNES_V3 || parentSeq->version == AKAOSNES_V4) {
-        const uint16_t pitchSlideSteps = akaoSnesPitchSlideSteps(pitchSlideTime);
+        const uint16_t pitchSlideSteps = static_cast<uint16_t>(pitchSlideTime) + 1;
         setPendingPitchSlide(pitchSlideSteps, pitchSlideSemitones);
         desc = fmt::format("Time: {}  Steps: {}  Key: {} semitones",
                            pitchSlideTime,

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -32,6 +32,23 @@ int32_t akaoSnesPitchForSemitoneOffset(int8_t semitones) {
   return static_cast<int32_t>(std::lround(pitch)) * AKAOSNES_PITCH_FRACTION_SCALE;
 }
 
+int32_t akaoSnesPitchSlideStep(AkaoSnesVersion version,
+                               int32_t currentPitch,
+                               int32_t targetPitch,
+                               uint16_t steps) {
+  const int32_t diff = targetPitch - currentPitch;
+  if (version == AKAOSNES_V3) {
+    const int32_t rawDiff = diff / AKAOSNES_PITCH_FRACTION_SCALE;
+    int32_t rawStep = rawDiff / static_cast<int32_t>(steps);
+    if (rawStep == 0 && rawDiff != 0) {
+      rawStep = (rawDiff > 0) ? 1 : -1;
+    }
+    return rawStep * AKAOSNES_PITCH_FRACTION_SCALE;
+  }
+
+  return diff / static_cast<int32_t>(steps);
+}
+
 double akaoSnesPitchCents(int32_t pitch, int32_t basePitch) {
   if (pitch <= 0 || basePitch <= 0) {
     return 0.0;
@@ -665,6 +682,7 @@ void AkaoSnesTrack::clearPendingPitchSlide() {
 }
 
 void AkaoSnesTrack::beginPendingPitchSlide() {
+  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
   if (pendingPitchSlideSteps == 0 || pendingPitchSlideSemitones == 0) {
     clearPendingPitchSlide();
     return;
@@ -680,7 +698,8 @@ void AkaoSnesTrack::beginPendingPitchSlide() {
 
   const int32_t currentPitch = pitchSlide.currentPitch();
   const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(semitones);
-  const int32_t step = (targetPitch - currentPitch) / static_cast<int32_t>(steps);
+  const int32_t step =
+      akaoSnesPitchSlideStep(parentSeq->version, currentPitch, targetPitch, steps);
 
   beginPitchBendAutomation(
       pitchSlide,
@@ -689,7 +708,7 @@ void AkaoSnesTrack::beginPendingPitchSlide() {
       AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS,
       true);
 
-  // FF6 applies the first slide increment on the same sequencer tick that consumes C8.
+  // Apply the first update on the same sequencer tick that consumes the setup command.
   updatePitchSlide();
 }
 
@@ -917,7 +936,7 @@ bool AkaoSnesTrack::readEvent(void) {
     case EVENT_PITCH_SLIDE: {
       uint8_t pitchSlideTime = readByte(curOffset++);
       int8_t pitchSlideSemitones = static_cast<int8_t>(readByte(curOffset++));
-      if (parentSeq->version == AKAOSNES_V4) {
+      if (parentSeq->version == AKAOSNES_V3 || parentSeq->version == AKAOSNES_V4) {
         const uint16_t pitchSlideSteps = akaoSnesPitchSlideSteps(pitchSlideTime);
         setPendingPitchSlide(pitchSlideSteps, pitchSlideSemitones);
         desc = fmt::format("Time: {}  Steps: {}  Key: {} semitones",

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -795,6 +795,7 @@ bool AkaoSnesTrack::readEvent(void) {
         pitchEnvelopeDelay = readByte(curOffset++);
         pitchEnvelopeLength = readByte(curOffset++);
         pitchEnvelopeSemitones = static_cast<int8_t>(readByte(curOffset++));
+        // FF4 stores dd + 1 in an 8-bit counter; dd=$ff intentionally wraps to zero.
         setPitchEnvelope(pitchEnvelopeSemitones,
                          static_cast<uint8_t>(pitchEnvelopeDelay + 1),
                          pitchEnvelopeLength);

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -677,7 +677,7 @@ bool AkaoSnesTrack::readEvent(void) {
 
       if (noteIndex < 12) {
         uint8_t note = octave * 12 + noteIndex;
-        beginNotePitch(!percussion);
+        beginNotePitch(note, !percussion);
         beginPendingPitchSlide();
 
         if (!slur && !legato) {

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -789,6 +789,8 @@ bool AkaoSnesTrack::readEvent(void) {
       uint8_t pitchEnvelopeDelay;
       uint8_t pitchEnvelopeLength;
 
+      // V1/FF4: D6 dd ll ss. V2/RS1: DB ss dd ll. Both commands install a
+      // persistent per-voice envelope; the next normal note starts the ramp.
       if (parentSeq->version == AKAOSNES_V1) {
         pitchEnvelopeDelay = readByte(curOffset++);
         pitchEnvelopeLength = readByte(curOffset++);
@@ -836,6 +838,8 @@ bool AkaoSnesTrack::readEvent(void) {
       uint8_t pitchSlideTime = readByte(curOffset++);
       int8_t pitchSlideSemitones = static_cast<int8_t>(readByte(curOffset++));
       if (parentSeq->version == AKAOSNES_V3 || parentSeq->version == AKAOSNES_V4) {
+        // V3 D6 and V4 C8 are one-shot pitch-slide setup commands:
+        // tt stores as tt + 1, wrapping $ff to the 256-step case.
         const uint16_t pitchSlideSteps = static_cast<uint16_t>(pitchSlideTime) + 1;
         setPendingPitchSlide(pitchSlideSteps, pitchSlideSemitones);
         desc = fmt::format("Time: {}  Steps: {}  Key: {} semitones",

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.h
@@ -170,7 +170,7 @@ public:
   void updateVibratoFade();
   void updateTremoloFade();
   void resetPitchState();
-  void beginNotePitch(uint8_t note, bool validForPitchBend);
+  void beginNotePitch(bool validForPitchBend);
   void resetPitchBendForNewNote();
   void setPitchEnvelope(int8_t semitones, uint8_t delay, uint8_t length);
   void clearPitchEnvelope();

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.h
@@ -20,8 +20,8 @@ enum AkaoSnesSeqEventType {
   EVENT_VOLUME_FADE,
   EVENT_PAN,
   EVENT_PAN_FADE,
-  EVENT_PITCH_SLIDE_ON,
-  EVENT_PITCH_SLIDE_OFF,
+  EVENT_PITCH_ENVELOPE_ON,
+  EVENT_PITCH_ENVELOPE_OFF,
   EVENT_PITCH_SLIDE,
   EVENT_VIBRATO_ON,
   EVENT_VIBRATO_OFF,
@@ -171,6 +171,10 @@ public:
   void updateTremoloFade();
   void beginNotePitch(uint8_t note, bool validForPitchBend);
   void resetPitchBendForNewNote();
+  void setPitchEnvelope(int8_t semitones, uint8_t delay, uint8_t length);
+  void clearPitchEnvelope();
+  void beginPitchEnvelopeForNote();
+  void updatePitchEnvelope();
   void setPendingPitchSlide(uint16_t steps, int8_t semitones);
   void clearPendingPitchSlide();
   void beginPendingPitchSlide();
@@ -189,6 +193,17 @@ public:
   uint16_t loopStart[AKAOSNES_LOOP_LEVEL_MAX];
 
   uint8_t ignoreMasterVolumeProgNum;
+  struct PitchEnvelopeState {
+    bool enabled = false;
+    bool active = false;
+    int8_t semitones = 0;
+    uint8_t delay = 0;
+    uint8_t length = 0;
+    uint16_t progressStep = 0;
+    uint8_t activeDelay = 0;
+    uint32_t progress = 0;
+    int32_t targetOffset = 0;
+  } pitchEnvelope;
   uint16_t pendingPitchSlideSteps;
   int8_t pendingPitchSlideSemitones;
   SeqPitchBendAutomation<int32_t> pitchSlide;

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.h
@@ -169,6 +169,7 @@ public:
   uint8_t tremoloFadeDepthMidiValue(int32_t depth) const;
   void updateVibratoFade();
   void updateTremoloFade();
+  void resetPitchState();
   void beginNotePitch(uint8_t note, bool validForPitchBend);
   void resetPitchBendForNewNote();
   void setPitchEnvelope(int8_t semitones, uint8_t delay, uint8_t length);

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.h
@@ -196,6 +196,10 @@ public:
   uint16_t loopStart[AKAOSNES_LOOP_LEVEL_MAX];
 
   uint8_t ignoreMasterVolumeProgNum;
+
+  // Persistent V1/V2 pitch-envelope configuration plus the per-note active
+  // ramp state derived from it. V3/V4 pitch slides use the pending fields below
+  // because their setup commands are consumed by only the next note or tie.
   struct PitchEnvelopeState {
     bool enabled = false;
     bool active = false;
@@ -208,6 +212,9 @@ public:
     uint32_t progress = 0;
     int32_t targetOffset = 0;
   } pitchEnvelope;
+
+  // Pending one-shot V3/V4 pitch-slide setup. A normal note or tie consumes
+  // these fields; rests leave them pending for the next pitch setup path.
   uint16_t pendingPitchSlideSteps;
   int8_t pendingPitchSlideSemitones;
   SeqPitchBendAutomation<int32_t> pitchSlide;

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.h
@@ -169,6 +169,12 @@ public:
   uint8_t tremoloFadeDepthMidiValue(int32_t depth) const;
   void updateVibratoFade();
   void updateTremoloFade();
+  void beginNotePitch(uint8_t note, bool validForPitchBend);
+  void resetPitchBendForNewNote();
+  void setPendingPitchSlide(uint16_t steps, int8_t semitones);
+  void clearPendingPitchSlide();
+  void beginPendingPitchSlide();
+  void updatePitchSlide();
 
   uint8_t onetimeDuration;
   bool slur;
@@ -183,7 +189,9 @@ public:
   uint16_t loopStart[AKAOSNES_LOOP_LEVEL_MAX];
 
   uint8_t ignoreMasterVolumeProgNum;
-
+  uint16_t pendingPitchSlideSteps;
+  int8_t pendingPitchSlideSemitones;
+  SeqPitchBendAutomation<int32_t> pitchSlide;
   SeqSynthLfoAutomation vibrato;
   SeqSynthLfoAutomation tremolo;
 };

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.h
@@ -170,7 +170,7 @@ public:
   void updateVibratoFade();
   void updateTremoloFade();
   void resetPitchState();
-  void beginNotePitch(bool validForPitchBend);
+  void beginNotePitch(uint8_t note, bool validForPitchBend);
   void resetPitchBendForNewNote();
   void setPitchEnvelope(int8_t semitones, uint8_t delay, uint8_t length);
   void clearPitchEnvelope();
@@ -217,6 +217,12 @@ public:
   // these fields; rests leave them pending for the next pitch setup path.
   uint16_t pendingPitchSlideSteps;
   int8_t pendingPitchSlideSemitones;
+  // V3/V4 slide targets mutate the driver's stored corrected-note byte. The
+  // base note anchors MIDI pitch bend to the current sounding note; the current
+  // note advances cumulatively through tied slide chains.
+  bool pitchSlideNoteValid;
+  int16_t pitchSlideBaseNote;
+  int16_t pitchSlideCurrentNote;
   SeqPitchBendAutomation<int32_t> pitchSlide;
   SeqSynthLfoAutomation vibrato;
   SeqSynthLfoAutomation tremolo;

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.h
@@ -202,6 +202,7 @@ public:
     uint8_t length = 0;
     uint16_t progressStep = 0;
     uint8_t activeDelay = 0;
+    uint8_t activeCount = 0;
     uint32_t progress = 0;
     int32_t targetOffset = 0;
   } pitchEnvelope;

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.h
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.h
@@ -176,6 +176,8 @@ public:
   void clearPitchEnvelope();
   void beginPitchEnvelopeForNote();
   void updatePitchEnvelope();
+  bool pitchEnvelopeDelayElapsed();
+  bool advancePitchEnvelopeTick(AkaoSnesVersion version, int32_t& currentOffset);
   void setPendingPitchSlide(uint16_t steps, int8_t semitones);
   void clearPendingPitchSlide();
   void beginPendingPitchSlide();

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
@@ -93,21 +93,38 @@ void AkaoSnesTrack::updatePitchEnvelope() {
     return;
   }
 
+  if (!pitchEnvelopeDelayElapsed()) {
+    return;
+  }
+
+  int32_t currentOffset;
+  if (!advancePitchEnvelopeTick(parentSeq->version, currentOffset)) {
+    return;
+  }
+
+  pitchSlide.setCurrentPitch(pitchSlide.basePitch() + currentOffset);
+  applyPitchBendAutomation(pitchSlide);
+}
+
+bool AkaoSnesTrack::pitchEnvelopeDelayElapsed() {
   if (pitchEnvelope.activeDelay > 1) {
     pitchEnvelope.activeDelay--;
-    return;
+    return false;
   }
   if (pitchEnvelope.activeDelay == 1) {
     pitchEnvelope.activeDelay = 0;
   }
 
-  if (parentSeq->version == AKAOSNES_V1 && pitchEnvelope.activeCount == 0) {
+  return true;
+}
+
+bool AkaoSnesTrack::advancePitchEnvelopeTick(AkaoSnesVersion version, int32_t& currentOffset) {
+  if (version == AKAOSNES_V1 && pitchEnvelope.activeCount == 0) {
     pitchEnvelope.active = false;
-    return;
+    return false;
   }
 
-  int32_t currentOffset;
-  if (parentSeq->version == AKAOSNES_V1) {
+  if (version == AKAOSNES_V1) {
     pitchEnvelope.activeCount--;
     pitchEnvelope.progress += pitchEnvelope.progressStep;
     const uint8_t progressHigh = static_cast<uint8_t>(pitchEnvelope.progress >> 8);
@@ -127,8 +144,7 @@ void AkaoSnesTrack::updatePitchEnvelope() {
     currentOffset = akaoSnesPitchEnvelopeOffset(pitchEnvelope.targetOffset, progressHigh);
   }
 
-  pitchSlide.setCurrentPitch(pitchSlide.basePitch() + currentOffset);
-  applyPitchBendAutomation(pitchSlide);
+  return true;
 }
 
 void AkaoSnesTrack::resetPitchBendForNewNote() {

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
@@ -36,7 +36,11 @@ int32_t akaoSnesBasePitch() {
   return AKAOSNES_NOMINAL_DSP_PITCH * AKAOSNES_PITCH_FRACTION_SCALE;
 }
 
-int32_t akaoSnesPitchForSemitoneOffset(int8_t semitones) {
+int16_t akaoSnesCorrectedNote(uint8_t note, int8_t transpose) {
+  return static_cast<int16_t>(note) + static_cast<int16_t>(transpose) - 10;
+}
+
+int32_t akaoSnesPitchForSemitoneOffset(int semitones) {
   const double pitch =
       static_cast<double>(AKAOSNES_NOMINAL_DSP_PITCH) * std::pow(2.0, static_cast<double>(semitones) / 12.0);
   return static_cast<int32_t>(std::lround(pitch)) * AKAOSNES_PITCH_FRACTION_SCALE;
@@ -100,6 +104,9 @@ void AkaoSnesTrack::resetPitchState() {
   pitchEnvelope = {};
   pendingPitchSlideSteps = 0;
   pendingPitchSlideSemitones = 0;
+  pitchSlideNoteValid = false;
+  pitchSlideBaseNote = 0;
+  pitchSlideCurrentNote = 0;
   pitchSlide.setPitchToCents(akaoSnesPitchCents);
   pitchSlide.reset(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS);
 }
@@ -177,6 +184,7 @@ void AkaoSnesTrack::resetPitchBendForNewNote() {
   const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
   pitchSlide.clearMotion();
   pitchSlide.invalidateBase();
+  pitchSlideNoteValid = false;
 
   if (!pitchSlide.atRest(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS)) {
     if (akaoSnesSupportsPitchEnvelope(parentSeq->version) && pitchEnvelope.enabled) {
@@ -187,9 +195,12 @@ void AkaoSnesTrack::resetPitchBendForNewNote() {
   }
 }
 
-void AkaoSnesTrack::beginNotePitch(bool validForPitchBend) {
+void AkaoSnesTrack::beginNotePitch(uint8_t note, bool validForPitchBend) {
   resetPitchBendForNewNote();
   if (validForPitchBend) {
+    pitchSlideBaseNote = akaoSnesCorrectedNote(note, transpose);
+    pitchSlideCurrentNote = pitchSlideBaseNote;
+    pitchSlideNoteValid = true;
     pitchSlide.beginNote(akaoSnesBasePitch());
     beginPitchEnvelopeForNote();
   }
@@ -276,12 +287,13 @@ void AkaoSnesTrack::beginPendingPitchSlide() {
   const int8_t semitones = pendingPitchSlideSemitones;
   clearPendingPitchSlide();
 
-  if (!pitchSlide.baseValid()) {
+  if (!pitchSlide.baseValid() || !pitchSlideNoteValid) {
     return;
   }
 
+  pitchSlideCurrentNote = static_cast<int16_t>(pitchSlideCurrentNote + semitones);
   const int32_t currentPitch = pitchSlide.currentPitch();
-  const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(semitones);
+  const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(pitchSlideCurrentNote - pitchSlideBaseNote);
   const int32_t step = akaoSnesPitchSlideStep(parentSeq->version, currentPitch, targetPitch, steps);
   const int32_t finalPitch = currentPitch + (step * static_cast<int32_t>(steps));
   const uint16_t rangeCents = std::max(

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
@@ -6,6 +6,7 @@
 
 #include "AkaoSnesSeq.h"
 #include "automation/SeqTrackAutomation.h"
+#include <algorithm>
 #include <cmath>
 
 namespace {
@@ -188,7 +189,7 @@ void AkaoSnesTrack::resetPitchBendForNewNote() {
   }
 }
 
-void AkaoSnesTrack::beginNotePitch(uint8_t, bool validForPitchBend) {
+void AkaoSnesTrack::beginNotePitch(bool validForPitchBend) {
   resetPitchBendForNewNote();
   if (validForPitchBend) {
     pitchSlide.beginNote(akaoSnesBasePitch());
@@ -216,16 +217,7 @@ void AkaoSnesTrack::clearPitchEnvelope() {
   // The driver off commands stop future envelope updates; they do not generate
   // a return-to-base bend. The current output naturally gets reset by the next
   // normal note setup.
-  pitchEnvelope.enabled = false;
-  pitchEnvelope.active = false;
-  pitchEnvelope.semitones = 0;
-  pitchEnvelope.delay = 0;
-  pitchEnvelope.length = 0;
-  pitchEnvelope.progressStep = 0;
-  pitchEnvelope.activeDelay = 0;
-  pitchEnvelope.activeCount = 0;
-  pitchEnvelope.progress = 0;
-  pitchEnvelope.targetOffset = 0;
+  pitchEnvelope = {};
 }
 
 void AkaoSnesTrack::beginPitchEnvelopeForNote() {
@@ -294,13 +286,16 @@ void AkaoSnesTrack::beginPendingPitchSlide() {
 
   const int32_t currentPitch = pitchSlide.currentPitch();
   const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(semitones);
-  const int32_t step =
-      akaoSnesPitchSlideStep(parentSeq->version, currentPitch, targetPitch, steps);
+  const int32_t step = akaoSnesPitchSlideStep(parentSeq->version, currentPitch, targetPitch, steps);
+  const int32_t finalPitch = currentPitch + (step * static_cast<int32_t>(steps));
+  const uint16_t rangeCents = std::max(
+      pitchSlide.rangeCentsForSlide(currentPitch, targetPitch, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS),
+      pitchSlide.rangeCentsForSlide(currentPitch, finalPitch, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS));
 
   beginPitchBendAutomation(
       pitchSlide,
-      pitchSlide.motionToTargetWithStepNoSnap(targetPitch, step, steps),
-      pitchSlide.rangeCentsForSlide(currentPitch, targetPitch, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS),
+      SeqMotionPlan<int32_t>::targetOverTicksWithStep(finalPitch, step, steps),
+      rangeCents,
       AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS,
       true);
 

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
@@ -14,7 +14,23 @@ static constexpr uint16_t AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS = 200;
 static constexpr int32_t AKAOSNES_NOMINAL_DSP_PITCH = 0x1000;
 static constexpr int32_t AKAOSNES_PITCH_FRACTION_SCALE = 0x100;
 
-// For MIDI bend output, only target/base ratios matter, so normalize every new note to DSP pitch $1000.
+/*
+ * AkaoSnes has two different families of pitch automation:
+ *
+ * V1 and V2 use persistent pitch envelopes. The setup command stays
+ * active until the matching off command, and every later normal note starts a
+ * fresh ramp from that note's base pitch toward note + signed semitone offset.
+ * Ties do not restart the envelope.
+ *
+ * V3 and V4 use one-shot pitch slides. The command only arms the next
+ * note or tie; rests do not consume it. The slide target is also relative to
+ * the note/tie being initialized, not to the previous note.
+ *
+ * MIDI pitch bend only needs ratios between base and current pitch, so we
+ * normalize each started note to DSP pitch $1000 and express all automation in
+ * that source-space pitch, with an 8-bit fractional scale where needed.
+ */
+
 int32_t akaoSnesBasePitch() {
   return AKAOSNES_NOMINAL_DSP_PITCH * AKAOSNES_PITCH_FRACTION_SCALE;
 }
@@ -31,6 +47,9 @@ int32_t akaoSnesPitchSlideStep(AkaoSnesVersion version,
                                int32_t targetPitch,
                                uint16_t steps) {
   const int32_t diff = targetPitch - currentPitch;
+
+  // V3 steps a signed 16-bit DSP pitch word directly and forces a nonzero
+  // step when the target differs. This can overshoot for tiny long slides.
   if (version == AKAOSNES_V3) {
     const int32_t rawDiff = diff / AKAOSNES_PITCH_FRACTION_SCALE;
     int32_t rawStep = rawDiff / static_cast<int32_t>(steps);
@@ -40,6 +59,8 @@ int32_t akaoSnesPitchSlideStep(AkaoSnesVersion version,
     return rawStep * AKAOSNES_PITCH_FRACTION_SCALE;
   }
 
+  // V4 keeps an 8-bit fractional accumulator, so the truncated step is in
+  // 16.8 pitch units. The driver does not snap to the exact target at the end.
   return diff / static_cast<int32_t>(steps);
 }
 
@@ -52,6 +73,9 @@ uint16_t akaoSnesPitchEnvelopeProgressStep(AkaoSnesVersion version, uint8_t leng
     return 0;
   }
 
+  // V1 runs for exactly length updates with floor(65535 / length), then
+  // holds the last computed offset, which is just short of the target. V2
+  // uses floor($FF00 / length) and clamps to the target when progress overflows.
   return static_cast<uint16_t>((version == AKAOSNES_V1 ? 0xffff : 0xff00) / length);
 }
 
@@ -107,6 +131,9 @@ void AkaoSnesTrack::updatePitchEnvelope() {
 }
 
 bool AkaoSnesTrack::pitchEnvelopeDelayElapsed() {
+  // Both V1 and V2 update on sequencer ticks after note setup. A stored delay
+  // value of 0 or 1 therefore allows the first movement on the next eligible
+  // tick; larger values wait until the countdown reaches 1.
   if (pitchEnvelope.activeDelay > 1) {
     pitchEnvelope.activeDelay--;
     return false;
@@ -171,6 +198,8 @@ void AkaoSnesTrack::beginNotePitch(uint8_t, bool validForPitchBend) {
 
 void AkaoSnesTrack::setPitchEnvelope(int8_t semitones, uint8_t delay, uint8_t length) {
   const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
+  // An offset of zero disables the persistent envelope. We also treat zero
+  // length as off for MIDI export, matching V2 and avoiding V1's no-motion case.
   if (semitones == 0 || length == 0) {
     clearPitchEnvelope();
     return;
@@ -184,6 +213,9 @@ void AkaoSnesTrack::setPitchEnvelope(int8_t semitones, uint8_t delay, uint8_t le
 }
 
 void AkaoSnesTrack::clearPitchEnvelope() {
+  // The driver off commands stop future envelope updates; they do not generate
+  // a return-to-base bend. The current output naturally gets reset by the next
+  // normal note setup.
   pitchEnvelope.enabled = false;
   pitchEnvelope.active = false;
   pitchEnvelope.semitones = 0;
@@ -204,6 +236,9 @@ void AkaoSnesTrack::beginPitchEnvelopeForNote() {
     return;
   }
 
+  // The target offset is relative to the note being started, after octave and
+  // transpose have produced the current MIDI note. It is not a previous-note
+  // glide. Ties intentionally do not call this path.
   const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(pitchEnvelope.semitones);
   const int32_t rawDiff =
       (targetPitch - pitchSlide.basePitch()) / AKAOSNES_PITCH_FRACTION_SCALE;
@@ -241,6 +276,9 @@ void AkaoSnesTrack::clearPendingPitchSlide() {
 
 void AkaoSnesTrack::beginPendingPitchSlide() {
   const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
+  // V3/V4 pitch slide commands are pending state. A following normal note
+  // consumes the state after that note establishes its base pitch; a following
+  // tie consumes it against the already-sounding pitch; a rest leaves it primed.
   if (pendingPitchSlideSteps == 0 || pendingPitchSlideSemitones == 0) {
     clearPendingPitchSlide();
     return;

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
@@ -11,9 +11,9 @@
 
 namespace {
 
-static constexpr uint16_t AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS = 200;
-static constexpr int32_t AKAOSNES_NOMINAL_DSP_PITCH = 0x1000;
-static constexpr int32_t AKAOSNES_PITCH_FRACTION_SCALE = 0x100;
+static constexpr uint16_t kDefaultPitchBendRangeCents = 200;
+static constexpr int32_t kNominalDspPitch = 0x1000;
+static constexpr int32_t kPitchFractionScale = 0x100;
 
 /*
  * AkaoSnes has two different families of pitch automation:
@@ -32,18 +32,14 @@ static constexpr int32_t AKAOSNES_PITCH_FRACTION_SCALE = 0x100;
  * that source-space pitch, with an 8-bit fractional scale where needed.
  */
 
-int32_t akaoSnesBasePitch() {
-  return AKAOSNES_NOMINAL_DSP_PITCH * AKAOSNES_PITCH_FRACTION_SCALE;
-}
-
 int16_t akaoSnesCorrectedNote(uint8_t note, int8_t transpose) {
   return static_cast<int16_t>(note) + static_cast<int16_t>(transpose) - 10;
 }
 
 int32_t akaoSnesPitchForSemitoneOffset(int semitones) {
   const double pitch =
-      static_cast<double>(AKAOSNES_NOMINAL_DSP_PITCH) * std::pow(2.0, static_cast<double>(semitones) / 12.0);
-  return static_cast<int32_t>(std::lround(pitch)) * AKAOSNES_PITCH_FRACTION_SCALE;
+      static_cast<double>(kNominalDspPitch) * std::pow(2.0, static_cast<double>(semitones) / 12.0);
+  return static_cast<int32_t>(std::lround(pitch)) * kPitchFractionScale;
 }
 
 int32_t akaoSnesPitchSlideStep(AkaoSnesVersion version,
@@ -55,12 +51,12 @@ int32_t akaoSnesPitchSlideStep(AkaoSnesVersion version,
   // V3 steps a signed 16-bit DSP pitch word directly and forces a nonzero
   // step when the target differs. This can overshoot for tiny long slides.
   if (version == AKAOSNES_V3) {
-    const int32_t rawDiff = diff / AKAOSNES_PITCH_FRACTION_SCALE;
+    const int32_t rawDiff = diff / kPitchFractionScale;
     int32_t rawStep = rawDiff / static_cast<int32_t>(steps);
     if (rawStep == 0 && rawDiff != 0) {
       rawStep = (rawDiff > 0) ? 1 : -1;
     }
-    return rawStep * AKAOSNES_PITCH_FRACTION_SCALE;
+    return rawStep * kPitchFractionScale;
   }
 
   // V4 keeps an 8-bit fractional accumulator, so the truncated step is in
@@ -85,8 +81,8 @@ uint16_t akaoSnesPitchEnvelopeProgressStep(AkaoSnesVersion version, uint8_t leng
 
 int32_t akaoSnesPitchEnvelopeOffset(int32_t targetOffset, uint8_t progressHigh) {
   const int32_t targetMagnitude = targetOffset < 0 ? -targetOffset : targetOffset;
-  int32_t currentMagnitude = (targetMagnitude / AKAOSNES_PITCH_FRACTION_SCALE) * progressHigh / 256;
-  currentMagnitude *= AKAOSNES_PITCH_FRACTION_SCALE;
+  int32_t currentMagnitude = (targetMagnitude / kPitchFractionScale) * progressHigh / 256;
+  currentMagnitude *= kPitchFractionScale;
   return targetOffset < 0 ? -currentMagnitude : currentMagnitude;
 }
 
@@ -108,7 +104,7 @@ void AkaoSnesTrack::resetPitchState() {
   pitchSlideBaseNote = 0;
   pitchSlideCurrentNote = 0;
   pitchSlide.setPitchToCents(akaoSnesPitchCents);
-  pitchSlide.reset(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS);
+  pitchSlide.reset(kDefaultPitchBendRangeCents);
 }
 
 void AkaoSnesTrack::updatePitchSlide() {
@@ -186,12 +182,12 @@ void AkaoSnesTrack::resetPitchBendForNewNote() {
   pitchSlide.invalidateBase();
   pitchSlideNoteValid = false;
 
-  if (!pitchSlide.atRest(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS)) {
+  if (!pitchSlide.atRest(kDefaultPitchBendRangeCents)) {
     if (akaoSnesSupportsPitchEnvelope(parentSeq->version) && pitchEnvelope.enabled) {
       setPitchBendAutomationBend(pitchSlide, 0);
       return;
     }
-    resetPitchBendAutomation(pitchSlide, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS);
+    resetPitchBendAutomation(pitchSlide, kDefaultPitchBendRangeCents);
   }
 }
 
@@ -201,7 +197,7 @@ void AkaoSnesTrack::beginNotePitch(uint8_t note, bool validForPitchBend) {
     pitchSlideBaseNote = akaoSnesCorrectedNote(note, transpose);
     pitchSlideCurrentNote = pitchSlideBaseNote;
     pitchSlideNoteValid = true;
-    pitchSlide.beginNote(akaoSnesBasePitch());
+    pitchSlide.beginNote(kNominalDspPitch * kPitchFractionScale);
     beginPitchEnvelopeForNote();
   }
 }
@@ -241,10 +237,10 @@ void AkaoSnesTrack::beginPitchEnvelopeForNote() {
   // transpose have produced the current MIDI note. It is not a previous-note
   // glide. Ties intentionally do not call this path.
   const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(pitchEnvelope.semitones);
-  const int32_t rawDiff = (targetPitch - pitchSlide.basePitch()) / AKAOSNES_PITCH_FRACTION_SCALE;
+  const int32_t rawDiff = (targetPitch - pitchSlide.basePitch()) / kPitchFractionScale;
   const int32_t rawMagnitude = rawDiff < 0 ? -rawDiff : rawDiff;
   const int32_t signedMagnitude = pitchEnvelope.semitones < 0 ? -rawMagnitude : rawMagnitude;
-  pitchEnvelope.targetOffset = signedMagnitude * AKAOSNES_PITCH_FRACTION_SCALE;
+  pitchEnvelope.targetOffset = signedMagnitude * kPitchFractionScale;
   pitchEnvelope.activeDelay = pitchEnvelope.delay;
   pitchEnvelope.activeCount = parentSeq->version == AKAOSNES_V1 ? pitchEnvelope.length : 0;
   pitchEnvelope.progress = 0;
@@ -256,7 +252,7 @@ void AkaoSnesTrack::beginPitchEnvelopeForNote() {
         pitchSlide,
         pitchSlide.rangeCentsForSlide(pitchSlide.basePitch(),
                                       pitchSlide.basePitch() + pitchEnvelope.targetOffset,
-                                      AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS));
+                                      kDefaultPitchBendRangeCents));
   }
 }
 
@@ -297,14 +293,14 @@ void AkaoSnesTrack::beginPendingPitchSlide() {
   const int32_t step = akaoSnesPitchSlideStep(parentSeq->version, currentPitch, targetPitch, steps);
   const int32_t finalPitch = currentPitch + (step * static_cast<int32_t>(steps));
   const uint16_t rangeCents = std::max(
-      pitchSlide.rangeCentsForSlide(currentPitch, targetPitch, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS),
-      pitchSlide.rangeCentsForSlide(currentPitch, finalPitch, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS));
+      pitchSlide.rangeCentsForSlide(currentPitch, targetPitch, kDefaultPitchBendRangeCents),
+      pitchSlide.rangeCentsForSlide(currentPitch, finalPitch, kDefaultPitchBendRangeCents));
 
   beginPitchBendAutomation(
       pitchSlide,
       SeqMotionPlan<int32_t>::targetOverTicksWithStep(finalPitch, step, steps),
       rangeCents,
-      AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS,
+      kDefaultPitchBendRangeCents,
       true);
 
   // Apply the first update on the same sequencer tick that consumes the setup command.

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
@@ -43,8 +43,24 @@ int32_t akaoSnesPitchSlideStep(AkaoSnesVersion version,
   return diff / static_cast<int32_t>(steps);
 }
 
-uint16_t akaoSnesV2PitchEnvelopeProgressStep(uint8_t length) {
-  return length == 0 ? 0 : static_cast<uint16_t>(0xff00 / length);
+bool akaoSnesSupportsPitchEnvelope(AkaoSnesVersion version) {
+  return version == AKAOSNES_V1 || version == AKAOSNES_V2;
+}
+
+uint16_t akaoSnesPitchEnvelopeProgressStep(AkaoSnesVersion version, uint8_t length) {
+  if (length == 0) {
+    return 0;
+  }
+
+  return static_cast<uint16_t>((version == AKAOSNES_V1 ? 0xffff : 0xff00) / length);
+}
+
+int32_t akaoSnesPitchEnvelopeOffset(int32_t targetOffset, uint8_t progressHigh) {
+  const int32_t targetMagnitude = targetOffset < 0 ? -targetOffset : targetOffset;
+  int32_t currentMagnitude =
+      (targetMagnitude / AKAOSNES_PITCH_FRACTION_SCALE) * progressHigh / 256;
+  currentMagnitude *= AKAOSNES_PITCH_FRACTION_SCALE;
+  return targetOffset < 0 ? -currentMagnitude : currentMagnitude;
 }
 
 double akaoSnesPitchCents(int32_t pitch, int32_t basePitch) {
@@ -71,7 +87,9 @@ void AkaoSnesTrack::updatePitchSlide() {
 
 void AkaoSnesTrack::updatePitchEnvelope() {
   const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
-  if (parentSeq->version != AKAOSNES_V2 || !pitchEnvelope.active || !pitchSlide.baseValid()) {
+  if (!akaoSnesSupportsPitchEnvelope(parentSeq->version) ||
+      !pitchEnvelope.active ||
+      !pitchSlide.baseValid()) {
     return;
   }
 
@@ -83,22 +101,30 @@ void AkaoSnesTrack::updatePitchEnvelope() {
     pitchEnvelope.activeDelay = 0;
   }
 
-  pitchEnvelope.progress += pitchEnvelope.progressStep;
+  if (parentSeq->version == AKAOSNES_V1 && pitchEnvelope.activeCount == 0) {
+    pitchEnvelope.active = false;
+    return;
+  }
 
   int32_t currentOffset;
-  if (pitchEnvelope.progress > 0xffff) {
+  if (parentSeq->version == AKAOSNES_V1) {
+    pitchEnvelope.activeCount--;
+    pitchEnvelope.progress += pitchEnvelope.progressStep;
+    const uint8_t progressHigh = static_cast<uint8_t>(pitchEnvelope.progress >> 8);
+    currentOffset = akaoSnesPitchEnvelopeOffset(pitchEnvelope.targetOffset, progressHigh);
+    if (pitchEnvelope.activeCount == 0) {
+      pitchEnvelope.active = false;
+    }
+  }
+  else if (pitchEnvelope.progress + pitchEnvelope.progressStep > 0xffff) {
     currentOffset = pitchEnvelope.targetOffset;
     pitchEnvelope.progress = 0x10000;
     pitchEnvelope.active = false;
   }
   else {
+    pitchEnvelope.progress += pitchEnvelope.progressStep;
     const uint8_t progressHigh = static_cast<uint8_t>(pitchEnvelope.progress >> 8);
-    const int32_t targetMagnitude =
-        pitchEnvelope.targetOffset < 0 ? -pitchEnvelope.targetOffset : pitchEnvelope.targetOffset;
-    int32_t currentMagnitude =
-        (targetMagnitude / AKAOSNES_PITCH_FRACTION_SCALE) * progressHigh / 256;
-    currentMagnitude *= AKAOSNES_PITCH_FRACTION_SCALE;
-    currentOffset = pitchEnvelope.targetOffset < 0 ? -currentMagnitude : currentMagnitude;
+    currentOffset = akaoSnesPitchEnvelopeOffset(pitchEnvelope.targetOffset, progressHigh);
   }
 
   pitchSlide.setCurrentPitch(pitchSlide.basePitch() + currentOffset);
@@ -111,7 +137,7 @@ void AkaoSnesTrack::resetPitchBendForNewNote() {
   pitchSlide.invalidateBase();
 
   if (!pitchSlide.atRest(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS)) {
-    if (parentSeq->version == AKAOSNES_V2 && pitchEnvelope.enabled) {
+    if (akaoSnesSupportsPitchEnvelope(parentSeq->version) && pitchEnvelope.enabled) {
       setPitchBendAutomationBend(pitchSlide, 0);
       return;
     }
@@ -128,6 +154,7 @@ void AkaoSnesTrack::beginNotePitch(uint8_t, bool validForPitchBend) {
 }
 
 void AkaoSnesTrack::setPitchEnvelope(int8_t semitones, uint8_t delay, uint8_t length) {
+  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
   if (semitones == 0 || length == 0) {
     clearPitchEnvelope();
     return;
@@ -137,7 +164,7 @@ void AkaoSnesTrack::setPitchEnvelope(int8_t semitones, uint8_t delay, uint8_t le
   pitchEnvelope.semitones = semitones;
   pitchEnvelope.delay = delay;
   pitchEnvelope.length = length;
-  pitchEnvelope.progressStep = akaoSnesV2PitchEnvelopeProgressStep(length);
+  pitchEnvelope.progressStep = akaoSnesPitchEnvelopeProgressStep(parentSeq->version, length);
 }
 
 void AkaoSnesTrack::clearPitchEnvelope() {
@@ -148,13 +175,16 @@ void AkaoSnesTrack::clearPitchEnvelope() {
   pitchEnvelope.length = 0;
   pitchEnvelope.progressStep = 0;
   pitchEnvelope.activeDelay = 0;
+  pitchEnvelope.activeCount = 0;
   pitchEnvelope.progress = 0;
   pitchEnvelope.targetOffset = 0;
 }
 
 void AkaoSnesTrack::beginPitchEnvelopeForNote() {
   const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
-  if (parentSeq->version != AKAOSNES_V2 || !pitchEnvelope.enabled || !pitchSlide.baseValid()) {
+  if (!akaoSnesSupportsPitchEnvelope(parentSeq->version) ||
+      !pitchEnvelope.enabled ||
+      !pitchSlide.baseValid()) {
     return;
   }
 
@@ -166,6 +196,7 @@ void AkaoSnesTrack::beginPitchEnvelopeForNote() {
       pitchEnvelope.semitones < 0 ? -rawMagnitude : rawMagnitude;
   pitchEnvelope.targetOffset = signedMagnitude * AKAOSNES_PITCH_FRACTION_SCALE;
   pitchEnvelope.activeDelay = pitchEnvelope.delay;
+  pitchEnvelope.activeCount = parentSeq->version == AKAOSNES_V1 ? pitchEnvelope.length : 0;
   pitchEnvelope.progress = 0;
   pitchEnvelope.active = pitchEnvelope.targetOffset != 0 && pitchEnvelope.progressStep != 0;
   pitchSlide.setCurrentPitch(pitchSlide.basePitch());

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
@@ -38,8 +38,7 @@ int32_t akaoSnesBasePitch() {
 
 int32_t akaoSnesPitchForSemitoneOffset(int8_t semitones) {
   const double pitch =
-      static_cast<double>(AKAOSNES_NOMINAL_DSP_PITCH) *
-      std::pow(2.0, static_cast<double>(semitones) / 12.0);
+      static_cast<double>(AKAOSNES_NOMINAL_DSP_PITCH) * std::pow(2.0, static_cast<double>(semitones) / 12.0);
   return static_cast<int32_t>(std::lround(pitch)) * AKAOSNES_PITCH_FRACTION_SCALE;
 }
 
@@ -82,8 +81,7 @@ uint16_t akaoSnesPitchEnvelopeProgressStep(AkaoSnesVersion version, uint8_t leng
 
 int32_t akaoSnesPitchEnvelopeOffset(int32_t targetOffset, uint8_t progressHigh) {
   const int32_t targetMagnitude = targetOffset < 0 ? -targetOffset : targetOffset;
-  int32_t currentMagnitude =
-      (targetMagnitude / AKAOSNES_PITCH_FRACTION_SCALE) * progressHigh / 256;
+  int32_t currentMagnitude = (targetMagnitude / AKAOSNES_PITCH_FRACTION_SCALE) * progressHigh / 256;
   currentMagnitude *= AKAOSNES_PITCH_FRACTION_SCALE;
   return targetOffset < 0 ? -currentMagnitude : currentMagnitude;
 }
@@ -232,11 +230,9 @@ void AkaoSnesTrack::beginPitchEnvelopeForNote() {
   // transpose have produced the current MIDI note. It is not a previous-note
   // glide. Ties intentionally do not call this path.
   const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(pitchEnvelope.semitones);
-  const int32_t rawDiff =
-      (targetPitch - pitchSlide.basePitch()) / AKAOSNES_PITCH_FRACTION_SCALE;
+  const int32_t rawDiff = (targetPitch - pitchSlide.basePitch()) / AKAOSNES_PITCH_FRACTION_SCALE;
   const int32_t rawMagnitude = rawDiff < 0 ? -rawDiff : rawDiff;
-  const int32_t signedMagnitude =
-      pitchEnvelope.semitones < 0 ? -rawMagnitude : rawMagnitude;
+  const int32_t signedMagnitude = pitchEnvelope.semitones < 0 ? -rawMagnitude : rawMagnitude;
   pitchEnvelope.targetOffset = signedMagnitude * AKAOSNES_PITCH_FRACTION_SCALE;
   pitchEnvelope.activeDelay = pitchEnvelope.delay;
   pitchEnvelope.activeCount = parentSeq->version == AKAOSNES_V1 ? pitchEnvelope.length : 0;

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackPitch.cpp
@@ -1,0 +1,224 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+
+#include "AkaoSnesSeq.h"
+#include "automation/SeqTrackAutomation.h"
+#include <cmath>
+
+namespace {
+
+static constexpr uint16_t AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS = 200;
+static constexpr int32_t AKAOSNES_NOMINAL_DSP_PITCH = 0x1000;
+static constexpr int32_t AKAOSNES_PITCH_FRACTION_SCALE = 0x100;
+
+// For MIDI bend output, only target/base ratios matter, so normalize every new note to DSP pitch $1000.
+int32_t akaoSnesBasePitch() {
+  return AKAOSNES_NOMINAL_DSP_PITCH * AKAOSNES_PITCH_FRACTION_SCALE;
+}
+
+int32_t akaoSnesPitchForSemitoneOffset(int8_t semitones) {
+  const double pitch =
+      static_cast<double>(AKAOSNES_NOMINAL_DSP_PITCH) *
+      std::pow(2.0, static_cast<double>(semitones) / 12.0);
+  return static_cast<int32_t>(std::lround(pitch)) * AKAOSNES_PITCH_FRACTION_SCALE;
+}
+
+int32_t akaoSnesPitchSlideStep(AkaoSnesVersion version,
+                               int32_t currentPitch,
+                               int32_t targetPitch,
+                               uint16_t steps) {
+  const int32_t diff = targetPitch - currentPitch;
+  if (version == AKAOSNES_V3) {
+    const int32_t rawDiff = diff / AKAOSNES_PITCH_FRACTION_SCALE;
+    int32_t rawStep = rawDiff / static_cast<int32_t>(steps);
+    if (rawStep == 0 && rawDiff != 0) {
+      rawStep = (rawDiff > 0) ? 1 : -1;
+    }
+    return rawStep * AKAOSNES_PITCH_FRACTION_SCALE;
+  }
+
+  return diff / static_cast<int32_t>(steps);
+}
+
+uint16_t akaoSnesV2PitchEnvelopeProgressStep(uint8_t length) {
+  return length == 0 ? 0 : static_cast<uint16_t>(0xff00 / length);
+}
+
+double akaoSnesPitchCents(int32_t pitch, int32_t basePitch) {
+  if (pitch <= 0 || basePitch <= 0) {
+    return 0.0;
+  }
+
+  return 1200.0 * std::log2(static_cast<double>(pitch) / static_cast<double>(basePitch));
+}
+
+}  // namespace
+
+void AkaoSnesTrack::resetPitchState() {
+  pitchEnvelope = {};
+  pendingPitchSlideSteps = 0;
+  pendingPitchSlideSemitones = 0;
+  pitchSlide.setPitchToCents(akaoSnesPitchCents);
+  pitchSlide.reset(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS);
+}
+
+void AkaoSnesTrack::updatePitchSlide() {
+  advancePitchBendAutomation(pitchSlide);
+}
+
+void AkaoSnesTrack::updatePitchEnvelope() {
+  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
+  if (parentSeq->version != AKAOSNES_V2 || !pitchEnvelope.active || !pitchSlide.baseValid()) {
+    return;
+  }
+
+  if (pitchEnvelope.activeDelay > 1) {
+    pitchEnvelope.activeDelay--;
+    return;
+  }
+  if (pitchEnvelope.activeDelay == 1) {
+    pitchEnvelope.activeDelay = 0;
+  }
+
+  pitchEnvelope.progress += pitchEnvelope.progressStep;
+
+  int32_t currentOffset;
+  if (pitchEnvelope.progress > 0xffff) {
+    currentOffset = pitchEnvelope.targetOffset;
+    pitchEnvelope.progress = 0x10000;
+    pitchEnvelope.active = false;
+  }
+  else {
+    const uint8_t progressHigh = static_cast<uint8_t>(pitchEnvelope.progress >> 8);
+    const int32_t targetMagnitude =
+        pitchEnvelope.targetOffset < 0 ? -pitchEnvelope.targetOffset : pitchEnvelope.targetOffset;
+    int32_t currentMagnitude =
+        (targetMagnitude / AKAOSNES_PITCH_FRACTION_SCALE) * progressHigh / 256;
+    currentMagnitude *= AKAOSNES_PITCH_FRACTION_SCALE;
+    currentOffset = pitchEnvelope.targetOffset < 0 ? -currentMagnitude : currentMagnitude;
+  }
+
+  pitchSlide.setCurrentPitch(pitchSlide.basePitch() + currentOffset);
+  applyPitchBendAutomation(pitchSlide);
+}
+
+void AkaoSnesTrack::resetPitchBendForNewNote() {
+  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
+  pitchSlide.clearMotion();
+  pitchSlide.invalidateBase();
+
+  if (!pitchSlide.atRest(AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS)) {
+    if (parentSeq->version == AKAOSNES_V2 && pitchEnvelope.enabled) {
+      setPitchBendAutomationBend(pitchSlide, 0);
+      return;
+    }
+    resetPitchBendAutomation(pitchSlide, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS);
+  }
+}
+
+void AkaoSnesTrack::beginNotePitch(uint8_t, bool validForPitchBend) {
+  resetPitchBendForNewNote();
+  if (validForPitchBend) {
+    pitchSlide.beginNote(akaoSnesBasePitch());
+    beginPitchEnvelopeForNote();
+  }
+}
+
+void AkaoSnesTrack::setPitchEnvelope(int8_t semitones, uint8_t delay, uint8_t length) {
+  if (semitones == 0 || length == 0) {
+    clearPitchEnvelope();
+    return;
+  }
+
+  pitchEnvelope.enabled = true;
+  pitchEnvelope.semitones = semitones;
+  pitchEnvelope.delay = delay;
+  pitchEnvelope.length = length;
+  pitchEnvelope.progressStep = akaoSnesV2PitchEnvelopeProgressStep(length);
+}
+
+void AkaoSnesTrack::clearPitchEnvelope() {
+  pitchEnvelope.enabled = false;
+  pitchEnvelope.active = false;
+  pitchEnvelope.semitones = 0;
+  pitchEnvelope.delay = 0;
+  pitchEnvelope.length = 0;
+  pitchEnvelope.progressStep = 0;
+  pitchEnvelope.activeDelay = 0;
+  pitchEnvelope.progress = 0;
+  pitchEnvelope.targetOffset = 0;
+}
+
+void AkaoSnesTrack::beginPitchEnvelopeForNote() {
+  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
+  if (parentSeq->version != AKAOSNES_V2 || !pitchEnvelope.enabled || !pitchSlide.baseValid()) {
+    return;
+  }
+
+  const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(pitchEnvelope.semitones);
+  const int32_t rawDiff =
+      (targetPitch - pitchSlide.basePitch()) / AKAOSNES_PITCH_FRACTION_SCALE;
+  const int32_t rawMagnitude = rawDiff < 0 ? -rawDiff : rawDiff;
+  const int32_t signedMagnitude =
+      pitchEnvelope.semitones < 0 ? -rawMagnitude : rawMagnitude;
+  pitchEnvelope.targetOffset = signedMagnitude * AKAOSNES_PITCH_FRACTION_SCALE;
+  pitchEnvelope.activeDelay = pitchEnvelope.delay;
+  pitchEnvelope.progress = 0;
+  pitchEnvelope.active = pitchEnvelope.targetOffset != 0 && pitchEnvelope.progressStep != 0;
+  pitchSlide.setCurrentPitch(pitchSlide.basePitch());
+
+  if (pitchEnvelope.active) {
+    setPitchBendAutomationRange(
+        pitchSlide,
+        pitchSlide.rangeCentsForSlide(pitchSlide.basePitch(),
+                                      pitchSlide.basePitch() + pitchEnvelope.targetOffset,
+                                      AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS));
+  }
+}
+
+void AkaoSnesTrack::setPendingPitchSlide(uint16_t steps, int8_t semitones) {
+  pendingPitchSlideSteps = steps;
+  pendingPitchSlideSemitones = semitones;
+  if (pendingPitchSlideSemitones == 0) {
+    clearPendingPitchSlide();
+  }
+}
+
+void AkaoSnesTrack::clearPendingPitchSlide() {
+  pendingPitchSlideSteps = 0;
+  pendingPitchSlideSemitones = 0;
+}
+
+void AkaoSnesTrack::beginPendingPitchSlide() {
+  const auto *parentSeq = static_cast<AkaoSnesSeq*>(this->parentSeq);
+  if (pendingPitchSlideSteps == 0 || pendingPitchSlideSemitones == 0) {
+    clearPendingPitchSlide();
+    return;
+  }
+
+  const uint16_t steps = pendingPitchSlideSteps;
+  const int8_t semitones = pendingPitchSlideSemitones;
+  clearPendingPitchSlide();
+
+  if (!pitchSlide.baseValid()) {
+    return;
+  }
+
+  const int32_t currentPitch = pitchSlide.currentPitch();
+  const int32_t targetPitch = akaoSnesPitchForSemitoneOffset(semitones);
+  const int32_t step =
+      akaoSnesPitchSlideStep(parentSeq->version, currentPitch, targetPitch, steps);
+
+  beginPitchBendAutomation(
+      pitchSlide,
+      pitchSlide.motionToTargetWithStepNoSnap(targetPitch, step, steps),
+      pitchSlide.rangeCentsForSlide(currentPitch, targetPitch, AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS),
+      AKAOSNES_DEFAULT_PITCH_BEND_RANGE_CENTS,
+      true);
+
+  // Apply the first update on the same sequencer tick that consumes the setup command.
+  updatePitchSlide();
+}


### PR DESCRIPTION
Akao SNES has two different pitch automation behaviors depending on the driver version. V1 and V2 use persistent pitch envelopes: new notes activate a pitch ramp from the note's base pitch, and this behavior continues until disabled. V3 and V4 use one-shot pitch slides, consumed by the next note or tie.

For accuracy, the implementation models pitch in source DSP pitch units, then converts that to MIDI pitch bend using pitch ratios.

The Akao-specific pitch logic lives in a new `AkaoSnesTrackPitch.cpp` file. This PR also extends `SeqPitchBendAutomation` to support an optional pitch-to-cents converter, so formats with non-linear pitch spaces can provide their own conversion instead of assuming one source unit equals a fixed number of cents.

This is using @loveemu's [analysis](https://github.com/loveemu/vgm-disasm/tree/master/snes/Square/Minoru%20Akao).

## How Has This Been Tested?
Testing by ear and examining MIDI.

## Audio Demo

https://github.com/user-attachments/assets/d5049afd-5440-4357-8a9b-c22a9c7c6745

https://github.com/user-attachments/assets/b7b3e0fa-1e33-4f5b-b551-9a7e5543aaae

https://github.com/user-attachments/assets/059db8aa-914d-410e-a77e-630adb9fda42

https://github.com/user-attachments/assets/c636c184-3926-432f-a798-13852e7f6611

https://github.com/user-attachments/assets/de3c604b-df5e-4f9c-ab73-adbda3a1f4ff


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
