### PR TITLE
N-SPC: AddmusikK support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@
 
 * **N-SPC:** Added drum kit, vibrato, and pitch slide support to the standard driver.
 * **N-SPC:** Improved detection of instrument data.
+* **N-SPC:** Added support for AddmusicK (special thanks to KungFuFurby for format info).
 * **KonamiSnes:** Added drum kit, portamento, and slide support for volume/pan/pitch.
 * **CapcomSnes:** Added vibrato, tremolo, more accurate portamento support, and fixed pan calculation.
 * **AkaoSnes:** Added vibrato support.
 * **SuzukiSnes:** Added drum kit support (Seiken Densetsu 3, Super Mario RPG, etc.).
 * **Intelligent Systems:** Improved support for late-era titles (Tetris Attack, Fire Emblem 4, Super Famicom Wars).
-* **SPC:** Fixed loading of older SPC files that do not have ID666 tags.
+* **SPC:** Fixed loading of older SPC files that do not have ID666 tags, improved handling of invalid tags.
 
 **Game Boy Advance (GBA)**
 

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -227,6 +227,7 @@ target_sources(vgmtranscore
     formats/NeverlandSnes/NeverlandSnesScanner.cpp
     formats/NeverlandSnes/NeverlandSnesSeq.cpp
     formats/NinSnes/NinSnesInstr.cpp
+    formats/NinSnes/NinSnesAddmusicK.cpp
     formats/NinSnes/NinSnesProfile.cpp
     formats/NinSnes/NinSnesScanner.cpp
     formats/NinSnes/NinSnesScannerPatterns.cpp

--- a/src/main/components/SPCFile.cpp
+++ b/src/main/components/SPCFile.cpp
@@ -10,7 +10,36 @@
 #include "RawFile.h"
 #include "VGMTag.h"
 
+#include <algorithm>
+#include <cctype>
 #include <stdexcept>
+
+namespace {
+
+u32 parseOptionalID666Number(std::string value, std::string_view fieldName) {
+  auto isWhitespace = [](unsigned char c) { return std::isspace(c) != 0; };
+  value.erase(value.begin(), std::find_if_not(value.begin(), value.end(), isWhitespace));
+  value.erase(std::find_if_not(value.rbegin(), value.rend(), isWhitespace).base(), value.end());
+
+  if (value.empty()) {
+    return 0;
+  }
+
+  const bool isDecimal = std::ranges::all_of(value, [](unsigned char c) { return std::isdigit(c) != 0; });
+  if (!isDecimal) {
+    L_WARN("Ignored malformed {} in ID666 tag: {}", fieldName, value);
+    return 0;
+  }
+
+  try {
+    return static_cast<u32>(std::stoul(value));
+  } catch (const std::exception& e) {
+    L_WARN("Failed to parse {} from ID666 tag: {}", fieldName, e.what());
+    return 0;
+  }
+}
+
+}  // namespace
 
 VGMTag SPCFile::tagFromSPCFile(const SPCFile& spc) {
   const auto& id666 = spc.id666Tag();
@@ -26,8 +55,7 @@ SPCFile::SPCFile(const RawFile& file) {
     throw std::length_error("SPC file is smaller than required length");
   }
 
-  if (!std::equal(file.begin(), file.begin() + 27, "SNES-SPC700 Sound File Data") ||
-      file.readShort(0x21) != 0x1a1a) {
+  if (!std::equal(file.begin(), file.begin() + 27, "SNES-SPC700 Sound File Data") || file.readShort(0x21) != 0x1a1a) {
     throw std::runtime_error("Invalid SPC signature");
   }
 
@@ -51,18 +79,8 @@ void SPCFile::loadID666Tag(const RawFile& file) {
   m_id666Tag.nameOfDumper = file.readNullTerminatedString(0x6E, 16);
   m_id666Tag.comments = file.readNullTerminatedString(0x7E, 32);
   m_id666Tag.dateDumped = file.readNullTerminatedString(0x9E, 11);
-  try {
-    m_id666Tag.secondsToPlay = std::stoi(file.readNullTerminatedString(0xA9, 3));
-  } catch (const std::exception& e) {
-    L_WARN("Failed to parse seconds to play from ID666 tag: {}", e.what());
-    m_id666Tag.secondsToPlay = 0;
-  }
-  try {
-    m_id666Tag.fadeLength = std::stoi(file.readNullTerminatedString(0xAC, 5));
-  } catch (const std::exception& e) {
-    L_WARN("Failed to parse fade length from ID666 tag: {}", e.what());
-    m_id666Tag.fadeLength = 0;
-  }
+  m_id666Tag.secondsToPlay = parseOptionalID666Number(file.readNullTerminatedString(0xA9, 3), "seconds to play");
+  m_id666Tag.fadeLength = parseOptionalID666Number(file.readNullTerminatedString(0xAC, 5), "fade length");
   m_id666Tag.artist = file.readNullTerminatedString(0xB1, 32);
   m_id666Tag.defaultChannelDisables = file.readByte(0xD1);
   m_id666Tag.emulatorUsed = file.readByte(0xD2);
@@ -70,7 +88,7 @@ void SPCFile::loadID666Tag(const RawFile& file) {
 
 void SPCFile::loadExtendedID666Tag(const RawFile& file, size_t offset) {
   if (!std::equal(file.begin() + offset, file.begin() + offset + 4, "xid6")) {
-    return; // No extended ID666 chunk found
+    return;  // No extended ID666 chunk found
   }
 
   size_t chunkSize = file.readWord(offset + 4);
@@ -121,7 +139,7 @@ void SPCFile::loadExtendedID666Tag(const RawFile& file, size_t offset) {
             L_INFO("Ignored id6 tag id: {} in SPC", id);
             break;
         }
-        currentOffset += 4 + ((dataLength + 3) & ~3); // Align to 32-bit boundary
+        currentOffset += 4 + ((dataLength + 3) & ~3);  // Align to 32-bit boundary
         break;
       }
 

--- a/src/main/formats/NinSnes/NinSnesAddmusicK.cpp
+++ b/src/main/formats/NinSnes/NinSnesAddmusicK.cpp
@@ -1,0 +1,347 @@
+#include "NinSnesSeq.h"
+
+#include "base/Types.h"
+#include "SeqEvent.h"
+
+#include <array>
+#include <vector>
+
+#include "spdlog/fmt/fmt.h"
+
+namespace {
+
+constexpr std::array<const char*, 8> kAddmusicKHotPatchPresetNames = {
+    "AddmusicK 1.0.8 and earlier",
+    "AddmusicK 1.0.9",
+    "AddmusicK Beta",
+    "Romi's Addmusic404",
+    "Addmusic405",
+    "AddmusicM",
+    "carol's MORE.bin",
+    "Vanilla SMW",
+};
+
+void appendHotPatchFlags(std::string& desc, const NinSnesAddmusicKHotPatchState& state) {
+  bool any = false;
+  auto appendFlag = [&](bool active, const char* name) {
+    if (!active) {
+      return;
+    }
+    fmt::format_to(std::back_inserter(desc), "{}{}", any ? ", " : "", name);
+    any = true;
+  };
+
+  desc += "  Active:";
+  appendFlag((state.byte0 & NinSnesAddmusicKHotPatchState::ArpeggioSkipsRests) != 0,
+             "arpeggio skips rests");
+  appendFlag((state.byte0 & NinSnesAddmusicKHotPatchState::GainBeforeAdsr) != 0,
+             "GAIN before ADSR");
+  appendFlag((state.byte0 & NinSnesAddmusicKHotPatchState::ReadaheadScansLoops) != 0,
+             "readahead scans loops");
+  appendFlag(state.pitchSlideAccountsForSemitoneTune(),
+             "$DD accounts for $FA $02");
+  appendFlag(state.sampleLoadClearsPitchFraction(),
+             "$F3 clears pitch fraction");
+  appendFlag((state.byte0 & NinSnesAddmusicKHotPatchState::ZeroDelayEchoWritesDisabled) != 0,
+             "zero-delay echo writes disabled");
+  appendFlag((state.byte0 & NinSnesAddmusicKHotPatchState::GlissandoStopsAfterOneNote) != 0,
+             "glissando stops after one note");
+  appendFlag((state.byte1 & NinSnesAddmusicKHotPatchState::RestsKeyOffOnlyInReadahead) != 0,
+             "rests key off only in readahead");
+  if (!any) {
+    desc += " none";
+  }
+}
+
+}  // namespace
+
+bool NinSnesAddmusicKHotPatchState::applyPreset(u8 preset) {
+  struct Preset {
+    u8 byte0;
+    u8 byte1;
+  };
+
+  // AddmusicKFF asm/Commands.asm HotPatchPresetTable. The high continuation bit
+  // is a stream encoding detail, so only the lower seven behavior bits are stored.
+  static constexpr std::array<Preset, 8> kPresets = {{
+      {0x80, 0x00},  // AddmusicK 1.0.8 and earlier
+      {0xff, 0x00},  // AddmusicK 1.0.9
+      {0x80, 0x00},  // AddmusicK Beta
+      {0x80, 0x01},  // Romi's Addmusic404
+      {0x80, 0x01},  // Addmusic405
+      {0x88, 0x00},  // AddmusicM
+      {0x80, 0x01},  // carol's MORE.bin
+      {0x80, 0x01},  // Vanilla SMW
+  }};
+
+  if (preset >= kPresets.size()) {
+    return false;
+  }
+
+  byte0 = kPresets[preset].byte0 & 0x7f;
+  byte1 = kPresets[preset].byte1 & 0x7f;
+  return true;
+}
+
+void NinSnesAddmusicKHotPatchState::applyBytes(std::span<const u8> bytes) {
+  byte0 = bytes.empty() ? 0 : bytes[0] & 0x7f;
+  byte1 = bytes.size() < 2 ? 0 : bytes[1] & 0x7f;
+}
+
+bool NinSnesTrack::handleAddmusicKEvent(NinSnesSeqEventType eventType, u32 beginOffset,
+                                        std::string& desc) {
+  auto& parentSeq = seq();
+
+  switch (eventType) {
+    case EVENT_ADDMUSICK_SUBLOOP: {
+      const u8 count = readByte(curOffset++);
+      if (count == 0) {
+        state.addmusicKSubloopStartAddress = curOffset;
+        state.addmusicKSubloopCount = 0;
+        state.addmusicKSubloopActive = false;
+        desc = fmt::format("Start: ${:04X}", state.addmusicKSubloopStartAddress);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Subloop Start", desc, Type::RepeatStart);
+      } else {
+        if (!state.addmusicKSubloopActive) {
+          state.addmusicKSubloopCount = count;
+          state.addmusicKSubloopActive = true;
+        }
+
+        desc = fmt::format("Start: ${:04X}  Remaining: {:d}", state.addmusicKSubloopStartAddress,
+                           state.addmusicKSubloopCount);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Subloop End", desc, Type::RepeatEnd);
+
+        if (state.addmusicKSubloopStartAddress != 0 && state.addmusicKSubloopCount != 0) {
+          state.addmusicKSubloopCount--;
+          curOffset = state.addmusicKSubloopStartAddress;
+        } else {
+          state.addmusicKSubloopActive = false;
+        }
+      }
+      return true;
+    }
+
+    case EVENT_ADDMUSICK_ADSR_GAIN: {
+      const u8 adsrOrGain = readByte(curOffset++);
+      const u8 value = readByte(curOffset++);
+      if (adsrOrGain == 0x80) {
+        desc = fmt::format("GAIN: ${:02X}", value);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "GAIN", desc, Type::Adsr);
+      } else {
+        desc = fmt::format("ADSR(1): ${:02X}  ADSR(2): ${:02X}", adsrOrGain, value);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "ADSR", desc, Type::Adsr);
+      }
+      return true;
+    }
+
+    case EVENT_ADDMUSICK_SAMPLE_LOAD: {
+      const u8 sample = readByte(curOffset++);
+      const u8 pitchMultiplier = readByte(curOffset++);
+      desc = fmt::format("Sample: ${:02X}  Pitch Multiplier: ${:02X}", sample, pitchMultiplier);
+      if (parentSeq.addmusicKHotPatch.sampleLoadClearsPitchFraction()) {
+        desc += "  Hot Patch: clears pitch fraction";
+      }
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Sample Load", desc, Type::Sample);
+      return true;
+    }
+
+    case EVENT_ADDMUSICK_OPTION: {
+      const u8 option = readByte(curOffset++);
+      std::string name = "AddmusicK Option";
+      switch (option) {
+        case 0x00:
+        case 0x06:
+          name = "Yoshi Drums";
+          break;
+        case 0x01:
+          name = "Legato";
+          intelliLegato = !intelliLegato;
+          break;
+        case 0x02:
+          name = "Light Staccato";
+          break;
+        case 0x03:
+          name = "Echo Toggle";
+          break;
+        case 0x05:
+          name = "SNES Sync";
+          break;
+        case 0x07:
+          name = "Tempo Hike Off";
+          break;
+        case 0x08:
+          name = "Velocity Table";
+          break;
+        case 0x09:
+          name = "Restore Instrument";
+          break;
+        default:
+          break;
+      }
+      desc = fmt::format("Subcommand: ${:02X}", option);
+      addGenericEvent(beginOffset, curOffset - beginOffset, name, desc, Type::ChangeState);
+      return true;
+    }
+
+    case EVENT_ADDMUSICK_FIR_FILTER: {
+      desc = "Coefficients:";
+      for (u8 coeffIndex = 0; coeffIndex < 8; coeffIndex++) {
+        fmt::format_to(std::back_inserter(desc), " ${:02X}", readByte(curOffset++));
+      }
+      addGenericEvent(beginOffset, curOffset - beginOffset, "FIR Filter", desc, Type::Reverb);
+      return true;
+    }
+
+    case EVENT_ADDMUSICK_DSP_WRITE: {
+      const u8 reg = readByte(curOffset++);
+      const u8 value = readByte(curOffset++);
+      desc = fmt::format("Register: ${:02X}  Value: ${:02X}", reg, value);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "DSP Write", desc, Type::Control);
+      return true;
+    }
+
+    case EVENT_ADDMUSICK_DATA_WRITE: {
+      const u8 addrHigh = readByte(curOffset++);
+      const u8 addrLow = readByte(curOffset++);
+      const u8 value = readByte(curOffset++);
+      desc = fmt::format("Address: ${:02X}{:02X}  Value: ${:02X}  Legacy AddmusicM command",
+                         addrHigh, addrLow, value);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Legacy Data Write", desc, Type::Misc);
+      return true;
+    }
+
+    case EVENT_ADDMUSICK_NOISE: {
+      const u8 noisePitch = readByte(curOffset++);
+      desc = fmt::format("Pitch: ${:02X}", noisePitch);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Noise", desc, Type::Noise);
+      return true;
+    }
+
+    case EVENT_ADDMUSICK_DATA_SEND: {
+      const u8 byte1 = readByte(curOffset++);
+      const u8 byte2 = readByte(curOffset++);
+      desc = fmt::format("Byte 1: ${:02X}  Byte 2: ${:02X}", byte1, byte2);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Data Send", desc, Type::Misc);
+      return true;
+    }
+
+    case EVENT_ADDMUSICK_EXTENDED: {
+      const u8 subcommand = readByte(curOffset++);
+      const u8 value = readByte(curOffset++);
+      std::string name = "AddmusicK Extended";
+      switch (subcommand) {
+        case 0x00:
+          name = "Pitch Modulation";
+          desc = fmt::format("Channels: ${:02X}", value);
+          break;
+        case 0x01:
+          name = "GAIN";
+          desc = fmt::format("GAIN: ${:02X}", value);
+          addGenericEvent(beginOffset, curOffset - beginOffset, name, desc, Type::Adsr);
+          return true;
+        case 0x02: {
+          const s8 semitones = static_cast<s8>(value);
+          name = "Semitone Tune";
+          desc = fmt::format("Semitones: {:d}", semitones);
+          state.spcTranspose = semitones;
+          addTranspose(beginOffset, curOffset - beginOffset, semitones, name);
+          return true;
+        }
+        case 0x03:
+          name = "Amplify";
+          desc = fmt::format("Value: ${:02X}", value);
+          state.addmusicKVolumeMultiplier = value;
+          addVolNoItem(midiVolumeForCurrentState());
+          break;
+        case 0x04:
+          name = "Echo Buffer Reserve";
+          desc = fmt::format("Size: ${:02X}", value);
+          break;
+        case 0x06:
+          name = "Velocity Table";
+          parentSeq.addmusicKVelocityTableId = value;
+          desc = fmt::format("Table: ${:02X}", value);
+          break;
+        case 0x7f:
+          name = "Hot Patch Preset";
+          if (parentSeq.addmusicKHotPatch.applyPreset(value)) {
+            desc = fmt::format("Preset: ${:02X} ({})  Bytes: ${:02X} ${:02X}",
+                               value,
+                               kAddmusicKHotPatchPresetNames[value],
+                               parentSeq.addmusicKHotPatch.byte0,
+                               parentSeq.addmusicKHotPatch.byte1);
+            appendHotPatchFlags(desc, parentSeq.addmusicKHotPatch);
+          } else {
+            desc = fmt::format("Preset: ${:02X} (reserved/user-defined, not modeled)", value);
+          }
+          break;
+        case 0xfe: {
+          name = "Hot Patch Toggle Bits";
+          std::vector<u8> patchBytes;
+          patchBytes.push_back(value);
+          desc = "Bytes:";
+          fmt::format_to(std::back_inserter(desc), " ${:02X}", value);
+          u8 patchByte = value;
+          while ((patchByte & 0x80) != 0 && curOffset < 0x10000) {
+            patchByte = readByte(curOffset++);
+            patchBytes.push_back(patchByte);
+            fmt::format_to(std::back_inserter(desc), " ${:02X}", patchByte);
+          }
+          parentSeq.addmusicKHotPatch.applyBytes(patchBytes);
+          fmt::format_to(std::back_inserter(desc),
+                         "  Effective: ${:02X} ${:02X}",
+                         parentSeq.addmusicKHotPatch.byte0,
+                         parentSeq.addmusicKHotPatch.byte1);
+          appendHotPatchFlags(desc, parentSeq.addmusicKHotPatch);
+          break;
+        }
+        default:
+          desc = fmt::format("Subcommand: ${:02X}  Value: ${:02X}", subcommand, value);
+          break;
+      }
+      addGenericEvent(beginOffset, curOffset - beginOffset, name, desc, Type::ChangeState);
+      return true;
+    }
+
+    case EVENT_ADDMUSICK_ARPEGGIO: {
+      const u8 subcommand = readByte(curOffset++);
+      if (subcommand == 0) {
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Arpeggio Off", desc, Type::PitchBend);
+      } else if (subcommand == 0x80 || subcommand == 0x81) {
+        const u8 duration = readByte(curOffset++);
+        const s8 semitones = static_cast<s8>(readByte(curOffset++));
+        desc = fmt::format("Duration: {:d}  Semitones: {:d}", duration, semitones);
+        addGenericEvent(beginOffset, curOffset - beginOffset,
+                        subcommand == 0x80 ? "Trill" : "Glissando", desc, Type::PitchBend);
+      } else if (subcommand < 0x80) {
+        const u8 count = subcommand;
+        const u8 duration = readByte(curOffset++);
+        desc = fmt::format("Count: {:d}  Duration: {:d}  Steps:", count, duration);
+        for (u8 step = 0; step < count && curOffset < 0x10000; step++) {
+          fmt::format_to(std::back_inserter(desc), " ${:02X}", readByte(curOffset++));
+        }
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Arpeggio", desc, Type::PitchBend);
+      } else {
+        const u8 duration = readByte(curOffset++);
+        const u8 value = readByte(curOffset++);
+        desc = fmt::format("Subcommand: ${:02X}  Duration: {:d}  Value: ${:02X}", subcommand,
+                           duration, value);
+        addGenericEvent(beginOffset, curOffset - beginOffset, "Arpeggio", desc, Type::PitchBend);
+      }
+      return true;
+    }
+
+    case EVENT_ADDMUSICK_REMOTE_COMMAND: {
+      const u16 addr = getShortAddress(curOffset);
+      curOffset += 2;
+      const u8 event = readByte(curOffset++);
+      const u8 wait = readByte(curOffset++);
+      desc = fmt::format("Address: ${:04X}  Event: {:d}  Wait: {:d}", addr, event, wait);
+      addGenericEvent(beginOffset, curOffset - beginOffset, "Remote Command", desc, Type::Misc);
+      return true;
+    }
+
+    default:
+      return false;
+  }
+}

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -11,6 +11,7 @@
 #include "SNESDSP.h"
 #include "VGMColl.h"
 
+#include <array>
 #include <memory>
 #include <span>
 
@@ -146,7 +147,8 @@ std::unique_ptr<VGMRgn> createRgnFromHeaderData(VGMInstr* instr,
                                                 RawFile* rawFile,
                                                 NinSnesProfileId profileId,
                                                 u32 spcDirAddr,
-                                                const std::array<u8, 6>& regionData) {
+                                                const std::array<u8, 6>& regionData,
+                                                u32 regionOffset = 0) {
   const auto& profile = getNinSnesProfile(profileId);
   const u8 srcn = regionData[0];
   const u8 adsr1 = regionData[1];
@@ -160,7 +162,7 @@ std::unique_ptr<VGMRgn> createRgnFromHeaderData(VGMInstr* instr,
 
   const auto tuning = calculatePitchTuning(readPitchScale(profile, regionData[4], regionData[5]));
 
-  auto rgn = std::make_unique<VGMRgn>(instr, 0, NinSnesInstr::expectedSize(profileId));
+  auto rgn = std::make_unique<VGMRgn>(instr, regionOffset, NinSnesInstr::expectedSize(profileId));
   rgn->sampOffset = rawFile->readShort(offDirEnt) - spcDirAddr;
   rgn->sampNum = srcn;
   rgn->unityKey = tuning.unityKey;
@@ -198,6 +200,9 @@ NinSnesInstrSet::NinSnesInstrSet(RawFile* file, const NinSnesScanResult& scanRes
   profileId = scanResult.profile;
   konamiTuningTableAddress = scanResult.konamiTuningTableAddress;
   konamiTuningTableSize = scanResult.konamiTuningTableSize;
+  addmusicKCustomInstrTableAddr = scanResult.addmusicKCustomInstrTableAddr;
+  addmusicKCustomInstrBase = scanResult.addmusicKCustomInstrBase;
+  addmusicKCustomInstrCount = scanResult.addmusicKCustomInstrCount;
 }
 
 NinSnesInstrSet::~NinSnesInstrSet() {
@@ -266,6 +271,9 @@ bool NinSnesInstrSet::parseInstrPointers() {
     newInstr->konamiTuningTableAddress = konamiTuningTableAddress;
     newInstr->konamiTuningTableSize = konamiTuningTableSize;
   }
+
+  addAddmusicKCustomInstruments();
+
   if (!hasInstrs()) {
     return false;
   }
@@ -283,6 +291,52 @@ bool NinSnesInstrSet::parseInstrPointers() {
   }
 
   return true;
+}
+
+void NinSnesInstrSet::addAddmusicKCustomInstruments() {
+  if (profileId != NinSnesProfileId::AddmusicK || addmusicKCustomInstrTableAddr == 0 ||
+      addmusicKCustomInstrCount == 0) {
+    return;
+  }
+
+  for (u8 instrIndex = 0; instrIndex < addmusicKCustomInstrCount; instrIndex++) {
+    const u32 entryOffset = addmusicKCustomInstrTableAddr + instrIndex * 6;
+    if (entryOffset + 6 > 0x10000) {
+      break;
+    }
+
+    const u8 srcn = readByte(entryOffset);
+    std::array<u8, 6> regionData = {
+        srcn,
+        readByte(entryOffset + 1),
+        readByte(entryOffset + 2),
+        readByte(entryOffset + 3),
+        readByte(entryOffset + 4),
+        readByte(entryOffset + 5),
+    };
+
+    auto newInstr = std::make_unique<VGMInstr>(
+        this,
+        entryOffset,
+        6,
+        0,
+        addmusicKCustomInstrBase + instrIndex,
+        fmt::format("Instrument {}", addmusicKCustomInstrBase + instrIndex));
+    newInstr->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
+
+    auto rgn =
+        createRgnFromHeaderData(newInstr.get(), rawFile(), profileId, spcDirAddr, regionData, entryOffset);
+    if (rgn == nullptr) {
+      continue;
+    }
+
+    newInstr->sinkRgn(std::move(rgn));
+    sinkInstr(std::move(newInstr));
+
+    if (std::find(usedSRCNs.begin(), usedSRCNs.end(), srcn) == usedSRCNs.end()) {
+      usedSRCNs.push_back(srcn);
+    }
+  }
 }
 
 void NinSnesInstrSet::useColl(const VGMColl* coll) {

--- a/src/main/formats/NinSnes/NinSnesInstr.h
+++ b/src/main/formats/NinSnes/NinSnesInstr.h
@@ -43,9 +43,14 @@ class NinSnesInstrSet:
   std::vector<u8> usedSRCNs;
 
  private:
+  void addAddmusicKCustomInstruments();
   void addStandardPercussionDrumKit(const NinSnesSeq& seq);
   void addIntelliOverrideInstrs(const NinSnesSeq& seq);
   void addIntelliDrumKits(const NinSnesSeq& seq);
+
+  u32 addmusicKCustomInstrTableAddr = 0;
+  u8 addmusicKCustomInstrBase = 0;
+  u8 addmusicKCustomInstrCount = 0;
 };
 
 // *************

--- a/src/main/formats/NinSnes/NinSnesProfile.cpp
+++ b/src/main/formats/NinSnes/NinSnesProfile.cpp
@@ -111,16 +111,15 @@ void initializeSeqDefinition(NinSnesSeqDefinition& definition, const NinSnesProf
     definition.eventMap[static_cast<u8>(statusByte)] = EVENT_NOTE_PARAM;
   }
 
-  for (int statusByte = definition.status.noteMin; statusByte <= definition.status.noteMax;
-       statusByte++) {
+  for (int statusByte = definition.status.noteMin; statusByte <= definition.status.noteMax; statusByte++) {
     definition.eventMap[static_cast<u8>(statusByte)] = EVENT_NOTE;
   }
 
   definition.eventMap[definition.status.noteMax + 1] = EVENT_TIE;
   definition.eventMap[definition.status.noteMax + 2] = EVENT_REST;
 
-  for (int statusByte = definition.status.percussionNoteMin;
-       statusByte <= definition.status.percussionNoteMax; statusByte++) {
+  for (int statusByte = definition.status.percussionNoteMin; statusByte <= definition.status.percussionNoteMax;
+       statusByte++) {
     definition.eventMap[static_cast<u8>(statusByte)] = EVENT_PERCUSSION_NOTE;
   }
 }
@@ -255,6 +254,23 @@ void applyBaseSeqDialect(NinSnesSeqDefinition& definition, const NinSnesProfile&
 
 void applyDerivedSeqOverrides(NinSnesSeqDefinition& definition, const NinSnesProfile& profile) {
   switch (profile.id) {
+    case NinSnesProfileId::AddmusicK:
+      definition.eventMap[0xe6] = EVENT_ADDMUSICK_SUBLOOP;
+      definition.eventMap[0xed] = EVENT_ADDMUSICK_ADSR_GAIN;
+      definition.eventMap[0xf3] = EVENT_ADDMUSICK_SAMPLE_LOAD;
+      definition.eventMap[0xf4] = EVENT_ADDMUSICK_OPTION;
+      definition.eventMap[0xf5] = EVENT_ADDMUSICK_FIR_FILTER;
+      definition.eventMap[0xf6] = EVENT_ADDMUSICK_DSP_WRITE;
+      definition.eventMap[0xf7] = EVENT_ADDMUSICK_DATA_WRITE;
+      definition.eventMap[0xf8] = EVENT_ADDMUSICK_NOISE;
+      definition.eventMap[0xf9] = EVENT_ADDMUSICK_DATA_SEND;
+      definition.eventMap[0xfa] = EVENT_ADDMUSICK_EXTENDED;
+      definition.eventMap[0xfb] = EVENT_ADDMUSICK_ARPEGGIO;
+      definition.eventMap[0xfc] = EVENT_ADDMUSICK_REMOTE_COMMAND;
+      definition.eventMap[0xfd] = EVENT_TREMOLO_OFF;
+      definition.eventMap[0xfe] = EVENT_PITCH_ENVELOPE_OFF;
+      break;
+
     case NinSnesProfileId::Rd1:
       definition.eventMap[0xfb] = EVENT_UNKNOWN2;
       definition.eventMap[0xfc] = EVENT_UNKNOWN0;
@@ -337,108 +353,96 @@ constexpr NinSnesProfile kUnknownProfile{
     NinSnesIntelliModeId::None,
 };
 
-constexpr std::array<NinSnesProfile, 17> kProfiles{{
-    {NinSnesProfileId::Earlier, "Earlier", NinSnesBaseProfileId::Earlier,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
+constexpr std::array<NinSnesProfile, 18> kProfiles{{
+    {NinSnesProfileId::Earlier, "Earlier", NinSnesBaseProfileId::Earlier, NinSnesAddressModelId::Direct,
+     NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
      NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Earlier5Byte,
      NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 
-    {NinSnesProfileId::Standard, "Standard", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
+    {NinSnesProfileId::AddmusicK, "AddmusicK", NinSnesBaseProfileId::Earlier, NinSnesAddressModelId::Direct,
+     NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
      NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
      NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 
-    {NinSnesProfileId::Rd1, "RD1", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
+    {NinSnesProfileId::Standard, "Standard", NinSnesBaseProfileId::Standard, NinSnesAddressModelId::Direct,
+     NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
      NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
      NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 
-    {NinSnesProfileId::Rd2, "RD2", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
+    {NinSnesProfileId::Rd1, "RD1", NinSnesBaseProfileId::Standard, NinSnesAddressModelId::Direct,
+     NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
      NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
      NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 
-    {NinSnesProfileId::Hal, "HAL", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
-     NinSnesPanModelId::HalTable, NinSnesInstrumentLayoutId::Standard6Byte,
+    {NinSnesProfileId::Rd2, "RD2", NinSnesBaseProfileId::Standard, NinSnesAddressModelId::Direct,
+     NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
+     NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
      NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 
-    {NinSnesProfileId::Konami, "Konami", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::KonamiBase, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
+    {NinSnesProfileId::Hal, "HAL", NinSnesBaseProfileId::Standard, NinSnesAddressModelId::Direct,
+     NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
+     NinSnesPanModelId::HalTable, NinSnesInstrumentLayoutId::Standard6Byte, NinSnesInstrTableAddressModelId::Standard,
+     NinSnesIntelliModeId::None},
+
+    {NinSnesProfileId::Konami, "Konami", NinSnesBaseProfileId::Standard, NinSnesAddressModelId::KonamiBase,
+     NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
      NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::KonamiTuningTable,
      NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 
-    {NinSnesProfileId::Lemmings, "Lemmings", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Lemmings, NinSnesProgramResolverId::StandardPercussion,
+    {NinSnesProfileId::Lemmings, "Lemmings", NinSnesBaseProfileId::Standard, NinSnesAddressModelId::Direct,
+     NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Lemmings, NinSnesProgramResolverId::StandardPercussion,
      NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
      NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 
     {NinSnesProfileId::IntelliFe3, "Intelligent Systems FE3", NinSnesBaseProfileId::Intelli,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::IntelliTable, NinSnesProgramResolverId::Direct,
-     NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
+     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::IntelliTable,
+     NinSnesProgramResolverId::Direct, NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
      NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::Fe3},
 
     {NinSnesProfileId::IntelliTa, "Intelligent Systems TA", NinSnesBaseProfileId::Intelli,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::IntelliTaOverride,
-     NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
-     NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::Ta},
+     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard,
+     NinSnesProgramResolverId::IntelliTaOverride, NinSnesPanModelId::StandardTable,
+     NinSnesInstrumentLayoutId::Standard6Byte, NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::Ta},
 
     {NinSnesProfileId::IntelliFe4, "Intelligent Systems FE4", NinSnesBaseProfileId::Intelli,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::IntelliTable, NinSnesProgramResolverId::Direct,
-     NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
+     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::IntelliTable,
+     NinSnesProgramResolverId::Direct, NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
      NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::Fe4},
 
-    {NinSnesProfileId::Human, "Human", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::Direct,
-     NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
-     NinSnesInstrTableAddressModelId::Human, NinSnesIntelliModeId::None},
+    {NinSnesProfileId::Human, "Human", NinSnesBaseProfileId::Standard, NinSnesAddressModelId::Direct,
+     NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::Direct,
+     NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte, NinSnesInstrTableAddressModelId::Human,
+     NinSnesIntelliModeId::None},
 
-    {NinSnesProfileId::Tose, "TOSE", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Tose,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
-     NinSnesPanModelId::ToseLinear, NinSnesInstrumentLayoutId::Standard6Byte,
-     NinSnesInstrTableAddressModelId::Tose, NinSnesIntelliModeId::None},
+    {NinSnesProfileId::Tose, "TOSE", NinSnesBaseProfileId::Standard, NinSnesAddressModelId::Direct,
+     NinSnesPlaylistModelId::Tose, NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
+     NinSnesPanModelId::ToseLinear, NinSnesInstrumentLayoutId::Standard6Byte, NinSnesInstrTableAddressModelId::Tose,
+     NinSnesIntelliModeId::None},
 
-    {NinSnesProfileId::QuintetActR, "Quintet ActRaiser", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::QuintetActRBase,
+    {NinSnesProfileId::QuintetActR, "Quintet ActRaiser", NinSnesBaseProfileId::Standard, NinSnesAddressModelId::Direct,
+     NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::QuintetActRBase,
      NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
      NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 
     {NinSnesProfileId::QuintetActR2, "Quintet ActRaiser 2", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::QuintetLookup,
-     NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
-     NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
+     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard,
+     NinSnesProgramResolverId::QuintetLookup, NinSnesPanModelId::StandardTable,
+     NinSnesInstrumentLayoutId::Standard6Byte, NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 
     {NinSnesProfileId::QuintetIog, "Quintet Illusion of Gaia", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::QuintetLookup,
-     NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
-     NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
+     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard,
+     NinSnesProgramResolverId::QuintetLookup, NinSnesPanModelId::StandardTable,
+     NinSnesInstrumentLayoutId::Standard6Byte, NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 
-    {NinSnesProfileId::QuintetTs, "Quintet Terranigma", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::Direct, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::QuintetLookup,
+    {NinSnesProfileId::QuintetTs, "Quintet Terranigma", NinSnesBaseProfileId::Standard, NinSnesAddressModelId::Direct,
+     NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::QuintetLookup,
      NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
      NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 
     {NinSnesProfileId::FalcomYs4, "Falcom Ys IV", NinSnesBaseProfileId::Standard,
-     NinSnesAddressModelId::FalcomBaseOffset, NinSnesPlaylistModelId::Standard,
-     NinSnesNoteParamModelId::Standard, NinSnesProgramResolverId::StandardPercussion,
-     NinSnesPanModelId::StandardTable, NinSnesInstrumentLayoutId::Standard6Byte,
-     NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
+     NinSnesAddressModelId::FalcomBaseOffset, NinSnesPlaylistModelId::Standard, NinSnesNoteParamModelId::Standard,
+     NinSnesProgramResolverId::StandardPercussion, NinSnesPanModelId::StandardTable,
+     NinSnesInstrumentLayoutId::Standard6Byte, NinSnesInstrTableAddressModelId::Standard, NinSnesIntelliModeId::None},
 }};
 
 }  // namespace
@@ -452,8 +456,7 @@ const NinSnesProfile& getNinSnesProfile(NinSnesProfileId id) {
 
   return kUnknownProfile;
 }
-u16 convertNinSnesAddress(const NinSnesProfile& profile, u16 rawAddress,
-                               u16 konamiBaseAddress, u16 falcomBaseOffset) {
+u16 convertNinSnesAddress(const NinSnesProfile& profile, u16 rawAddress, u16 konamiBaseAddress, u16 falcomBaseOffset) {
   switch (profile.addressModel) {
     case NinSnesAddressModelId::KonamiBase:
       return static_cast<u16>(konamiBaseAddress + rawAddress);
@@ -467,10 +470,9 @@ u16 convertNinSnesAddress(const NinSnesProfile& profile, u16 rawAddress,
   }
 }
 
-u16 readNinSnesAddress(const NinSnesProfile& profile, const RawFile* file, u32 offset,
-                            u16 konamiBaseAddress, u16 falcomBaseOffset) {
-  return convertNinSnesAddress(profile, file->readShort(offset), konamiBaseAddress,
-                               falcomBaseOffset);
+u16 readNinSnesAddress(const NinSnesProfile& profile, const RawFile* file, u32 offset, u16 konamiBaseAddress,
+                       u16 falcomBaseOffset) {
+  return convertNinSnesAddress(profile, file->readShort(offset), konamiBaseAddress, falcomBaseOffset);
 }
 
 u32 getNinSnesInstrumentHeaderSize(const NinSnesProfile& profile) {
@@ -485,8 +487,7 @@ u16 getNinSnesInstrumentSlotCount(const NinSnesProfile& profile) {
   return 0x80;
 }
 
-bool isBlankNinSnesInstrumentSlot(const NinSnesProfile& profile, const RawFile* file,
-                                  u32 addrInstrHeader) {
+bool isBlankNinSnesInstrumentSlot(const NinSnesProfile& profile, const RawFile* file, u32 addrInstrHeader) {
   const u32 instrItemSize = getNinSnesInstrumentHeaderSize(profile);
   if (addrInstrHeader + instrItemSize > 0x10000) {
     return false;
@@ -506,9 +507,8 @@ bool isBlankNinSnesInstrumentSlot(const NinSnesProfile& profile, const RawFile* 
   return allZero || allFF;
 }
 
-bool isValidNinSnesInstrumentHeader(const NinSnesProfile& profile, const RawFile* file,
-                                    u32 addrInstrHeader, u32 spcDirAddr,
-                                    bool validateSample) {
+bool isValidNinSnesInstrumentHeader(const NinSnesProfile& profile, const RawFile* file, u32 addrInstrHeader,
+                                    u32 spcDirAddr, bool validateSample) {
   const u32 instrItemSize = getNinSnesInstrumentHeaderSize(profile);
   if (addrInstrHeader + instrItemSize > 0x10000) {
     return false;
@@ -516,8 +516,7 @@ bool isValidNinSnesInstrumentHeader(const NinSnesProfile& profile, const RawFile
 
   std::vector<u8> instrHeader(instrItemSize);
   file->readBytes(addrInstrHeader, instrItemSize, instrHeader.data());
-  if (std::all_of(instrHeader.cbegin(), instrHeader.cend(),
-                  [](u8 b) { return b == 0x00 || b == 0xFF; })) {
+  if (std::all_of(instrHeader.cbegin(), instrHeader.cend(), [](u8 b) { return b == 0x00 || b == 0xFF; })) {
     return false;
   }
 
@@ -543,25 +542,21 @@ bool isValidNinSnesInstrumentHeader(const NinSnesProfile& profile, const RawFile
 }
 
 bool requiresNinSnesSampleStartAfterDirEntry(const NinSnesProfile& profile) {
-  return profile.baseProfile == NinSnesBaseProfileId::Earlier ||
-         profile.id == NinSnesProfileId::Standard;
+  return profile.baseProfile == NinSnesBaseProfileId::Earlier || profile.id == NinSnesProfileId::Standard;
 }
 
 bool loadsFullNinSnesSampleDirectory(const NinSnesProfile& profile) {
   return profile.intelliMode == NinSnesIntelliModeId::Ta;
 }
 
-u32 resolveNinSnesProgramNumber(const NinSnesProfile& profile, const RawFile* file,
-                                     u8 instrumentByte, u8 percussionStatusMin,
-                                     u8 percussionBase, u8 quintetBgmInstrBase,
-                                     u16 quintetInstrLookupAddr,
-                                     const std::array<u32, 0x80>* intelliInstrumentProgramMap,
-                                     u8* logicalProgram) {
+u32 resolveNinSnesProgramNumber(const NinSnesProfile& profile, const RawFile* file, u8 instrumentByte,
+                                u8 percussionStatusMin, u8 percussionBase, u8 quintetBgmInstrBase,
+                                u16 quintetInstrLookupAddr, const std::array<u32, 0x80>* intelliInstrumentProgramMap,
+                                u8* logicalProgram) {
   u8 resolvedLogicalProgram = instrumentByte;
 
   if (profile.programResolver != NinSnesProgramResolverId::Direct && instrumentByte >= 0x80) {
-    resolvedLogicalProgram =
-        static_cast<u8>((instrumentByte - percussionStatusMin) + percussionBase);
+    resolvedLogicalProgram = static_cast<u8>((instrumentByte - percussionStatusMin) + percussionBase);
   }
 
   switch (profile.programResolver) {
@@ -587,8 +582,7 @@ u32 resolveNinSnesProgramNumber(const NinSnesProfile& profile, const RawFile* fi
   }
 
   if (profile.programResolver == NinSnesProgramResolverId::IntelliTaOverride &&
-      intelliInstrumentProgramMap != nullptr &&
-      resolvedLogicalProgram < intelliInstrumentProgramMap->size()) {
+      intelliInstrumentProgramMap != nullptr && resolvedLogicalProgram < intelliInstrumentProgramMap->size()) {
     return (*intelliInstrumentProgramMap)[resolvedLogicalProgram];
   }
 
@@ -597,19 +591,16 @@ u32 resolveNinSnesProgramNumber(const NinSnesProfile& profile, const RawFile* fi
 
 bool usesNinSnesIntelliCustomPercTable(const NinSnesProfile& profile, bool runtimeCustomPercTable,
                                        u8 intelliPercFlags) {
-  if (profile.intelliMode == NinSnesIntelliModeId::Ta ||
-      profile.intelliMode == NinSnesIntelliModeId::Fe4) {
+  if (profile.intelliMode == NinSnesIntelliModeId::Ta || profile.intelliMode == NinSnesIntelliModeId::Fe4) {
     return (intelliPercFlags & 0x40) != 0;
   }
 
   return runtimeCustomPercTable;
 }
 
-void setNinSnesIntelliCustomPercTableEnabled(const NinSnesProfile& profile, bool enabled,
-                                             bool& runtimeCustomPercTable,
+void setNinSnesIntelliCustomPercTableEnabled(const NinSnesProfile& profile, bool enabled, bool& runtimeCustomPercTable,
                                              u8& intelliPercFlags) {
-  if (profile.intelliMode == NinSnesIntelliModeId::Ta ||
-      profile.intelliMode == NinSnesIntelliModeId::Fe4) {
+  if (profile.intelliMode == NinSnesIntelliModeId::Ta || profile.intelliMode == NinSnesIntelliModeId::Fe4) {
     if (enabled) {
       intelliPercFlags |= 0x40;
     } else {
@@ -621,8 +612,7 @@ void setNinSnesIntelliCustomPercTableEnabled(const NinSnesProfile& profile, bool
   runtimeCustomPercTable = enabled;
 }
 
-u8 readNinSnesPanTable(const NinSnesProfile& profile, const std::vector<u8>& panTable,
-                            u16 pan) {
+u8 readNinSnesPanTable(const NinSnesProfile& profile, const std::vector<u8>& panTable, u16 pan) {
   if (profile.panModel == NinSnesPanModelId::ToseLinear) {
     return 0;
   }
@@ -647,8 +637,8 @@ u8 readNinSnesPanTable(const NinSnesProfile& profile, const std::vector<u8>& pan
   return volumeRate;
 }
 
-void getNinSnesVolumeBalance(const NinSnesProfile& profile, const std::vector<u8>& panTable,
-                             u16 pan, double& volumeLeft, double& volumeRight) {
+void getNinSnesVolumeBalance(const NinSnesProfile& profile, const std::vector<u8>& panTable, u16 pan,
+                             double& volumeLeft, double& volumeRight) {
   u8 panIndex = pan >> 8;
   if (profile.panModel == NinSnesPanModelId::ToseLinear) {
     if (panIndex <= 10) {
@@ -693,10 +683,8 @@ NinSnesPanState decodeNinSnesPanValue(const NinSnesProfile& profile, u8 pan) {
   };
 }
 
-NinSnesSeqDefinition buildNinSnesSeqDefinition(NinSnesProfileId profileId,
-                                               const std::vector<u8>& volumeTable,
-                                               const std::vector<u8>& durRateTable,
-                                               const std::vector<u8>& panTable,
+NinSnesSeqDefinition buildNinSnesSeqDefinition(NinSnesProfileId profileId, const std::vector<u8>& volumeTable,
+                                               const std::vector<u8>& durRateTable, const std::vector<u8>& panTable,
                                                const std::vector<u8>& intelliDurVolTable) {
   const auto& profile = getNinSnesProfile(profileId);
   NinSnesSeqDefinition definition;

--- a/src/main/formats/NinSnes/NinSnesScanResult.h
+++ b/src/main/formats/NinSnes/NinSnesScanResult.h
@@ -20,6 +20,10 @@ struct NinSnesScanResult {
   u32 instrTableAddr = 0;
   u16 spcDirAddr = 0;
 
+  u32 addmusicKCustomInstrTableAddr = 0;
+  u8 addmusicKCustomInstrBase = 0;
+  u8 addmusicKCustomInstrCount = 0;
+
   u16 konamiBaseAddress = 0;
   u16 falcomBaseOffset = 0;
   u8 quintetBGMInstrBase = 0;

--- a/src/main/formats/NinSnes/NinSnesScanner.cpp
+++ b/src/main/formats/NinSnes/NinSnesScanner.cpp
@@ -8,7 +8,9 @@
 #include "NinSnesInstr.h"
 #include "NinSnesSeq.h"
 #include "ScannerManager.h"
+#include "SNESDSP.h"
 
+#include <algorithm>
 #include <array>
 #include <optional>
 
@@ -40,6 +42,17 @@ struct NinSnesInstrumentProbeInfo {
   u16 dirAddress = 0;
 };
 
+struct NinSnesAddmusicKCustomInstrInfo {
+  u32 tableAddress = 0;
+  u8 baseInstrument = 0;
+  u8 count = 0;
+};
+
+struct NinSnesDirProbeInfo {
+  u16 address = 0;
+  u8 score = 0;
+};
+
 template <size_t N>
 bool matchNinSnesByteTable(RawFile* file, u16 offset, const std::array<u8, N>& table) {
   return file->matchBytes(table.data(), offset, table.size());
@@ -54,12 +67,60 @@ std::vector<u8> readNinSnesByteTable(RawFile* file, u16 address, u8 length) {
   return table;
 }
 
-u8 countNinSnesVoiceCommands(u8 firstVoiceCmd, u16 addressTable,
-                                  u16 lengthTable) {
+u8 countNinSnesVoiceCommands(u8 firstVoiceCmd, u16 addressTable, u16 lengthTable) {
   if (addressTable < lengthTable && addressTable + (0x100 - firstVoiceCmd) * 2 >= lengthTable) {
     return static_cast<u8>((lengthTable - addressTable) / 2);
   }
   return 0;
+}
+
+NinSnesDirProbeInfo scoreNinSnesDirAddress(RawFile* file, NinSnesProfileId profileId, u32 instrTableAddress,
+                                           u16 dirAddress) {
+  const auto& profile = getNinSnesProfile(profileId);
+  const u32 instrItemSize = NinSnesInstr::expectedSize(profileId);
+  NinSnesDirProbeInfo info{dirAddress, 0};
+
+  for (u8 instrIndex = 0; instrIndex < 32; instrIndex++) {
+    const u32 addrInstrHeader = instrTableAddress + instrItemSize * instrIndex;
+    if (addrInstrHeader + instrItemSize > 0x10000) {
+      break;
+    }
+
+    const u8 srcn = file->readByte(addrInstrHeader);
+    const u8 adsr1 = file->readByte(addrInstrHeader + 1);
+    const u8 gain = file->readByte(addrInstrHeader + 3);
+    if (srcn >= 0x80 || (adsr1 == 0 && gain == 0)) {
+      continue;
+    }
+
+    if (NinSnesInstr::isValidHeader(file, profileId, addrInstrHeader, dirAddress, true)) {
+      if (requiresNinSnesSampleStartAfterDirEntry(profile)) {
+        const u32 addrDirEntry = dirAddress + srcn * 4;
+        if (file->readShort(addrDirEntry) < addrDirEntry + 4) {
+          continue;
+        }
+      }
+      info.score++;
+    }
+  }
+
+  return info;
+}
+
+std::optional<NinSnesDirProbeInfo> inferNinSnesDirAddress(RawFile* file, NinSnesProfileId profileId,
+                                                          u32 instrTableAddress) {
+  NinSnesDirProbeInfo best;
+  for (u32 dirAddress = 0; dirAddress < 0x10000; dirAddress += 0x100) {
+    const auto candidate = scoreNinSnesDirAddress(file, profileId, instrTableAddress, static_cast<u16>(dirAddress));
+    if (candidate.score > best.score) {
+      best = candidate;
+    }
+  }
+
+  if (best.score < 4) {
+    return std::nullopt;
+  }
+  return best;
 }
 
 constexpr std::array<u8, 27> kStandardVcmdLengthTable = {
@@ -74,15 +135,13 @@ constexpr std::array<u8, 40> kIntelliFe3VcmdLengthTable = {
 };
 
 constexpr std::array<u8, 36> kIntelliFe4VcmdLengthTable = {
-    0x01, 0x01, 0x02, 0x03, 0x00, 0x01, 0x02, 0x01, 0x02, 0x01, 0x01, 0x03,
-    0x00, 0x01, 0x02, 0x03, 0x01, 0x03, 0x03, 0x00, 0x01, 0x03, 0x00, 0x03,
-    0x03, 0x03, 0x01, 0x00, 0x00, 0x02, 0x01, 0x00, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x01, 0x02, 0x03, 0x00, 0x01, 0x02, 0x01, 0x02, 0x01, 0x01, 0x03, 0x00, 0x01, 0x02, 0x03, 0x01, 0x03,
+    0x03, 0x00, 0x01, 0x03, 0x00, 0x03, 0x03, 0x03, 0x01, 0x00, 0x00, 0x02, 0x01, 0x00, 0x01, 0x01, 0x01, 0x01,
 };
 
 constexpr std::array<u8, 36> kIntelliTaVcmdLengthTable = {
-    0x01, 0x01, 0x02, 0x03, 0x00, 0x01, 0x02, 0x01, 0x02, 0x01, 0x01, 0x03,
-    0x00, 0x01, 0x02, 0x03, 0x01, 0x03, 0x03, 0x00, 0x01, 0x03, 0x00, 0x03,
-    0x03, 0x03, 0x01, 0x00, 0x00, 0x02, 0x02, 0x00, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x01, 0x02, 0x03, 0x00, 0x01, 0x02, 0x01, 0x02, 0x01, 0x01, 0x03, 0x00, 0x01, 0x02, 0x03, 0x01, 0x03,
+    0x03, 0x00, 0x01, 0x03, 0x00, 0x03, 0x03, 0x03, 0x01, 0x00, 0x00, 0x02, 0x02, 0x00, 0x01, 0x01, 0x01, 0x01,
 };
 
 }  // namespace
@@ -96,21 +155,24 @@ void NinSnesScanner::scan(RawFile* file, void* info) {
   }
 }
 
-void NinSnesScanner::loadFromScanResult(RawFile* file, const NinSnesScanResult& scanResult) {
+bool NinSnesScanner::loadFromScanResult(RawFile* file, const NinSnesScanResult& scanResult,
+                                        bool loadInstrumentSet) {
   auto* newSeq = pRoot->loadVGMFile<NinSnesSeq>(file, scanResult);
   if (!newSeq) {
-    return;
+    return false;
   }
 
-  if (scanResult.profile == NinSnesProfileId::Unknown || scanResult.instrTableAddr == 0 ||
-      scanResult.spcDirAddr == 0) {
-    return;
+  if (!loadInstrumentSet || scanResult.profile == NinSnesProfileId::Unknown ||
+      scanResult.instrTableAddr == 0 || scanResult.spcDirAddr == 0) {
+    return true;
   }
 
   auto* newInstrSet = pRoot->loadVGMFile<NinSnesInstrSet>(file, scanResult);
   if (!newInstrSet) {
-    return;
+    return true;
   }
+
+  return true;
 }
 
 void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
@@ -150,6 +212,7 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
     const BytePattern ptnInitSectionPtr = makeInitSectionPtrPattern(addrSectionPtr);
     const BytePattern ptnInitSectionPtrYI = makeInitSectionPtrYIPattern(addrSectionPtr);
     const BytePattern ptnInitSectionPtrSMW = makeInitSectionPtrSMWPattern(addrSectionPtr);
+    const BytePattern ptnInitSectionPtrSMWAddmusicK = makeInitSectionPtrSMWAddmusicKPattern(addrSectionPtr);
     const BytePattern ptnInitSectionPtrGD3 = makeInitSectionPtrGD3Pattern(addrSectionPtr);
     const BytePattern ptnInitSectionPtrYSFR = makeInitSectionPtrYSFRPattern(addrSectionPtr);
     const BytePattern ptnInitSectionPtrTS = makeInitSectionPtrTSPattern(addrSectionPtr);
@@ -178,6 +241,14 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
     if (file->searchBytePattern(ptnInitSectionPtrSMW, ofsInitSectionPtr)) {
       info.signature = NinSnesSignatureId::Earlier;
       info.address = file->readShort(ofsInitSectionPtr + 3);
+      return info;
+    }
+
+    if (file->searchBytePattern(ptnInitSectionPtrSMWAddmusicK, ofsInitSectionPtr)) {
+      info.signature = NinSnesSignatureId::Earlier;
+      info.profileId = NinSnesProfileId::AddmusicK;
+      // AddmusicK keeps a dummy word before the real song pointer list.
+      info.address = file->readShort(ofsInitSectionPtr + 3) + 2;
       return info;
     }
 
@@ -211,8 +282,7 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
         return std::nullopt;
       }
 
-      info.address =
-          file->readByte(ofsInitSongListPtr + 1) | (file->readByte(ofsInitSongListPtr + 4) << 8);
+      info.address = file->readByte(ofsInitSongListPtr + 1) | (file->readByte(ofsInitSongListPtr + 4) << 8);
       return info;
     }
 
@@ -254,10 +324,8 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
 
       info.firstVoiceCmd = file->readByte(ofsReadVcmdLength + 2);
       info.lengthTable = file->readShort(ofsReadVcmdLength + 7);
-      info.profileId =
-          info.firstVoiceCmd == 0xe0 ? NinSnesProfileId::Tose : NinSnesProfileId::Unknown;
-      info.numCommands =
-          countNinSnesVoiceCommands(info.firstVoiceCmd, info.addressTable, info.lengthTable);
+      info.profileId = info.firstVoiceCmd == 0xe0 ? NinSnesProfileId::Tose : NinSnesProfileId::Unknown;
+      info.numCommands = countNinSnesVoiceCommands(info.firstVoiceCmd, info.addressTable, info.lengthTable);
       return info;
     }
 
@@ -271,8 +339,7 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
 
       info.firstVoiceCmd = file->readByte(ofsReadVcmdLength + 1);
       info.lengthTable = file->readShort(ofsReadVcmdLength + 9) + info.firstVoiceCmd;
-      info.numCommands =
-          countNinSnesVoiceCommands(info.firstVoiceCmd, info.addressTable, info.lengthTable);
+      info.numCommands = countNinSnesVoiceCommands(info.firstVoiceCmd, info.addressTable, info.lengthTable);
       return info;
     }
 
@@ -300,19 +367,24 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
       }
     } else if (file->searchBytePattern(ptnJumpToVcmdSMW, ofsJumpToVcmd)) {
       u32 ofsReadVcmdLength;
-      if (!file->searchBytePattern(ptnReadVcmdLengthSMW, ofsReadVcmdLength)) {
+      if (file->searchBytePattern(ptnReadVcmdLengthSMW, ofsReadVcmdLength)) {
+        info.lengthTable = file->readShort(ofsReadVcmdLength + 9) + info.firstVoiceCmd;
+      } else if (file->searchBytePattern(ptnReadVcmdLengthSMWAddmusicK, ofsReadVcmdLength)) {
+        info.profileId = NinSnesProfileId::AddmusicK;
+        info.lengthTable = file->readShort(ofsReadVcmdLength + 35) + info.firstVoiceCmd;
+      } else {
         return std::nullopt;
       }
 
-      info.profileId = NinSnesProfileId::Earlier;
+      if (info.profileId == NinSnesProfileId::Unknown) {
+        info.profileId = NinSnesProfileId::Earlier;
+      }
       info.addressTable = file->readShort(ofsJumpToVcmd + 5) + ((info.firstVoiceCmd * 2) & 0xff);
-      info.lengthTable = file->readShort(ofsReadVcmdLength + 9) + info.firstVoiceCmd;
     } else {
       return std::nullopt;
     }
 
-    info.numCommands =
-        countNinSnesVoiceCommands(info.firstVoiceCmd, info.addressTable, info.lengthTable);
+    info.numCommands = countNinSnesVoiceCommands(info.firstVoiceCmd, info.addressTable, info.lengthTable);
     return info;
   };
 
@@ -338,8 +410,7 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
   u16 addrVolumeTable = 0;
   std::vector<u8> durRateTable;
   std::vector<u8> volumeTable;
-  auto loadNoteTable = [&](const BytePattern& pattern, u8 durTableOffset,
-                           u8 volumeTableOffset) -> bool {
+  auto loadNoteTable = [&](const BytePattern& pattern, u8 durTableOffset, u8 volumeTableOffset) -> bool {
     if (!file->searchBytePattern(pattern, ofsDispatchNote)) {
       return false;
     }
@@ -363,21 +434,18 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
     }
 
     if (file->searchBytePattern(ptnDispatchNoteFE3, ofsDispatchNote)) {
-      return firstVoiceCmd == 0xd6 && matchNinSnesByteTable(file, addrVoiceCmdLengthTable,
-                                                            kIntelliFe3VcmdLengthTable)
+      return firstVoiceCmd == 0xd6 && matchNinSnesByteTable(file, addrVoiceCmdLengthTable, kIntelliFe3VcmdLengthTable)
                  ? NinSnesProfileId::IntelliFe3
                  : NinSnesProfileId::Unknown;
     }
 
     if (file->searchBytePattern(ptnDispatchNoteFE4, ofsDispatchNote)) {
-      return firstVoiceCmd == 0xda && matchNinSnesByteTable(file, addrVoiceCmdLengthTable,
-                                                            kIntelliFe4VcmdLengthTable)
+      return firstVoiceCmd == 0xda && matchNinSnesByteTable(file, addrVoiceCmdLengthTable, kIntelliFe4VcmdLengthTable)
                  ? NinSnesProfileId::IntelliFe4
                  : NinSnesProfileId::Unknown;
     }
 
-    return firstVoiceCmd == 0xda &&
-                   matchNinSnesByteTable(file, addrVoiceCmdLengthTable, kIntelliTaVcmdLengthTable)
+    return firstVoiceCmd == 0xda && matchNinSnesByteTable(file, addrVoiceCmdLengthTable, kIntelliTaVcmdLengthTable)
                ? NinSnesProfileId::IntelliTa
                : NinSnesProfileId::Unknown;
   };
@@ -391,8 +459,7 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
       return firstVoiceCmd == 0xe0 ? NinSnesProfileId::Lemmings : NinSnesProfileId::Unknown;
     }
 
-    if (firstVoiceCmd != 0xe0 ||
-        !matchNinSnesByteTable(file, addrVoiceCmdLengthTable, kStandardVcmdLengthTable)) {
+    if (firstVoiceCmd != 0xe0 || !matchNinSnesByteTable(file, addrVoiceCmdLengthTable, kStandardVcmdLengthTable)) {
       return classifyIntelligentProfile();
     }
 
@@ -415,8 +482,7 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
 
     u32 ofsRD1VCmd_FA_FE;
     u32 ofsRD2VCmdInstrADSR;
-    const bool hasQuintetLookupTail =
-        numOfVoiceCmd == 32 && file->readByte(addrVoiceCmdLengthTable + 31) == 1;
+    const bool hasQuintetLookupTail = numOfVoiceCmd == 32 && file->readByte(addrVoiceCmdLengthTable + 31) == 1;
 
     if (file->searchBytePattern(ptnRD1VCmd_FA_FE, ofsRD1VCmd_FA_FE)) {
       return NinSnesProfileId::Rd1;
@@ -455,8 +521,7 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
 
     case NinSnesProgramResolverId::QuintetLookup:
       signature = NinSnesSignatureId::Quintet;
-      quintetAddrBGMInstrLookup =
-          file->readShort(ofsInstrVCmd + (profile.id == NinSnesProfileId::QuintetTs ? 18 : 19));
+      quintetAddrBGMInstrLookup = file->readShort(ofsInstrVCmd + (profile.id == NinSnesProfileId::QuintetTs ? 18 : 19));
       break;
 
     case NinSnesProgramResolverId::Direct:
@@ -469,8 +534,7 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
   auto readSectionListPtr = [&](u32 addrSectionListPtr) -> u16 {
     u16 firstSectionPtr = file->readShort(addrSectionListPtr);
     if (profile.addressModel == NinSnesAddressModelId::KonamiBase) {
-      firstSectionPtr =
-          convertNinSnesAddress(profile, firstSectionPtr, konamiBaseAddress, falcomBaseOffset);
+      firstSectionPtr = convertNinSnesAddress(profile, firstSectionPtr, konamiBaseAddress, falcomBaseOffset);
     }
     return firstSectionPtr;
   };
@@ -491,8 +555,7 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
         return true;
       }
 
-      addrTrackStart =
-          convertNinSnesAddress(profile, addrTrackStart, konamiBaseAddress, falcomBaseOffset);
+      addrTrackStart = convertNinSnesAddress(profile, addrTrackStart, konamiBaseAddress, falcomBaseOffset);
       if ((addrTrackStart & 0xff00) == 0 || addrTrackStart == 0xffff) {
         return true;
       }
@@ -503,6 +566,12 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
   auto findSongListLength = [&]() -> u8 {
     u8 songListLength = 1;
     u16 addrSectionListCutoff = 0xffff;
+    if (profile.id == NinSnesProfileId::AddmusicK) {
+      const u16 firstSectionListPtr = readSectionListPtr(addrSongList);
+      if (firstSectionListPtr >= 0x0100 && firstSectionListPtr < 0xfff0) {
+        addrSectionListCutoff = firstSectionListPtr;
+      }
+    }
 
     for (u8 songIndex = 1; songIndex <= 0x7f; songIndex++) {
       const u32 addrSectionListPtr = addrSongList + songIndex * 2;
@@ -527,8 +596,7 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
       }
 
       updateFalcomBaseOffset(firstSectionPtr);
-      addrFirstSection =
-          convertNinSnesAddress(profile, addrFirstSection, konamiBaseAddress, falcomBaseOffset);
+      addrFirstSection = convertNinSnesAddress(profile, addrFirstSection, konamiBaseAddress, falcomBaseOffset);
       if (addrFirstSection + 16 > 0x10000 || hasIllegalTrackPointers(addrFirstSection)) {
         break;
       }
@@ -553,16 +621,14 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
 
       const u16 firstSectionPtr = readSectionListPtr(addrSectionListPtr);
       updateFalcomBaseOffset(firstSectionPtr);
-      if (firstSectionPtr > addrCurrentSection ||
-          (addrCurrentSection % 2) != (firstSectionPtr % 2)) {
+      if (firstSectionPtr > addrCurrentSection || (addrCurrentSection % 2) != (firstSectionPtr % 2)) {
         continue;
       }
 
       u16 curAddress = firstSectionPtr;
       u8 sectionCount = 0;
       while (curAddress >= 0x0100 && curAddress < 0xfff0 && sectionCount < 32) {
-        const u16 addrSection =
-            readNinSnesAddress(profile, file, curAddress, konamiBaseAddress, falcomBaseOffset);
+        const u16 addrSection = readNinSnesAddress(profile, file, curAddress, konamiBaseAddress, falcomBaseOffset);
         if (curAddress == addrCurrentSection) {
           return songIndex;
         }
@@ -578,17 +644,152 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
     return std::nullopt;
   };
 
-  const u8 songListLength = findSongListLength();
-  const auto guessedSongIndex = findCurrentSongIndex(songListLength);
-  if (!guessedSongIndex) {
-    return;
-  }
+  auto scoreFallbackSongIndex = [&](u8 songIndex) -> std::optional<u32> {
+    const u16 firstSectionPtr = readSectionListPtr(addrSongList + songIndex * 2);
+    if (firstSectionPtr < 0x0100 || firstSectionPtr >= 0xfff0) {
+      return std::nullopt;
+    }
 
-  // load the song
-  u16 addrSongStart = file->readShort(addrSongList + (*guessedSongIndex) * 2);
-  if (profile.addressModel == NinSnesAddressModelId::KonamiBase) {
-    addrSongStart =
-        convertNinSnesAddress(profile, addrSongStart, konamiBaseAddress, falcomBaseOffset);
+    updateFalcomBaseOffset(firstSectionPtr);
+    u16 addrFirstSection =
+        convertNinSnesAddress(profile, file->readShort(firstSectionPtr), konamiBaseAddress, falcomBaseOffset);
+    if (addrFirstSection + 16 > 0x10000 || hasIllegalTrackPointers(addrFirstSection)) {
+      return std::nullopt;
+    }
+
+    u8 trackCount = 0;
+    u16 minTrackStart = 0xffff;
+    u16 maxTrackStart = 0;
+    for (u8 trackIndex = 0; trackIndex < 8; trackIndex++) {
+      const u16 addrTrackStart =
+          convertNinSnesAddress(profile, file->readShort(addrFirstSection + trackIndex * 2), konamiBaseAddress,
+                                falcomBaseOffset);
+      if (addrTrackStart < 0x0100 || addrTrackStart >= 0xfff0) {
+        continue;
+      }
+
+      trackCount++;
+      minTrackStart = std::min(minTrackStart, addrTrackStart);
+      maxTrackStart = std::max(maxTrackStart, addrTrackStart);
+    }
+
+    if (trackCount == 0) {
+      return std::nullopt;
+    }
+
+    return (static_cast<u32>(trackCount) << 16) + (maxTrackStart - minTrackStart);
+  };
+
+  auto findFallbackSongIndex = [&](u8 songListLength) -> std::optional<u8> {
+    std::optional<u8> bestSongIndex;
+    u32 bestScore = 0;
+
+    for (u8 songIndex = 0; songIndex < songListLength; songIndex++) {
+      const auto score = scoreFallbackSongIndex(songIndex);
+      if (!score) {
+        continue;
+      }
+
+      if (profile.id != NinSnesProfileId::AddmusicK) {
+        return songIndex;
+      }
+      if (!bestSongIndex || *score > bestScore) {
+        bestSongIndex = songIndex;
+        bestScore = *score;
+      }
+    }
+
+    return bestSongIndex;
+  };
+
+  auto findValidSongIndexes = [&](u8 songListLength) -> std::vector<u8> {
+    std::vector<u8> songIndexes;
+    for (u8 songIndex = 0; songIndex < songListLength; songIndex++) {
+      if (scoreFallbackSongIndex(songIndex)) {
+        songIndexes.push_back(songIndex);
+      }
+    }
+    return songIndexes;
+  };
+
+  auto findAddmusicKCustomInstrInfo = [&](u16 songStartAddr,
+                                          u16 spcDirAddr) -> std::optional<NinSnesAddmusicKCustomInstrInfo> {
+    if (profile.id != NinSnesProfileId::AddmusicK || songStartAddr < 0x0100 || songStartAddr >= 0xfff0) {
+      return std::nullopt;
+    }
+
+    u32 curOffset = songStartAddr;
+    u16 firstSectionAddr = 0xffff;
+    for (u8 sectionIndex = 0; sectionIndex < 32; sectionIndex++) {
+      if (curOffset + 2 > 0x10000) {
+        return std::nullopt;
+      }
+
+      const u16 sectionAddress = readNinSnesAddress(profile, file, curOffset, konamiBaseAddress, falcomBaseOffset);
+      curOffset += 2;
+      if (sectionAddress == 0) {
+        break;
+      }
+      if (sectionAddress <= 0xff) {
+        if (curOffset + 2 > 0x10000) {
+          return std::nullopt;
+        }
+        curOffset += 2;
+        break;
+      }
+      if (sectionAddress < 0xfff0) {
+        firstSectionAddr = std::min(firstSectionAddr, sectionAddress);
+      }
+    }
+
+    if (firstSectionAddr == 0xffff || firstSectionAddr <= curOffset ||
+        ((firstSectionAddr - curOffset) % 6) != 0) {
+      return std::nullopt;
+    }
+
+    const u32 entryCount = (firstSectionAddr - curOffset) / 6;
+    if (entryCount == 0 || entryCount > 0x40) {
+      return std::nullopt;
+    }
+
+    for (u32 entryIndex = 0; entryIndex < entryCount; entryIndex++) {
+      const u32 entryOffset = curOffset + entryIndex * 6;
+      const u8 srcn = file->readByte(entryOffset);
+      if (srcn >= 0x80) {
+        return std::nullopt;
+      }
+
+      const u32 dirEntryOffset = spcDirAddr + srcn * 4;
+      if (dirEntryOffset + 4 > 0x10000 || !SNESSampColl::isValidSampleDir(file, dirEntryOffset, true)) {
+        return std::nullopt;
+      }
+      if (requiresNinSnesSampleStartAfterDirEntry(profile) && file->readShort(dirEntryOffset) < dirEntryOffset + 4) {
+        return std::nullopt;
+      }
+    }
+
+    return NinSnesAddmusicKCustomInstrInfo{
+        .tableAddress = curOffset,
+        .baseInstrument = 0x1e,
+        .count = static_cast<u8>(entryCount),
+    };
+  };
+
+  const u8 songListLength = findSongListLength();
+  std::vector<u8> songIndexesToLoad;
+  if (profile.id == NinSnesProfileId::AddmusicK) {
+    songIndexesToLoad = findValidSongIndexes(songListLength);
+  } else {
+    auto guessedSongIndex = findCurrentSongIndex(songListLength);
+    if (!guessedSongIndex) {
+      guessedSongIndex = findFallbackSongIndex(songListLength);
+    }
+    if (guessedSongIndex) {
+      songIndexesToLoad.push_back(*guessedSongIndex);
+    }
+  }
+  if (songIndexesToLoad.empty()) {
+    return;
   }
 
   auto findDirAddress = [&]() -> std::optional<u16> {
@@ -623,23 +824,25 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
     u32 ofsLoadInstrTableAddressASM;
     NinSnesInstrumentProbeInfo info;
     if (file->searchBytePattern(ptnLoadInstrTableAddress, ofsLoadInstrTableAddressASM)) {
-      info.tableAddress = file->readByte(ofsLoadInstrTableAddressASM + 7) |
-                          (file->readByte(ofsLoadInstrTableAddressASM + 10) << 8);
+      info.tableAddress =
+          file->readByte(ofsLoadInstrTableAddressASM + 7) | (file->readByte(ofsLoadInstrTableAddressASM + 10) << 8);
       const u32 firstWord = file->readWord(info.tableAddress);
       if (firstWord == 0 || firstWord == 0xFFFFFFFF) {
         info.tableAddress += 4;
       }
     } else if (file->searchBytePattern(ptnLoadInstrTableAddressSMW, ofsLoadInstrTableAddressASM)) {
-      info.tableAddress = file->readByte(ofsLoadInstrTableAddressASM + 3) |
-                          (file->readByte(ofsLoadInstrTableAddressASM + 6) << 8);
+      info.tableAddress =
+          file->readByte(ofsLoadInstrTableAddressASM + 3) | (file->readByte(ofsLoadInstrTableAddressASM + 6) << 8);
+    } else if (file->searchBytePattern(ptnLoadInstrTableAddressSMWAddmusicK, ofsLoadInstrTableAddressASM)) {
+      info.tableAddress =
+          file->readByte(ofsLoadInstrTableAddressASM + 1) | (file->readByte(ofsLoadInstrTableAddressASM + 4) << 8);
     } else {
       switch (profile.instrTableAddressModel) {
         case NinSnesInstrTableAddressModelId::Human:
           if (file->searchBytePattern(ptnLoadInstrTableAddressCTOW, ofsLoadInstrTableAddressASM)) {
             info.tableAddress = file->readByte(ofsLoadInstrTableAddressASM + 7) |
                                 (file->readByte(ofsLoadInstrTableAddressASM + 10) << 8);
-          } else if (file->searchBytePattern(ptnLoadInstrTableAddressSOS,
-                                             ofsLoadInstrTableAddressASM)) {
+          } else if (file->searchBytePattern(ptnLoadInstrTableAddressSOS, ofsLoadInstrTableAddressASM)) {
             info.tableAddress = file->readByte(ofsLoadInstrTableAddressASM + 1) |
                                 (file->readByte(ofsLoadInstrTableAddressASM + 4) << 8);
           } else {
@@ -665,9 +868,22 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
     if (info.dirAddress == 0) {
       const auto dirAddress = findDirAddress();
       if (!dirAddress) {
-        return std::nullopt;
+        const auto inferredDirAddress = inferNinSnesDirAddress(file, profile.id, info.tableAddress);
+        if (!inferredDirAddress) {
+          return std::nullopt;
+        }
+        info.dirAddress = inferredDirAddress->address;
+        return info;
       }
       info.dirAddress = *dirAddress;
+    }
+
+    if (profile.id == NinSnesProfileId::AddmusicK) {
+      const auto currentDirScore = scoreNinSnesDirAddress(file, profile.id, info.tableAddress, info.dirAddress);
+      const auto inferredDirAddress = inferNinSnesDirAddress(file, profile.id, info.tableAddress);
+      if (inferredDirAddress && inferredDirAddress->score > currentDirScore.score) {
+        info.dirAddress = inferredDirAddress->address;
+      }
     }
 
     return info;
@@ -697,24 +913,58 @@ void NinSnesScanner::searchForNinSnesFromARAM(RawFile* file) {
     }
   }
 
-  NinSnesScanResult scanResult;
-  scanResult.signature = signature;
-  scanResult.profile = profileId;
-  scanResult.name = name;
-  scanResult.songIndex = *guessedSongIndex;
-  scanResult.songListAddr = addrSongList;
-  scanResult.songStartAddr = addrSongStart;
-  scanResult.sectionPtrAddr = addrSectionPtr;
-  scanResult.instrTableAddr = addrInstrTable;
-  scanResult.spcDirAddr = spcDirAddr;
-  scanResult.konamiBaseAddress = konamiBaseAddress == 0xffff ? 0 : konamiBaseAddress;
-  scanResult.falcomBaseOffset = falcomBaseOffset;
-  scanResult.quintetBGMInstrBase = quintetBGMInstrBase;
-  scanResult.quintetAddrBGMInstrLookup = quintetAddrBGMInstrLookup;
-  scanResult.konamiTuningTableAddress = konamiTuningTableAddress;
-  scanResult.konamiTuningTableSize = konamiTuningTableSize;
-  scanResult.volumeTable = std::move(volumeTable);
-  scanResult.durRateTable = std::move(durRateTable);
+  NinSnesScanResult baseScanResult;
+  baseScanResult.signature = signature;
+  baseScanResult.profile = profileId;
+  baseScanResult.songListAddr = addrSongList;
+  baseScanResult.sectionPtrAddr = addrSectionPtr;
+  baseScanResult.instrTableAddr = addrInstrTable;
+  baseScanResult.spcDirAddr = spcDirAddr;
+  baseScanResult.konamiBaseAddress = konamiBaseAddress == 0xffff ? 0 : konamiBaseAddress;
+  baseScanResult.falcomBaseOffset = falcomBaseOffset;
+  baseScanResult.quintetBGMInstrBase = quintetBGMInstrBase;
+  baseScanResult.quintetAddrBGMInstrLookup = quintetAddrBGMInstrLookup;
+  baseScanResult.konamiTuningTableAddress = konamiTuningTableAddress;
+  baseScanResult.konamiTuningTableSize = konamiTuningTableSize;
+  baseScanResult.volumeTable = volumeTable;
+  baseScanResult.durRateTable = durRateTable;
 
-  loadFromScanResult(file, scanResult);
+  const bool appendSongIndex = profile.id == NinSnesProfileId::AddmusicK || songIndexesToLoad.size() > 1;
+  std::vector<NinSnesScanResult> scanResults;
+  for (const u8 songIndex : songIndexesToLoad) {
+    NinSnesScanResult scanResult = baseScanResult;
+    scanResult.name = appendSongIndex ? name + " (index " + std::to_string(songIndex) + ")" : name;
+    scanResult.songIndex = songIndex;
+    scanResult.songStartAddr = file->readShort(addrSongList + songIndex * 2);
+    if (profile.addressModel == NinSnesAddressModelId::KonamiBase) {
+      scanResult.songStartAddr =
+          convertNinSnesAddress(profile, scanResult.songStartAddr, konamiBaseAddress, falcomBaseOffset);
+    }
+
+    if (const auto customInstrInfo =
+            findAddmusicKCustomInstrInfo(static_cast<u16>(scanResult.songStartAddr), scanResult.spcDirAddr)) {
+      scanResult.addmusicKCustomInstrTableAddr = customInstrInfo->tableAddress;
+      scanResult.addmusicKCustomInstrBase = customInstrInfo->baseInstrument;
+      scanResult.addmusicKCustomInstrCount = customInstrInfo->count;
+    }
+
+    scanResults.push_back(scanResult);
+  }
+
+  std::stable_sort(scanResults.begin(), scanResults.end(), [](const auto& lhs, const auto& rhs) {
+    const bool lhsHasCustomInstruments = lhs.addmusicKCustomInstrCount != 0;
+    const bool rhsHasCustomInstruments = rhs.addmusicKCustomInstrCount != 0;
+    if (lhsHasCustomInstruments != rhsHasCustomInstruments) {
+      return lhsHasCustomInstruments;
+    }
+    return lhs.songStartAddr > rhs.songStartAddr;
+  });
+
+  bool loadedInstrumentSet = false;
+  for (const auto& scanResult : scanResults) {
+    const bool loadInstrumentSet = scanResult.addmusicKCustomInstrCount != 0 || !loadedInstrumentSet;
+    if (loadFromScanResult(file, scanResult, loadInstrumentSet) && scanResult.addmusicKCustomInstrCount == 0) {
+      loadedInstrumentSet = true;
+    }
+  }
 }

--- a/src/main/formats/NinSnes/NinSnesScanner.h
+++ b/src/main/formats/NinSnes/NinSnesScanner.h
@@ -18,10 +18,12 @@ public:
   void searchForNinSnesFromARAM(RawFile* file);
 
 private:
-  void loadFromScanResult(RawFile* file, const NinSnesScanResult& scanResult);
+  bool loadFromScanResult(RawFile* file, const NinSnesScanResult& scanResult,
+                          bool loadInstrumentSet = true);
   static BytePattern makeInitSectionPtrPattern(u8 addrSectionPtr);
   static BytePattern makeInitSectionPtrYIPattern(u8 addrSectionPtr);
   static BytePattern makeInitSectionPtrSMWPattern(u8 addrSectionPtr);
+  static BytePattern makeInitSectionPtrSMWAddmusicKPattern(u8 addrSectionPtr);
   static BytePattern makeInitSectionPtrGD3Pattern(u8 addrSectionPtr);
   static BytePattern makeInitSectionPtrYSFRPattern(u8 addrSectionPtr);
   static BytePattern makeInitSectionPtrTSPattern(u8 addrSectionPtr);
@@ -33,10 +35,12 @@ private:
   static BytePattern ptnJumpToVcmd;
   static BytePattern ptnJumpToVcmdSMW;
   static BytePattern ptnReadVcmdLengthSMW;
+  static BytePattern ptnReadVcmdLengthSMWAddmusicK;
   static BytePattern ptnDispatchNoteYI;
   static BytePattern ptnIncSectionPtr;
   static BytePattern ptnLoadInstrTableAddress;
   static BytePattern ptnLoadInstrTableAddressSMW;
+  static BytePattern ptnLoadInstrTableAddressSMWAddmusicK;
   static BytePattern ptnSetDIR;
   static BytePattern ptnSetDIRYI;
   static BytePattern ptnSetDIRVS;

--- a/src/main/formats/NinSnes/NinSnesScannerPatterns.cpp
+++ b/src/main/formats/NinSnes/NinSnesScannerPatterns.cpp
@@ -42,12 +42,19 @@ BytePattern NinSnesScanner::makeInitSectionPtrYIPattern(u8 addrSectionPtr) {
 }
 
 BytePattern NinSnesScanner::makeInitSectionPtrSMWPattern(u8 addrSectionPtr) {
-  return makePatchedBytePattern(
-      "\x1c\xfd\xf6\x5e\x13\xc4\x40\xf6"
-      "\x5f\x13\xc4\x41",
-      "xxx??xxx"
-      "??xx",
-      {{6, addrSectionPtr}, {11, static_cast<u8>(addrSectionPtr + 1)}});
+  return makePatchedBytePattern("\x1c\xfd\xf6\x5e\x13\xc4\x40\xf6"
+                                "\x5f\x13\xc4\x41",
+                                "xxx??xxx"
+                                "??xx",
+                                {{6, addrSectionPtr}, {11, static_cast<u8>(addrSectionPtr + 1)}});
+}
+
+BytePattern NinSnesScanner::makeInitSectionPtrSMWAddmusicKPattern(u8 addrSectionPtr) {
+  return makePatchedBytePattern("\x1c\xfd\xf6\x5b\x23\x2d\xc4\x40"
+                                "\xf6\x5c\x23\x2d\xc4\x41",
+                                "xxx??xxx"
+                                "x??xxx",
+                                {{7, addrSectionPtr}, {13, static_cast<u8>(addrSectionPtr + 1)}});
 }
 
 BytePattern NinSnesScanner::makeInitSectionPtrGD3Pattern(u8 addrSectionPtr) {
@@ -59,12 +66,11 @@ BytePattern NinSnesScanner::makeInitSectionPtrGD3Pattern(u8 addrSectionPtr) {
 }
 
 BytePattern NinSnesScanner::makeInitSectionPtrYSFRPattern(u8 addrSectionPtr) {
-  return makePatchedBytePattern(
-      "\xfd\xf7\x48\xc4\x4c\xfc\xf7\x48"
-      "\xc4\x4d",
-      "xx?xxxx?"
-      "xx",
-      {{4, addrSectionPtr}, {9, static_cast<u8>(addrSectionPtr + 1)}});
+  return makePatchedBytePattern("\xfd\xf7\x48\xc4\x4c\xfc\xf7\x48"
+                                "\xc4\x4d",
+                                "xx?xxxx?"
+                                "xx",
+                                {{4, addrSectionPtr}, {9, static_cast<u8>(addrSectionPtr + 1)}});
 }
 
 BytePattern NinSnesScanner::makeInitSectionPtrTSPattern(u8 addrSectionPtr) {
@@ -86,9 +92,8 @@ BytePattern NinSnesScanner::makeInitSectionPtrYs4Pattern(u8 addrSectionPtr) {
 }
 
 BytePattern NinSnesScanner::makeInitSongListPtrYSFRPattern(u8 addrSongListPtr) {
-  return makePatchedBytePattern(
-      "\x8f\x00\x48\x8f\x1e\x49", "x?xx?x",
-      {{2, addrSongListPtr}, {5, static_cast<u8>(addrSongListPtr + 1)}});
+  return makePatchedBytePattern("\x8f\x00\x48\x8f\x1e\x49", "x?xx?x",
+                                {{2, addrSongListPtr}, {5, static_cast<u8>(addrSongListPtr + 1)}});
 }
 
 //; Yoshi's Island SPC
@@ -163,6 +168,25 @@ BytePattern NinSnesScanner::ptnReadVcmdLengthSMW("\x68\xda\x90\x0a\x6d\xfd\xae\x
                                                  "x??xx?",
                                                  14);
 
+//; AddmusicK-style Super Mario World SPC
+//; read vcmd length table
+// 14e8: 68 da     cmp   a,#$da
+// ...
+// 1509: fd        mov   y,a
+// 150a: ae        pop   a
+// 150b: 60        clrc
+// 150c: 96 04 13  adc   a,$1304+y
+// 150f: fd        mov   y,a
+BytePattern NinSnesScanner::ptnReadVcmdLengthSMWAddmusicK("\x68\xda\x90\x24\x6d\x68\xfb\xd0"
+                                                          "\x16\xee\xfc\xf7\x14\x10\x06\xdd"
+                                                          "\x60\x88\x03\x2f\x10\xc4\x10\xdd"
+                                                          "\x60\x84\x10\xbc\xbc\x2f\x06\xfd"
+                                                          "\xae\x60\x96\x04\x13\xfd\x2f\xc9",
+                                                          "x?x?????????????"
+                                                          "????????????????"
+                                                          "xxx??xx?",
+                                                          40);
+
 //; Yoshi's Island SPC
 // 07fb: 2d        push  a
 // 07fc: 9f        xcn   a
@@ -224,6 +248,28 @@ BytePattern NinSnesScanner::ptnLoadInstrTableAddressSMW("\x8d\x05\x8f\x46\x14\x8
                                                         "xxx??x??"
                                                         "xx?x?",
                                                         13);
+
+//; AddmusicK-style Super Mario World SPC
+// 0d52: 8f 44 14  mov   $14,#$44
+// 0d55: 8f 18 15  mov   $15,#$18          ; instrument table base = $1844
+// ...
+// 0d75: 8d 06     mov   y,#$06
+// 0d77: cf        mul   ya
+// 0d78: 7a 14     addw  ya,$14
+// 0d7a: da 14     movw  $14,ya
+BytePattern NinSnesScanner::ptnLoadInstrTableAddressSMWAddmusicK("\x8f\x44\x14\x8f\x18\x15\x8d\x06"
+                                                                 "\xbc\xd4\xc1\x9c\x10\x0c\x8f\xbc"
+                                                                 "\x14\x8f\x18\x15\x80\xa8\xcf\xfc"
+                                                                 "\x2f\x0f\x68\x1e\x90\x0b\x2d\xba"
+                                                                 "\x6c\xda\x14\xae\x80\xa8\x1e\x8d"
+                                                                 "\x06\xcf\x7a\x14\xda\x14",
+                                                                 "x?xx?xxx"
+                                                                 "????????"
+                                                                 "????????"
+                                                                 "????????"
+                                                                 "???????x"
+                                                                 "xxxxxx",
+                                                                 46);
 
 //; Kirby Super Star SPC
 // 071e: 8f 5d f2  mov   $f2,#$5d

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -2,24 +2,28 @@
 
 #include "base/Types.h"
 #include "NinSnesVibrato.h"
-#include "Options.h"
 
 #include <algorithm>
-
-#include "spdlog/fmt/fmt.h"
 
 DECLARE_FORMAT(NinSnes);
 
 //  **********
 //  NinSnesSeq
 //  **********
-#define SEQ_PPQN 48
+constexpr u16 SEQ_PPQN = 48;
+constexpr u16 ADDMUSICK_SEQ_PPQN = 48;
+constexpr u8 ADDMUSICK_DEFAULT_TEMPO = 0x36;
 
 namespace {
 
 constexpr size_t MAX_TRACKS = kNinSnesTrackCount;
 constexpr u16 kNinSnesDefaultPitchBendRangeCents =
     NinSnesTrackState::kDefaultPitchBendRangeCents;
+
+constexpr u8 defaultTempoForProfile(NinSnesProfileId profileId) {
+  return profileId == NinSnesProfileId::AddmusicK ? ADDMUSICK_DEFAULT_TEMPO
+                                                  : nin_snes::vibrato::kDefaultTempo;
+}
 
 }  // namespace
 
@@ -29,7 +33,7 @@ NinSnesSeq::NinSnesSeq(RawFile* file, NinSnesProfileId profile, u32 offset,
     : VGMSeq(NinSnesFormat::name, file, offset, 0, name),
       signature(NinSnesSignatureId::None), profileId(profile),
       volumeTable(volumeTable), durRateTable(durRateTable),
-      tempo(nin_snes::vibrato::kDefaultTempo),
+      tempo(defaultTempoForProfile(profile)),
       maxVibratoDepthCents(nin_snes::vibrato::kMinMaxDepthCents),
       maxVibratoRateHz(nin_snes::vibrato::kMinMaxRateHz),
       dwStartOffset(offset), curOffset(offset),
@@ -82,7 +86,9 @@ void NinSnesSeq::resetVars() {
   sectionRepeatCount = 0;
   m_sectionForeverLoops = 0;
   globalTranspose = 0;
-  setImmediateTempo(nin_snes::vibrato::kDefaultTempo);
+  addmusicKHotPatch.reset();
+  addmusicKVelocityTableId = 0;
+  setImmediateTempo(defaultTempoForProfile(profileId));
 
   if (readMode != READMODE_CONVERT_TO_MIDI) {
     maxVibratoDepthCents = nin_snes::vibrato::kMinMaxDepthCents;
@@ -220,7 +226,7 @@ bool NinSnesSeq::addLoopForeverNoItem() {
 }
 
 bool NinSnesSeq::parseHeader() {
-  setPPQN(SEQ_PPQN);
+  setPPQN(profileId == NinSnesProfileId::AddmusicK ? ADDMUSICK_SEQ_PPQN : SEQ_PPQN);
   nNumTracks = MAX_TRACKS;
   createTracks();
 
@@ -420,6 +426,12 @@ double NinSnesSeq::getTempoInBPM() {
 
 double NinSnesSeq::getTempoInBPM(u8 tempoValue) {
   if (tempoValue != 0) {
+    if (profileId == NinSnesProfileId::AddmusicK) {
+      // AddmusicKFF's length estimator treats one music tick as 1 / (2 * tempo) seconds.
+      constexpr double kAddmusicKTempoTicksPerSecond = 2.0;
+      return static_cast<double>(tempoValue) *
+             (60.0 * kAddmusicKTempoTicksPerSecond / ADDMUSICK_SEQ_PPQN);
+    }
     return static_cast<double>(60000000) / (SEQ_PPQN * 2000) * (static_cast<double>(tempoValue) / 256);
   } else {
     return 1.0;  // since tempo 0 cannot be expressed, this function returns a very small value.

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -66,6 +66,8 @@ public:
   u8 spcPercussionBase;
   u8 sectionRepeatCount;
   s8 globalTranspose;
+  NinSnesAddmusicKHotPatchState addmusicKHotPatch;
+  u8 addmusicKVelocityTableId;
   u8 tempo;
   SeqFixedPointAutomation<> tempoFade;
   double maxVibratoDepthCents;
@@ -207,6 +209,8 @@ public:
     u8 delay = 0;
     u8 length = 0;
     u8 targetNote = 0;
+    s8 semitoneTune = 0;
+    bool accountForSemitoneTune = true;
   };
 
   NinSnesTrack(NinSnesSeq* parentSeq, u32 offset = 0, u32 length = 0,
@@ -244,8 +248,11 @@ private:
                              std::string& desc);
   bool handleVariantEvent(NinSnesSeqEventType eventType, u32 beginOffset, u8 statusByte,
                           std::string& desc);
+  bool handleAddmusicKEvent(NinSnesSeqEventType eventType, u32 beginOffset,
+                            std::string& desc);
   bool handleIntelliEvent(NinSnesSeqEventType eventType, u32 beginOffset, u8 statusByte,
                           std::string& desc);
+  u8 midiVolumeForCurrentState() const;
   PitchSlideEvent readPitchSlide(u32 offset);
   bool consumeQueuedPitchSlide();
   void addPitchSlideEvent(const PitchSlideEvent& slide);

--- a/src/main/formats/NinSnes/NinSnesSeqState.h
+++ b/src/main/formats/NinSnes/NinSnesSeqState.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <span>
 
 enum NinSnesSeqEventType {
   // start enum at 1 because if map[] look up fails, it returns 0, and we don't want that to get
@@ -15,6 +16,10 @@ enum NinSnesSeqEventType {
   EVENT_UNKNOWN2,
   EVENT_UNKNOWN3,
   EVENT_UNKNOWN4,
+  EVENT_UNKNOWN5,
+  EVENT_UNKNOWN6,
+  EVENT_UNKNOWN7,
+  EVENT_UNKNOWN8,
   EVENT_NOP,
   EVENT_NOP1,
   EVENT_END,
@@ -50,6 +55,18 @@ enum NinSnesSeqEventType {
   EVENT_ECHO_VOLUME_FADE,
   EVENT_PITCH_SLIDE,
   EVENT_PERCUSSION_PATCH_BASE,
+  EVENT_ADDMUSICK_SUBLOOP,
+  EVENT_ADDMUSICK_ADSR_GAIN,
+  EVENT_ADDMUSICK_SAMPLE_LOAD,
+  EVENT_ADDMUSICK_OPTION,
+  EVENT_ADDMUSICK_FIR_FILTER,
+  EVENT_ADDMUSICK_DSP_WRITE,
+  EVENT_ADDMUSICK_DATA_WRITE,
+  EVENT_ADDMUSICK_NOISE,
+  EVENT_ADDMUSICK_DATA_SEND,
+  EVENT_ADDMUSICK_EXTENDED,
+  EVENT_ADDMUSICK_ARPEGGIO,
+  EVENT_ADDMUSICK_REMOTE_COMMAND,
 
   // Nintendo RD2:
   EVENT_RD2_PROGCHANGE_AND_ADSR,
@@ -100,10 +117,15 @@ class NinSnesTrackState {
   u8 spcNoteDuration;
   u8 spcNoteDurRate;
   u8 spcNoteVolume;
+  u8 spcVolume;
   s8 spcTranspose;
   u16 loopReturnAddress;
   u16 loopStartAddress;
   u8 loopCount;
+  u16 addmusicKSubloopStartAddress;
+  u8 addmusicKSubloopCount;
+  bool addmusicKSubloopActive;
+  u8 addmusicKVolumeMultiplier;
 
   // Konami:
   u16 konamiLoopStart;
@@ -130,6 +152,40 @@ class NinSnesTrackState {
   SeqSynthLfoAutomation vibrato;
   StoredPitchEnvelope pitchEnvelope;
   SeqPitchBendAutomation<s32> pitch {100.0 / 256.0};
+};
+
+struct NinSnesAddmusicKHotPatchState {
+  enum Byte0Bit : u8 {
+    ArpeggioSkipsRests = 1 << 0,
+    GainBeforeAdsr = 1 << 1,
+    ReadaheadScansLoops = 1 << 2,
+    PitchSlideAccountsForSemitoneTune = 1 << 3,
+    SampleLoadClearsPitchFraction = 1 << 4,
+    ZeroDelayEchoWritesDisabled = 1 << 5,
+    GlissandoStopsAfterOneNote = 1 << 6,
+  };
+
+  enum Byte1Bit : u8 {
+    RestsKeyOffOnlyInReadahead = 1 << 0,
+  };
+
+  void reset() {
+    applyPreset(1);
+  }
+
+  bool applyPreset(u8 preset);
+  void applyBytes(std::span<const u8> bytes);
+
+  [[nodiscard]] bool pitchSlideAccountsForSemitoneTune() const {
+    return (byte0 & PitchSlideAccountsForSemitoneTune) != 0;
+  }
+
+  [[nodiscard]] bool sampleLoadClearsPitchFraction() const {
+    return (byte0 & SampleLoadClearsPitchFraction) != 0;
+  }
+
+  u8 byte0 = 0xff;
+  u8 byte1 = 0x00;
 };
 
 struct NinSnesPercussionDef {

--- a/src/main/formats/NinSnes/NinSnesTrack.cpp
+++ b/src/main/formats/NinSnes/NinSnesTrack.cpp
@@ -4,12 +4,17 @@
 #include "SeqEvent.h"
 
 #include <algorithm>
+#include <array>
 
 #include "spdlog/fmt/fmt.h"
 
 namespace {
 constexpr size_t MAX_TRACKS = kNinSnesTrackCount;
 constexpr u8 SEQ_KEYOFS = 24;
+
+constexpr std::array<u8, 16> kAddmusicKStandardVelocityTable = {
+    0x19, 0x33, 0x4c, 0x66, 0x72, 0x7f, 0x8c, 0x99, 0xa5, 0xb2, 0xbf, 0xcc, 0xd8, 0xe5, 0xf2, 0xfc,
+};
 }  // namespace
 
 NinSnesTrackState::NinSnesTrackState() {
@@ -18,12 +23,17 @@ NinSnesTrackState::NinSnesTrackState() {
 
 void NinSnesTrackState::resetVars() {
   loopCount = 0;
+  addmusicKSubloopStartAddress = 0;
+  addmusicKSubloopCount = 0;
+  addmusicKSubloopActive = false;
   spcTranspose = 0;
 
   // just in case
   spcNoteDuration = 1;
   spcNoteDurRate = 0xfc;
   spcNoteVolume = 0xfc;
+  spcVolume = 0xff;
+  addmusicKVolumeMultiplier = 0;
 
   // Konami:
   konamiLoopStart = 0;
@@ -208,6 +218,14 @@ NinSnesIntelliModeId NinSnesTrack::intelliMode() const {
   return seq().profile().intelliMode;
 }
 
+u8 NinSnesTrack::midiVolumeForCurrentState() const {
+  u32 effectiveVolume = state.spcVolume;
+  if (seq().profileId == NinSnesProfileId::AddmusicK) {
+    effectiveVolume += (effectiveVolume * state.addmusicKVolumeMultiplier) >> 8;
+  }
+  return static_cast<u8>(std::min<u32>(effectiveVolume / 2, 127));
+}
+
 void NinSnesTrack::readStandardNoteParam(u32 beginOffset, u8 statusByte,
                                          std::string& desc) {
   auto& parentSeq = seq();
@@ -220,11 +238,18 @@ void NinSnesTrack::readStandardNoteParam(u32 beginOffset, u8 statusByte,
     const u8 velIndex = quantizeAndVelocity & 15;
 
     state.spcNoteDurRate = parentSeq.durRateTable[durIndex];
-    state.spcNoteVolume = parentSeq.volumeTable[velIndex];
+    state.spcNoteVolume =
+        parentSeq.profileId == NinSnesProfileId::AddmusicK && parentSeq.addmusicKVelocityTableId != 0
+            ? kAddmusicKStandardVelocityTable[velIndex]
+            : parentSeq.volumeTable[velIndex];
 
     fmt::format_to(std::back_inserter(desc),
                    "  Quantize: {:d} ({:d}/256)  Velocity: {:d} ({:d}/256)", durIndex,
                    state.spcNoteDurRate, velIndex, state.spcNoteVolume);
+    if (parentSeq.profileId == NinSnesProfileId::AddmusicK) {
+      fmt::format_to(std::back_inserter(desc), "  Velocity Table: ${:02X}",
+                     parentSeq.addmusicKVelocityTableId);
+    }
   }
 
   addGenericEvent(beginOffset, curOffset - beginOffset, "Note Param", desc, Type::DurationChange);
@@ -263,38 +288,20 @@ bool NinSnesTrack::handleCoreEvent(NinSnesSeqEventType eventType, u32 beginOffse
       addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       return true;
 
-    case EVENT_UNKNOWN1: {
-      const u8 arg1 = readByte(curOffset++);
-      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}", statusByte, arg1);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
-      return true;
-    }
-
-    case EVENT_UNKNOWN2: {
-      const u8 arg1 = readByte(curOffset++);
-      const u8 arg2 = readByte(curOffset++);
-      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}", statusByte, arg1, arg2);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
-      return true;
-    }
-
-    case EVENT_UNKNOWN3: {
-      const u8 arg1 = readByte(curOffset++);
-      const u8 arg2 = readByte(curOffset++);
-      const u8 arg3 = readByte(curOffset++);
-      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}", statusByte, arg1,
-                         arg2, arg3);
-      addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
-      return true;
-    }
-
-    case EVENT_UNKNOWN4: {
-      const u8 arg1 = readByte(curOffset++);
-      const u8 arg2 = readByte(curOffset++);
-      const u8 arg3 = readByte(curOffset++);
-      const u8 arg4 = readByte(curOffset++);
-      desc = fmt::format("Event: 0x{:02X}  Arg1: {:d}  Arg2: {:d}  Arg3: {:d}  Arg4: {:d}",
-                         statusByte, arg1, arg2, arg3, arg4);
+    case EVENT_UNKNOWN1:
+    case EVENT_UNKNOWN2:
+    case EVENT_UNKNOWN3:
+    case EVENT_UNKNOWN4:
+    case EVENT_UNKNOWN5:
+    case EVENT_UNKNOWN6:
+    case EVENT_UNKNOWN7:
+    case EVENT_UNKNOWN8: {
+      const u8 argCount = static_cast<u8>(eventType - EVENT_UNKNOWN0);
+      desc = fmt::format("Event: 0x{:02X}", statusByte);
+      for (u8 argIndex = 0; argIndex < argCount; argIndex++) {
+        const u8 arg = readByte(curOffset++);
+        desc += fmt::format("  Arg{:d}: {:d}", argIndex + 1, arg);
+      }
       addUnknown(beginOffset, curOffset - beginOffset, "Unknown Event", desc);
       return true;
     }
@@ -425,6 +432,10 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, u32 begi
                                          std::string& desc) {
   auto& parentSeq = seq();
 
+  if (eventType == EVENT_ADDMUSICK_SUBLOOP) {
+    return handleAddmusicKEvent(eventType, beginOffset, desc);
+  }
+
   switch (eventType) {
     case EVENT_PAN: {
       const u8 newPan = readByte(curOffset++);
@@ -536,14 +547,16 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, u32 begi
 
     case EVENT_VOLUME: {
       const u8 newVol = readByte(curOffset++);
-      addVol(beginOffset, curOffset - beginOffset, newVol / 2);
+      state.spcVolume = newVol;
+      addVol(beginOffset, curOffset - beginOffset, midiVolumeForCurrentState());
       return true;
     }
 
     case EVENT_VOLUME_FADE: {
       const u8 fadeLength = readByte(curOffset++);
       const u8 newVol = readByte(curOffset++);
-      addVolSlide(beginOffset, curOffset - beginOffset, fadeLength, newVol / 2);
+      state.spcVolume = newVol;
+      addVolSlide(beginOffset, curOffset - beginOffset, fadeLength, midiVolumeForCurrentState());
       return true;
     }
 
@@ -676,6 +689,11 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, u32 begi
 bool NinSnesTrack::handleVariantEvent(NinSnesSeqEventType eventType, u32 beginOffset,
                                       u8 statusByte, std::string& desc) {
   auto& parentSeq = seq();
+
+  if (eventType >= EVENT_ADDMUSICK_ADSR_GAIN &&
+      eventType <= EVENT_ADDMUSICK_REMOTE_COMMAND) {
+    return handleAddmusicKEvent(eventType, beginOffset, desc);
+  }
 
   switch (eventType) {
     case EVENT_RD2_PROGCHANGE_AND_ADSR: {

--- a/src/main/formats/NinSnes/NinSnesTrackModulation.cpp
+++ b/src/main/formats/NinSnes/NinSnesTrackModulation.cpp
@@ -36,20 +36,26 @@ u8 convertVibratoDelayToMidi(u8 delay, double tempo) {
                                     nin_snes::vibrato::kMaxDelaySeconds);
 }
 
-s32 notePitch(u8 note) {
+s32 notePitch(s16 note) {
   // NinSnes stores slide pitch in semitone units with an 8-bit fractional part.
-  return static_cast<s32>(note & 0x7f) << 8;
+  return static_cast<s32>(note) << 8;
 }
 
 }  // namespace
 
 NinSnesTrack::PitchSlideEvent NinSnesTrack::readPitchSlide(u32 offset) {
+  const u8 delay = readByte(curOffset++);
+  const u8 length = readByte(curOffset++);
+  const u8 targetNote = readByte(curOffset++);
   return PitchSlideEvent {
     offset,
     4,
-    readByte(curOffset++),
-    readByte(curOffset++),
-    readByte(curOffset++),
+    delay,
+    length,
+    targetNote,
+    state.spcTranspose,
+    seq().profileId != NinSnesProfileId::AddmusicK ||
+        seq().addmusicKHotPatch.pitchSlideAccountsForSemitoneTune(),
   };
 }
 
@@ -76,11 +82,18 @@ void NinSnesTrack::addPitchSlideEvent(const PitchSlideEvent& slide) {
                           slide.delay,
                           slide.length,
                           slide.targetNote & 0x7f);
+  if (!slide.accountForSemitoneTune && slide.semitoneTune != 0) {
+    fmt::format_to(std::back_inserter(desc),
+                   "  Hot Patch: ignores semitone tune ({:d})",
+                   slide.semitoneTune);
+  }
   addGenericEvent(slide.offset, slide.eventLength, "Pitch Slide", desc, Type::PitchBendSlide);
 }
 
 void NinSnesTrack::beginPitchSlide(const PitchSlideEvent& slide) {
-  activatePitchMotion(slide.delay, slide.length, notePitch(slide.targetNote));
+  const s16 targetNote =
+      slide.accountForSemitoneTune ? slide.targetNote : slide.targetNote - slide.semitoneTune;
+  activatePitchMotion(slide.delay, slide.length, notePitch(targetNote));
 }
 
 void NinSnesTrack::activatePitchMotion(u8 delay, u8 length, s32 targetPitch) {

--- a/src/main/formats/NinSnes/NinSnesTypes.h
+++ b/src/main/formats/NinSnes/NinSnesTypes.h
@@ -15,6 +15,7 @@ enum class NinSnesSignatureId {
 enum class NinSnesProfileId {
   Unknown = 0,
   Earlier,
+  AddmusicK,
   Standard,
   Rd1,
   Rd2,


### PR DESCRIPTION
## Description

Adds NinSnes/AddmusicK SPC support and improves SPC metadata handling.

- clearer logging for malformed ID666 play/fade time fields
- AddmusicK SPC detection in the NinSnes scanner
- AddmusicK custom instrument loading
- AddmusicK sequence timing/event parsing
- changelog entries for SPC and AddmusicK support

## Motivation and Context

Some AddmusicK/custom SNES SPC files were not being detected or exported correctly, often producing empty MIDI output or incorrect playback/conversion behavior. This adds explicit AddmusicK handling while preserving the existing NinSnes paths for standard SPCs.

The SPC ID666 warning change also makes malformed metadata easier to diagnose without treating it as the root playback issue.

- Fixes #897 

In the future I might rework how the NinSnes classes work a little because I'm not sure how I feel about the shared/unencapsulated profile-related members 

## How Has This Been Tested?

Tested a bunch of files from SMWCentral, other N-SPC files.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
