### PR TITLE
add commits to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,6 +8,18 @@
 # This file is automatically used by GitHub.com's blame view.
 
 
+# Convert codebase to Google style
+c92aa1671ff5c3acc57aff098625321e35730588
+
+# More code reformatting
+5270f82f11d3a066f7ac77d0d04eddb65da8f77c
+
+# More code reformatting
+a45aa530389b5bc79d3dcec96b365221599d64ac
+
+# Formatting cleanup
+cf648c2fd6f50545441f7720e18476630142226f
+
 # Move format code into subdirectories
 ed533cd46d853523d184ff1a60f769223ee97845
 
@@ -26,5 +38,11 @@ ed533cd46d853523d184ff1a60f769223ee97845
 # Rename the Qt implementation methods
 6a066930d0281c1ddd356baaedf4db3a1c3fada4
 
+# Reorganize Matcher classes
+828f82d30c6fc3106c291726e1a33fbcf27924d9
+
 # Rename VGMItem::EventColor to VGMItem::Type
 52a20efc1561423b95146da6f688defe7d00f0f5
+
+# Remove common.h, use fixed-width type aliases universally
+8743874e195990714b7d73eb984ac1db8457ebc7


### PR DESCRIPTION
This adds a few commits to .git-blame-ignore-revs:

- commits circa 2016 when I did a codebase wide reformat
- a commit for a PR that renamed Matcher classes which I forgot to add
- the recent common.h removal / fixed-width type alias PR commit