### PR TITLE
Modernize ownership with smart pointers

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -46,3 +46,6 @@ ed533cd46d853523d184ff1a60f769223ee97845
 
 # Remove common.h, use fixed-width type aliases universally
 8743874e195990714b7d73eb984ac1db8457ebc7
+
+# Cleanup constructor parameter names
+f986dfecb0525429d4fcb649a143549c06398778

--- a/src/main/LogManager.h
+++ b/src/main/LogManager.h
@@ -25,9 +25,8 @@ class UISink : public spdlog::sinks::base_sink<Mutex> {
 protected:
   void sink_it_(const spdlog::details::log_msg& msg) override {
     auto level = convertSpdlogLevel(msg.level);
-    auto logItem = new LogItem( fmt::to_string(msg.payload), level, msg.source.filename);
-    pRoot->log(logItem);
-    delete logItem;
+    LogItem logItem(fmt::to_string(msg.payload), level, msg.source.filename);
+    pRoot->log(&logItem);
   }
 
   void flush_() override {}

--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -185,18 +185,18 @@ bool VGMRoot::loadVGMFile(std::unique_ptr<VGMFile> file, bool useMatcher) {
     return false;
   }
 
-  adoptVGMFile(std::move(file), useMatcher);
+  sinkVGMFile(std::move(file), useMatcher);
   return true;
 }
 
-void VGMRoot::adoptVGMFile(std::unique_ptr<VGMFile> file, bool useMatcher) {
+void VGMRoot::sinkVGMFile(std::unique_ptr<VGMFile>&& file, bool useMatcher) {
   if (!file) {
     return;
   }
 
   auto discoveredFiles = file->releaseDiscoveredFiles();
   for (auto& discoveredFile : discoveredFiles) {
-    adoptVGMFile(std::move(discoveredFile), useMatcher);
+    sinkVGMFile(std::move(discoveredFile), useMatcher);
   }
 
   auto* vgmFile = file.get();
@@ -262,11 +262,11 @@ bool VGMRoot::loadVGMColl(std::unique_ptr<VGMColl> coll) {
     return false;
   }
 
-  adoptVGMColl(std::move(coll));
+  sinkVGMColl(std::move(coll));
   return true;
 }
 
-void VGMRoot::adoptVGMColl(std::unique_ptr<VGMColl> coll) {
+void VGMRoot::sinkVGMColl(std::unique_ptr<VGMColl>&& coll) {
   if (!coll) {
     return;
   }

--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -28,6 +28,7 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <variant>
 
@@ -76,9 +77,7 @@ bool VGMRoot::openRawFile(const std::filesystem::path &filePath) {
     return false;
   }
   size_t vgmFileCountBefore = vgmFiles().size();
-  if (loadRawFile(newFile.get())) {
-    newFile.release();
-  }
+  loadRawFile(std::move(newFile));
   return vgmFiles().size() > vgmFileCountBefore;
 }
 
@@ -87,67 +86,63 @@ bool VGMRoot::createVirtFile(const u8 *databuf, u32 fileSize, const std::string&
                              const std::filesystem::path &parRawFileFullPath, const VGMTag& tag) {
   assert(fileSize != 0);
 
-  auto newVirtFile = std::make_unique<VirtFile>(databuf, fileSize, filename, parRawFileFullPath, tag);
-
-  if (loadRawFile(newVirtFile.get())) {
-    newVirtFile.release();
-    return true;
-  }
-  return false;
+  return loadRawFile(std::make_unique<VirtFile>(databuf, fileSize, filename, parRawFileFullPath, tag));
 }
 
 // Applies loaders and scanners to a rawfile, loading any discovered files
 // returns true if files were discovered
-bool VGMRoot::loadRawFile(RawFile *newRawFile) {
+bool VGMRoot::loadRawFile(std::unique_ptr<RawFile> newRawFile) {
+  if (!newRawFile) {
+    return false;
+  }
+
+  RawFile* rawFile = newRawFile.get();
   pushLoadRawFile();
-  if (newRawFile->useLoaders()) {
+  if (rawFile->useLoaders()) {
     for (const auto &l : LoaderManager::get().loaders()) {
-      l->apply(newRawFile);
+      l->apply(rawFile);
       auto res = l->results();
 
       /* If the loader extracted anything, we shouldn't have to scan */
       if (!res.empty()) {
-        newRawFile->setUseScanners(false);
+        rawFile->setUseScanners(false);
 
         for (auto& file : res) {
-          RawFile* rawFile = file.get();
-          if (loadRawFile(rawFile)) {
-            file.release();
-          }
+          loadRawFile(std::move(file));
         }
       }
     }
   }
 
-  if (newRawFile->useScanners()) {
+  if (rawFile->useScanners()) {
     /*
      * Make use of the extension to run only a subset of scanners.
      * Unsure how good of an idea this is
      */
     auto specific_scanners =
-      ScannerManager::get().scannersWithExtension(newRawFile->extension());
+      ScannerManager::get().scannersWithExtension(rawFile->extension());
     if (!specific_scanners.empty()) {
       for (const auto &scanner : specific_scanners) {
-        scanner->scan(newRawFile);
+        scanner->scan(rawFile);
         if (auto matcher = scanner->format()->matcher.get()) {
-          matcher->onFinishedScan(newRawFile);
+          matcher->onFinishedScan(rawFile);
         }
       }
     } else {
       for (const auto &scanner : ScannerManager::get().scanners()) {
-        scanner->scan(newRawFile);
+        scanner->scan(rawFile);
         if (auto matcher = scanner->format()->matcher.get()) {
-          matcher->onFinishedScan(newRawFile);
+          matcher->onFinishedScan(rawFile);
         }
       }
     }
   }
 
-  bool foundFiles = !newRawFile->containedVGMFiles().empty();
+  bool foundFiles = !rawFile->containedVGMFiles().empty();
   if (foundFiles) {
-    m_ownedRawFiles.emplace_back(newRawFile);
-    m_rawfiles.emplace_back(newRawFile);
-    UI_loadRawFile(newRawFile);
+    m_rawfiles.emplace_back(rawFile);
+    UI_loadRawFile(rawFile);
+    m_ownedRawFiles.emplace_back(std::move(newRawFile));
   }
 
   popLoadRawFile();
@@ -185,12 +180,38 @@ bool VGMRoot::removeRawFile(RawFile *rawfile) {
   return true;
 }
 
-void VGMRoot::addVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file) {
-  auto vgmFile = variantToVGMFile(file);
-  m_ownedVGMFiles.emplace_back(vgmFile);
-  m_vgmfiles.push_back(file);
+bool VGMRoot::loadVGMFile(std::unique_ptr<VGMFile> file, bool useMatcher) {
+  if (!file || !file->load()) {
+    return false;
+  }
+
+  adoptVGMFile(std::move(file), useMatcher);
+  return true;
+}
+
+void VGMRoot::adoptVGMFile(std::unique_ptr<VGMFile> file, bool useMatcher) {
+  if (!file) {
+    return;
+  }
+
+  auto discoveredFiles = file->releaseDiscoveredFiles();
+  for (auto& discoveredFile : discoveredFiles) {
+    adoptVGMFile(std::move(discoveredFile), useMatcher);
+  }
+
+  auto* vgmFile = file.get();
+  auto variant = vgmFileToVariant(vgmFile);
+  vgmFile->rawFile()->addContainedVGMFile(variant);
+  m_ownedVGMFiles.emplace_back(std::move(file));
+  m_vgmfiles.push_back(variant);
   L_INFO("Loaded {} ({} bytes at {:x}) successfully.", vgmFile->name(), vgmFile->length(), vgmFile->offset());
-  UI_addVGMFile(file);
+  UI_addVGMFile(variant);
+
+  if (useMatcher) {
+    if (auto fmt = vgmFile->format(); fmt) {
+      fmt->onNewFile(variant);
+    }
+  }
 }
 
 // Removes a VGMFile from the interface.  The UI_RemoveVGMFile will handle the
@@ -214,8 +235,8 @@ void VGMRoot::removeVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
     L_WARN("Requested deletion for VGMFile but it was not found");
   }
 
-  while (!targFile->assocColls.empty()) {
-    removeVGMColl(targFile->assocColls.back());
+  while (targFile->hasAssocColls()) {
+    removeVGMColl(targFile->assocColls().back());
   }
 
   if (bRemoveEmptyRawFile) {
@@ -233,14 +254,27 @@ void VGMRoot::removeVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
     m_ownedVGMFiles.erase(ownedIter);
   } else {
     L_WARN("VGMFile removed from Root did not have an owning entry");
-    delete targFile;
   }
 }
 
-void VGMRoot::addVGMColl(VGMColl *theColl) {
-  m_ownedVGMColls.emplace_back(theColl);
-  m_vgmcolls.push_back(theColl);
-  UI_addVGMColl(theColl);
+bool VGMRoot::loadVGMColl(std::unique_ptr<VGMColl> coll) {
+  if (!coll || !coll->load()) {
+    return false;
+  }
+
+  addVGMColl(std::move(coll));
+  return true;
+}
+
+void VGMRoot::addVGMColl(std::unique_ptr<VGMColl> coll) {
+  if (!coll) {
+    return;
+  }
+
+  auto* rawColl = coll.get();
+  m_vgmcolls.push_back(rawColl);
+  UI_addVGMColl(rawColl);
+  m_ownedVGMColls.emplace_back(std::move(coll));
 }
 
 void VGMRoot::removeVGMColl(VGMColl *coll) {
@@ -263,7 +297,6 @@ void VGMRoot::removeVGMColl(VGMColl *coll) {
     m_ownedVGMColls.erase(ownedIter);
   } else {
     L_WARN("VGMColl removed from Root did not have an owning entry");
-    delete coll;
   }
 }
 

--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -262,11 +262,11 @@ bool VGMRoot::loadVGMColl(std::unique_ptr<VGMColl> coll) {
     return false;
   }
 
-  addVGMColl(std::move(coll));
+  adoptVGMColl(std::move(coll));
   return true;
 }
 
-void VGMRoot::addVGMColl(std::unique_ptr<VGMColl> coll) {
+void VGMRoot::adoptVGMColl(std::unique_ptr<VGMColl> coll) {
   if (!coll) {
     return;
   }

--- a/src/main/Root.cpp
+++ b/src/main/Root.cpp
@@ -27,12 +27,16 @@
 #include <cassert>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <string>
 #include <variant>
 
 #include <spdlog/fmt/std.h>
 
 VGMRoot *pRoot;
+
+VGMRoot::VGMRoot() = default;
+VGMRoot::~VGMRoot() = default;
 
 VGMFile* variantToVGMFile(VGMFileVariant variant) {
   VGMFile *vgmFilePtr = nullptr;
@@ -62,18 +66,18 @@ bool VGMRoot::init() {
 /* Opens up a file from the filesystem and scans it.
  * Returns bool indicating if VGMFiles were found. */
 bool VGMRoot::openRawFile(const std::filesystem::path &filePath) {
-  DiskFile* newFile = nullptr;
+  std::unique_ptr<DiskFile> newFile;
 
   try {
-    newFile = new DiskFile(filePath);
+    newFile = std::make_unique<DiskFile>(filePath);
   } catch (...) {
     L_ERROR("Failed to open file '{}': could not read from disk (file not found or permission denied)", filePath);
     UI_toast(fmt::format("Error opening file at path: {}", filePath), ToastType::Error);
     return false;
   }
   size_t vgmFileCountBefore = vgmFiles().size();
-  if (!loadRawFile(newFile)) {
-    delete newFile;
+  if (loadRawFile(newFile.get())) {
+    newFile.release();
   }
   return vgmFiles().size() > vgmFileCountBefore;
 }
@@ -83,13 +87,13 @@ bool VGMRoot::createVirtFile(const u8 *databuf, u32 fileSize, const std::string&
                              const std::filesystem::path &parRawFileFullPath, const VGMTag& tag) {
   assert(fileSize != 0);
 
-  auto newVirtFile = new VirtFile(databuf, fileSize, filename, parRawFileFullPath, tag);
+  auto newVirtFile = std::make_unique<VirtFile>(databuf, fileSize, filename, parRawFileFullPath, tag);
 
-  if (!loadRawFile(newVirtFile)) {
-    delete newVirtFile;
-    return false;
+  if (loadRawFile(newVirtFile.get())) {
+    newVirtFile.release();
+    return true;
   }
-  return true;
+  return false;
 }
 
 // Applies loaders and scanners to a rawfile, loading any discovered files
@@ -105,9 +109,10 @@ bool VGMRoot::loadRawFile(RawFile *newRawFile) {
       if (!res.empty()) {
         newRawFile->setUseScanners(false);
 
-        for (const auto &file : res) {
-          if (!loadRawFile(file)) {
-            delete file;
+        for (auto& file : res) {
+          RawFile* rawFile = file.get();
+          if (loadRawFile(rawFile)) {
+            file.release();
           }
         }
       }
@@ -124,14 +129,14 @@ bool VGMRoot::loadRawFile(RawFile *newRawFile) {
     if (!specific_scanners.empty()) {
       for (const auto &scanner : specific_scanners) {
         scanner->scan(newRawFile);
-        if (auto matcher = scanner->format()->matcher) {
+        if (auto matcher = scanner->format()->matcher.get()) {
           matcher->onFinishedScan(newRawFile);
         }
       }
     } else {
       for (const auto &scanner : ScannerManager::get().scanners()) {
         scanner->scan(newRawFile);
-        if (auto matcher = scanner->format()->matcher) {
+        if (auto matcher = scanner->format()->matcher.get()) {
           matcher->onFinishedScan(newRawFile);
         }
       }
@@ -140,6 +145,7 @@ bool VGMRoot::loadRawFile(RawFile *newRawFile) {
 
   bool foundFiles = !newRawFile->containedVGMFiles().empty();
   if (foundFiles) {
+    m_ownedRawFiles.emplace_back(newRawFile);
     m_rawfiles.emplace_back(newRawFile);
     UI_loadRawFile(newRawFile);
   }
@@ -158,9 +164,9 @@ bool VGMRoot::removeRawFile(RawFile *rawfile) {
     return false;
   }
 
-  auto &vgmfiles = rawfile->containedVGMFiles();
-  for (const auto & vgmfile : vgmfiles) {
-    removeVGMFile(*vgmfile, false);
+  auto vgmfiles = rawfile->containedVGMFiles();
+  for (const auto &vgmfile : vgmfiles) {
+    removeVGMFile(vgmfile, false);
   }
 
   pushRemoveRawFiles();
@@ -168,13 +174,21 @@ bool VGMRoot::removeRawFile(RawFile *rawfile) {
   m_rawfiles.erase(iter);
   popRemoveRawFiles();
 
-  delete rawfile;
+  auto ownedIter = std::ranges::find_if(m_ownedRawFiles, [rawfile](const auto& ownedRawFile) {
+    return ownedRawFile.get() == rawfile;
+  });
+  if (ownedIter != m_ownedRawFiles.end()) {
+    m_ownedRawFiles.erase(ownedIter);
+  } else {
+    L_WARN("RawFile removed from Root did not have an owning entry");
+  }
   return true;
 }
 
 void VGMRoot::addVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file) {
-  m_vgmfiles.push_back(file);
   auto vgmFile = variantToVGMFile(file);
+  m_ownedVGMFiles.emplace_back(vgmFile);
+  m_vgmfiles.push_back(file);
   L_INFO("Loaded {} ({} bytes at {:x}) successfully.", vgmFile->name(), vgmFile->length(), vgmFile->offset());
   UI_addVGMFile(file);
 }
@@ -211,10 +225,20 @@ void VGMRoot::removeVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
       removeRawFile(rawFile);
     }
   }
-  delete targFile;
+
+  auto ownedIter = std::ranges::find_if(m_ownedVGMFiles, [targFile](const auto& ownedVGMFile) {
+    return ownedVGMFile.get() == targFile;
+  });
+  if (ownedIter != m_ownedVGMFiles.end()) {
+    m_ownedVGMFiles.erase(ownedIter);
+  } else {
+    L_WARN("VGMFile removed from Root did not have an owning entry");
+    delete targFile;
+  }
 }
 
 void VGMRoot::addVGMColl(VGMColl *theColl) {
+  m_ownedVGMColls.emplace_back(theColl);
   m_vgmcolls.push_back(theColl);
   UI_addVGMColl(theColl);
 }
@@ -231,7 +255,16 @@ void VGMRoot::removeVGMColl(VGMColl *coll) {
   coll->removeFileAssocs();
   UI_removeVGMColl(coll);
   popRemoveVGMColls();
-  delete coll;
+
+  auto ownedIter = std::ranges::find_if(m_ownedVGMColls, [coll](const auto& ownedColl) {
+    return ownedColl.get() == coll;
+  });
+  if (ownedIter != m_ownedVGMColls.end()) {
+    m_ownedVGMColls.erase(ownedIter);
+  } else {
+    L_WARN("VGMColl removed from Root did not have an owning entry");
+    delete coll;
+  }
 }
 
 void VGMRoot::removeAllFilesAndCollections() {
@@ -239,7 +272,8 @@ void VGMRoot::removeAllFilesAndCollections() {
 
   for (auto vgmcoll : m_vgmcolls)
     UI_removeVGMColl(vgmcoll);
-  deleteVect(m_vgmcolls);
+  m_vgmcolls.clear();
+  m_ownedVGMColls.clear();
 
   for (auto variant : m_vgmfiles) {
     auto vgmfile = variantToVGMFile(variant);
@@ -247,13 +281,14 @@ void VGMRoot::removeAllFilesAndCollections() {
       fmt->onCloseFile(variant);
     }
     UI_removeVGMFile(vgmfile);
-    delete variantToVGMFile(variant);
   }
   m_vgmfiles.clear();
+  m_ownedVGMFiles.clear();
 
   for (auto rawfile: m_rawfiles)
     UI_removeRawFile(rawfile);
-  deleteVect(m_rawfiles);
+  m_rawfiles.clear();
+  m_ownedRawFiles.clear();
 
   popRemoveAll();
 }

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <variant>
+#include <utility>
 #include <vector>
 
 class VGMScanner;
@@ -49,11 +50,36 @@ public:
   virtual bool openRawFile(const std::filesystem::path& filePath);
   bool createVirtFile(const u8* databuf, u32 fileSize, const std::string& filename,
                       const std::filesystem::path& parRawFileFullPath = {}, const VGMTag& tag = VGMTag());
-  bool loadRawFile(RawFile* newRawFile);
+  bool loadRawFile(std::unique_ptr<RawFile> newRawFile);
   bool removeRawFile(RawFile *targFile);
-  void addVGMFile(VGMFileVariant file);
+  bool loadVGMFile(std::unique_ptr<VGMFile> file, bool useMatcher = true);
+  void adoptVGMFile(std::unique_ptr<VGMFile> file, bool useMatcher = true);
+  template <class FileType, class... Args>
+  FileType* emplaceVGMFile(Args&&... args) {
+    return emplaceVGMFileWithMatcher<FileType>(true, std::forward<Args>(args)...);
+  }
+  template <class FileType, class... Args>
+  FileType* emplaceVGMFileWithMatcher(bool useMatcher, Args&&... args) {
+    auto file = std::make_unique<FileType>(std::forward<Args>(args)...);
+    auto* rawFile = file.get();
+    return loadVGMFile(std::move(file), useMatcher) ? rawFile : nullptr;
+  }
+  template <class FileType, class... Args>
+  FileType* emplacePendingVGMFile(Args&&... args) {
+    auto file = std::make_unique<FileType>(std::forward<Args>(args)...);
+    auto* rawFile = file.get();
+    adoptVGMFile(std::move(file));
+    return rawFile;
+  }
   void removeVGMFile(VGMFileVariant file, bool bRemoveEmptyRawFile = true);
-  void addVGMColl(VGMColl *theColl);
+  bool loadVGMColl(std::unique_ptr<VGMColl> coll);
+  void addVGMColl(std::unique_ptr<VGMColl> coll);
+  template <class CollType, class... Args>
+  CollType* emplaceVGMColl(Args&&... args) {
+    auto coll = std::make_unique<CollType>(std::forward<Args>(args)...);
+    auto* rawColl = coll.get();
+    return loadVGMColl(std::move(coll)) ? rawColl : nullptr;
+  }
   void removeVGMColl(VGMColl *coll);
   void removeAllFilesAndCollections();
 

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -42,8 +42,8 @@ enum class ToastType { Info, Warning, Error, Success };
 
 class VGMRoot {
 public:
-  VGMRoot() = default;
-  virtual ~VGMRoot() = default;
+  VGMRoot();
+  virtual ~VGMRoot();
 
   virtual bool init();
   virtual bool openRawFile(const std::filesystem::path& filePath);
@@ -114,8 +114,11 @@ private:
   int vgmFileRemoveStack = 0;
   int vgmCollRemoveStack = 0;
 
+  std::vector<std::unique_ptr<RawFile>> m_ownedRawFiles;
   std::vector<RawFile *> m_rawfiles;
+  std::vector<std::unique_ptr<VGMFile>> m_ownedVGMFiles;
   std::vector<VGMFileVariant> m_vgmfiles;
+  std::vector<std::unique_ptr<VGMColl>> m_ownedVGMColls;
   std::vector<VGMColl *> m_vgmcolls;
 };
 

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -55,17 +55,17 @@ public:
   bool loadVGMFile(std::unique_ptr<VGMFile> file, bool useMatcher = true);
   void adoptVGMFile(std::unique_ptr<VGMFile> file, bool useMatcher = true);
   template <class FileType, class... Args>
-  FileType* emplaceVGMFile(Args&&... args) {
-    return emplaceVGMFileWithMatcher<FileType>(true, std::forward<Args>(args)...);
+  FileType* loadVGMFile(Args&&... args) {
+    return loadVGMFileWithMatcher<FileType>(true, std::forward<Args>(args)...);
   }
   template <class FileType, class... Args>
-  FileType* emplaceVGMFileWithMatcher(bool useMatcher, Args&&... args) {
+  FileType* loadVGMFileWithMatcher(bool useMatcher, Args&&... args) {
     auto file = std::make_unique<FileType>(std::forward<Args>(args)...);
     auto* rawFile = file.get();
     return loadVGMFile(std::move(file), useMatcher) ? rawFile : nullptr;
   }
   template <class FileType, class... Args>
-  FileType* emplacePendingVGMFile(Args&&... args) {
+  FileType* loadPendingVGMFile(Args&&... args) {
     auto file = std::make_unique<FileType>(std::forward<Args>(args)...);
     auto* rawFile = file.get();
     adoptVGMFile(std::move(file));
@@ -73,9 +73,9 @@ public:
   }
   void removeVGMFile(VGMFileVariant file, bool bRemoveEmptyRawFile = true);
   bool loadVGMColl(std::unique_ptr<VGMColl> coll);
-  void addVGMColl(std::unique_ptr<VGMColl> coll);
+  void adoptVGMColl(std::unique_ptr<VGMColl> coll);
   template <class CollType, class... Args>
-  CollType* emplaceVGMColl(Args&&... args) {
+  CollType* loadVGMColl(Args&&... args) {
     auto coll = std::make_unique<CollType>(std::forward<Args>(args)...);
     auto* rawColl = coll.get();
     return loadVGMColl(std::move(coll)) ? rawColl : nullptr;

--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -53,7 +53,7 @@ public:
   bool loadRawFile(std::unique_ptr<RawFile> newRawFile);
   bool removeRawFile(RawFile *targFile);
   bool loadVGMFile(std::unique_ptr<VGMFile> file, bool useMatcher = true);
-  void adoptVGMFile(std::unique_ptr<VGMFile> file, bool useMatcher = true);
+  void sinkVGMFile(std::unique_ptr<VGMFile>&& file, bool useMatcher = true);
   template <class FileType, class... Args>
   FileType* loadVGMFile(Args&&... args) {
     return loadVGMFileWithMatcher<FileType>(true, std::forward<Args>(args)...);
@@ -68,12 +68,12 @@ public:
   FileType* loadPendingVGMFile(Args&&... args) {
     auto file = std::make_unique<FileType>(std::forward<Args>(args)...);
     auto* rawFile = file.get();
-    adoptVGMFile(std::move(file));
+    sinkVGMFile(std::move(file));
     return rawFile;
   }
   void removeVGMFile(VGMFileVariant file, bool bRemoveEmptyRawFile = true);
   bool loadVGMColl(std::unique_ptr<VGMColl> coll);
-  void adoptVGMColl(std::unique_ptr<VGMColl> coll);
+  void sinkVGMColl(std::unique_ptr<VGMColl>&& coll);
   template <class CollType, class... Args>
   CollType* loadVGMColl(Args&&... args) {
     auto coll = std::make_unique<CollType>(std::forward<Args>(args)...);

--- a/src/main/components/FileLoader.cpp
+++ b/src/main/components/FileLoader.cpp
@@ -3,10 +3,11 @@
 #include <algorithm>
 #include <ranges>
 
-std::vector<RawFile*> FileLoader::results() {
-  std::vector<RawFile*> res;
+std::vector<std::unique_ptr<RawFile>> FileLoader::results() {
+  std::vector<std::unique_ptr<RawFile>> res;
 
   if (!m_res.empty()) {
+    res.reserve(m_res.size());
     std::ranges::move(m_res, std::back_inserter(res));
     m_res.clear();
   }
@@ -15,5 +16,11 @@ std::vector<RawFile*> FileLoader::results() {
 }
 
 void FileLoader::enqueue(RawFile* file) {
-  m_res.emplace_back(file);
+  enqueue(std::unique_ptr<RawFile>(file));
+}
+
+void FileLoader::enqueue(std::unique_ptr<RawFile> file) {
+  if (file) {
+    m_res.emplace_back(std::move(file));
+  }
 }

--- a/src/main/components/FileLoader.h
+++ b/src/main/components/FileLoader.h
@@ -3,17 +3,19 @@
 #include "RawFile.h"
 
 #include <deque>
+#include <memory>
 #include <vector>
 
 class FileLoader {
    public:
     virtual ~FileLoader() = default;
     virtual void apply(const RawFile *) = 0;
-    [[nodiscard]] std::vector<RawFile*> results();
+    [[nodiscard]] std::vector<std::unique_ptr<RawFile>> results();
 
    protected:
     void enqueue(RawFile* file);
+    void enqueue(std::unique_ptr<RawFile> file);
 
    private:
-    std::deque<RawFile*> m_res;
+    std::deque<std::unique_ptr<RawFile>> m_res;
 };

--- a/src/main/components/Scanner.h
+++ b/src/main/components/Scanner.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include "Root.h"
+
 class RawFile;
 class Format;
 

--- a/src/main/components/VGMColl.cpp
+++ b/src/main/components/VGMColl.cpp
@@ -73,10 +73,7 @@ void VGMColl::addMiscFile(VGMMiscFile *theMiscFile) {
 }
 
 bool VGMColl::load() {
-  if (!loadMain())
-    return false;
-  pRoot->addVGMColl(this);
-  return true;
+  return loadMain();
 }
 
 // A helper lambda function to search for a file in a vector of VGMFile*

--- a/src/main/components/VGMColl.cpp
+++ b/src/main/components/VGMColl.cpp
@@ -43,7 +43,7 @@ VGMSeq *VGMColl::seq() const {
   return m_seq;
 }
 
-void VGMColl::useSeq(VGMSeq *theSeq) {
+void VGMColl::attachSeq(VGMSeq *theSeq) {
   if (theSeq != nullptr)
     theSeq->addCollAssoc(this);
   if (m_seq && (theSeq != m_seq))  // if we associated with a previous sequence
@@ -51,21 +51,21 @@ void VGMColl::useSeq(VGMSeq *theSeq) {
   m_seq = theSeq;
 }
 
-void VGMColl::addInstrSet(VGMInstrSet *theInstrSet) {
+void VGMColl::attachInstrSet(VGMInstrSet *theInstrSet) {
   if (theInstrSet != nullptr) {
     theInstrSet->addCollAssoc(this);
     m_instrsets.push_back(theInstrSet);
   }
 }
 
-void VGMColl::addSampColl(VGMSampColl *theSampColl) {
+void VGMColl::attachSampColl(VGMSampColl *theSampColl) {
   if (theSampColl != nullptr) {
     theSampColl->addCollAssoc(this);
     m_sampcolls.push_back(theSampColl);
   }
 }
 
-void VGMColl::addMiscFile(VGMMiscFile *theMiscFile) {
+void VGMColl::attachMiscFile(VGMMiscFile *theMiscFile) {
   if (theMiscFile != nullptr) {
     theMiscFile->addCollAssoc(this);
     m_miscfiles.push_back(theMiscFile);

--- a/src/main/components/VGMColl.h
+++ b/src/main/components/VGMColl.h
@@ -27,10 +27,10 @@ class VGMColl {
   [[nodiscard]] const std::string& name() const;
   void setName(const std::string& newName);
   [[nodiscard]] VGMSeq* seq() const;
-  void useSeq(VGMSeq* theSeq);
-  void addInstrSet(VGMInstrSet* theInstrSet);
-  void addSampColl(VGMSampColl* theSampColl);
-  void addMiscFile(VGMMiscFile* theMiscFile);
+  void attachSeq(VGMSeq* theSeq);
+  void attachInstrSet(VGMInstrSet* theInstrSet);
+  void attachSampColl(VGMSampColl* theSampColl);
+  void attachMiscFile(VGMMiscFile* theMiscFile);
   bool load();
   virtual bool loadMain() { return true; }
 

--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -11,6 +11,7 @@
 #include "Root.h"
 
 #include <limits>
+#include <utility>
 
 VGMFile::VGMFile(std::string format, RawFile *rawfile, u32 offset,
                  u32 length, std::string name)
@@ -18,6 +19,19 @@ VGMFile::VGMFile(std::string format, RawFile *rawfile, u32 offset,
       m_rawfile(rawfile),
       m_format(std::move(format)),
       m_id(std::numeric_limits<u32>::max()) {}
+
+std::vector<std::unique_ptr<VGMFile>> VGMFile::releaseDiscoveredFiles() {
+  return std::exchange(m_discoveredFiles, {});
+}
+
+bool VGMFile::addDiscoveredFile(std::unique_ptr<VGMFile> file) {
+  if (!file || !file->load()) {
+    return false;
+  }
+
+  m_discoveredFiles.emplace_back(std::move(file));
+  return true;
+}
 
 // Only difference between this AddToUI and VGMItemContainer's version is that we do not add
 // this as an item because we do not want the VGMFile to be itself an item in the Item View
@@ -42,13 +56,13 @@ std::string VGMFile::description() {
 }
 
 void VGMFile::addCollAssoc(VGMColl *coll) {
-  assocColls.push_back(coll);
+  m_assocColls.push_back(coll);
 }
 
 void VGMFile::removeCollAssoc(VGMColl *coll) {
-  auto iter = std::ranges::find(assocColls, coll);
-  if (iter != assocColls.end())
-    assocColls.erase(iter);
+  auto iter = std::ranges::find(m_assocColls, coll);
+  if (iter != m_assocColls.end())
+    m_assocColls.erase(iter);
 }
 
 // These functions are common to all VGMItems, but no reason to refer to vgmfile
@@ -81,15 +95,15 @@ VGMHeader::~VGMHeader() = default;
 
 void VGMHeader::addPointer(u32 offset, u32 length, u32 /*destAddress*/, bool /*notNull*/,
                            const std::string &name) {
-  addChild(new VGMHeaderItem(this, VGMHeaderItem::HIT_POINTER, offset, length, name));
+  emplaceChild<VGMHeaderItem>(this, VGMHeaderItem::HIT_POINTER, offset, length, name);
 }
 
 void VGMHeader::addTempo(u32 offset, u32 length, const std::string &name) {
-  addChild(new VGMHeaderItem(this, VGMHeaderItem::HIT_TEMPO, offset, length, name));
+  emplaceChild<VGMHeaderItem>(this, VGMHeaderItem::HIT_TEMPO, offset, length, name);
 }
 
 void VGMHeader::addSig(u32 offset, u32 length, const std::string &name) {
-  addChild(new VGMHeaderItem(this, VGMHeaderItem::HIT_SIG, offset, length, name));
+  emplaceChild<VGMHeaderItem>(this, VGMHeaderItem::HIT_SIG, offset, length, name);
 }
 
 // *************

--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -24,7 +24,7 @@ std::vector<std::unique_ptr<VGMFile>> VGMFile::releaseDiscoveredFiles() {
   return std::exchange(m_discoveredFiles, {});
 }
 
-bool VGMFile::adoptDiscoveredFile(std::unique_ptr<VGMFile> file) {
+bool VGMFile::sinkDiscoveredFile(std::unique_ptr<VGMFile>&& file) {
   if (!file || !file->load()) {
     return false;
   }

--- a/src/main/components/VGMFile.cpp
+++ b/src/main/components/VGMFile.cpp
@@ -24,7 +24,7 @@ std::vector<std::unique_ptr<VGMFile>> VGMFile::releaseDiscoveredFiles() {
   return std::exchange(m_discoveredFiles, {});
 }
 
-bool VGMFile::addDiscoveredFile(std::unique_ptr<VGMFile> file) {
+bool VGMFile::adoptDiscoveredFile(std::unique_ptr<VGMFile> file) {
   if (!file || !file->load()) {
     return false;
   }
@@ -95,15 +95,15 @@ VGMHeader::~VGMHeader() = default;
 
 void VGMHeader::addPointer(u32 offset, u32 length, u32 /*destAddress*/, bool /*notNull*/,
                            const std::string &name) {
-  emplaceChild<VGMHeaderItem>(this, VGMHeaderItem::HIT_POINTER, offset, length, name);
+  addChild<VGMHeaderItem>(this, VGMHeaderItem::HIT_POINTER, offset, length, name);
 }
 
 void VGMHeader::addTempo(u32 offset, u32 length, const std::string &name) {
-  emplaceChild<VGMHeaderItem>(this, VGMHeaderItem::HIT_TEMPO, offset, length, name);
+  addChild<VGMHeaderItem>(this, VGMHeaderItem::HIT_TEMPO, offset, length, name);
 }
 
 void VGMHeader::addSig(u32 offset, u32 length, const std::string &name) {
-  emplaceChild<VGMHeaderItem>(this, VGMHeaderItem::HIT_SIG, offset, length, name);
+  addChild<VGMHeaderItem>(this, VGMHeaderItem::HIT_SIG, offset, length, name);
 }
 
 // *************

--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -9,7 +9,9 @@
 #include "RawFile.h"
 #include "VGMItem.h"
 
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 class VGMColl;
@@ -25,8 +27,21 @@ public:
 
   [[nodiscard]] std::string description() override;
 
-  virtual bool loadVGMFile(bool useMatcher) = 0;
   virtual bool load() = 0;
+  std::vector<std::unique_ptr<VGMFile>> releaseDiscoveredFiles();
+
+  template <class FileType, class... Args>
+  FileType* addDiscoveredFile(Args&&... args) {
+    auto file = std::make_unique<FileType>(std::forward<Args>(args)...);
+    auto* rawFile = file.get();
+    if (!file->load()) {
+      return nullptr;
+    }
+    m_discoveredFiles.emplace_back(std::move(file));
+    return rawFile;
+  }
+
+  bool addDiscoveredFile(std::unique_ptr<VGMFile> file);
   Format* format() const;
   [[nodiscard]] std::string formatName();
 
@@ -35,6 +50,8 @@ public:
 
   void addCollAssoc(VGMColl *coll);
   void removeCollAssoc(VGMColl *coll);
+  [[nodiscard]] const std::vector<VGMColl*>& assocColls() const { return m_assocColls; }
+  [[nodiscard]] bool hasAssocColls() const { return !m_assocColls.empty(); }
   [[nodiscard]] RawFile *rawFile() const;
 
   [[nodiscard]] size_t size() const noexcept { return length(); }
@@ -58,12 +75,12 @@ public:
 
   [[nodiscard]] const char *data() const { return m_rawfile->data() + offset(); }
 
-  std::vector<VGMColl*> assocColls;
-
 private:
   RawFile* m_rawfile;
   std::string m_format;
   u32 m_id;
+  std::vector<VGMColl*> m_assocColls;
+  std::vector<std::unique_ptr<VGMFile>> m_discoveredFiles;
 };
 
 // *********

--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -41,7 +41,7 @@ public:
     return rawFile;
   }
 
-  bool adoptDiscoveredFile(std::unique_ptr<VGMFile> file);
+  bool sinkDiscoveredFile(std::unique_ptr<VGMFile>&& file);
   Format* format() const;
   [[nodiscard]] std::string formatName();
 

--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -41,7 +41,7 @@ public:
     return rawFile;
   }
 
-  bool addDiscoveredFile(std::unique_ptr<VGMFile> file);
+  bool adoptDiscoveredFile(std::unique_ptr<VGMFile> file);
   Format* format() const;
   [[nodiscard]] std::string formatName();
 

--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -18,14 +18,6 @@ VGMItem::VGMItem(VGMFile *vgmfile, u32 offset, u32 length, std::string name, Typ
       m_name(std::move(name)) {
 }
 
-VGMItem::VGMItem(const VGMItem& other)
-    : type(other.type),
-      m_vgmfile(other.m_vgmfile),
-      m_offset(other.m_offset),
-      m_length(other.m_length),
-      m_name(other.m_name) {
-}
-
 VGMItem::VGMItem(VGMItem&& other) noexcept
     : type(other.type),
       m_ownedChildren(std::move(other.m_ownedChildren)),

--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -18,9 +18,32 @@ VGMItem::VGMItem(VGMFile *vgmfile, u32 offset, u32 length, std::string name, Typ
       m_name(std::move(name)) {
 }
 
-VGMItem::~VGMItem() {
-  deleteVect(m_children);
+VGMItem::VGMItem(const VGMItem& other)
+    : type(other.type),
+      m_vgmfile(other.m_vgmfile),
+      m_offset(other.m_offset),
+      m_length(other.m_length),
+      m_name(other.m_name) {
 }
+
+VGMItem::VGMItem(VGMItem&& other) noexcept
+    : type(other.type),
+      m_ownedChildren(std::move(other.m_ownedChildren)),
+      m_children(std::move(other.m_children)),
+      m_childrenSorted(other.m_childrenSorted),
+      m_childrenPrefixMaxEnd(std::move(other.m_childrenPrefixMaxEnd)),
+      m_vgmfile(other.m_vgmfile),
+      m_offset(other.m_offset),
+      m_length(other.m_length),
+      m_name(std::move(other.m_name)) {
+  for (auto *child : m_children) {
+    child->m_parent = this;
+  }
+  other.m_children.clear();
+  other.m_childrenPrefixMaxEnd.clear();
+}
+
+VGMItem::~VGMItem() = default;
 
 bool operator>(const VGMItem &item1, const VGMItem &item2) {
   return item1.offset() > item2.offset();
@@ -142,56 +165,58 @@ bool VGMItem::isValidOffset(u32 offset) const {
   return m_vgmfile->isValidOffset(offset);
 }
 
-VGMItem* VGMItem::addChild(VGMItem *item) {
-  item->m_vgmfile = vgmFile();
-  item->m_parent = this;
-  m_children.emplace_back(item);
+VGMItem* VGMItem::addChild(std::unique_ptr<VGMItem> item) {
+  auto *rawChild = item.get();
+  rawChild->m_vgmfile = vgmFile();
+  rawChild->m_parent = this;
+  m_children.emplace_back(rawChild);
+  m_ownedChildren.emplace_back(std::move(item));
   m_childrenSorted = false;
   m_childrenPrefixMaxEnd.clear();
-  return item;
+  return rawChild;
+}
+
+VGMItem* VGMItem::addChild(VGMItem *item) {
+  return addChild(std::unique_ptr<VGMItem>(item));
 }
 
 VGMItem* VGMItem::addChild(u32 offset, u32 length, const std::string &name) {
-  auto child = new VGMItem(vgmFile(), offset, length, name, Type::Header);
-  child->m_parent = this;
-  m_children.emplace_back(child);
-  m_childrenSorted = false;
-  m_childrenPrefixMaxEnd.clear();
-  return child;
+  return addChild(std::make_unique<VGMItem>(vgmFile(), offset, length, name, Type::Header));
 }
 
 VGMItem* VGMItem::addUnknownChild(u32 offset, u32 length) {
-  auto child = new VGMItem(vgmFile(), offset, length, "Unknown");
-  child->m_parent = this;
-  m_children.emplace_back(child);
-  m_childrenSorted = false;
-  m_childrenPrefixMaxEnd.clear();
-  return child;
+  return addChild(std::make_unique<VGMItem>(vgmFile(), offset, length, "Unknown"));
 }
 
 VGMHeader* VGMItem::addHeader(u32 offset, u32 length, const std::string &name) {
-  auto *header = new VGMHeader(this, offset, length, name);
-  header->m_parent = this;
-  m_children.emplace_back(header);
-  m_childrenSorted = false;
-  m_childrenPrefixMaxEnd.clear();
-  return header;
+  auto header = std::make_unique<VGMHeader>(this, offset, length, name);
+  auto *rawHeader = header.get();
+  addChild(std::move(header));
+  return rawHeader;
 }
 
 void VGMItem::removeChildren() {
   for (auto *child : m_children) {
     child->m_parent = nullptr;
   }
+  m_ownedChildren.clear();
   m_children.clear();
   m_childrenSorted = true;
   m_childrenPrefixMaxEnd.clear();
 }
 
 void VGMItem::transferChildren(VGMItem* destination) {
-  destination->addChildren(m_children);
+  destination->m_children.insert(destination->m_children.end(), m_children.begin(), m_children.end());
+  for (auto *child : m_children) {
+    child->m_parent = destination;
+  }
+  std::ranges::move(m_ownedChildren, std::back_inserter(destination->m_ownedChildren));
+  m_ownedChildren.clear();
   m_children.clear();
   m_childrenSorted = true;
   m_childrenPrefixMaxEnd.clear();
+  destination->m_childrenSorted = false;
+  destination->m_childrenPrefixMaxEnd.clear();
 }
 
 void VGMItem::ensureChildrenSorted() {

--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -165,7 +165,7 @@ bool VGMItem::isValidOffset(u32 offset) const {
   return m_vgmfile->isValidOffset(offset);
 }
 
-VGMItem* VGMItem::addChild(std::unique_ptr<VGMItem> item) {
+VGMItem* VGMItem::adoptChild(std::unique_ptr<VGMItem> item) {
   auto *rawChild = item.get();
   rawChild->m_vgmfile = vgmFile();
   rawChild->m_parent = this;
@@ -177,17 +177,17 @@ VGMItem* VGMItem::addChild(std::unique_ptr<VGMItem> item) {
 }
 
 VGMItem* VGMItem::addChild(u32 offset, u32 length, const std::string &name) {
-  return addChild(std::make_unique<VGMItem>(vgmFile(), offset, length, name, Type::Header));
+  return adoptChild(std::make_unique<VGMItem>(vgmFile(), offset, length, name, Type::Header));
 }
 
 VGMItem* VGMItem::addUnknownChild(u32 offset, u32 length) {
-  return addChild(std::make_unique<VGMItem>(vgmFile(), offset, length, "Unknown"));
+  return adoptChild(std::make_unique<VGMItem>(vgmFile(), offset, length, "Unknown"));
 }
 
 VGMHeader* VGMItem::addHeader(u32 offset, u32 length, const std::string &name) {
   auto header = std::make_unique<VGMHeader>(this, offset, length, name);
   auto *rawHeader = header.get();
-  addChild(std::move(header));
+  adoptChild(std::move(header));
   return rawHeader;
 }
 

--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -165,7 +165,7 @@ bool VGMItem::isValidOffset(u32 offset) const {
   return m_vgmfile->isValidOffset(offset);
 }
 
-VGMItem* VGMItem::adoptChild(std::unique_ptr<VGMItem> item) {
+VGMItem* VGMItem::sinkChild(std::unique_ptr<VGMItem>&& item) {
   auto *rawChild = item.get();
   rawChild->m_vgmfile = vgmFile();
   rawChild->m_parent = this;
@@ -177,17 +177,17 @@ VGMItem* VGMItem::adoptChild(std::unique_ptr<VGMItem> item) {
 }
 
 VGMItem* VGMItem::addChild(u32 offset, u32 length, const std::string &name) {
-  return adoptChild(std::make_unique<VGMItem>(vgmFile(), offset, length, name, Type::Header));
+  return sinkChild(std::make_unique<VGMItem>(vgmFile(), offset, length, name, Type::Header));
 }
 
 VGMItem* VGMItem::addUnknownChild(u32 offset, u32 length) {
-  return adoptChild(std::make_unique<VGMItem>(vgmFile(), offset, length, "Unknown"));
+  return sinkChild(std::make_unique<VGMItem>(vgmFile(), offset, length, "Unknown"));
 }
 
 VGMHeader* VGMItem::addHeader(u32 offset, u32 length, const std::string &name) {
   auto header = std::make_unique<VGMHeader>(this, offset, length, name);
   auto *rawHeader = header.get();
-  adoptChild(std::move(header));
+  sinkChild(std::move(header));
   return rawHeader;
 }
 

--- a/src/main/components/VGMItem.cpp
+++ b/src/main/components/VGMItem.cpp
@@ -176,10 +176,6 @@ VGMItem* VGMItem::addChild(std::unique_ptr<VGMItem> item) {
   return rawChild;
 }
 
-VGMItem* VGMItem::addChild(VGMItem *item) {
-  return addChild(std::unique_ptr<VGMItem>(item));
-}
-
 VGMItem* VGMItem::addChild(u32 offset, u32 length, const std::string &name) {
   return addChild(std::make_unique<VGMItem>(vgmFile(), offset, length, name, Type::Header));
 }

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -3,7 +3,9 @@
 #include "base/Types.h"
 
 #include <algorithm>
+#include <concepts>
 #include <iterator>
+#include <memory>
 #include <ranges>
 #include <string>
 #include <vector>
@@ -87,6 +89,10 @@ public:
           u32 length = 0,
           std::string name = "",
           Type type = Type::Unknown);
+  VGMItem(const VGMItem& other);
+  VGMItem(VGMItem&& other) noexcept;
+  VGMItem& operator=(const VGMItem& other) = delete;
+  VGMItem& operator=(VGMItem&& other) noexcept = delete;
   virtual ~VGMItem();
 
   friend bool operator>(VGMItem &item1, VGMItem &item2);
@@ -114,6 +120,7 @@ public:
   void setOffset(u32 offset);
   void setLength(u32 length);
   void setRange(u32 offset, u32 length);
+  VGMItem* addChild(std::unique_ptr<VGMItem> child);
   VGMItem* addChild(VGMItem* child);
   VGMItem* addChild(u32 offset, u32 length, const std::string &name);
   VGMItem* addUnknownChild(u32 offset, u32 length);
@@ -124,12 +131,9 @@ public:
   template <std::ranges::input_range Range>
   requires std::convertible_to<std::ranges::range_value_t<Range>, VGMItem*>
   void addChildren(const Range& items) {
-    std::ranges::copy(items, std::back_inserter(m_children));
-    for (auto *child : m_children) {
-      child->m_parent = this;
+    for (auto *child : items) {
+      addChild(child);
     }
-    m_childrenSorted = false;
-    m_childrenPrefixMaxEnd.clear();
   }
 
   void sortChildrenByOffset();
@@ -148,6 +152,7 @@ public:
   const Type type;
 
 private:
+  std::vector<std::unique_ptr<VGMItem>> m_ownedChildren;
   std::vector<VGMItem *> m_children;
   // Maintains sort + prefix-max end cache for fast offset lookups.
   bool m_childrenSorted = true;

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -3,11 +3,9 @@
 #include "base/Types.h"
 
 #include <algorithm>
-#include <concepts>
-#include <iterator>
 #include <memory>
-#include <ranges>
 #include <string>
+#include <utility>
 #include <vector>
 
 template <class T>
@@ -114,27 +112,25 @@ public:
   virtual std::string description() { return ""; }
   virtual void addToUI(VGMItem *parent, void *UI_specific);
 
-  const std::vector<VGMItem*>& children() { return m_children; }
+  [[nodiscard]] const std::vector<VGMItem*>& children() const { return m_children; }
   [[nodiscard]] u32 offset() const noexcept { return m_offset; }
   [[nodiscard]] u32 length() const noexcept { return m_length; }
   void setOffset(u32 offset);
   void setLength(u32 length);
   void setRange(u32 offset, u32 length);
   VGMItem* addChild(std::unique_ptr<VGMItem> child);
-  VGMItem* addChild(VGMItem* child);
+  template <class ChildType, class... Args>
+  ChildType* emplaceChild(Args&&... args) {
+    auto child = std::make_unique<ChildType>(std::forward<Args>(args)...);
+    auto* rawChild = child.get();
+    addChild(std::move(child));
+    return rawChild;
+  }
   VGMItem* addChild(u32 offset, u32 length, const std::string &name);
   VGMItem* addUnknownChild(u32 offset, u32 length);
   VGMHeader* addHeader(u32 offset, u32 length, const std::string &name = "Header");
   void removeChildren();
   void transferChildren(VGMItem* destination);
-
-  template <std::ranges::input_range Range>
-  requires std::convertible_to<std::ranges::range_value_t<Range>, VGMItem*>
-  void addChildren(const Range& items) {
-    for (auto *child : items) {
-      addChild(child);
-    }
-  }
 
   void sortChildrenByOffset();
 

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -118,12 +118,12 @@ public:
   void setOffset(u32 offset);
   void setLength(u32 length);
   void setRange(u32 offset, u32 length);
-  VGMItem* addChild(std::unique_ptr<VGMItem> child);
+  VGMItem* adoptChild(std::unique_ptr<VGMItem> child);
   template <class ChildType, class... Args>
-  ChildType* emplaceChild(Args&&... args) {
+  ChildType* addChild(Args&&... args) {
     auto child = std::make_unique<ChildType>(std::forward<Args>(args)...);
     auto* rawChild = child.get();
-    addChild(std::move(child));
+    adoptChild(std::move(child));
     return rawChild;
   }
   VGMItem* addChild(u32 offset, u32 length, const std::string &name);

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -118,12 +118,12 @@ public:
   void setOffset(u32 offset);
   void setLength(u32 length);
   void setRange(u32 offset, u32 length);
-  VGMItem* adoptChild(std::unique_ptr<VGMItem> child);
+  VGMItem* sinkChild(std::unique_ptr<VGMItem>&& child);
   template <class ChildType, class... Args>
   ChildType* addChild(Args&&... args) {
     auto child = std::make_unique<ChildType>(std::forward<Args>(args)...);
     auto* rawChild = child.get();
-    adoptChild(std::move(child));
+    sinkChild(std::move(child));
     return rawChild;
   }
   VGMItem* addChild(u32 offset, u32 length, const std::string &name);

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -87,7 +87,7 @@ public:
           u32 length = 0,
           std::string name = "",
           Type type = Type::Unknown);
-  VGMItem(const VGMItem& other);
+  VGMItem(const VGMItem& other) = delete;
   VGMItem(VGMItem&& other) noexcept;
   VGMItem& operator=(const VGMItem& other) = delete;
   VGMItem& operator=(VGMItem&& other) noexcept = delete;

--- a/src/main/components/VGMMiscFile.cpp
+++ b/src/main/components/VGMMiscFile.cpp
@@ -23,21 +23,6 @@ bool VGMMiscFile::loadMain() {
   return true;
 }
 
-bool VGMMiscFile::loadVGMFile(bool useMatcher) {
-  bool val = load();
-  if (!val) {
-    return false;
-  }
-
-  if (useMatcher) {
-    if (auto fmt = format(); fmt) {
-      fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
-    }
-  }
-
-  return val;
-}
-
 bool VGMMiscFile::load() {
   if (!loadMain()) {
     return false;
@@ -46,7 +31,5 @@ bool VGMMiscFile::load() {
     return false;
   }
 
-  rawFile()->addContainedVGMFile(this);
-  pRoot->addVGMFile(this);
   return true;
 }

--- a/src/main/components/VGMMiscFile.cpp
+++ b/src/main/components/VGMMiscFile.cpp
@@ -46,7 +46,7 @@ bool VGMMiscFile::load() {
     return false;
   }
 
-  rawFile()->addContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(this));
+  rawFile()->addContainedVGMFile(this);
   pRoot->addVGMFile(this);
   return true;
 }

--- a/src/main/components/VGMMiscFile.h
+++ b/src/main/components/VGMMiscFile.h
@@ -21,7 +21,6 @@ public:
   VGMMiscFile(const std::string &format, RawFile *file, u32 offset, u32 length = 0,
               std::string name = "VGMMiscFile");
 
-  bool loadVGMFile(bool useMatcher = true) override;
   virtual bool loadMain();
   bool load() override;
 };

--- a/src/main/components/VGMSampColl.cpp
+++ b/src/main/components/VGMSampColl.cpp
@@ -51,7 +51,7 @@ bool VGMSampColl::load() {
   }
 
   for (auto& sample : m_ownedSamples) {
-    adoptChild(std::move(sample));
+    sinkChild(std::move(sample));
   }
   m_ownedSamples.clear();
 
@@ -92,7 +92,7 @@ VGMSamp *VGMSampColl::addSamp(u32 offset, u32 length, u32 dataOffset,
   return addSamp<VGMSamp>(this, offset, length, dataOffset, dataLength, nChannels, bps, rate, std::move(name));
 }
 
-VGMSamp *VGMSampColl::adoptSamp(std::unique_ptr<VGMSamp> samp) {
+VGMSamp *VGMSampColl::sinkSamp(std::unique_ptr<VGMSamp>&& samp) {
   auto* rawSamp = samp.get();
   m_samples.emplace_back(rawSamp);
   m_ownedSamples.emplace_back(std::move(samp));

--- a/src/main/components/VGMSampColl.cpp
+++ b/src/main/components/VGMSampColl.cpp
@@ -51,7 +51,7 @@ bool VGMSampColl::load() {
   }
 
   for (auto& sample : m_ownedSamples) {
-    addChild(std::move(sample));
+    adoptChild(std::move(sample));
   }
   m_ownedSamples.clear();
 
@@ -89,10 +89,10 @@ bool VGMSampColl::parseSampleInfo() {
 VGMSamp *VGMSampColl::addSamp(u32 offset, u32 length, u32 dataOffset,
                               u32 dataLength, u8 nChannels, BPS bps,
                               u32 rate, std::string name) {
-  return emplaceSamp<VGMSamp>(this, offset, length, dataOffset, dataLength, nChannels, bps, rate, std::move(name));
+  return addSamp<VGMSamp>(this, offset, length, dataOffset, dataLength, nChannels, bps, rate, std::move(name));
 }
 
-VGMSamp *VGMSampColl::addSamp(std::unique_ptr<VGMSamp> samp) {
+VGMSamp *VGMSampColl::adoptSamp(std::unique_ptr<VGMSamp> samp) {
   auto* rawSamp = samp.get();
   m_samples.emplace_back(rawSamp);
   m_ownedSamples.emplace_back(std::move(samp));

--- a/src/main/components/VGMSampColl.cpp
+++ b/src/main/components/VGMSampColl.cpp
@@ -24,11 +24,7 @@ VGMSampColl::VGMSampColl(const std::string &format, RawFile *rawfile, u32 offset
       bLoaded(false) {
 }
 
-VGMSampColl::~VGMSampColl() {
-  if (!m_samples_owned_by_children) {
-    deleteVect(samples);
-  }
-}
+VGMSampColl::~VGMSampColl() = default;
 
 VGMSampColl::VGMSampColl(const std::string &format, RawFile *rawfile, VGMInstrSet *instrset,
                          u32 offset, u32 length, std::string name)
@@ -39,40 +35,28 @@ VGMSampColl::VGMSampColl(const std::string &format, RawFile *rawfile, VGMInstrSe
       bLoaded(false) {
 }
 
-bool VGMSampColl::loadVGMFile(bool useMatcher) {
-  bool val = load();
-  if (!val) {
-    return false;
-  }
-
-  if (useMatcher) {
-    if (auto fmt = format(); fmt) {
-      fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
-    }
-  }
-
-  return val;
-}
-
-
 bool VGMSampColl::load() {
   if (bLoaded)
     return true;
   if (!parseHeader())
     return false;
-  if (!parseSampleInfo())
+  if (!parseSampleInfo()) {
+    clearSamples();
     return false;
+  }
 
-  if (samples.size() == 0)
+  if (m_samples.empty()) {
+    clearSamples();
     return false;
+  }
 
-  addChildren(samples);
-  m_samples_owned_by_children = true;
+  for (auto& sample : m_ownedSamples) {
+    addChild(std::move(sample));
+  }
+  m_ownedSamples.clear();
 
   if (length() == 0) {
-    for (std::vector<VGMSamp *>::iterator itr = samples.begin(); itr != samples.end(); ++itr) {
-      VGMSamp *samp = *itr;
-
+    for (auto* samp : m_samples) {
       // Some formats can have negative sample offset
       // For example, Konami's SNES format and Hudson's SNES format
       // TODO: Fix negative sample offset without breaking instrument
@@ -90,11 +74,6 @@ bool VGMSampColl::load() {
     }
   }
 
-  if (!parInstrSet) {
-    rawFile()->addContainedVGMFile(this);
-    pRoot->addVGMFile(this);
-  }
-
   bLoaded = true;
   return true;
 }
@@ -110,7 +89,17 @@ bool VGMSampColl::parseSampleInfo() {
 VGMSamp *VGMSampColl::addSamp(u32 offset, u32 length, u32 dataOffset,
                               u32 dataLength, u8 nChannels, BPS bps,
                               u32 rate, std::string name) {
-  VGMSamp *newSamp = new VGMSamp(this, offset, length, dataOffset, dataLength, nChannels, bps, rate, std::move(name));
-  samples.push_back(newSamp);
-  return newSamp;
+  return emplaceSamp<VGMSamp>(this, offset, length, dataOffset, dataLength, nChannels, bps, rate, std::move(name));
+}
+
+VGMSamp *VGMSampColl::addSamp(std::unique_ptr<VGMSamp> samp) {
+  auto* rawSamp = samp.get();
+  m_samples.emplace_back(rawSamp);
+  m_ownedSamples.emplace_back(std::move(samp));
+  return rawSamp;
+}
+
+void VGMSampColl::clearSamples() {
+  m_samples.clear();
+  m_ownedSamples.clear();
 }

--- a/src/main/components/VGMSampColl.cpp
+++ b/src/main/components/VGMSampColl.cpp
@@ -7,6 +7,7 @@
 
 #include "base/Types.h"
 #include "Format.h"
+#include "Helper.h"
 #include "Root.h"
 #include "VGMSamp.h"
 
@@ -21,6 +22,12 @@ VGMSampColl::VGMSampColl(const std::string &format, RawFile *rawfile, u32 offset
       parInstrSet(nullptr),
       m_should_load_on_instr_set_match(false),
       bLoaded(false) {
+}
+
+VGMSampColl::~VGMSampColl() {
+  if (!m_samples_owned_by_children) {
+    deleteVect(samples);
+  }
 }
 
 VGMSampColl::VGMSampColl(const std::string &format, RawFile *rawfile, VGMInstrSet *instrset,
@@ -60,6 +67,7 @@ bool VGMSampColl::load() {
     return false;
 
   addChildren(samples);
+  m_samples_owned_by_children = true;
 
   if (length() == 0) {
     for (std::vector<VGMSamp *>::iterator itr = samples.begin(); itr != samples.end(); ++itr) {
@@ -83,7 +91,7 @@ bool VGMSampColl::load() {
   }
 
   if (!parInstrSet) {
-    rawFile()->addContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(this));
+    rawFile()->addContainedVGMFile(this);
     pRoot->addVGMFile(this);
   }
 

--- a/src/main/components/VGMSampColl.h
+++ b/src/main/components/VGMSampColl.h
@@ -32,12 +32,12 @@ class VGMSampColl : public VGMFile {
   VGMSamp *addSamp(u32 offset, u32 length, u32 dataOffset, u32 dataLength,
                    u8 nChannels = 1, BPS bps = BPS::PCM16, u32 rate = 0,
                    std::string name = "Sample");
-  VGMSamp *adoptSamp(std::unique_ptr<VGMSamp> samp);
+  VGMSamp *sinkSamp(std::unique_ptr<VGMSamp>&& samp);
   template <class SampType, class... Args>
   SampType* addSamp(Args&&... args) {
     auto samp = std::make_unique<SampType>(std::forward<Args>(args)...);
     auto* rawSamp = samp.get();
-    adoptSamp(std::move(samp));
+    sinkSamp(std::move(samp));
     return rawSamp;
   }
 

--- a/src/main/components/VGMSampColl.h
+++ b/src/main/components/VGMSampColl.h
@@ -23,7 +23,7 @@ class VGMSampColl : public VGMFile {
   VGMSampColl(const std::string &format, RawFile *rawfile, VGMInstrSet *instrset, u32 offset,
                 u32 length = 0, std::string name = "VGMSampColl");
   ~VGMSampColl() override;
-  void useInstrSet(VGMInstrSet *instrset) { parInstrSet = instrset; }
+  void attachInstrSet(VGMInstrSet *instrset) { parInstrSet = instrset; }
 
   bool load() override;
   virtual bool parseHeader();        // retrieve any header data
@@ -32,12 +32,12 @@ class VGMSampColl : public VGMFile {
   VGMSamp *addSamp(u32 offset, u32 length, u32 dataOffset, u32 dataLength,
                    u8 nChannels = 1, BPS bps = BPS::PCM16, u32 rate = 0,
                    std::string name = "Sample");
-  VGMSamp *addSamp(std::unique_ptr<VGMSamp> samp);
+  VGMSamp *adoptSamp(std::unique_ptr<VGMSamp> samp);
   template <class SampType, class... Args>
-  SampType* emplaceSamp(Args&&... args) {
+  SampType* addSamp(Args&&... args) {
     auto samp = std::make_unique<SampType>(std::forward<Args>(args)...);
     auto* rawSamp = samp.get();
-    addSamp(std::move(samp));
+    adoptSamp(std::move(samp));
     return rawSamp;
   }
 

--- a/src/main/components/VGMSampColl.h
+++ b/src/main/components/VGMSampColl.h
@@ -4,7 +4,9 @@
 #include "VGMFile.h"
 #include "VGMSamp.h"
 
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 class VGMInstrSet;
@@ -23,7 +25,6 @@ class VGMSampColl : public VGMFile {
   ~VGMSampColl() override;
   void useInstrSet(VGMInstrSet *instrset) { parInstrSet = instrset; }
 
-  bool loadVGMFile(bool useMatcher = true) override;
   bool load() override;
   virtual bool parseHeader();        // retrieve any header data
   virtual bool parseSampleInfo();        // retrieve sample info, including pointers to data, # channels, rate, etc.
@@ -31,20 +32,35 @@ class VGMSampColl : public VGMFile {
   VGMSamp *addSamp(u32 offset, u32 length, u32 dataOffset, u32 dataLength,
                    u8 nChannels = 1, BPS bps = BPS::PCM16, u32 rate = 0,
                    std::string name = "Sample");
+  VGMSamp *addSamp(std::unique_ptr<VGMSamp> samp);
+  template <class SampType, class... Args>
+  SampType* emplaceSamp(Args&&... args) {
+    auto samp = std::make_unique<SampType>(std::forward<Args>(args)...);
+    auto* rawSamp = samp.get();
+    addSamp(std::move(samp));
+    return rawSamp;
+  }
+
+  [[nodiscard]] const std::vector<VGMSamp*>& samples() const { return m_samples; }
+  [[nodiscard]] bool hasSamples() const { return !m_samples.empty(); }
+  [[nodiscard]] size_t sampleCount() const { return m_samples.size(); }
+  [[nodiscard]] VGMSamp* sample(size_t index) const { return m_samples.at(index); }
 
   bool shouldLoadOnInstrSetMatch() const { return m_should_load_on_instr_set_match; }
 
 public:
   u32 sampDataOffset;        // offset of the beginning of the sample data.  Used for rgn->sampOffset matching
   VGMInstrSet *parInstrSet;
-  std::vector<VGMSamp *> samples;
 
 protected:
   void setShouldLoadOnInstrSetMatch(bool should_load) { m_should_load_on_instr_set_match = should_load; }
+  void reserveSamples(size_t count) { m_ownedSamples.reserve(count); m_samples.reserve(count); }
+  void clearSamples();
 
 private:
   bool m_should_load_on_instr_set_match, bLoaded;
-  bool m_samples_owned_by_children{false};
+  std::vector<std::unique_ptr<VGMSamp>> m_ownedSamples;
+  std::vector<VGMSamp*> m_samples;
 };
 
 namespace conversion {

--- a/src/main/components/VGMSampColl.h
+++ b/src/main/components/VGMSampColl.h
@@ -20,6 +20,7 @@ class VGMSampColl : public VGMFile {
               std::string name = "VGMSampColl");
   VGMSampColl(const std::string &format, RawFile *rawfile, VGMInstrSet *instrset, u32 offset,
                 u32 length = 0, std::string name = "VGMSampColl");
+  ~VGMSampColl() override;
   void useInstrSet(VGMInstrSet *instrset) { parInstrSet = instrset; }
 
   bool loadVGMFile(bool useMatcher = true) override;
@@ -43,6 +44,7 @@ protected:
 
 private:
   bool m_should_load_on_instr_set_match, bLoaded;
+  bool m_samples_owned_by_children{false};
 };
 
 namespace conversion {

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -59,7 +59,7 @@ VGMInstr* VGMInstrSet::sinkInstrAsChild(VGMItem& parent, std::unique_ptr<VGMInst
 
 std::vector<std::unique_ptr<VGMInstr>> VGMInstrSet::releaseInstrs() {
   m_instrs.clear();
-  return std::move(m_ownedInstrs);
+  return std::exchange(m_ownedInstrs, {});
 }
 
 void VGMInstrSet::clearInstrs() {
@@ -167,18 +167,6 @@ VGMInstr::VGMInstr(VGMInstrSet *instrSet, u32 offset, u32 length, u32 bank,
                    u32 instrNum, std::string name, float reverb)
     : VGMItem(instrSet, offset, length, std::move(name), Type::Instrument),
       bank(bank), instrNum(instrNum), parInstrSet(instrSet), reverb(reverb) {
-}
-
-VGMInstr::VGMInstr(const VGMInstr& other)
-    : VGMItem(other),
-      bank(other.bank),
-      instrNum(other.instrNum),
-      parInstrSet(other.parInstrSet),
-      reverb(other.reverb),
-      m_auto_add_regions_as_children(other.m_auto_add_regions_as_children),
-      m_regions(other.m_regions),
-      m_modulators(other.m_modulators),
-      m_generators(other.m_generators) {
 }
 
 VGMInstr::~VGMInstr() = default;

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -34,7 +34,7 @@ VGMInstrSet::~VGMInstrSet() = default;
 
 VGMInstr *VGMInstrSet::addInstr(u32 offset, u32 length, u32 bank,
                                 u32 instrNum, const std::string &instrName) {
-  return emplaceInstr<VGMInstr>(
+  return addInstr<VGMInstr>(
       this, offset, length, bank, instrNum,
       instrName.empty() ? fmt::format("Instrument {}", instrCount()) : instrName);
 }
@@ -53,7 +53,7 @@ VGMInstr* VGMInstrSet::adoptInstrAsChild(std::unique_ptr<VGMInstr> instr) {
 VGMInstr* VGMInstrSet::adoptInstrAsChild(VGMItem& parent, std::unique_ptr<VGMInstr> instr) {
   auto* rawInstr = instr.get();
   m_instrs.push_back(rawInstr);
-  parent.addChild(std::move(instr));
+  parent.adoptChild(std::move(instr));
   return rawInstr;
 }
 
@@ -81,7 +81,7 @@ bool VGMInstrSet::load() {
 
   if (m_auto_add_instruments_as_children) {
     for (auto& instr : m_ownedInstrs) {
-      addChild(std::move(instr));
+      adoptChild(std::move(instr));
     }
     m_ownedInstrs.clear();
   }
@@ -139,7 +139,7 @@ const std::vector<VGMInstr*>& VGMInstrSet::exportInstrs() const {
   return m_exportInstrs.empty() ? m_instrs : m_exportInstrs;
 }
 
-void VGMInstrSet::addTempInstr(std::unique_ptr<VGMInstr> instr) {
+void VGMInstrSet::adoptTempInstr(std::unique_ptr<VGMInstr> instr) {
   assert(instr != nullptr);
   m_exportInstrs.push_back(instr.get());
   m_tempInstrs.emplace_back(std::move(instr));
@@ -187,11 +187,11 @@ void VGMInstr::setInstrNum(u32 theInstrNum) {
   instrNum = theInstrNum;
 }
 
-VGMRgn *VGMInstr::addRgn(std::unique_ptr<VGMRgn> rgn) {
+VGMRgn *VGMInstr::adoptRgn(std::unique_ptr<VGMRgn> rgn) {
   auto* rawRgn = rgn.get();
   m_regions.emplace_back(rawRgn);
   if (m_auto_add_regions_as_children) {
-    addChild(std::move(rgn));
+    adoptChild(std::move(rgn));
   } else {
     m_ownedRegions.emplace_back(std::move(rgn));
   }
@@ -200,7 +200,7 @@ VGMRgn *VGMInstr::addRgn(std::unique_ptr<VGMRgn> rgn) {
 
 VGMRgn *VGMInstr::addRgn(u32 offset, u32 length, int sampNum, u8 keyLow,
                          u8 keyHigh, u8 velLow, u8 velHigh) {
-  return emplaceRgn<VGMRgn>(this, offset, length, keyLow, keyHigh, velLow, velHigh, sampNum);
+  return addRgn<VGMRgn>(this, offset, length, keyLow, keyHigh, velLow, velHigh, sampNum);
 }
 
 void VGMInstr::deleteRegions() {

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -16,6 +16,8 @@
 #include "VGMSamp.h"
 #include "VGMSampColl.h"
 
+#include <utility>
+
 #include <spdlog/fmt/fmt.h>
 
 // ***********
@@ -25,55 +27,63 @@
 VGMInstrSet::VGMInstrSet(const std::string &format, RawFile *file, u32 offset, u32 length,
                          std::string name, VGMSampColl *sampColl)
     : VGMFile(format, file, offset, length, std::move(name)),
-      sampColl(sampColl),
-      m_ownedSampColl(sampColl) {
+      sampColl(sampColl) {
 }
 
-VGMInstrSet::~VGMInstrSet() {
-  if (!m_instruments_owned_by_children) {
-    deleteVect(aInstrs);
-  }
-}
+VGMInstrSet::~VGMInstrSet() = default;
 
 VGMInstr *VGMInstrSet::addInstr(u32 offset, u32 length, u32 bank,
                                 u32 instrNum, const std::string &instrName) {
-  VGMInstr *instr =
-      new VGMInstr(this, offset, length, bank, instrNum,
-                   instrName.empty() ? fmt::format("Instrument {}", aInstrs.size()) : instrName);
-  aInstrs.push_back(instr);
-  return instr;
+  return emplaceInstr<VGMInstr>(
+      this, offset, length, bank, instrNum,
+      instrName.empty() ? fmt::format("Instrument {}", instrCount()) : instrName);
 }
 
-bool VGMInstrSet::loadVGMFile(bool useMatcher) {
-  bool val = load();
-  if (!val) {
-    return false;
-  }
+VGMInstr* VGMInstrSet::adoptInstr(std::unique_ptr<VGMInstr> instr) {
+  auto* rawInstr = instr.get();
+  m_instrs.push_back(rawInstr);
+  m_ownedInstrs.emplace_back(std::move(instr));
+  return rawInstr;
+}
 
-  if (useMatcher) {
-    if (auto fmt = format(); fmt) {
-      fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
-    }
-  }
+VGMInstr* VGMInstrSet::adoptInstrAsChild(std::unique_ptr<VGMInstr> instr) {
+  return adoptInstrAsChild(*this, std::move(instr));
+}
 
-  return val;
+VGMInstr* VGMInstrSet::adoptInstrAsChild(VGMItem& parent, std::unique_ptr<VGMInstr> instr) {
+  auto* rawInstr = instr.get();
+  m_instrs.push_back(rawInstr);
+  parent.addChild(std::move(instr));
+  return rawInstr;
+}
+
+std::vector<std::unique_ptr<VGMInstr>> VGMInstrSet::releaseInstrs() {
+  m_instrs.clear();
+  return std::move(m_ownedInstrs);
+}
+
+void VGMInstrSet::clearInstrs() {
+  m_instrs.clear();
+  m_ownedInstrs.clear();
 }
 
 bool VGMInstrSet::load() {
   if (!parseHeader())
     return false;
   if (!parseInstrPointers()) {
-    deleteVect(aInstrs);
+    clearInstrs();
     return false;
   }
   if (!loadInstrs()) {
-    deleteVect(aInstrs);
+    clearInstrs();
     return false;
   }
 
   if (m_auto_add_instruments_as_children) {
-    addChildren(aInstrs);
-    m_instruments_owned_by_children = true;
+    for (auto& instr : m_ownedInstrs) {
+      addChild(std::move(instr));
+    }
+    m_ownedInstrs.clear();
   }
 
   if (length() == 0) {
@@ -88,8 +98,6 @@ bool VGMInstrSet::load() {
     }
   }
 
-  rawFile()->addContainedVGMFile(this);
-  pRoot->addVGMFile(this);
   return true;
 }
 
@@ -102,9 +110,9 @@ bool VGMInstrSet::parseInstrPointers() {
 }
 
 bool VGMInstrSet::loadInstrs() {
-  size_t nInstrs = aInstrs.size();
+  size_t nInstrs = m_instrs.size();
   for (size_t i = 0; i < nInstrs; i++) {
-    if (!aInstrs[i]->loadInstr())
+    if (!m_instrs[i]->loadInstr())
       return false;
   }
   return true;
@@ -112,7 +120,7 @@ bool VGMInstrSet::loadInstrs() {
 
 void VGMInstrSet::prepareForExport(const VGMColl* coll) {
   cleanupAfterExport();
-  m_exportInstrs = aInstrs;
+  m_exportInstrs = m_instrs;
   if (coll != nullptr) {
     if (coll->seq() == nullptr) {
       L_DEBUG("Collection is missing a sequence. This is unusual.");
@@ -128,18 +136,18 @@ void VGMInstrSet::cleanupAfterExport() {
 }
 
 const std::vector<VGMInstr*>& VGMInstrSet::exportInstrs() const {
-  return m_exportInstrs.empty() ? aInstrs : m_exportInstrs;
+  return m_exportInstrs.empty() ? m_instrs : m_exportInstrs;
 }
 
-void VGMInstrSet::addTempInstr(VGMInstr* instr) {
+void VGMInstrSet::addTempInstr(std::unique_ptr<VGMInstr> instr) {
   assert(instr != nullptr);
-  m_exportInstrs.push_back(instr);
-  m_tempInstrs.emplace_back(instr);
+  m_exportInstrs.push_back(instr.get());
+  m_tempInstrs.emplace_back(std::move(instr));
 }
 
-void VGMInstrSet::adoptSampColl(VGMSampColl* newSampColl) {
-  m_ownedSampColl.reset(newSampColl);
-  sampColl = newSampColl;
+void VGMInstrSet::adoptSampColl(std::unique_ptr<VGMSampColl> newSampColl) {
+  sampColl = newSampColl.get();
+  m_ownedSampColl = std::move(newSampColl);
 }
 
 void VGMInstrSet::clearSampColl() {
@@ -179,26 +187,20 @@ void VGMInstr::setInstrNum(u32 theInstrNum) {
   instrNum = theInstrNum;
 }
 
-VGMRgn *VGMInstr::addRgn(VGMRgn *rgn) {
-  m_regions.emplace_back(rgn);
+VGMRgn *VGMInstr::addRgn(std::unique_ptr<VGMRgn> rgn) {
+  auto* rawRgn = rgn.get();
+  m_regions.emplace_back(rawRgn);
   if (m_auto_add_regions_as_children) {
-    addChild(rgn);
+    addChild(std::move(rgn));
   } else {
-    m_ownedRegions.emplace_back(rgn);
+    m_ownedRegions.emplace_back(std::move(rgn));
   }
-  return rgn;
+  return rawRgn;
 }
 
 VGMRgn *VGMInstr::addRgn(u32 offset, u32 length, int sampNum, u8 keyLow,
                          u8 keyHigh, u8 velLow, u8 velHigh) {
-  VGMRgn *newRgn = new VGMRgn(this, offset, length, keyLow, keyHigh, velLow, velHigh, sampNum);
-  m_regions.emplace_back(newRgn);
-  if (m_auto_add_regions_as_children) {
-    addChild(newRgn);
-  } else {
-    m_ownedRegions.emplace_back(newRgn);
-  }
-  return newRgn;
+  return emplaceRgn<VGMRgn>(this, offset, length, keyLow, keyHigh, velLow, velHigh, sampNum);
 }
 
 void VGMInstr::deleteRegions() {

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -110,9 +110,8 @@ bool VGMInstrSet::parseInstrPointers() {
 }
 
 bool VGMInstrSet::loadInstrs() {
-  size_t nInstrs = m_instrs.size();
-  for (size_t i = 0; i < nInstrs; i++) {
-    if (!m_instrs[i]->loadInstr())
+  for (auto* instr : m_instrs) {
+    if (!instr->loadInstr())
       return false;
   }
   return true;

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -27,7 +27,7 @@
 VGMInstrSet::VGMInstrSet(const std::string &format, RawFile *file, u32 offset, u32 length,
                          std::string name, VGMSampColl *sampColl)
     : VGMFile(format, file, offset, length, std::move(name)),
-      sampColl(sampColl) {
+      m_sampColl(sampColl) {
 }
 
 VGMInstrSet::~VGMInstrSet() = default;
@@ -90,11 +90,11 @@ bool VGMInstrSet::load() {
     setGuessedLength();
   }
 
-  if (sampColl != nullptr) {
-    if (!sampColl->load()) {
+  if (m_sampColl != nullptr) {
+    if (!m_sampColl->load()) {
       L_WARN("Failed to load VGMSampColl");
     } else {
-      sampColl->transferChildren(this);
+      m_sampColl->transferChildren(this);
     }
   }
 
@@ -144,14 +144,19 @@ void VGMInstrSet::sinkTempInstr(std::unique_ptr<VGMInstr>&& instr) {
   m_tempInstrs.emplace_back(std::move(instr));
 }
 
+void VGMInstrSet::attachSampColl(VGMSampColl* newSampColl) {
+  m_ownedSampColl.reset();
+  m_sampColl = newSampColl;
+}
+
 void VGMInstrSet::sinkSampColl(std::unique_ptr<VGMSampColl>&& newSampColl) {
-  sampColl = newSampColl.get();
+  m_sampColl = newSampColl.get();
   m_ownedSampColl = std::move(newSampColl);
 }
 
 void VGMInstrSet::clearSampColl() {
   m_ownedSampColl.reset();
-  sampColl = nullptr;
+  m_sampColl = nullptr;
 }
 
 // ********

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -25,12 +25,14 @@
 VGMInstrSet::VGMInstrSet(const std::string &format, RawFile *file, u32 offset, u32 length,
                          std::string name, VGMSampColl *sampColl)
     : VGMFile(format, file, offset, length, std::move(name)),
-      sampColl(sampColl) {
+      sampColl(sampColl),
+      m_ownedSampColl(sampColl) {
 }
 
 VGMInstrSet::~VGMInstrSet() {
-  deleteVect(m_tempInstrs);
-  delete sampColl;
+  if (!m_instruments_owned_by_children) {
+    deleteVect(aInstrs);
+  }
 }
 
 VGMInstr *VGMInstrSet::addInstr(u32 offset, u32 length, u32 bank,
@@ -69,8 +71,10 @@ bool VGMInstrSet::load() {
     return false;
   }
 
-  if (m_auto_add_instruments_as_children)
+  if (m_auto_add_instruments_as_children) {
     addChildren(aInstrs);
+    m_instruments_owned_by_children = true;
+  }
 
   if (length() == 0) {
     setGuessedLength();
@@ -84,8 +88,7 @@ bool VGMInstrSet::load() {
     }
   }
 
-  rawFile()->addContainedVGMFile(
-      std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(this));
+  rawFile()->addContainedVGMFile(this);
   pRoot->addVGMFile(this);
   return true;
 }
@@ -121,7 +124,7 @@ void VGMInstrSet::prepareForExport(const VGMColl* coll) {
 void VGMInstrSet::cleanupAfterExport() {
   unuseColl();
   m_exportInstrs.clear();
-  deleteVect(m_tempInstrs);
+  m_tempInstrs.clear();
 }
 
 const std::vector<VGMInstr*>& VGMInstrSet::exportInstrs() const {
@@ -130,8 +133,18 @@ const std::vector<VGMInstr*>& VGMInstrSet::exportInstrs() const {
 
 void VGMInstrSet::addTempInstr(VGMInstr* instr) {
   assert(instr != nullptr);
-  m_tempInstrs.push_back(instr);
   m_exportInstrs.push_back(instr);
+  m_tempInstrs.emplace_back(instr);
+}
+
+void VGMInstrSet::adoptSampColl(VGMSampColl* newSampColl) {
+  m_ownedSampColl.reset(newSampColl);
+  sampColl = newSampColl;
+}
+
+void VGMInstrSet::clearSampColl() {
+  m_ownedSampColl.reset();
+  sampColl = nullptr;
 }
 
 // ********
@@ -144,6 +157,20 @@ VGMInstr::VGMInstr(VGMInstrSet *instrSet, u32 offset, u32 length, u32 bank,
       bank(bank), instrNum(instrNum), parInstrSet(instrSet), reverb(reverb) {
 }
 
+VGMInstr::VGMInstr(const VGMInstr& other)
+    : VGMItem(other),
+      bank(other.bank),
+      instrNum(other.instrNum),
+      parInstrSet(other.parInstrSet),
+      reverb(other.reverb),
+      m_auto_add_regions_as_children(other.m_auto_add_regions_as_children),
+      m_regions(other.m_regions),
+      m_modulators(other.m_modulators),
+      m_generators(other.m_generators) {
+}
+
+VGMInstr::~VGMInstr() = default;
+
 void VGMInstr::setBank(u32 bankNum) {
   bank = bankNum;
 }
@@ -154,8 +181,11 @@ void VGMInstr::setInstrNum(u32 theInstrNum) {
 
 VGMRgn *VGMInstr::addRgn(VGMRgn *rgn) {
   m_regions.emplace_back(rgn);
-  if (m_auto_add_regions_as_children)
+  if (m_auto_add_regions_as_children) {
     addChild(rgn);
+  } else {
+    m_ownedRegions.emplace_back(rgn);
+  }
   return rgn;
 }
 
@@ -163,13 +193,17 @@ VGMRgn *VGMInstr::addRgn(u32 offset, u32 length, int sampNum, u8 keyLow,
                          u8 keyHigh, u8 velLow, u8 velHigh) {
   VGMRgn *newRgn = new VGMRgn(this, offset, length, keyLow, keyHigh, velLow, velHigh, sampNum);
   m_regions.emplace_back(newRgn);
-  if (m_auto_add_regions_as_children)
+  if (m_auto_add_regions_as_children) {
     addChild(newRgn);
+  } else {
+    m_ownedRegions.emplace_back(newRgn);
+  }
   return newRgn;
 }
 
 void VGMInstr::deleteRegions() {
-  deleteVect(m_regions);
+  m_ownedRegions.clear();
+  m_regions.clear();
 }
 
 // Modulator methods

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -39,21 +39,21 @@ VGMInstr *VGMInstrSet::addInstr(u32 offset, u32 length, u32 bank,
       instrName.empty() ? fmt::format("Instrument {}", instrCount()) : instrName);
 }
 
-VGMInstr* VGMInstrSet::adoptInstr(std::unique_ptr<VGMInstr> instr) {
+VGMInstr* VGMInstrSet::sinkInstr(std::unique_ptr<VGMInstr>&& instr) {
   auto* rawInstr = instr.get();
   m_instrs.push_back(rawInstr);
   m_ownedInstrs.emplace_back(std::move(instr));
   return rawInstr;
 }
 
-VGMInstr* VGMInstrSet::adoptInstrAsChild(std::unique_ptr<VGMInstr> instr) {
-  return adoptInstrAsChild(*this, std::move(instr));
+VGMInstr* VGMInstrSet::sinkInstrAsChild(std::unique_ptr<VGMInstr>&& instr) {
+  return sinkInstrAsChild(*this, std::move(instr));
 }
 
-VGMInstr* VGMInstrSet::adoptInstrAsChild(VGMItem& parent, std::unique_ptr<VGMInstr> instr) {
+VGMInstr* VGMInstrSet::sinkInstrAsChild(VGMItem& parent, std::unique_ptr<VGMInstr>&& instr) {
   auto* rawInstr = instr.get();
   m_instrs.push_back(rawInstr);
-  parent.adoptChild(std::move(instr));
+  parent.sinkChild(std::move(instr));
   return rawInstr;
 }
 
@@ -81,7 +81,7 @@ bool VGMInstrSet::load() {
 
   if (m_auto_add_instruments_as_children) {
     for (auto& instr : m_ownedInstrs) {
-      adoptChild(std::move(instr));
+      sinkChild(std::move(instr));
     }
     m_ownedInstrs.clear();
   }
@@ -139,13 +139,13 @@ const std::vector<VGMInstr*>& VGMInstrSet::exportInstrs() const {
   return m_exportInstrs.empty() ? m_instrs : m_exportInstrs;
 }
 
-void VGMInstrSet::adoptTempInstr(std::unique_ptr<VGMInstr> instr) {
+void VGMInstrSet::sinkTempInstr(std::unique_ptr<VGMInstr>&& instr) {
   assert(instr != nullptr);
   m_exportInstrs.push_back(instr.get());
   m_tempInstrs.emplace_back(std::move(instr));
 }
 
-void VGMInstrSet::adoptSampColl(std::unique_ptr<VGMSampColl> newSampColl) {
+void VGMInstrSet::sinkSampColl(std::unique_ptr<VGMSampColl>&& newSampColl) {
   sampColl = newSampColl.get();
   m_ownedSampColl = std::move(newSampColl);
 }
@@ -187,11 +187,11 @@ void VGMInstr::setInstrNum(u32 theInstrNum) {
   instrNum = theInstrNum;
 }
 
-VGMRgn *VGMInstr::adoptRgn(std::unique_ptr<VGMRgn> rgn) {
+VGMRgn *VGMInstr::sinkRgn(std::unique_ptr<VGMRgn>&& rgn) {
   auto* rawRgn = rgn.get();
   m_regions.emplace_back(rawRgn);
   if (m_auto_add_regions_as_children) {
-    adoptChild(std::move(rgn));
+    sinkChild(std::move(rgn));
   } else {
     m_ownedRegions.emplace_back(std::move(rgn));
   }

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 class VGMSampColl;
@@ -27,7 +28,6 @@ public:
               std::string name = "VGMInstrSet", VGMSampColl *sampColl = nullptr);
   ~VGMInstrSet() override;
 
-  bool loadVGMFile(bool useMatcher = true) override;
   bool load() override;
   virtual bool parseHeader();
   virtual bool parseInstrPointers();
@@ -39,23 +39,48 @@ public:
   void prepareForExport(const VGMColl* coll);
   void cleanupAfterExport();
 
+  [[nodiscard]] const std::vector<VGMInstr*>& instrs() const { return m_instrs; }
+  [[nodiscard]] bool hasInstrs() const { return !m_instrs.empty(); }
+  [[nodiscard]] size_t instrCount() const { return m_instrs.size(); }
+  VGMInstr* instr(size_t index) const { return m_instrs.at(index); }
   const std::vector<VGMInstr*>& exportInstrs() const;
 
   VGMInstr *addInstr(u32 offset, u32 length, u32 bank, u32 instrNum,
                      const std::string &instrName = "");
-  void adoptSampColl(VGMSampColl* newSampColl);
+  void adoptSampColl(std::unique_ptr<VGMSampColl> newSampColl);
+  template <class SampCollType, class... Args>
+  SampCollType* emplaceSampColl(Args&&... args) {
+    auto newSampColl = std::make_unique<SampCollType>(std::forward<Args>(args)...);
+    auto* rawSampColl = newSampColl.get();
+    adoptSampColl(std::move(newSampColl));
+    return rawSampColl;
+  }
   void clearSampColl();
 
-  std::vector<VGMInstr *> aInstrs;
+  // Observer; use adoptSampColl/emplaceSampColl when the instrument set owns the sample collection.
   VGMSampColl *sampColl;
 
 protected:
-   void addTempInstr(VGMInstr* instr);
+   void reserveInstrs(size_t count) { m_ownedInstrs.reserve(count); m_instrs.reserve(count); }
+   VGMInstr* adoptInstr(std::unique_ptr<VGMInstr> instr);
+   VGMInstr* adoptInstrAsChild(std::unique_ptr<VGMInstr> instr);
+   VGMInstr* adoptInstrAsChild(VGMItem& parent, std::unique_ptr<VGMInstr> instr);
+   template <class InstrType, class... Args>
+   InstrType* emplaceInstr(Args&&... args) {
+     auto instr = std::make_unique<InstrType>(std::forward<Args>(args)...);
+     auto* rawInstr = instr.get();
+     adoptInstr(std::move(instr));
+     return rawInstr;
+   }
+   std::vector<std::unique_ptr<VGMInstr>> releaseInstrs();
+   void clearInstrs();
+   void addTempInstr(std::unique_ptr<VGMInstr> instr);
    void disableAutoAddInstrumentsAsChildren() { m_auto_add_instruments_as_children = false; }
 
 private:
    bool m_auto_add_instruments_as_children{true};
-   bool m_instruments_owned_by_children{false};
+   std::vector<std::unique_ptr<VGMInstr>> m_ownedInstrs;
+   std::vector<VGMInstr*> m_instrs;
    std::vector<VGMInstr*> m_exportInstrs;
    std::vector<std::unique_ptr<VGMInstr>> m_tempInstrs;
    std::unique_ptr<VGMSampColl> m_ownedSampColl;
@@ -79,7 +104,14 @@ public:
   inline void setBank(u32 bankNum);
   inline void setInstrNum(u32 theInstrNum);
 
-  VGMRgn *addRgn(VGMRgn *rgn);
+  VGMRgn *addRgn(std::unique_ptr<VGMRgn> rgn);
+  template <class RgnType, class... Args>
+  RgnType* emplaceRgn(Args&&... args) {
+    auto rgn = std::make_unique<RgnType>(std::forward<Args>(args)...);
+    auto* rawRgn = rgn.get();
+    addRgn(std::move(rgn));
+    return rawRgn;
+  }
   VGMRgn *addRgn(u32 offset, u32 length, int sampNum, u8 keyLow = 0,
                  u8 keyHigh = 0x7F, u8 velLow = 0, u8 velHigh = 0x7F);
 

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -49,7 +49,7 @@ public:
                      const std::string &instrName = "");
   void adoptSampColl(std::unique_ptr<VGMSampColl> newSampColl);
   template <class SampCollType, class... Args>
-  SampCollType* emplaceSampColl(Args&&... args) {
+  SampCollType* addSampColl(Args&&... args) {
     auto newSampColl = std::make_unique<SampCollType>(std::forward<Args>(args)...);
     auto* rawSampColl = newSampColl.get();
     adoptSampColl(std::move(newSampColl));
@@ -57,7 +57,7 @@ public:
   }
   void clearSampColl();
 
-  // Observer; use adoptSampColl/emplaceSampColl when the instrument set owns the sample collection.
+  // Observer; use adoptSampColl/addSampColl<T> when the instrument set owns the sample collection.
   VGMSampColl *sampColl;
 
 protected:
@@ -66,7 +66,7 @@ protected:
    VGMInstr* adoptInstrAsChild(std::unique_ptr<VGMInstr> instr);
    VGMInstr* adoptInstrAsChild(VGMItem& parent, std::unique_ptr<VGMInstr> instr);
    template <class InstrType, class... Args>
-   InstrType* emplaceInstr(Args&&... args) {
+   InstrType* addInstr(Args&&... args) {
      auto instr = std::make_unique<InstrType>(std::forward<Args>(args)...);
      auto* rawInstr = instr.get();
      adoptInstr(std::move(instr));
@@ -74,7 +74,7 @@ protected:
    }
    std::vector<std::unique_ptr<VGMInstr>> releaseInstrs();
    void clearInstrs();
-   void addTempInstr(std::unique_ptr<VGMInstr> instr);
+   void adoptTempInstr(std::unique_ptr<VGMInstr> instr);
    void disableAutoAddInstrumentsAsChildren() { m_auto_add_instruments_as_children = false; }
 
 private:
@@ -104,12 +104,12 @@ public:
   inline void setBank(u32 bankNum);
   inline void setInstrNum(u32 theInstrNum);
 
-  VGMRgn *addRgn(std::unique_ptr<VGMRgn> rgn);
+  VGMRgn *adoptRgn(std::unique_ptr<VGMRgn> rgn);
   template <class RgnType, class... Args>
-  RgnType* emplaceRgn(Args&&... args) {
+  RgnType* addRgn(Args&&... args) {
     auto rgn = std::make_unique<RgnType>(std::forward<Args>(args)...);
     auto* rawRgn = rgn.get();
-    addRgn(std::move(rgn));
+    adoptRgn(std::move(rgn));
     return rawRgn;
   }
   VGMRgn *addRgn(u32 offset, u32 length, int sampNum, u8 keyLow = 0,

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -3,6 +3,7 @@
 #include "Modulation.h"
 #include "VGMFile.h"
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -42,6 +43,8 @@ public:
 
   VGMInstr *addInstr(u32 offset, u32 length, u32 bank, u32 instrNum,
                      const std::string &instrName = "");
+  void adoptSampColl(VGMSampColl* newSampColl);
+  void clearSampColl();
 
   std::vector<VGMInstr *> aInstrs;
   VGMSampColl *sampColl;
@@ -52,8 +55,10 @@ protected:
 
 private:
    bool m_auto_add_instruments_as_children{true};
+   bool m_instruments_owned_by_children{false};
    std::vector<VGMInstr*> m_exportInstrs;
-   std::vector<VGMInstr*> m_tempInstrs;
+   std::vector<std::unique_ptr<VGMInstr>> m_tempInstrs;
+   std::unique_ptr<VGMSampColl> m_ownedSampColl;
 };
 
 // ********
@@ -65,6 +70,8 @@ public:
   VGMInstr(VGMInstrSet *parInstrSet, u32 offset, u32 length, u32 bank,
            u32 instrNum, std::string name = "Instrument",
            float reverb = defaultReverbPercent);
+  VGMInstr(const VGMInstr& other);
+  ~VGMInstr() override;
 
   const std::vector<VGMRgn*>& regions() { return m_regions; }
   const std::vector<VGMRgn*>& regions() const { return m_regions; }
@@ -119,6 +126,7 @@ protected:
 private:
   bool m_auto_add_regions_as_children{true};
   std::vector<VGMRgn*> m_regions;
+  std::vector<std::unique_ptr<VGMRgn>> m_ownedRegions;
   std::vector<SynthModulator> m_modulators;
   std::vector<SynthGenerator> m_generators;
 };

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -47,34 +47,34 @@ public:
 
   VGMInstr *addInstr(u32 offset, u32 length, u32 bank, u32 instrNum,
                      const std::string &instrName = "");
-  void adoptSampColl(std::unique_ptr<VGMSampColl> newSampColl);
+  void sinkSampColl(std::unique_ptr<VGMSampColl>&& newSampColl);
   template <class SampCollType, class... Args>
   SampCollType* addSampColl(Args&&... args) {
     auto newSampColl = std::make_unique<SampCollType>(std::forward<Args>(args)...);
     auto* rawSampColl = newSampColl.get();
-    adoptSampColl(std::move(newSampColl));
+    sinkSampColl(std::move(newSampColl));
     return rawSampColl;
   }
   void clearSampColl();
 
-  // Observer; use adoptSampColl/addSampColl<T> when the instrument set owns the sample collection.
+  // Observer; use sinkSampColl/addSampColl<T> when the instrument set owns the sample collection.
   VGMSampColl *sampColl;
 
 protected:
    void reserveInstrs(size_t count) { m_ownedInstrs.reserve(count); m_instrs.reserve(count); }
-   VGMInstr* adoptInstr(std::unique_ptr<VGMInstr> instr);
-   VGMInstr* adoptInstrAsChild(std::unique_ptr<VGMInstr> instr);
-   VGMInstr* adoptInstrAsChild(VGMItem& parent, std::unique_ptr<VGMInstr> instr);
+   VGMInstr* sinkInstr(std::unique_ptr<VGMInstr>&& instr);
+   VGMInstr* sinkInstrAsChild(std::unique_ptr<VGMInstr>&& instr);
+   VGMInstr* sinkInstrAsChild(VGMItem& parent, std::unique_ptr<VGMInstr>&& instr);
    template <class InstrType, class... Args>
    InstrType* addInstr(Args&&... args) {
      auto instr = std::make_unique<InstrType>(std::forward<Args>(args)...);
      auto* rawInstr = instr.get();
-     adoptInstr(std::move(instr));
+     sinkInstr(std::move(instr));
      return rawInstr;
    }
    std::vector<std::unique_ptr<VGMInstr>> releaseInstrs();
    void clearInstrs();
-   void adoptTempInstr(std::unique_ptr<VGMInstr> instr);
+   void sinkTempInstr(std::unique_ptr<VGMInstr>&& instr);
    void disableAutoAddInstrumentsAsChildren() { m_auto_add_instruments_as_children = false; }
 
 private:
@@ -104,12 +104,12 @@ public:
   inline void setBank(u32 bankNum);
   inline void setInstrNum(u32 theInstrNum);
 
-  VGMRgn *adoptRgn(std::unique_ptr<VGMRgn> rgn);
+  VGMRgn *sinkRgn(std::unique_ptr<VGMRgn>&& rgn);
   template <class RgnType, class... Args>
   RgnType* addRgn(Args&&... args) {
     auto rgn = std::make_unique<RgnType>(std::forward<Args>(args)...);
     auto* rawRgn = rgn.get();
-    adoptRgn(std::move(rgn));
+    sinkRgn(std::move(rgn));
     return rawRgn;
   }
   VGMRgn *addRgn(u32 offset, u32 length, int sampNum, u8 keyLow = 0,

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -47,6 +47,8 @@ public:
 
   VGMInstr *addInstr(u32 offset, u32 length, u32 bank, u32 instrNum,
                      const std::string &instrName = "");
+  [[nodiscard]] VGMSampColl* sampColl() const { return m_sampColl; }
+  void attachSampColl(VGMSampColl* newSampColl);
   void sinkSampColl(std::unique_ptr<VGMSampColl>&& newSampColl);
   template <class SampCollType, class... Args>
   SampCollType* addSampColl(Args&&... args) {
@@ -56,9 +58,6 @@ public:
     return rawSampColl;
   }
   void clearSampColl();
-
-  // Observer; use sinkSampColl/addSampColl<T> when the instrument set owns the sample collection.
-  VGMSampColl *sampColl;
 
 protected:
    void reserveInstrs(size_t count) { m_ownedInstrs.reserve(count); m_instrs.reserve(count); }
@@ -83,6 +82,7 @@ private:
    std::vector<VGMInstr*> m_instrs;
    std::vector<VGMInstr*> m_exportInstrs;
    std::vector<std::unique_ptr<VGMInstr>> m_tempInstrs;
+   VGMSampColl* m_sampColl{};
    std::unique_ptr<VGMSampColl> m_ownedSampColl;
 };
 

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -95,7 +95,8 @@ public:
   VGMInstr(VGMInstrSet *parInstrSet, u32 offset, u32 length, u32 bank,
            u32 instrNum, std::string name = "Instrument",
            float reverb = defaultReverbPercent);
-  VGMInstr(const VGMInstr& other);
+  VGMInstr(const VGMInstr& other) = delete;
+  VGMInstr& operator=(const VGMInstr& other) = delete;
   ~VGMInstr() override;
 
   const std::vector<VGMRgn*>& regions() { return m_regions; }

--- a/src/main/components/instr/VGMRgn.cpp
+++ b/src/main/components/instr/VGMRgn.cpp
@@ -75,17 +75,17 @@ void VGMRgn::setADSR(long attackTime, u16 atkTransform, long decayTime, long sus
 }
 
 void VGMRgn::addGeneralItem(u32 offset, u32 length, const std::string &name) {
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_GENERIC, offset, length, name);
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_GENERIC, offset, length, name);
 }
 
 void VGMRgn::addUnknown(u32 offset, u32 length) {
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_UNKNOWN, offset, length, "Unknown");
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_UNKNOWN, offset, length, "Unknown");
 }
 
 //assumes pan is given as 0-127 value, converts it to our double -1.0 to 1.0 format
 void VGMRgn::addPan(u8 p, u32 offset, u32 length, const std::string& name) {
   setPan(p);
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_PAN, offset, length, name);
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_PAN, offset, length, name);
 }
 
 void VGMRgn::setVolume(double vol) {
@@ -98,56 +98,56 @@ void VGMRgn::setAttenuation(double attenDb) {
 
 void VGMRgn::addVolume(double vol, u32 offset, u32 length) {
   setVolume(vol);
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_VOL, offset, length, "Volume");
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_VOL, offset, length, "Volume");
 }
 
 void VGMRgn::addAttenuation(double attenDb, u32 offset, u32 length) {
   setAttenuation(attenDb);
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_VOL, offset, length, "Attenuation");
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_VOL, offset, length, "Attenuation");
 }
 
 void VGMRgn::addUnityKey(u8 uk, u32 offset, u32 length) {
   this->unityKey = uk;
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_UNITYKEY, offset, length, "Unity Key");
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_UNITYKEY, offset, length, "Unity Key");
 }
 
 void VGMRgn::addCoarseTune(s16 relativeSemitones, u32 offset, u32 length) {
   this->coarseTune = relativeSemitones;
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_FINETUNE, offset, length, "Coarse Tune");
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_FINETUNE, offset, length, "Coarse Tune");
 }
 
 void VGMRgn::addFineTune(s16 relativePitchCents, u32 offset, u32 length) {
   this->fineTune = relativePitchCents;
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_FINETUNE, offset, length, "Fine Tune");
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_FINETUNE, offset, length, "Fine Tune");
 }
 
 void VGMRgn::addKeyLow(u8 kl, u32 offset, u32 length) {
   keyLow = kl;
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_KEYLOW, offset, length, "Note Range: Low Key");
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_KEYLOW, offset, length, "Note Range: Low Key");
 }
 
 void VGMRgn::addKeyHigh(u8 kh, u32 offset, u32 length) {
   keyHigh = kh;
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_KEYHIGH, offset, length, "Note Range: High Key");
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_KEYHIGH, offset, length, "Note Range: High Key");
 }
 
 void VGMRgn::addVelLow(u8 vl, u32 offset, u32 length) {
   velLow = vl;
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_VELLOW, offset, length, "Vel Range: Low");
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_VELLOW, offset, length, "Vel Range: Low");
 }
 
 void VGMRgn::addVelHigh(u8 vh, u32 offset, u32 length) {
   velHigh = vh;
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_VELHIGH, offset, length, "Vel Range: High");
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_VELHIGH, offset, length, "Vel Range: High");
 }
 
 void VGMRgn::addSampNum(int sn, u32 offset, u32 length) {
   sampNum = sn;
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_SAMPNUM, offset, length, "Sample Number");
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_SAMPNUM, offset, length, "Sample Number");
 }
 
 void VGMRgn::addADSRValue(u32 offset, u32 length, const std::string& name) {
-  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_ADSR, offset, length, name);
+  addChild<VGMRgnItem>(this, VGMRgnItem::RIT_ADSR, offset, length, name);
 }
 
 

--- a/src/main/components/instr/VGMRgn.cpp
+++ b/src/main/components/instr/VGMRgn.cpp
@@ -75,17 +75,17 @@ void VGMRgn::setADSR(long attackTime, u16 atkTransform, long decayTime, long sus
 }
 
 void VGMRgn::addGeneralItem(u32 offset, u32 length, const std::string &name) {
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_GENERIC, offset, length, name));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_GENERIC, offset, length, name);
 }
 
 void VGMRgn::addUnknown(u32 offset, u32 length) {
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_UNKNOWN, offset, length, "Unknown"));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_UNKNOWN, offset, length, "Unknown");
 }
 
 //assumes pan is given as 0-127 value, converts it to our double -1.0 to 1.0 format
 void VGMRgn::addPan(u8 p, u32 offset, u32 length, const std::string& name) {
   setPan(p);
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_PAN, offset, length, name));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_PAN, offset, length, name);
 }
 
 void VGMRgn::setVolume(double vol) {
@@ -98,56 +98,56 @@ void VGMRgn::setAttenuation(double attenDb) {
 
 void VGMRgn::addVolume(double vol, u32 offset, u32 length) {
   setVolume(vol);
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_VOL, offset, length, "Volume"));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_VOL, offset, length, "Volume");
 }
 
 void VGMRgn::addAttenuation(double attenDb, u32 offset, u32 length) {
   setAttenuation(attenDb);
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_VOL, offset, length, "Attenuation"));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_VOL, offset, length, "Attenuation");
 }
 
 void VGMRgn::addUnityKey(u8 uk, u32 offset, u32 length) {
   this->unityKey = uk;
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_UNITYKEY, offset, length, "Unity Key"));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_UNITYKEY, offset, length, "Unity Key");
 }
 
 void VGMRgn::addCoarseTune(s16 relativeSemitones, u32 offset, u32 length) {
   this->coarseTune = relativeSemitones;
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_FINETUNE, offset, length, "Coarse Tune"));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_FINETUNE, offset, length, "Coarse Tune");
 }
 
 void VGMRgn::addFineTune(s16 relativePitchCents, u32 offset, u32 length) {
   this->fineTune = relativePitchCents;
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_FINETUNE, offset, length, "Fine Tune"));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_FINETUNE, offset, length, "Fine Tune");
 }
 
 void VGMRgn::addKeyLow(u8 kl, u32 offset, u32 length) {
   keyLow = kl;
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_KEYLOW, offset, length, "Note Range: Low Key"));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_KEYLOW, offset, length, "Note Range: Low Key");
 }
 
 void VGMRgn::addKeyHigh(u8 kh, u32 offset, u32 length) {
   keyHigh = kh;
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_KEYHIGH, offset, length, "Note Range: High Key"));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_KEYHIGH, offset, length, "Note Range: High Key");
 }
 
 void VGMRgn::addVelLow(u8 vl, u32 offset, u32 length) {
   velLow = vl;
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_VELLOW, offset, length, "Vel Range: Low"));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_VELLOW, offset, length, "Vel Range: Low");
 }
 
 void VGMRgn::addVelHigh(u8 vh, u32 offset, u32 length) {
   velHigh = vh;
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_VELHIGH, offset, length, "Vel Range: High"));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_VELHIGH, offset, length, "Vel Range: High");
 }
 
 void VGMRgn::addSampNum(int sn, u32 offset, u32 length) {
   sampNum = sn;
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_SAMPNUM, offset, length, "Sample Number"));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_SAMPNUM, offset, length, "Sample Number");
 }
 
 void VGMRgn::addADSRValue(u32 offset, u32 length, const std::string& name) {
-  addChild(new VGMRgnItem(this, VGMRgnItem::RIT_ADSR, offset, length, name));
+  emplaceChild<VGMRgnItem>(this, VGMRgnItem::RIT_ADSR, offset, length, name);
 }
 
 

--- a/src/main/components/matcher/FilegroupMatcher.cpp
+++ b/src/main/components/matcher/FilegroupMatcher.cpp
@@ -12,6 +12,7 @@
 #include "VGMSampColl.h"
 #include "VGMSeq.h"
 
+#include <memory>
 #include <regex>
 
 FilegroupMatcher::FilegroupMatcher(Format *format) : Matcher(format) {}
@@ -133,7 +134,7 @@ void FilegroupMatcher::lookForMatch() {
   for (VGMSeq* seq : seqs) {
     const InstrAssoc& assoc = *assocIt;
 
-    VGMColl* coll = fmt->newCollection();
+    std::unique_ptr<VGMColl> coll(fmt->newCollection());
     coll->setName(seq->name());
     coll->useSeq(seq);
     coll->addInstrSet(assoc.instrSet);
@@ -142,8 +143,9 @@ void FilegroupMatcher::lookForMatch() {
     }
 
     if (!coll->load()) {
-      delete coll;
+      return;
     }
+    coll.release();
 
     // advance through the association list; keep using the last one once we run out
     if (std::next(assocIt) != instrAssocs.end()) {

--- a/src/main/components/matcher/FilegroupMatcher.cpp
+++ b/src/main/components/matcher/FilegroupMatcher.cpp
@@ -7,6 +7,7 @@
 #include "FilegroupMatcher.h"
 
 #include "Format.h"
+#include "Root.h"
 #include "VGMColl.h"
 #include "VGMInstrSet.h"
 #include "VGMSampColl.h"
@@ -134,7 +135,7 @@ void FilegroupMatcher::lookForMatch() {
   for (VGMSeq* seq : seqs) {
     const InstrAssoc& assoc = *assocIt;
 
-    std::unique_ptr<VGMColl> coll(fmt->newCollection());
+    auto coll = fmt->newCollection();
     coll->setName(seq->name());
     coll->useSeq(seq);
     coll->addInstrSet(assoc.instrSet);
@@ -142,10 +143,9 @@ void FilegroupMatcher::lookForMatch() {
       coll->addSampColl(assoc.sampColl);
     }
 
-    if (!coll->load()) {
+    if (!pRoot->loadVGMColl(std::move(coll))) {
       return;
     }
-    coll.release();
 
     // advance through the association list; keep using the last one once we run out
     if (std::next(assocIt) != instrAssocs.end()) {

--- a/src/main/components/matcher/FilegroupMatcher.cpp
+++ b/src/main/components/matcher/FilegroupMatcher.cpp
@@ -95,7 +95,7 @@ void FilegroupMatcher::lookForMatch() {
   for (VGMInstrSet* instr : instrsets) {
     VGMSampColl* extraSamp = nullptr;
 
-    if (instr->sampColl == nullptr) {
+    if (instr->sampColl() == nullptr) {
       if (forcePairSingle) {                     // exactly one‑and‑one: pair regardless
         extraSamp = sampcolls.front();
         sampcolls.clear();
@@ -117,7 +117,7 @@ void FilegroupMatcher::lookForMatch() {
         }
       }
     } else {
-      extraSamp = instr->sampColl;                // use the existing sample collection
+      extraSamp = instr->sampColl();                // use the existing sample collection
     }
 
     // keep only instrsets that actually have a sample collection to work with
@@ -139,7 +139,7 @@ void FilegroupMatcher::lookForMatch() {
     coll->setName(seq->name());
     coll->attachSeq(seq);
     coll->attachInstrSet(assoc.instrSet);
-    if (assoc.sampColl && assoc.instrSet->sampColl == nullptr) {
+    if (assoc.sampColl && assoc.instrSet->sampColl() == nullptr) {
       coll->attachSampColl(assoc.sampColl);
     }
 

--- a/src/main/components/matcher/FilegroupMatcher.cpp
+++ b/src/main/components/matcher/FilegroupMatcher.cpp
@@ -137,10 +137,10 @@ void FilegroupMatcher::lookForMatch() {
 
     auto coll = fmt->newCollection();
     coll->setName(seq->name());
-    coll->useSeq(seq);
-    coll->addInstrSet(assoc.instrSet);
+    coll->attachSeq(seq);
+    coll->attachInstrSet(assoc.instrSet);
     if (assoc.sampColl && assoc.instrSet->sampColl == nullptr) {
-      coll->addSampColl(assoc.sampColl);
+      coll->attachSampColl(assoc.sampColl);
     }
 
     if (!pRoot->loadVGMColl(std::move(coll))) {

--- a/src/main/components/matcher/SimpleMatcher.h
+++ b/src/main/components/matcher/SimpleMatcher.h
@@ -14,6 +14,7 @@
 #include "VGMSeq.h"
 
 #include <map>
+#include <memory>
 #include <utility>
 
 // *************
@@ -46,7 +47,7 @@ protected:
     if (VGMInstrSet *matchingInstrSet = instrsets[id]) {
       if (bRequiresSampColl) {
         if (VGMSampColl *matchingSampColl = sampcolls[id]) {
-          VGMColl *coll = fmt->newCollection();
+          std::unique_ptr<VGMColl> coll(fmt->newCollection());
           if (!coll)
             return false;
           coll->setName(seq->name());
@@ -54,21 +55,21 @@ protected:
           coll->addInstrSet(matchingInstrSet);
           coll->addSampColl(matchingSampColl);
           if (!coll->load()) {
-            delete coll;
             return false;
           }
+          coll.release();
         }
       } else {
-        VGMColl *coll = fmt->newCollection();
+        std::unique_ptr<VGMColl> coll(fmt->newCollection());
         if (!coll)
           return false;
         coll->setName(seq->name());
         coll->useSeq(seq);
         coll->addInstrSet(matchingInstrSet);
         if (!coll->load()) {
-          delete coll;
           return false;
         }
+        coll.release();
       }
     }
 
@@ -108,26 +109,28 @@ protected:
 
       if (bRequiresSampColl) {
         if (matchingSampColl) {
-          VGMColl *coll = fmt->newCollection();
+          std::unique_ptr<VGMColl> coll(fmt->newCollection());
           if (!coll)
             return false;
           coll->setName(matchingSeq->name());
           coll->useSeq(matchingSeq);
           coll->addInstrSet(instrset);
           coll->addSampColl(matchingSampColl);
-          coll->load();
+          if (!coll->load())
+            return false;
+          coll.release();
         }
       } else {
-        VGMColl *coll = fmt->newCollection();
+        std::unique_ptr<VGMColl> coll(fmt->newCollection());
         if (!coll)
           return false;
         coll->setName(matchingSeq->name());
         coll->useSeq(matchingSeq);
         coll->addInstrSet(instrset);
         if (!coll->load()) {
-          delete coll;
           return false;
         }
+        coll.release();
       }
     }
     return true;
@@ -166,7 +169,7 @@ protected:
         VGMSeq *matchingSeq = (*it2).second;
 
         if (matchingSeq && matchingInstrSet) {
-          VGMColl *coll = fmt->newCollection();
+          std::unique_ptr<VGMColl> coll(fmt->newCollection());
           if (!coll)
             return false;
           coll->setName(matchingSeq->name());
@@ -174,9 +177,9 @@ protected:
           coll->addInstrSet(matchingInstrSet);
           coll->addSampColl(sampcoll);
           if (!coll->load()) {
-            delete coll;
             return false;
           }
+          coll.release();
         }
       }
       return true;

--- a/src/main/components/matcher/SimpleMatcher.h
+++ b/src/main/components/matcher/SimpleMatcher.h
@@ -8,6 +8,7 @@
 
 #include "Format.h"
 #include "Matcher.h"
+#include "Root.h"
 #include "VGMColl.h"
 #include "VGMInstrSet.h"
 #include "VGMSampColl.h"
@@ -47,29 +48,27 @@ protected:
     if (VGMInstrSet *matchingInstrSet = instrsets[id]) {
       if (bRequiresSampColl) {
         if (VGMSampColl *matchingSampColl = sampcolls[id]) {
-          std::unique_ptr<VGMColl> coll(fmt->newCollection());
+          auto coll = fmt->newCollection();
           if (!coll)
             return false;
           coll->setName(seq->name());
           coll->useSeq(seq);
           coll->addInstrSet(matchingInstrSet);
           coll->addSampColl(matchingSampColl);
-          if (!coll->load()) {
+          if (!pRoot->loadVGMColl(std::move(coll))) {
             return false;
           }
-          coll.release();
         }
       } else {
-        std::unique_ptr<VGMColl> coll(fmt->newCollection());
+        auto coll = fmt->newCollection();
         if (!coll)
           return false;
         coll->setName(seq->name());
         coll->useSeq(seq);
         coll->addInstrSet(matchingInstrSet);
-        if (!coll->load()) {
+        if (!pRoot->loadVGMColl(std::move(coll))) {
           return false;
         }
-        coll.release();
       }
     }
 
@@ -109,28 +108,26 @@ protected:
 
       if (bRequiresSampColl) {
         if (matchingSampColl) {
-          std::unique_ptr<VGMColl> coll(fmt->newCollection());
+          auto coll = fmt->newCollection();
           if (!coll)
             return false;
           coll->setName(matchingSeq->name());
           coll->useSeq(matchingSeq);
           coll->addInstrSet(instrset);
           coll->addSampColl(matchingSampColl);
-          if (!coll->load())
+          if (!pRoot->loadVGMColl(std::move(coll)))
             return false;
-          coll.release();
         }
       } else {
-        std::unique_ptr<VGMColl> coll(fmt->newCollection());
+        auto coll = fmt->newCollection();
         if (!coll)
           return false;
         coll->setName(matchingSeq->name());
         coll->useSeq(matchingSeq);
         coll->addInstrSet(instrset);
-        if (!coll->load()) {
+        if (!pRoot->loadVGMColl(std::move(coll))) {
           return false;
         }
-        coll.release();
       }
     }
     return true;
@@ -169,17 +166,16 @@ protected:
         VGMSeq *matchingSeq = (*it2).second;
 
         if (matchingSeq && matchingInstrSet) {
-          std::unique_ptr<VGMColl> coll(fmt->newCollection());
+          auto coll = fmt->newCollection();
           if (!coll)
             return false;
           coll->setName(matchingSeq->name());
           coll->useSeq(matchingSeq);
           coll->addInstrSet(matchingInstrSet);
           coll->addSampColl(sampcoll);
-          if (!coll->load()) {
+          if (!pRoot->loadVGMColl(std::move(coll))) {
             return false;
           }
-          coll.release();
         }
       }
       return true;

--- a/src/main/components/matcher/SimpleMatcher.h
+++ b/src/main/components/matcher/SimpleMatcher.h
@@ -52,9 +52,9 @@ protected:
           if (!coll)
             return false;
           coll->setName(seq->name());
-          coll->useSeq(seq);
-          coll->addInstrSet(matchingInstrSet);
-          coll->addSampColl(matchingSampColl);
+          coll->attachSeq(seq);
+          coll->attachInstrSet(matchingInstrSet);
+          coll->attachSampColl(matchingSampColl);
           if (!pRoot->loadVGMColl(std::move(coll))) {
             return false;
           }
@@ -64,8 +64,8 @@ protected:
         if (!coll)
           return false;
         coll->setName(seq->name());
-        coll->useSeq(seq);
-        coll->addInstrSet(matchingInstrSet);
+        coll->attachSeq(seq);
+        coll->attachInstrSet(matchingInstrSet);
         if (!pRoot->loadVGMColl(std::move(coll))) {
           return false;
         }
@@ -88,7 +88,7 @@ protected:
     if (bRequiresSampColl) {
       matchingSampColl = sampcolls[id];
       if (matchingSampColl && matchingSampColl->shouldLoadOnInstrSetMatch()) {
-        matchingSampColl->useInstrSet(instrset);
+        matchingSampColl->attachInstrSet(instrset);
         if (!matchingSampColl->load()) {
           onCloseSampColl(matchingSampColl);
           return false;
@@ -112,9 +112,9 @@ protected:
           if (!coll)
             return false;
           coll->setName(matchingSeq->name());
-          coll->useSeq(matchingSeq);
-          coll->addInstrSet(instrset);
-          coll->addSampColl(matchingSampColl);
+          coll->attachSeq(matchingSeq);
+          coll->attachInstrSet(instrset);
+          coll->attachSampColl(matchingSampColl);
           if (!pRoot->loadVGMColl(std::move(coll)))
             return false;
         }
@@ -123,8 +123,8 @@ protected:
         if (!coll)
           return false;
         coll->setName(matchingSeq->name());
-        coll->useSeq(matchingSeq);
-        coll->addInstrSet(instrset);
+        coll->attachSeq(matchingSeq);
+        coll->attachInstrSet(instrset);
         if (!pRoot->loadVGMColl(std::move(coll))) {
           return false;
         }
@@ -147,7 +147,7 @@ protected:
 
       if (matchingInstrSet) {
         if (sampcoll->shouldLoadOnInstrSetMatch()) {
-          sampcoll->useInstrSet(matchingInstrSet);
+          sampcoll->attachInstrSet(matchingInstrSet);
           if (!sampcoll->load()) {
             onCloseSampColl(sampcoll);
             return false;
@@ -170,9 +170,9 @@ protected:
           if (!coll)
             return false;
           coll->setName(matchingSeq->name());
-          coll->useSeq(matchingSeq);
-          coll->addInstrSet(matchingInstrSet);
-          coll->addSampColl(sampcoll);
+          coll->attachSeq(matchingSeq);
+          coll->attachInstrSet(matchingInstrSet);
+          coll->attachSampColl(sampcoll);
           if (!pRoot->loadVGMColl(std::move(coll))) {
             return false;
           }

--- a/src/main/components/seq/ReadMode.h
+++ b/src/main/components/seq/ReadMode.h
@@ -1,0 +1,14 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+#pragma once
+
+#include "base/Types.h"
+
+enum ReadMode : u8 {
+  READMODE_ADD_TO_UI,
+  READMODE_CONVERT_TO_MIDI,
+  READMODE_FIND_DELTA_LENGTH
+};

--- a/src/main/components/seq/SeqEvent.cpp
+++ b/src/main/components/seq/SeqEvent.cpp
@@ -7,6 +7,7 @@
 
 #include "base/Types.h"
 #include "SeqTrack.h"
+#include "VGMSeq.h"
 
 //  ********
 //  SeqEvent

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -398,12 +398,12 @@ bool SeqTrack::onEvent(u32 offset, u32 length) {
   return visitedAddresses.insert(offset).second;
 }
 
-SeqEvent* SeqTrack::addEvent(std::unique_ptr<SeqEvent> seqEvent) {
+SeqEvent* SeqTrack::adoptEvent(std::unique_ptr<SeqEvent> seqEvent) {
   if (readMode != READMODE_ADD_TO_UI)
     return nullptr;
 
   auto* rawEvent = seqEvent.get();
-  addChild(std::move(seqEvent));
+  adoptChild(std::move(seqEvent));
 
   // care for a case where the new event is located before the start address
   // (example: Donkey Kong Country - Map, Track 7 of 8)
@@ -456,7 +456,7 @@ SeqEvent* SeqTrack::addGenericEvent(u32 offset,
       auto* target = seqEventTarget();
       auto event = std::make_unique<SeqEvent>(target, offset, length, sEventName, type, sEventDesc);
       event->channel = static_cast<u8>(channel);
-      return target->addEvent(std::move(event));
+      return target->adoptEvent(std::move(event));
     }
     return nullptr;
   }

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -38,6 +38,16 @@ SeqTrack::SeqTrack(VGMSeq *parentFile, u32 offset, u32 length, std::string name)
   SeqTrack::resetVars();
 }
 
+bool SeqTrack::usesLinearAmplitudeScale() const {
+  return m_useLinearAmpScale || parentSeq->usesLinearAmplitudeScale();
+}
+
+SeqEventTimeIndex::Index SeqTrack::addTimedEventIndexEntry(SeqEvent* event,
+                                                           u32 startTick,
+                                                           u32 duration) {
+  return parentSeq->timedEventIndex().addEvent(event, startTick, duration);
+}
+
 void SeqTrack::resetVars() {
   active = true;
   bInLoop = false;
@@ -388,28 +398,29 @@ bool SeqTrack::onEvent(u32 offset, u32 length) {
   return visitedAddresses.insert(offset).second;
 }
 
-SeqEvent* SeqTrack::addEvent(SeqEvent *pSeqEvent) {
+SeqEvent* SeqTrack::addEvent(std::unique_ptr<SeqEvent> seqEvent) {
   if (readMode != READMODE_ADD_TO_UI)
     return nullptr;
 
-  addChild(pSeqEvent);
+  auto* rawEvent = seqEvent.get();
+  addChild(std::move(seqEvent));
 
   // care for a case where the new event is located before the start address
   // (example: Donkey Kong Country - Map, Track 7 of 8)
-  if (offset() > pSeqEvent->offset()) {
+  if (offset() > rawEvent->offset()) {
     if (bDetermineTrackLengthEventByEvent) {
-      setLength(length() + ((offset() - pSeqEvent->offset())));
+      setLength(length() + ((offset() - rawEvent->offset())));
     }
-    setOffset(pSeqEvent->offset());
+    setOffset(rawEvent->offset());
   }
 
   if (bDetermineTrackLengthEventByEvent) {
-    u32 newTrkLen = pSeqEvent->offset() + pSeqEvent->length() - offset();
+    u32 newTrkLen = rawEvent->offset() + rawEvent->length() - offset();
     if (length() < newTrkLen)
       setLength(newTrkLen);
   }
 
-  return pSeqEvent;
+  return rawEvent;
 }
 
 SeqEvent* SeqTrack::findSeqEventAtOffset(u32 offset, u32 length) {
@@ -443,9 +454,9 @@ SeqEvent* SeqTrack::addGenericEvent(u32 offset,
   if (readMode == READMODE_ADD_TO_UI) {
     if (isNewOffset && m_emitSeqEvents) {
       auto* target = seqEventTarget();
-      auto* event = new SeqEvent(target, offset, length, sEventName, type, sEventDesc);
+      auto event = std::make_unique<SeqEvent>(target, offset, length, sEventName, type, sEventDesc);
       event->channel = static_cast<u8>(channel);
-      return target->addEvent(event);
+      return target->addEvent(std::move(event));
     }
     return nullptr;
   }
@@ -848,7 +859,7 @@ void SeqTrack::makePrevDurNoteEnd() const {
 
 void SeqTrack::makePrevDurNoteEnd(u32 absTime) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
-    for (auto& prevDurNoteOff : pMidiTrack->prevDurNoteOffs) {
+    for (auto* prevDurNoteOff : pMidiTrack->previousDurNoteOffs()) {
       prevDurNoteOff->absTime = absTime;
     }
     auto& timeline = parentSeq->timedEventIndex();
@@ -865,7 +876,7 @@ void SeqTrack::limitPrevDurNoteEnd() const {
 
 void SeqTrack::limitPrevDurNoteEnd(u32 absTime) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
-    for (auto& prevDurNoteOff : pMidiTrack->prevDurNoteOffs) {
+    for (auto* prevDurNoteOff : pMidiTrack->previousDurNoteOffs()) {
       if (prevDurNoteOff->absTime > absTime) {
         prevDurNoteOff->absTime = absTime;
       }

--- a/src/main/components/seq/SeqTrack.cpp
+++ b/src/main/components/seq/SeqTrack.cpp
@@ -398,12 +398,12 @@ bool SeqTrack::onEvent(u32 offset, u32 length) {
   return visitedAddresses.insert(offset).second;
 }
 
-SeqEvent* SeqTrack::adoptEvent(std::unique_ptr<SeqEvent> seqEvent) {
+SeqEvent* SeqTrack::sinkEvent(std::unique_ptr<SeqEvent>&& seqEvent) {
   if (readMode != READMODE_ADD_TO_UI)
     return nullptr;
 
   auto* rawEvent = seqEvent.get();
-  adoptChild(std::move(seqEvent));
+  sinkChild(std::move(seqEvent));
 
   // care for a case where the new event is located before the start address
   // (example: Donkey Kong Country - Map, Track 7 of 8)
@@ -456,7 +456,7 @@ SeqEvent* SeqTrack::addGenericEvent(u32 offset,
       auto* target = seqEventTarget();
       auto event = std::make_unique<SeqEvent>(target, offset, length, sEventName, type, sEventDesc);
       event->channel = static_cast<u8>(channel);
-      return target->adoptEvent(std::move(event));
+      return target->sinkEvent(std::move(event));
     }
     return nullptr;
   }

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -120,7 +120,7 @@ protected:
   virtual bool isOffsetUsed(u32 offset);
 
   virtual bool onEvent(u32 offset, u32 length);
-  virtual SeqEvent* adoptEvent(std::unique_ptr<SeqEvent> seqEvent);
+  virtual SeqEvent* sinkEvent(std::unique_ptr<SeqEvent>&& seqEvent);
   // Some parsers emit SeqEvents under a display track that differs from the parser track.
   void setSeqEventTarget(SeqTrack* target, bool emitEvents = true) {
     m_seqEventTarget = target;
@@ -144,7 +144,7 @@ protected:
         auto* target = seqEventTarget();
         auto event = std::make_unique<EventType>(target, std::forward<Args>(args)...);
         event->channel = static_cast<u8>(channel);
-        target->adoptEvent(std::move(event));
+        target->sinkEvent(std::move(event));
       }
       return SeqEventTimeIndex::kInvalidIndex;
     }

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -120,7 +120,7 @@ protected:
   virtual bool isOffsetUsed(u32 offset);
 
   virtual bool onEvent(u32 offset, u32 length);
-  virtual SeqEvent* addEvent(std::unique_ptr<SeqEvent> seqEvent);
+  virtual SeqEvent* adoptEvent(std::unique_ptr<SeqEvent> seqEvent);
   // Some parsers emit SeqEvents under a display track that differs from the parser track.
   void setSeqEventTarget(SeqTrack* target, bool emitEvents = true) {
     m_seqEventTarget = target;
@@ -144,7 +144,7 @@ protected:
         auto* target = seqEventTarget();
         auto event = std::make_unique<EventType>(target, std::forward<Args>(args)...);
         event->channel = static_cast<u8>(channel);
-        target->addEvent(std::move(event));
+        target->adoptEvent(std::move(event));
       }
       return SeqEventTimeIndex::kInvalidIndex;
     }

--- a/src/main/components/seq/SeqTrack.h
+++ b/src/main/components/seq/SeqTrack.h
@@ -8,12 +8,14 @@
 #include "base/Types.h"
 #include "LogManager.h"
 #include "Modulation.h"
+#include "ReadMode.h"
 #include "SynthType.h"
 #include "VGMItem.h"
-#include "VGMSeq.h"
+#include "SeqEventTimeIndex.h"
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -33,8 +35,6 @@ template <typename ValueType>
 struct SeqMotionTick;
 template <typename PitchType>
 class SeqPitchBendAutomation;
-
-enum ReadMode : u8;
 
 enum class LevelController : u8 {
   Volume,
@@ -93,9 +93,7 @@ class SeqTrack : public VGMItem {
  public:
   SeqTrack(VGMSeq *parentSeqFile, u32 offset = 0, u32 length = 0, std::string name = "Track");
 
-  [[nodiscard]] bool usesLinearAmplitudeScale() const {
-    return m_useLinearAmpScale || parentSeq->usesLinearAmplitudeScale();
-  }
+  [[nodiscard]] bool usesLinearAmplitudeScale() const;
   void setUseLinearAmplitudeScale(bool set) { m_useLinearAmpScale = set; }
 
   virtual bool loadTrackInit(int trackNum, MidiTrack *preparedMidiTrack);
@@ -122,7 +120,7 @@ protected:
   virtual bool isOffsetUsed(u32 offset);
 
   virtual bool onEvent(u32 offset, u32 length);
-  virtual SeqEvent* addEvent(SeqEvent *pSeqEvent);
+  virtual SeqEvent* addEvent(std::unique_ptr<SeqEvent> seqEvent);
   // Some parsers emit SeqEvents under a display track that differs from the parser track.
   void setSeqEventTarget(SeqTrack* target, bool emitEvents = true) {
     m_seqEventTarget = target;
@@ -144,20 +142,22 @@ protected:
     if (readMode == READMODE_ADD_TO_UI) {
       if (isNewOffset && m_emitSeqEvents) {
         auto* target = seqEventTarget();
-        auto* event = new EventType(target, std::forward<Args>(args)...);
+        auto event = std::make_unique<EventType>(target, std::forward<Args>(args)...);
         event->channel = static_cast<u8>(channel);
-        target->addEvent(event);
+        target->addEvent(std::move(event));
       }
       return SeqEventTimeIndex::kInvalidIndex;
     }
     if (readMode == READMODE_CONVERT_TO_MIDI) {
       if (SeqEvent* existing =
               seqEventTarget()->findSeqEventAtOffset(m_lastEventOffset, m_lastEventLength)) {
-        return parentSeq->timedEventIndex().addEvent(existing, startTick, duration);
+        return addTimedEventIndexEntry(existing, startTick, duration);
       }
     }
     return SeqEventTimeIndex::kInvalidIndex;
   }
+
+  SeqEventTimeIndex::Index addTimedEventIndexEntry(SeqEvent* event, u32 startTick, u32 duration);
 
   bool shouldTrackControlFlowState() const;
   void addControlFlowState(u32 destinationOffset);

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -50,7 +50,7 @@ VGMSeq::VGMSeq(const std::string &format, RawFile *file, u32 offset, u32 length,
 
 VGMSeq::~VGMSeq() = default;
 
-SeqTrack* VGMSeq::adoptTrack(std::unique_ptr<SeqTrack> track) {
+SeqTrack* VGMSeq::sinkTrack(std::unique_ptr<SeqTrack>&& track) {
   auto* rawTrack = track.get();
   m_tracks.push_back(rawTrack);
   m_ownedTracks.emplace_back(std::move(track));
@@ -62,7 +62,7 @@ void VGMSeq::clearTracks() {
   m_ownedTracks.clear();
 }
 
-ISeqSlider* VGMSeq::adoptSlider(std::unique_ptr<ISeqSlider> slider) {
+ISeqSlider* VGMSeq::sinkSlider(std::unique_ptr<ISeqSlider>&& slider) {
   auto* rawSlider = slider.get();
   m_sliders.emplace_back(std::move(slider));
   return rawSlider;
@@ -126,7 +126,7 @@ bool VGMSeq::postLoad() {
       track->sortChildrenByOffset();
     }
     for (auto& track : m_ownedTracks) {
-      adoptChild(std::move(track));
+      sinkChild(std::move(track));
     }
     m_ownedTracks.clear();
 

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -50,7 +50,7 @@ VGMSeq::VGMSeq(const std::string &format, RawFile *file, u32 offset, u32 length,
 
 VGMSeq::~VGMSeq() = default;
 
-SeqTrack* VGMSeq::addTrack(std::unique_ptr<SeqTrack> track) {
+SeqTrack* VGMSeq::adoptTrack(std::unique_ptr<SeqTrack> track) {
   auto* rawTrack = track.get();
   m_tracks.push_back(rawTrack);
   m_ownedTracks.emplace_back(std::move(track));
@@ -62,7 +62,7 @@ void VGMSeq::clearTracks() {
   m_ownedTracks.clear();
 }
 
-ISeqSlider* VGMSeq::addSlider(std::unique_ptr<ISeqSlider> slider) {
+ISeqSlider* VGMSeq::adoptSlider(std::unique_ptr<ISeqSlider> slider) {
   auto* rawSlider = slider.get();
   m_sliders.emplace_back(std::move(slider));
   return rawSlider;
@@ -126,7 +126,7 @@ bool VGMSeq::postLoad() {
       track->sortChildrenByOffset();
     }
     for (auto& track : m_ownedTracks) {
-      addChild(std::move(track));
+      adoptChild(std::move(track));
     }
     m_ownedTracks.clear();
 

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -16,6 +16,7 @@
 
 #include <climits>
 #include <ranges>
+#include <vector>
 
 VGMSeq::VGMSeq(const std::string &format, RawFile *file, u32 offset, u32 length, std::string name)
     : VGMFile(format, file, offset, length, std::move(name)),
@@ -49,7 +50,6 @@ VGMSeq::VGMSeq(const std::string &format, RawFile *file, u32 offset, u32 length,
 
 VGMSeq::~VGMSeq() {
   deleteVect<ISeqSlider>(aSliders);
-  delete midi;
 }
 
 bool VGMSeq::loadVGMFile(bool useMatcher) {
@@ -59,8 +59,7 @@ bool VGMSeq::loadVGMFile(bool useMatcher) {
     return false;
   }
 
-  rawFile()->addContainedVGMFile(std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *,
-    VGMMiscFile *>>(this));
+  rawFile()->addContainedVGMFile(this);
   pRoot->addVGMFile(this);
 
   if (useMatcher) {
@@ -72,12 +71,12 @@ bool VGMSeq::loadVGMFile(bool useMatcher) {
   return true;
 }
 
-MidiFile *VGMSeq::convertToMidi(const VGMColl* coll) {
+std::unique_ptr<MidiFile> VGMSeq::convertToMidi(const VGMColl* coll) {
   const auto context = ConversionContext::fromOptions(ConversionOptions::the(), SynthTarget::SoundFont);
   return convertToMidi(coll, context);
 }
 
-MidiFile *VGMSeq::convertToMidi(const VGMColl* coll, const ConversionContext& context) {
+std::unique_ptr<MidiFile> VGMSeq::convertToMidi(const VGMColl* coll, const ConversionContext& context) {
   setConversionContext(context);
   size_t numTracks = aTracks.size();
 
@@ -92,16 +91,15 @@ MidiFile *VGMSeq::convertToMidi(const VGMColl* coll, const ConversionContext& co
   for (size_t i = 0; i < numTracks; i++)
     stopTime = std::max(stopTime, aTracks[i]->totalTicks);
 
-  auto *newmidi = new MidiFile(this);
-  this->midi = newmidi;
+  auto newMidi = std::make_unique<MidiFile>(this);
+  this->midi = newMidi.get();
   if (!loadTracks(READMODE_CONVERT_TO_MIDI, stopTime)) {
-    delete midi;
     this->midi = nullptr;
     m_timedEvents.clear();
     return nullptr;
   }
   this->midi = nullptr;
-  return newmidi;
+  return newMidi;
 }
 
 MidiTrack *VGMSeq::firstMidiTrack() {
@@ -168,7 +166,7 @@ bool VGMSeq::loadTracks(ReadMode seqReadMode, u32 stopTime) {
 
 void VGMSeq::loadTracksMain(u32 stopTime) {
   // determine the stop offsets
-  u32 *aStopOffset = new u32[nNumTracks];
+  std::vector<u32> aStopOffset(nNumTracks);
   for (u32 trackNum = 0; trackNum < nNumTracks; trackNum++) {
     if (readMode == READMODE_ADD_TO_UI) {
       aStopOffset[trackNum] = endOffset();
@@ -264,7 +262,6 @@ void VGMSeq::loadTracksMain(u32 stopTime) {
       aTracks[trackNum]->active = false;
     }
   }
-  delete[] aStopOffset;
 }
 
 bool VGMSeq::hasActiveTracks() {
@@ -351,10 +348,9 @@ bool VGMSeq::saveAsMidi(const std::filesystem::path &filepath, const VGMColl* co
 bool VGMSeq::saveAsMidi(const std::filesystem::path& filepath,
                         const VGMColl* coll,
                         const ConversionContext& context) {
-  MidiFile *midiFile = this->convertToMidi(coll, context);
+  auto midiFile = this->convertToMidi(coll, context);
   if (!midiFile)
     return false;
   bool result = midiFile->saveMidiFile(filepath);
-  delete midiFile;
   return result;
 }

--- a/src/main/components/seq/VGMSeq.cpp
+++ b/src/main/components/seq/VGMSeq.cpp
@@ -48,27 +48,24 @@ VGMSeq::VGMSeq(const std::string &format, RawFile *file, u32 offset, u32 length,
   setConversionContext(ConversionContext::fromOptions(ConversionOptions::the(), SynthTarget::SoundFont));
 }
 
-VGMSeq::~VGMSeq() {
-  deleteVect<ISeqSlider>(aSliders);
+VGMSeq::~VGMSeq() = default;
+
+SeqTrack* VGMSeq::addTrack(std::unique_ptr<SeqTrack> track) {
+  auto* rawTrack = track.get();
+  m_tracks.push_back(rawTrack);
+  m_ownedTracks.emplace_back(std::move(track));
+  return rawTrack;
 }
 
-bool VGMSeq::loadVGMFile(bool useMatcher) {
-  setConversionContext(ConversionContext::fromOptions(ConversionOptions::the(), SynthTarget::SoundFont));
+void VGMSeq::clearTracks() {
+  m_tracks.clear();
+  m_ownedTracks.clear();
+}
 
-  if (!load()) {
-    return false;
-  }
-
-  rawFile()->addContainedVGMFile(this);
-  pRoot->addVGMFile(this);
-
-  if (useMatcher) {
-    if (auto fmt = format(); fmt) {
-      fmt->onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>(this));
-    }
-  }
-
-  return true;
+ISeqSlider* VGMSeq::addSlider(std::unique_ptr<ISeqSlider> slider) {
+  auto* rawSlider = slider.get();
+  m_sliders.emplace_back(std::move(slider));
+  return rawSlider;
 }
 
 std::unique_ptr<MidiFile> VGMSeq::convertToMidi(const VGMColl* coll) {
@@ -78,7 +75,7 @@ std::unique_ptr<MidiFile> VGMSeq::convertToMidi(const VGMColl* coll) {
 
 std::unique_ptr<MidiFile> VGMSeq::convertToMidi(const VGMColl* coll, const ConversionContext& context) {
   setConversionContext(context);
-  size_t numTracks = aTracks.size();
+  size_t numTracks = m_tracks.size();
 
   if (!loadTracks(READMODE_FIND_DELTA_LENGTH)) {
       return nullptr;
@@ -89,7 +86,7 @@ std::unique_ptr<MidiFile> VGMSeq::convertToMidi(const VGMColl* coll, const Conve
   // Find the greatest length of all tracks to use as stop point for every track
   long stopTime = 0;
   for (size_t i = 0; i < numTracks; i++)
-    stopTime = std::max(stopTime, aTracks[i]->totalTicks);
+    stopTime = std::max(stopTime, m_tracks[i]->totalTicks);
 
   auto newMidi = std::make_unique<MidiFile>(this);
   this->midi = newMidi.get();
@@ -103,17 +100,18 @@ std::unique_ptr<MidiFile> VGMSeq::convertToMidi(const VGMColl* coll, const Conve
 }
 
 MidiTrack *VGMSeq::firstMidiTrack() {
-  return aTracks.empty() ? nullptr : aTracks[0]->pMidiTrack;
+  return m_tracks.empty() ? nullptr : m_tracks[0]->pMidiTrack;
 }
 
 bool VGMSeq::load() {
+  setConversionContext(ConversionContext::fromOptions(ConversionOptions::the(), SynthTarget::SoundFont));
   readMode = READMODE_ADD_TO_UI;
 
   if (!parseHeader())
     return false;
   if (!parseTrackPointers())
     return false;
-  nNumTracks = static_cast<u32>(aTracks.size());
+  nNumTracks = static_cast<u32>(m_tracks.size());
   if (nNumTracks == 0)
     return false;
 
@@ -124,10 +122,13 @@ bool VGMSeq::postLoad() {
   if (readMode == READMODE_ADD_TO_UI) {
     std::ranges::sort(aInstrumentsUsed);
 
-    for (auto & track : aTracks) {
+    for (auto & track : m_tracks) {
       track->sortChildrenByOffset();
     }
-    addChildren(aTracks);
+    for (auto& track : m_ownedTracks) {
+      addChild(std::move(track));
+    }
+    m_ownedTracks.clear();
 
     setGuessedLength();
     if (length() == 0) {
@@ -145,7 +146,7 @@ bool VGMSeq::loadTracks(ReadMode seqReadMode, u32 stopTime) {
   // set read mode
   this->readMode = seqReadMode;
   for (u32 trackNum = 0; trackNum < nNumTracks; trackNum++) {
-    aTracks[trackNum]->readMode = seqReadMode;
+    m_tracks[trackNum]->readMode = seqReadMode;
   }
 
   if (seqReadMode == READMODE_CONVERT_TO_MIDI) {
@@ -155,7 +156,7 @@ bool VGMSeq::loadTracks(ReadMode seqReadMode, u32 stopTime) {
   // reset variables
   resetVars();
   for (u32 trackNum = 0; trackNum < nNumTracks; trackNum++) {
-    if (!aTracks[trackNum]->loadTrackInit(trackNum, nullptr))
+    if (!m_tracks[trackNum]->loadTrackInit(trackNum, nullptr))
       return false;
   }
 
@@ -176,15 +177,15 @@ void VGMSeq::loadTracksMain(u32 stopTime) {
         if (!m_allow_discontinuous_track_data) {
           // set length from the next track by offset
           for (u32 j = 0; j < nNumTracks; j++) {
-            if (aTracks[j]->offset() > aTracks[trackNum]->offset() &&
-                aTracks[j]->offset() < aStopOffset[trackNum]) {
-              aStopOffset[trackNum] = aTracks[j]->offset();
+            if (m_tracks[j]->offset() > m_tracks[trackNum]->offset() &&
+                m_tracks[j]->offset() < aStopOffset[trackNum]) {
+              aStopOffset[trackNum] = m_tracks[j]->offset();
             }
           }
         }
       }
     } else {
-      aStopOffset[trackNum] = aTracks[trackNum]->offset() + aTracks[trackNum]->length();
+      aStopOffset[trackNum] = m_tracks[trackNum]->offset() + m_tracks[trackNum]->length();
     }
   }
 
@@ -203,24 +204,24 @@ void VGMSeq::loadTracksMain(u32 stopTime) {
 
       // process tracks
       for (u32 trackNum = 0; trackNum < nNumTracks; trackNum++) {
-        if (!aTracks[trackNum]->active)
+        if (!m_tracks[trackNum]->active)
           continue;
 
         // tick
-        aTracks[trackNum]->loadTrackMainLoop(aStopOffset[trackNum], stopTime);
+        m_tracks[trackNum]->loadTrackMainLoop(aStopOffset[trackNum], stopTime);
       }
 
       // process sliders
-      auto itrSlider = aSliders.begin();
-      while (itrSlider != aSliders.end()) {
+      auto itrSlider = m_sliders.begin();
+      while (itrSlider != m_sliders.end()) {
         auto itrNextSlider = itrSlider + 1;
 
-        ISeqSlider *slider = *itrSlider;
+        ISeqSlider *slider = itrSlider->get();
         if (slider->isStarted(time)) {
           if (slider->isActive(time)) {
             slider->write(time);
           } else {
-            itrNextSlider = aSliders.erase(itrSlider);
+            itrNextSlider = m_sliders.erase(itrSlider);
           }
         }
 
@@ -237,8 +238,8 @@ void VGMSeq::loadTracksMain(u32 stopTime) {
       bIncTickAfterProcessingTracks = true;
       if (readMode == READMODE_CONVERT_TO_MIDI) {
         for (u32 trackNum = 0; trackNum < nNumTracks; trackNum++) {
-          if (aTracks.at(trackNum)->pMidiTrack != nullptr) {
-            aTracks[trackNum]->pMidiTrack->setDelta(time);
+          if (m_tracks.at(trackNum)->pMidiTrack != nullptr) {
+            m_tracks[trackNum]->pMidiTrack->setDelta(time);
           }
         }
       }
@@ -255,18 +256,18 @@ void VGMSeq::loadTracksMain(u32 stopTime) {
     u32 initialTime = time;  // preserve current time for multi section sequence
 
     // load track by track
-    for (u32 trackNum = 0; trackNum < nNumTracks && trackNum < aTracks.size(); trackNum++) {
+    for (u32 trackNum = 0; trackNum < nNumTracks && trackNum < m_tracks.size(); trackNum++) {
       time = initialTime;
 
-      aTracks[trackNum]->loadTrackMainLoop(aStopOffset[trackNum], stopTime);
-      aTracks[trackNum]->active = false;
+      m_tracks[trackNum]->loadTrackMainLoop(aStopOffset[trackNum], stopTime);
+      m_tracks[trackNum]->active = false;
     }
   }
 }
 
 bool VGMSeq::hasActiveTracks() {
   for (u32 trackNum = 0; trackNum < nNumTracks; trackNum++) {
-    if (aTracks[trackNum]->active)
+    if (m_tracks[trackNum]->active)
       return true;
   }
   return false;
@@ -274,7 +275,7 @@ bool VGMSeq::hasActiveTracks() {
 
 void VGMSeq::deactivateAllTracks() {
   for (u32 trackNum = 0; trackNum < nNumTracks; trackNum++) {
-    aTracks[trackNum]->active = false;
+    m_tracks[trackNum]->active = false;
   }
 }
 
@@ -284,11 +285,11 @@ int VGMSeq::foreverLoopCount() {
 
   int foreverLoops = INT_MAX;
   for (u32 trackNum = 0; trackNum < nNumTracks; trackNum++) {
-    if (!aTracks[trackNum]->active)
+    if (!m_tracks[trackNum]->active)
       continue;
 
-    if (foreverLoops > aTracks[trackNum]->infiniteLoops)
-      foreverLoops = aTracks[trackNum]->infiniteLoops;
+    if (foreverLoops > m_tracks[trackNum]->infiniteLoops)
+      foreverLoops = m_tracks[trackNum]->infiniteLoops;
   }
   return (foreverLoops != INT_MAX) ? foreverLoops : 0;
 }
@@ -307,7 +308,7 @@ void VGMSeq::resetVars() {
   time = 0;
   tempoBPM = initialTempoBPM;
 
-  deleteVect<ISeqSlider>(aSliders);
+  m_sliders.clear();
 
   if (readMode == READMODE_ADD_TO_UI) {
     aInstrumentsUsed.clear();

--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -9,25 +9,20 @@
 #include "ConversionContext.h"
 #include "MidiFile.h"
 #include "RawFile.h"
+#include "ReadMode.h"
 #include "SeqEventTimeIndex.h"
+#include "SeqSlider.h"
+#include "SeqTrack.h"
 #include "VGMFile.h"
 
 #include <filesystem>
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
-class SeqTrack;
 class SeqEvent;
-class ISeqSlider;
-
-enum ReadMode : u8 {
-  READMODE_ADD_TO_UI,
-  READMODE_CONVERT_TO_MIDI,
-  READMODE_FIND_DELTA_LENGTH
-};
-
 enum class PanVolumeCorrectionMode : u8 {
   kNoVolumeAdjust,
   kAdjustVolumeController,
@@ -40,7 +35,6 @@ class VGMSeq : public VGMFile {
          std::string name = "VGM Sequence");
   ~VGMSeq() override;
 
-  bool loadVGMFile(bool useMatcher = true) override;
   bool load() override;
   virtual bool parseHeader();
   virtual bool parseTrackPointers();  // Function to find all of the track pointers.   Returns number of total tracks.
@@ -124,9 +118,31 @@ class VGMSeq : public VGMFile {
   void setInitialPitchBendRange(u16 cents) { m_initial_pitch_bend_range_cents = cents; }
 
   SeqEventTimeIndex& timedEventIndex() { return m_timedEvents; }
+  [[nodiscard]] const std::vector<SeqTrack*>& tracks() const { return m_tracks; }
+  [[nodiscard]] bool hasTracks() const { return !m_tracks.empty(); }
+  [[nodiscard]] size_t trackCount() const { return m_tracks.size(); }
+  SeqTrack* track(size_t index) const { return m_tracks.at(index); }
 
  protected:
   void setConversionContext(const ConversionContext& context) { m_conversionContext = context; }
+  void reserveTracks(size_t count) { m_ownedTracks.reserve(count); m_tracks.reserve(count); }
+  void clearTracks();
+  SeqTrack* addTrack(std::unique_ptr<SeqTrack> track);
+  template <class TrackType, class... Args>
+  TrackType* addTrack(Args&&... args) {
+    auto track = std::make_unique<TrackType>(std::forward<Args>(args)...);
+    auto* rawTrack = track.get();
+    addTrack(std::move(track));
+    return rawTrack;
+  }
+  ISeqSlider* addSlider(std::unique_ptr<ISeqSlider> slider);
+  template <class SliderType, class... Args>
+  SliderType* addSlider(Args&&... args) {
+    auto slider = std::make_unique<SliderType>(std::forward<Args>(args)...);
+    auto* rawSlider = slider.get();
+    addSlider(std::move(slider));
+    return rawSlider;
+  }
 
   virtual bool loadTracks(ReadMode seqReadMode, u32 stopTime = 1000000);
   virtual void loadTracksMain(u32 stopTime);
@@ -162,12 +178,12 @@ private:
 
   double initialTempoBPM;
 
-  std::vector<SeqTrack *> aTracks;  // array of track pointers
   std::vector<u32> aInstrumentsUsed;
 
-  std::vector<ISeqSlider *> aSliders;
-
 private:
+  std::vector<std::unique_ptr<SeqTrack>> m_ownedTracks;
+  std::vector<SeqTrack *> m_tracks;
+  std::vector<std::unique_ptr<ISeqSlider>> m_sliders;
   ConversionContext m_conversionContext;
   std::set<u16> m_referencedBanks;
 

--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -127,20 +127,20 @@ class VGMSeq : public VGMFile {
   void setConversionContext(const ConversionContext& context) { m_conversionContext = context; }
   void reserveTracks(size_t count) { m_ownedTracks.reserve(count); m_tracks.reserve(count); }
   void clearTracks();
-  SeqTrack* addTrack(std::unique_ptr<SeqTrack> track);
+  SeqTrack* adoptTrack(std::unique_ptr<SeqTrack> track);
   template <class TrackType, class... Args>
   TrackType* addTrack(Args&&... args) {
     auto track = std::make_unique<TrackType>(std::forward<Args>(args)...);
     auto* rawTrack = track.get();
-    addTrack(std::move(track));
+    adoptTrack(std::move(track));
     return rawTrack;
   }
-  ISeqSlider* addSlider(std::unique_ptr<ISeqSlider> slider);
+  ISeqSlider* adoptSlider(std::unique_ptr<ISeqSlider> slider);
   template <class SliderType, class... Args>
   SliderType* addSlider(Args&&... args) {
     auto slider = std::make_unique<SliderType>(std::forward<Args>(args)...);
     auto* rawSlider = slider.get();
-    addSlider(std::move(slider));
+    adoptSlider(std::move(slider));
     return rawSlider;
   }
 

--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -13,6 +13,7 @@
 #include "VGMFile.h"
 
 #include <filesystem>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -46,8 +47,8 @@ class VGMSeq : public VGMFile {
   virtual void resetVars();
   virtual void onTickEnd() {}
   virtual void useColl(const VGMColl* coll) {}
-  virtual MidiFile *convertToMidi(const VGMColl* coll = nullptr);
-  virtual MidiFile *convertToMidi(const VGMColl* coll, const ConversionContext& context);
+  virtual std::unique_ptr<MidiFile> convertToMidi(const VGMColl* coll = nullptr);
+  virtual std::unique_ptr<MidiFile> convertToMidi(const VGMColl* coll, const ConversionContext& context);
   virtual MidiTrack *firstMidiTrack();
   void setPPQN(u16 ppqn);
   [[nodiscard]] u16 ppqn() const;

--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -127,20 +127,20 @@ class VGMSeq : public VGMFile {
   void setConversionContext(const ConversionContext& context) { m_conversionContext = context; }
   void reserveTracks(size_t count) { m_ownedTracks.reserve(count); m_tracks.reserve(count); }
   void clearTracks();
-  SeqTrack* adoptTrack(std::unique_ptr<SeqTrack> track);
+  SeqTrack* sinkTrack(std::unique_ptr<SeqTrack>&& track);
   template <class TrackType, class... Args>
   TrackType* addTrack(Args&&... args) {
     auto track = std::make_unique<TrackType>(std::forward<Args>(args)...);
     auto* rawTrack = track.get();
-    adoptTrack(std::move(track));
+    sinkTrack(std::move(track));
     return rawTrack;
   }
-  ISeqSlider* adoptSlider(std::unique_ptr<ISeqSlider> slider);
+  ISeqSlider* sinkSlider(std::unique_ptr<ISeqSlider>&& slider);
   template <class SliderType, class... Args>
   SliderType* addSlider(Args&&... args) {
     auto slider = std::make_unique<SliderType>(std::forward<Args>(args)...);
     auto* rawSlider = slider.get();
-    adoptSlider(std::move(slider));
+    sinkSlider(std::move(slider));
     return rawSlider;
   }
 

--- a/src/main/components/seq/VGMSeqNoTrks.cpp
+++ b/src/main/components/seq/VGMSeqNoTrks.cpp
@@ -89,12 +89,12 @@ bool VGMSeqNoTrks::loadEvents(long stopTime) {
   return true;
 }
 
-MidiFile *VGMSeqNoTrks::convertToMidi(const VGMColl* coll) {
+std::unique_ptr<MidiFile> VGMSeqNoTrks::convertToMidi(const VGMColl* coll) {
   const auto context = ConversionContext::fromOptions(ConversionOptions::the(), SynthTarget::SoundFont);
   return convertToMidi(coll, context);
 }
 
-MidiFile *VGMSeqNoTrks::convertToMidi(const VGMColl* coll, const ConversionContext& context) {
+std::unique_ptr<MidiFile> VGMSeqNoTrks::convertToMidi(const VGMColl* coll, const ConversionContext& context) {
   setConversionContext(context);
   this->SeqTrack::readMode = this->VGMSeq::readMode = READMODE_FIND_DELTA_LENGTH;
 
@@ -107,24 +107,22 @@ MidiFile *VGMSeqNoTrks::convertToMidi(const VGMColl* coll, const ConversionConte
 
   long stopTime = totalTicks;
 
-  MidiFile *newmidi = new MidiFile(this);
-  this->midi = newmidi;
+  auto newMidi = std::make_unique<MidiFile>(this);
+  this->midi = newMidi.get();
   this->SeqTrack::readMode = this->VGMSeq::readMode = READMODE_CONVERT_TO_MIDI;
   timedEventIndex().clear();
   if (!loadEvents(stopTime)) {
-    delete midi;
     this->midi = nullptr;
     timedEventIndex().clear();
     return nullptr;
   }
   if (!postLoad()) {
-    delete midi;
     this->midi = nullptr;
     timedEventIndex().clear();
     return nullptr;
   }
   this->midi = nullptr;
-  return newmidi;
+  return newMidi;
 }
 
 MidiTrack *VGMSeqNoTrks::firstMidiTrack() {

--- a/src/main/components/seq/VGMSeqNoTrks.h
+++ b/src/main/components/seq/VGMSeqNoTrks.h
@@ -55,8 +55,8 @@ public:
 
   bool load() override;  // Function to load all the information about the sequence
   virtual bool loadEvents(long stopTime = 1000000);
-  MidiFile *convertToMidi(const VGMColl* coll) override;
-  MidiFile *convertToMidi(const VGMColl* coll, const ConversionContext& context) override;
+  std::unique_ptr<MidiFile> convertToMidi(const VGMColl* coll) override;
+  std::unique_ptr<MidiFile> convertToMidi(const VGMColl* coll, const ConversionContext& context) override;
   MidiTrack *firstMidiTrack() override;
 
   u32 dwEventsOffset;

--- a/src/main/conversion/DLSConversion.cpp
+++ b/src/main/conversion/DLSConversion.cpp
@@ -96,7 +96,7 @@ bool mainDLSCreation(
     }
   } else {
     for (auto & instrset : m_instrsets) {
-      if (auto instrset_sampcoll = instrset->sampColl) {
+      if (auto instrset_sampcoll = instrset->sampColl()) {
         finalSampColls.push_back(instrset_sampcoll);
         unpackSampColl(dls, instrset_sampcoll, finalSamps);
       }
@@ -141,8 +141,8 @@ bool mainDLSCreation(
         VGMSampColl *sampColl = rgn->sampCollPtr;
         if (!sampColl) {
           // If rgn is of an InstrSet with an embedded SampColl, use that SampColl.
-          if (static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl)
-            sampColl = static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl;
+          if (static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl())
+            sampColl = static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl();
 
             // If that does not exist, assume the first SampColl
           else

--- a/src/main/conversion/DLSConversion.cpp
+++ b/src/main/conversion/DLSConversion.cpp
@@ -25,9 +25,9 @@ namespace conversion {
 void unpackSampColl(DLSFile &dls, const VGMSampColl *sampColl, std::vector<VGMSamp *> &finalSamps) {
   assert(sampColl != nullptr);
 
-  size_t nSamples = sampColl->samples.size();
+  size_t nSamples = sampColl->sampleCount();
   for (size_t i = 0; i < nSamples; i++) {
-    VGMSamp *samp = sampColl->samples[i];
+    VGMSamp *samp = sampColl->sample(i);
 
     BPS targetBps = samp->bps();
     std::vector<u8> uncompSampBuf = samp->toPcm(
@@ -134,7 +134,7 @@ bool mainDLSCreation(
       DLSInstr *newInstr = dls.addInstr(bank_no, vgminstr->instrNum, name);
       for (u32 j = 0; j < nRgns; j++) {
         VGMRgn *rgn = vgminstr->regions()[j];
-        //				if (rgn->sampNum+1 > sampColl->samples.size())	//does thereferenced sample exist?
+        //				if (rgn->sampNum+1 > sampColl->sampleCount())	//does thereferenced sample exist?
         //					continue;
 
         // Determine the SampColl associated with this rgn.  If there's an explicit pointer to it, use that.
@@ -155,13 +155,12 @@ bool mainDLSCreation(
         // see sampOffset declaration in header file for more info.
         if (rgn->sampOffset != -1) {
           bool bFoundIt = false;
-          for (u32 s = 0; s < sampColl->samples.size(); s++) {             //for every sample
-            if (std::cmp_equal(rgn->sampOffset, sampColl->samples[s]->offset()) ||
-                std::cmp_equal(rgn->sampOffset, sampColl->samples[s]->offset() - sampColl->offset() - sampColl->sampDataOffset)) {
+          for (u32 s = 0; s < sampColl->sampleCount(); s++) {             //for every sample
+            auto* sample = sampColl->sample(s);
+            if (std::cmp_equal(rgn->sampOffset, sample->offset()) ||
+                std::cmp_equal(rgn->sampOffset, sample->offset() - sampColl->offset() - sampColl->sampDataOffset)) {
               realSampNum = s;
 
-              //samples[m]->loop.loopStart = parInstrSet->aInstrs[i]->aRgns[k]->loop.loopStart;
-              //samples[m]->loop.loopLength = (samples[m]->dataLength) - (parInstrSet->aInstrs[i]->aRgns[k]->loop.loopStart); //[aInstrs[i]->aRegions[k]->sample_num]->dwUncompSize/2) - ((aInstrs[i]->aRegions[k]->loop_point*28)/16); //to end of sample
               bFoundIt = true;
               break;
             }
@@ -185,7 +184,7 @@ bool mainDLSCreation(
         // now we add the number of samples from the preceding SampColls to the value to
         // get the real sampNum in the final DLS file.
         for (unsigned int k = 0; k < sampCollNum; k++)
-          realSampNum += finalSampColls[k]->samples.size();
+          realSampNum += finalSampColls[k]->sampleCount();
 
         // For collections with multiple SampColls
         // If a SampColl ptr is given, find the SampColl and adjust the sample number of the region
@@ -202,7 +201,7 @@ bool mainDLSCreation(
         //if (rgn->sampCollNum != -1)		//if a sampCollNum is defined
         //{									//then sampNum represents the sample number in the specific sample collection
         //	for (int k=0; k < rgn->sampCollNum; k++)
-        //		realSampNum += finalSampColls[k]->samples.size();	//so now we add all previous sample collection samples to the value to get the real (absolute) sampNum
+        //		realSampNum += finalSampColls[k]->sampleCount();	//so now we add all previous sample collection samples to the value to get the real (absolute) sampNum
         //}
 
         if (realSampNum >= finalSamps.size()) {
@@ -214,7 +213,7 @@ bool mainDLSCreation(
         newRgn->setRanges(rgn->keyLow, rgn->keyHigh, rgn->velLow, rgn->velHigh);
         newRgn->setWaveLinkInfo(0, 0, 1, static_cast<u32>(realSampNum));
 
-        VGMSamp *samp = finalSamps[realSampNum]; //sampColl->samples[rgn->sampNum];
+        VGMSamp *samp = finalSamps[realSampNum]; //sampColl->sample(rgn->sampNum);
         DLSWsmp *newWsmp = newRgn->addWsmp();
 
         // This is a really loopy way of determining the loop information, pardon the pun.  However, it works.

--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -33,11 +33,11 @@ MidiTrack *MidiFile::addTrack() {
 }
 
 MidiTrack *MidiFile::insertTrack(u32 trackNum) {
-  if (trackNum + 1 > aTracks.size())
-    aTracks.resize(trackNum + 1, nullptr);
+  if (trackNum + 1 > m_tracks.size())
+    m_tracks.resize(trackNum + 1, nullptr);
 
-  if (aTracks[trackNum]) {
-    std::erase_if(m_ownedTracks, [track = aTracks[trackNum]](const auto& ownedTrack) {
+  if (m_tracks[trackNum]) {
+    std::erase_if(m_ownedTracks, [track = m_tracks[trackNum]](const auto& ownedTrack) {
       return ownedTrack.get() == track;
     });
   }
@@ -45,7 +45,7 @@ MidiTrack *MidiFile::insertTrack(u32 trackNum) {
   auto track = std::make_unique<MidiTrack>(this, bMonophonicTracks);
   auto* rawTrack = track.get();
   m_ownedTracks.push_back(std::move(track));
-  aTracks[trackNum] = rawTrack;
+  m_tracks[trackNum] = rawTrack;
   return rawTrack;
 }
 
@@ -56,19 +56,19 @@ MidiTrack* MidiFile::adoptTrack(std::unique_ptr<MidiTrack> track) {
 
   auto* rawTrack = track.get();
   m_ownedTracks.push_back(std::move(track));
-  aTracks.push_back(rawTrack);
+  m_tracks.push_back(rawTrack);
   return rawTrack;
 }
 
 std::vector<std::unique_ptr<MidiTrack>> MidiFile::releaseTracks() {
-  aTracks.clear();
+  m_tracks.clear();
   return std::move(m_ownedTracks);
 }
 
 int MidiFile::getMidiTrackIndex(const MidiTrack *midiTrack) {
-  auto it = std::ranges::find(aTracks, midiTrack);
-  if (it != aTracks.end()) {
-    return static_cast<int>(std::distance(aTracks.begin(), it));
+  auto it = std::ranges::find(m_tracks, midiTrack);
+  if (it != m_tracks.end()) {
+    return static_cast<int>(std::distance(m_tracks.begin(), it));
   } else {
     return -1;
   }
@@ -83,15 +83,15 @@ u32 MidiFile::ppqn() const {
 }
 
 void MidiFile::sort() {
-  for (u32 i = 0; i < aTracks.size(); i++) {
-    if (aTracks[i]) {
-      if (aTracks[i]->aEvents.empty()) {
-        std::erase_if(m_ownedTracks, [track = aTracks[i]](const auto& ownedTrack) {
+  for (u32 i = 0; i < m_tracks.size(); i++) {
+    if (m_tracks[i]) {
+      if (!m_tracks[i]->hasEvents()) {
+        std::erase_if(m_ownedTracks, [track = m_tracks[i]](const auto& ownedTrack) {
           return ownedTrack.get() == track;
         });
-        aTracks.erase(aTracks.begin() + i--);
+        m_tracks.erase(m_tracks.begin() + i--);
       } else
-        aTracks[i]->sort();
+        m_tracks[i]->sort();
     }
   }
 }
@@ -103,7 +103,7 @@ bool MidiFile::saveMidiFile(const std::filesystem::path &filepath) {
 }
 
 void MidiFile::writeMidiToBuffer(std::vector<u8> &buf) {
-  size_t nNumTracks = aTracks.size();
+  size_t nNumTracks = m_tracks.size();
   buf.push_back('M');
   buf.push_back('T');
   buf.push_back('h');
@@ -121,7 +121,7 @@ void MidiFile::writeMidiToBuffer(std::vector<u8> &buf) {
 
   sort();
 
-  for (auto& aTrack : aTracks) {
+  for (auto& aTrack : m_tracks) {
     if (aTrack) {
       std::vector<u8> trackBuf;
       globalTranspose = 0;
@@ -154,7 +154,7 @@ MidiEvent* MidiTrack::adoptEvent(std::unique_ptr<MidiEvent> event) {
 
   auto* rawEvent = event.get();
   m_ownedEvents.push_back(std::move(event));
-  aEvents.push_back(rawEvent);
+  m_events.push_back(rawEvent);
   return rawEvent;
 }
 
@@ -170,22 +170,22 @@ void MidiTrack::prependEvents(std::vector<std::unique_ptr<MidiEvent>> events) {
     m_ownedEvents.push_back(std::move(event));
   }
 
-  aEvents.insert(aEvents.begin(), rawEvents.begin(), rawEvents.end());
+  m_events.insert(m_events.begin(), rawEvents.begin(), rawEvents.end());
 }
 
 std::vector<std::unique_ptr<MidiEvent>> MidiTrack::releaseEvents() {
   prevDurEvent = nullptr;
-  prevDurNoteOffs.clear();
-  aEvents.clear();
+  m_prevDurNoteOffs.clear();
+  m_events.clear();
   return std::move(m_ownedEvents);
 }
 
 void MidiTrack::sort() {
-  std::ranges::stable_sort(aEvents, PriorityCmp()); // Sort all the events by priority
-  std::ranges::stable_sort(aEvents, AbsTimeCmp());  // Sort all the events by absolute time,
+  std::ranges::stable_sort(m_events, PriorityCmp()); // Sort all the events by priority
+  std::ranges::stable_sort(m_events, AbsTimeCmp());  // Sort all the events by absolute time,
                                                              // so that delta times can be recorded correctly
-  if (!bHasEndOfTrack && !aEvents.empty()) {
-    addEvent<EndOfTrackEvent>(this, aEvents.back()->absTime);
+  if (!bHasEndOfTrack && !m_events.empty()) {
+    addEvent<EndOfTrackEvent>(this, m_events.back()->absTime);
     bHasEndOfTrack = true;
   }
 }
@@ -201,8 +201,8 @@ void MidiTrack::writeTrack(std::vector<u8> &buf) const {
   buf.push_back(0);
   u32 time = 0;  // start at 0 ticks
 
-  std::vector<MidiEvent *> finalEvents(aEvents);
-  std::vector<MidiEvent *> &globEvents = parentSeq->globalTrack.aEvents;
+  std::vector<MidiEvent *> finalEvents(m_events);
+  const auto& globEvents = parentSeq->globalTrack.events();
   finalEvents.insert(finalEvents.end(), globEvents.begin(), globEvents.end());
 
   std::ranges::stable_sort(finalEvents, PriorityCmp()); // Sort all the events by priority
@@ -266,13 +266,13 @@ void MidiTrack::addNoteByDur(u8 channel, s8 key, s8 vel, u32 duration) {
   purgePrevNoteOffs(getDelta());
   addEvent<NoteEvent>(this, channel, getDelta(), true, key, vel);  // add note on
   NoteEvent *prevDurNoteOff = addEvent<NoteEvent>(this, channel, getDelta() + duration, false, key);
-  prevDurNoteOffs.push_back(prevDurNoteOff);
+  m_prevDurNoteOffs.push_back(prevDurNoteOff);
 }
 
 //TODO: MOVE! This definitely doesn't belong here.
 void MidiTrack::addNoteByDur_TriAce(u8 channel, s8 key, s8 vel, u32 duration) {
   u32 CurDelta = getDelta();
-  size_t nNumEvents = aEvents.size();
+  size_t nNumEvents = m_events.size();
 
   NoteEvent* ContNote = nullptr;  // Continuted Note
   for (size_t curEvt = 0; curEvt < nNumEvents; curEvt++) {
@@ -286,8 +286,8 @@ void MidiTrack::addNoteByDur_TriAce(u8 channel, s8 key, s8 vel, u32 duration) {
     // Note: In previous TriAce drivers (like MegaDrive and SNES versions),
     //       a Note gets extended by a Note On event at the tick where another note expires.
     //       Valkyrie Profile: 225 Fragments of the Heart confirms, that this is NOT the case in the PS1 version.
-    if (aEvents[curEvt]->absTime > CurDelta) {
-      auto* noteEvt = dynamic_cast<NoteEvent*>(aEvents[curEvt]);
+    if (m_events[curEvt]->absTime > CurDelta) {
+      auto* noteEvt = dynamic_cast<NoteEvent*>(m_events[curEvt]);
       if (noteEvt != nullptr && noteEvt->key == key && !noteEvt->bNoteDown) {
         ContNote = noteEvt;
         break;
@@ -299,7 +299,7 @@ void MidiTrack::addNoteByDur_TriAce(u8 channel, s8 key, s8 vel, u32 duration) {
     purgePrevNoteOffs(CurDelta);
     addEvent<NoteEvent>(this, channel, CurDelta, true, key, vel);  // add note on
     NoteEvent *prevDurNoteOff = addEvent<NoteEvent>(this, channel, CurDelta + duration, false, key);
-    prevDurNoteOffs.push_back(prevDurNoteOff);
+    m_prevDurNoteOffs.push_back(prevDurNoteOff);
   } else {
     ContNote->absTime = CurDelta + duration;  // fix DeltaTime of the already inserted NoteOff event
   }
@@ -309,30 +309,18 @@ void MidiTrack::insertNoteByDur(u8 channel, s8 key, s8 vel, u32 duration, u32 ab
   purgePrevNoteOffs(std::max(getDelta(), absTime));
   addEvent<NoteEvent>(this, channel, absTime, true, key, vel);  // add note on
   NoteEvent *prevDurNoteOff = addEvent<NoteEvent>(this, channel, absTime + duration, false, key);
-  prevDurNoteOffs.push_back(prevDurNoteOff);
+  m_prevDurNoteOffs.push_back(prevDurNoteOff);
 }
 
 void MidiTrack::purgePrevNoteOffs() {
-  prevDurNoteOffs.clear();
+  m_prevDurNoteOffs.clear();
 }
 
 void MidiTrack::purgePrevNoteOffs(u32 absTime) {
-  prevDurNoteOffs.erase(std::remove_if(prevDurNoteOffs.begin(), prevDurNoteOffs.end(),
+  m_prevDurNoteOffs.erase(std::remove_if(m_prevDurNoteOffs.begin(), m_prevDurNoteOffs.end(),
     [absTime](const NoteEvent *e) { return e && e->absTime <= absTime; }),
-    prevDurNoteOffs.end());
+    m_prevDurNoteOffs.end());
 }
-
-/*void MidiTrack::AddVolMarker(u8 channel, u8 vol, s8 priority)
-{
-	MidiEvent* newEvent = new VolMarkerEvent(this, channel, GetDelta(), vol);
-	aEvents.push_back(newEvent);
-}
-
-void MidiTrack::InsertVolMarker(u8 channel, u8 vol, u32 absTime, s8 priority)
-{
-	MidiEvent* newEvent = new VolMarkerEvent(this, channel, absTime, vol);
-	aEvents.push_back(newEvent);
-}*/
 
 void MidiTrack::addControllerEvent(u8 channel, u8 controllerNum, u8 theDataByte) {
   addEvent<ControllerEvent>(this, channel, getDelta(), controllerNum, theDataByte);
@@ -864,13 +852,7 @@ u32 NoteEvent::writeEvent(std::vector<u8> &buf, u32 time) {
 //: MidiEvent(prntTrk, absoluteTime, channel, PRIORITY_LOWER), key(theKey), vel(theVel), duration(theDur)
 //{
 //}
-/*
-DurNoteEvent* DurNoteEvent::MakeCopy()
-{
-	return new DurNoteEvent(prntTrk, channel, AbsTime, key, vel, duration);
-}*/
-
-/*void DurNoteEvent::PrepareWrite(vector<MidiEvent*> & aEvents)
+/*void DurNoteEvent::PrepareWrite(vector<MidiEvent*> & m_events)
 {
 	prntTrk->addEvent<NoteEvent>(prntTrk, channel, AbsTime, true, key, vel);	//add note on
 	prntTrk->addEvent<NoteEvent>(prntTrk, channel, AbsTime+duration, false, key, vel);  //add note off at end of dur
@@ -890,10 +872,7 @@ DurNoteEvent* DurNoteEvent::MakeCopy()
 {
 }
 
-VolEvent* VolEvent::MakeCopy()
-{
-	return new VolEvent(prntTrk, channel, AbsTime, vol, priority);
-}*/
+*/
 
 //  ***************
 //  ControllerEvent

--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -5,11 +5,11 @@
  */
 
 #include "base/Types.h"
-#include "Helper.h"
 #include "LogManager.h"
 #include "Root.h"
 #include "VGMSeq.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <ranges>
 
@@ -26,21 +26,43 @@ MidiFile::MidiFile(VGMSeq *assocSeq)
   this->m_ppqn = assocSeq->ppqn();
 }
 
-MidiFile::~MidiFile() {
-  deleteVect<MidiTrack>(aTracks);
-}
+MidiFile::~MidiFile() = default;
 
 MidiTrack *MidiFile::addTrack() {
-  aTracks.push_back(new MidiTrack(this, bMonophonicTracks));
-  return aTracks.back();
+  return adoptTrack(std::make_unique<MidiTrack>(this, bMonophonicTracks));
 }
 
 MidiTrack *MidiFile::insertTrack(u32 trackNum) {
   if (trackNum + 1 > aTracks.size())
     aTracks.resize(trackNum + 1, nullptr);
 
-  aTracks[trackNum] = new MidiTrack(this, bMonophonicTracks);
-  return aTracks[trackNum];
+  if (aTracks[trackNum]) {
+    std::erase_if(m_ownedTracks, [track = aTracks[trackNum]](const auto& ownedTrack) {
+      return ownedTrack.get() == track;
+    });
+  }
+
+  auto track = std::make_unique<MidiTrack>(this, bMonophonicTracks);
+  auto* rawTrack = track.get();
+  m_ownedTracks.push_back(std::move(track));
+  aTracks[trackNum] = rawTrack;
+  return rawTrack;
+}
+
+MidiTrack* MidiFile::adoptTrack(std::unique_ptr<MidiTrack> track) {
+  if (!track) {
+    return nullptr;
+  }
+
+  auto* rawTrack = track.get();
+  m_ownedTracks.push_back(std::move(track));
+  aTracks.push_back(rawTrack);
+  return rawTrack;
+}
+
+std::vector<std::unique_ptr<MidiTrack>> MidiFile::releaseTracks() {
+  aTracks.clear();
+  return std::move(m_ownedTracks);
 }
 
 int MidiFile::getMidiTrackIndex(const MidiTrack *midiTrack) {
@@ -64,7 +86,9 @@ void MidiFile::sort() {
   for (u32 i = 0; i < aTracks.size(); i++) {
     if (aTracks[i]) {
       if (aTracks[i]->aEvents.empty()) {
-        delete aTracks[i];
+        std::erase_if(m_ownedTracks, [track = aTracks[i]](const auto& ownedTrack) {
+          return ownedTrack.get() == track;
+        });
         aTracks.erase(aTracks.begin() + i--);
       } else
         aTracks[i]->sort();
@@ -121,8 +145,39 @@ MidiTrack::MidiTrack(MidiFile *parentSeq, bool monophonic)
       prevDurEvent(nullptr),
       bSustain(false) {}
 
-MidiTrack::~MidiTrack() {
-  deleteVect<MidiEvent>(aEvents);
+MidiTrack::~MidiTrack() = default;
+
+MidiEvent* MidiTrack::adoptEvent(std::unique_ptr<MidiEvent> event) {
+  if (!event) {
+    return nullptr;
+  }
+
+  auto* rawEvent = event.get();
+  m_ownedEvents.push_back(std::move(event));
+  aEvents.push_back(rawEvent);
+  return rawEvent;
+}
+
+void MidiTrack::prependEvents(std::vector<std::unique_ptr<MidiEvent>> events) {
+  std::vector<MidiEvent*> rawEvents;
+  rawEvents.reserve(events.size());
+
+  for (auto& event : events) {
+    if (!event) {
+      continue;
+    }
+    rawEvents.push_back(event.get());
+    m_ownedEvents.push_back(std::move(event));
+  }
+
+  aEvents.insert(aEvents.begin(), rawEvents.begin(), rawEvents.end());
+}
+
+std::vector<std::unique_ptr<MidiEvent>> MidiTrack::releaseEvents() {
+  prevDurEvent = nullptr;
+  prevDurNoteOffs.clear();
+  aEvents.clear();
+  return std::move(m_ownedEvents);
 }
 
 void MidiTrack::sort() {
@@ -130,7 +185,7 @@ void MidiTrack::sort() {
   std::ranges::stable_sort(aEvents, AbsTimeCmp());  // Sort all the events by absolute time,
                                                              // so that delta times can be recorded correctly
   if (!bHasEndOfTrack && !aEvents.empty()) {
-    aEvents.push_back(new EndOfTrackEvent(this, aEvents.back()->absTime));
+    addEvent<EndOfTrackEvent>(this, aEvents.back()->absTime);
     bHasEndOfTrack = true;
   }
 }
@@ -192,27 +247,26 @@ void MidiTrack::resetDelta() {
 }
 
 void MidiTrack::addNoteOn(u8 channel, s8 key, s8 vel) {
-  aEvents.push_back(new NoteEvent(this, channel, getDelta(), true, key, vel));
+  addEvent<NoteEvent>(this, channel, getDelta(), true, key, vel);
 }
 
 void MidiTrack::insertNoteOn(u8 channel, s8 key, s8 vel, u32 absTime) {
-  aEvents.push_back(new NoteEvent(this, channel, absTime, true, key, vel));
+  addEvent<NoteEvent>(this, channel, absTime, true, key, vel);
 }
 
 void MidiTrack::addNoteOff(u8 channel, s8 key) {
-  aEvents.push_back(new NoteEvent(this, channel, getDelta(), false, key));
+  addEvent<NoteEvent>(this, channel, getDelta(), false, key);
 }
 
 void MidiTrack::insertNoteOff(u8 channel, s8 key, u32 absTime) {
-  aEvents.push_back(new NoteEvent(this, channel, absTime, false, key));
+  addEvent<NoteEvent>(this, channel, absTime, false, key);
 }
 
 void MidiTrack::addNoteByDur(u8 channel, s8 key, s8 vel, u32 duration) {
   purgePrevNoteOffs(getDelta());
-  aEvents.push_back(new NoteEvent(this, channel, getDelta(), true, key, vel));  // add note on
-  NoteEvent *prevDurNoteOff = new NoteEvent(this, channel, getDelta() + duration, false, key);
+  addEvent<NoteEvent>(this, channel, getDelta(), true, key, vel);  // add note on
+  NoteEvent *prevDurNoteOff = addEvent<NoteEvent>(this, channel, getDelta() + duration, false, key);
   prevDurNoteOffs.push_back(prevDurNoteOff);
-  aEvents.push_back(prevDurNoteOff);  // add note off at end of dur
 }
 
 //TODO: MOVE! This definitely doesn't belong here.
@@ -243,10 +297,9 @@ void MidiTrack::addNoteByDur_TriAce(u8 channel, s8 key, s8 vel, u32 duration) {
 
   if (ContNote == nullptr) {
     purgePrevNoteOffs(CurDelta);
-    aEvents.push_back(new NoteEvent(this, channel, CurDelta, true, key, vel));  // add note on
-    NoteEvent *prevDurNoteOff = new NoteEvent(this, channel, CurDelta + duration, false, key);
+    addEvent<NoteEvent>(this, channel, CurDelta, true, key, vel);  // add note on
+    NoteEvent *prevDurNoteOff = addEvent<NoteEvent>(this, channel, CurDelta + duration, false, key);
     prevDurNoteOffs.push_back(prevDurNoteOff);
-    aEvents.push_back(prevDurNoteOff);  // add note off at end of dur
   } else {
     ContNote->absTime = CurDelta + duration;  // fix DeltaTime of the already inserted NoteOff event
   }
@@ -254,10 +307,9 @@ void MidiTrack::addNoteByDur_TriAce(u8 channel, s8 key, s8 vel, u32 duration) {
 
 void MidiTrack::insertNoteByDur(u8 channel, s8 key, s8 vel, u32 duration, u32 absTime) {
   purgePrevNoteOffs(std::max(getDelta(), absTime));
-  aEvents.push_back(new NoteEvent(this, channel, absTime, true, key, vel));  // add note on
-  NoteEvent *prevDurNoteOff = new NoteEvent(this, channel, absTime + duration, false, key);
+  addEvent<NoteEvent>(this, channel, absTime, true, key, vel);  // add note on
+  NoteEvent *prevDurNoteOff = addEvent<NoteEvent>(this, channel, absTime + duration, false, key);
   prevDurNoteOffs.push_back(prevDurNoteOff);
-  aEvents.push_back(prevDurNoteOff);  // add note off at end of dur
 }
 
 void MidiTrack::purgePrevNoteOffs() {
@@ -283,34 +335,33 @@ void MidiTrack::InsertVolMarker(u8 channel, u8 vol, u32 absTime, s8 priority)
 }*/
 
 void MidiTrack::addControllerEvent(u8 channel, u8 controllerNum, u8 theDataByte) {
-  aEvents.push_back(new ControllerEvent(this, channel, getDelta(), controllerNum, theDataByte));
+  addEvent<ControllerEvent>(this, channel, getDelta(), controllerNum, theDataByte);
 }
 
 void MidiTrack::insertControllerEvent(u8 channel, u8 controllerNum, u8 theDataByte, u32 absTime) {
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, controllerNum, theDataByte));
+  addEvent<ControllerEvent>(this, channel, absTime, controllerNum, theDataByte);
 }
 
 void MidiTrack::addVol(u8 channel, u8 vol) {
-  aEvents.push_back(new VolumeEvent(this, channel, getDelta(), vol));
+  addEvent<VolumeEvent>(this, channel, getDelta(), vol);
 }
 
 void MidiTrack::insertVol(u8 channel, u8 vol, u32 absTime) {
-  aEvents.push_back(new VolumeEvent(this, channel, absTime, vol));
+  addEvent<VolumeEvent>(this, channel, absTime, vol);
 }
 
 void MidiTrack::addVolumeFine(u8 channel, u8 volume_lsb) {
-  aEvents.push_back(new VolumeFineEvent(this, channel, getDelta(), volume_lsb));
+  addEvent<VolumeFineEvent>(this, channel, getDelta(), volume_lsb);
 }
 
 void MidiTrack::insertVolumeFine(u8 channel, u8 volume_lsb, u32 absTime) {
-  aEvents.push_back(new VolumeFineEvent(this, channel, absTime, volume_lsb));
+  addEvent<VolumeFineEvent>(this, channel, absTime, volume_lsb);
 }
 
 //TODO: Master Volume sysex events are meant to be global to device, not per channel.
 // For per channel master volume, we should add a system for normalizing controller vol events.
 void MidiTrack::addMasterVol(u8 channel, u8 volMsb, u8 volLsb) {
-  MidiEvent *newEvent = new MasterVolEvent(this, channel, getDelta(), volMsb, volLsb);
-  aEvents.push_back(newEvent);
+  addEvent<MasterVolEvent>(this, channel, getDelta(), volMsb, volLsb);
 }
 
 void MidiTrack::insertMasterVol(u8 channel, u8 volMsb, u32 absTime) {
@@ -318,128 +369,127 @@ void MidiTrack::insertMasterVol(u8 channel, u8 volMsb, u32 absTime) {
 }
 
 void MidiTrack::insertMasterVol(u8 channel, u8 volMsb, u8 volLsb, u32 absTime) {
-  MidiEvent *newEvent = new MasterVolEvent(this, channel, absTime, volMsb, volLsb);
-  aEvents.push_back(newEvent);
+  addEvent<MasterVolEvent>(this, channel, absTime, volMsb, volLsb);
 }
 
 void MidiTrack::addExpression(u8 channel, u8 expression) {
-  aEvents.push_back(new ExpressionEvent(this, channel, getDelta(), expression));
+  addEvent<ExpressionEvent>(this, channel, getDelta(), expression);
 }
 
 void MidiTrack::insertExpression(u8 channel, u8 expression, u32 absTime) {
-  aEvents.push_back(new ExpressionEvent(this, channel, absTime, expression));
+  addEvent<ExpressionEvent>(this, channel, absTime, expression);
 }
 
 void MidiTrack::addExpressionFine(u8 channel, u8 expression_lsb) {
-  aEvents.push_back(new ExpressionFineEvent(this, channel, getDelta(), expression_lsb));
+  addEvent<ExpressionFineEvent>(this, channel, getDelta(), expression_lsb);
 }
 
 void MidiTrack::insertExpressionFine(u8 channel, u8 expression_lsb, u32 absTime) {
-  aEvents.push_back(new ExpressionFineEvent(this, channel, absTime, expression_lsb));
+  addEvent<ExpressionFineEvent>(this, channel, absTime, expression_lsb);
 }
 
 void MidiTrack::addSustain(u8 channel, u8 depth) {
-  aEvents.push_back(new SustainEvent(this, channel, getDelta(), depth));
+  addEvent<SustainEvent>(this, channel, getDelta(), depth);
 }
 
 void MidiTrack::insertSustain(u8 channel, u8 depth, u32 absTime) {
-  aEvents.push_back(new SustainEvent(this, channel, absTime, depth));
+  addEvent<SustainEvent>(this, channel, absTime, depth);
 }
 
 void MidiTrack::addPortamento(u8 channel, bool bOn) {
-  aEvents.push_back(new PortamentoEvent(this, channel, getDelta(), bOn));
+  addEvent<PortamentoEvent>(this, channel, getDelta(), bOn);
 }
 
 void MidiTrack::insertPortamento(u8 channel, bool bOn, u32 absTime) {
-  aEvents.push_back(new PortamentoEvent(this, channel, absTime, bOn));
+  addEvent<PortamentoEvent>(this, channel, absTime, bOn);
 }
 
 void MidiTrack::addPortamentoTime(u8 channel, u8 time) {
-  aEvents.push_back(new PortamentoTimeEvent(this, channel, getDelta(), time));
+  addEvent<PortamentoTimeEvent>(this, channel, getDelta(), time);
 }
 
 void MidiTrack::insertPortamentoTime(u8 channel, u8 time, u32 absTime) {
-  aEvents.push_back(new PortamentoTimeEvent(this, channel, absTime, time));
+  addEvent<PortamentoTimeEvent>(this, channel, absTime, time);
 }
 
 void MidiTrack::addPortamentoTimeFine(u8 channel, u8 time) {
-  aEvents.push_back(new PortamentoTimeFineEvent(this, channel, getDelta(), time));
+  addEvent<PortamentoTimeFineEvent>(this, channel, getDelta(), time);
 }
 
 void MidiTrack::insertPortamentoTimeFine(u8 channel, u8 time, u32 absTime) {
-  aEvents.push_back(new PortamentoTimeFineEvent(this, channel, absTime, time));
+  addEvent<PortamentoTimeFineEvent>(this, channel, absTime, time);
 }
 
 void MidiTrack::addPortamentoControl(u8 channel, u8 key) {
-  aEvents.push_back(new PortamentoControlEvent(this, channel, getDelta(), key));
+  addEvent<PortamentoControlEvent>(this, channel, getDelta(), key);
 }
 
 void MidiTrack::insertPortamentoControl(u8 channel, u8 key, u32 absTime) {
-  aEvents.push_back(new PortamentoControlEvent(this, channel, absTime, key));
+  addEvent<PortamentoControlEvent>(this, channel, absTime, key);
 }
 
 void MidiTrack::addMono(u8 channel) {
-  aEvents.push_back(new MonoEvent(this, channel, getDelta()));
+  addEvent<MonoEvent>(this, channel, getDelta());
 }
 
 void MidiTrack::insertMono(u8 channel, u32 absTime) {
-  aEvents.push_back(new MonoEvent(this, channel, absTime));
+  addEvent<MonoEvent>(this, channel, absTime);
 }
 
 void MidiTrack::addLegatoPedal(u8 channel, bool bOn) {
-  aEvents.push_back(new LegatoPedalEvent(this, channel, getDelta(), bOn));
+  addEvent<LegatoPedalEvent>(this, channel, getDelta(), bOn);
 }
 
 void MidiTrack::insertLegatoPedal(u8 channel, bool bOn, u32 absTime) {
-  aEvents.push_back(new LegatoPedalEvent(this, channel, absTime, bOn));
+  addEvent<LegatoPedalEvent>(this, channel, absTime, bOn);
 }
 
 void MidiTrack::addPan(u8 channel, u8 pan) {
-  aEvents.push_back(new PanEvent(this, channel, getDelta(), pan));
+  addEvent<PanEvent>(this, channel, getDelta(), pan);
 }
 
 void MidiTrack::insertPan(u8 channel, u8 pan, u32 absTime) {
-  aEvents.push_back(new PanEvent(this, channel, absTime, pan));
+  addEvent<PanEvent>(this, channel, absTime, pan);
 }
 
 void MidiTrack::addReverb(u8 channel, u8 reverb) {
-  aEvents.push_back(new ControllerEvent(this, channel, getDelta(), 91, reverb));
+  addEvent<ControllerEvent>(this, channel, getDelta(), 91, reverb);
 }
 
 void MidiTrack::insertReverb(u8 channel, u8 reverb, u32 absTime) {
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 91, reverb));
+  addEvent<ControllerEvent>(this, channel, absTime, 91, reverb);
 }
 
 void MidiTrack::addModulation(u8 channel, u8 depth) {
-  aEvents.push_back(new ModulationEvent(this, channel, getDelta(), depth));
+  addEvent<ModulationEvent>(this, channel, getDelta(), depth);
 }
 
 void MidiTrack::insertModulation(u8 channel, u8 depth, u32 absTime) {
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 1, depth));
+  addEvent<ControllerEvent>(this, channel, absTime, 1, depth);
 }
 
 void MidiTrack::addBreath(u8 channel, u8 depth) {
-  aEvents.push_back(new BreathEvent(this, channel, getDelta(), depth));
+  addEvent<BreathEvent>(this, channel, getDelta(), depth);
 }
 
 void MidiTrack::insertBreath(u8 channel, u8 depth, u32 absTime) {
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 2, depth));
+  addEvent<ControllerEvent>(this, channel, absTime, 2, depth);
 }
 
 void MidiTrack::addPitchBend(u8 channel, s16 bend) {
-  aEvents.push_back(new PitchBendEvent(this, channel, getDelta(), bend));
+  addEvent<PitchBendEvent>(this, channel, getDelta(), bend);
 }
 
 void MidiTrack::insertPitchBend(u8 channel, s16 bend, u32 absTime) {
-  aEvents.push_back(new PitchBendEvent(this, channel, absTime, bend));
+  addEvent<PitchBendEvent>(this, channel, absTime, bend);
 }
 
 void MidiTrack::addChannelPressure(u8 channel, u8 pressure) {
-  aEvents.push_back(new ChannelPressureEvent(this, channel, getDelta(), pressure));
+  addEvent<ChannelPressureEvent>(this, channel, getDelta(), pressure);
 }
 
 void MidiTrack::insertChannelPressure(u8 channel, u8 pressure, u32 absTime) {
-  aEvents.push_back(new ChannelPressureEvent(this, channel, absTime, pressure));
+  addEvent<ChannelPressureEvent>(this, channel, absTime, pressure);
 }
 
 void MidiTrack::addPitchBendRange(u8 channel, u16 cents) {
@@ -450,10 +500,10 @@ void MidiTrack::insertPitchBendRange(u8 channel, u16 cents, u32 absTime) {
   u8 semitones = cents / 100;
   u8 finetune_cents = cents % 100;
   // We push the LSB controller event first as somee virtual instruments only react upon receiving MSB
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 101, 0, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 100, 0, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 38, finetune_cents, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 6, semitones, PRIORITY_HIGHER - 1));
+  addEvent<ControllerEvent>(this, channel, absTime, 101, 0, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 100, 0, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 38, finetune_cents, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 6, semitones, PRIORITY_HIGHER - 1);
 }
 
 void MidiTrack::addFineTuning(u8 channel, u8 msb, u8 lsb) {
@@ -462,10 +512,10 @@ void MidiTrack::addFineTuning(u8 channel, u8 msb, u8 lsb) {
 
 void MidiTrack::insertFineTuning(u8 channel, u8 msb, u8 lsb, u32 absTime) {
   // We push the LSB controller event first as somee virtual instruments only react upon receiving MSB
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 101, 0, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 100, 1, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 38, lsb, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 6, msb, PRIORITY_HIGHER - 1));
+  addEvent<ControllerEvent>(this, channel, absTime, 101, 0, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 100, 1, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 38, lsb, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 6, msb, PRIORITY_HIGHER - 1);
 }
 
 void MidiTrack::addFineTuning(u8 channel, double cents) {
@@ -484,10 +534,10 @@ void MidiTrack::addCoarseTuning(u8 channel, u8 msb, u8 lsb) {
 }
 
 void MidiTrack::insertCoarseTuning(u8 channel, u8 msb, u8 lsb, u32 absTime) {
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 101, 0, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 100, 2, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 38, lsb, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 6, msb, PRIORITY_HIGHER - 1));
+  addEvent<ControllerEvent>(this, channel, absTime, 101, 0, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 100, 2, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 38, lsb, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 6, msb, PRIORITY_HIGHER - 1);
 }
 
 void MidiTrack::addCoarseTuning(u8 channel, double semitones) {
@@ -505,10 +555,10 @@ void MidiTrack::addModulationDepthRange(u8 channel, u8 msb, u8 lsb) {
 }
 
 void MidiTrack::insertModulationDepthRange(u8 channel, u8 msb, u8 lsb, u32 absTime) {
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 101, 0, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 100, 5, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 38, lsb, PRIORITY_HIGHER - 1));
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 6, msb, PRIORITY_HIGHER - 1));
+  addEvent<ControllerEvent>(this, channel, absTime, 101, 0, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 100, 5, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 38, lsb, PRIORITY_HIGHER - 1);
+  addEvent<ControllerEvent>(this, channel, absTime, 6, msb, PRIORITY_HIGHER - 1);
 }
 
 void MidiTrack::addModulationDepthRange(u8 channel, double semitones) {
@@ -522,125 +572,125 @@ void MidiTrack::insertModulationDepthRange(u8 channel, double semitones, u32 abs
 }
 
 void MidiTrack::addProgramChange(u8 channel, u8 progNum) {
-  aEvents.push_back(new ProgChangeEvent(this, channel, getDelta(), progNum));
+  addEvent<ProgChangeEvent>(this, channel, getDelta(), progNum);
 }
 
 void MidiTrack::addBankSelect(u8 channel, u8 bank) {
-  aEvents.push_back(new BankSelectEvent(this, channel, getDelta(), bank));
+  addEvent<BankSelectEvent>(this, channel, getDelta(), bank);
 }
 
 void MidiTrack::addBankSelectFine(u8 channel, u8 lsb) {
-  aEvents.push_back(new BankSelectFineEvent(this, channel, getDelta(), lsb));
+  addEvent<BankSelectFineEvent>(this, channel, getDelta(), lsb);
 }
 
 void MidiTrack::insertBankSelect(u8 channel, u8 bank, u32 absTime) {
-  aEvents.push_back(new ControllerEvent(this, channel, absTime, 0, bank));
+  addEvent<ControllerEvent>(this, channel, absTime, 0, bank);
 }
 
 void MidiTrack::addTempo(u32 microSeconds) {
-  aEvents.push_back(new TempoEvent(this, getDelta(), microSeconds));
+  addEvent<TempoEvent>(this, getDelta(), microSeconds);
   //bAddedTempo = true;
 }
 
 void MidiTrack::addTempoBPM(double BPM) {
   u32 microSecs = static_cast<u32>(std::round(60000000.0 / BPM));
-  aEvents.push_back(new TempoEvent(this, getDelta(), microSecs));
+  addEvent<TempoEvent>(this, getDelta(), microSecs);
   //bAddedTempo = true;
 }
 
 void MidiTrack::insertTempo(u32 microSeconds, u32 absTime) {
-  aEvents.push_back(new TempoEvent(this, absTime, microSeconds));
+  addEvent<TempoEvent>(this, absTime, microSeconds);
   //bAddedTempo = true;
 }
 
 void MidiTrack::insertTempoBPM(double BPM, u32 absTime) {
   u32 microSecs = static_cast<u32>(std::round(60000000.0 / BPM));
-  aEvents.push_back(new TempoEvent(this, absTime, microSecs));
+  addEvent<TempoEvent>(this, absTime, microSecs);
   //bAddedTempo = true;
 }
 
 void MidiTrack::addMidiPort(u8 port) {
-  aEvents.push_back(new MidiPortEvent(this, getDelta(), port));
+  addEvent<MidiPortEvent>(this, getDelta(), port);
 }
 
 void MidiTrack::insertMidiPort(u8 port, u32 absTime) {
-  aEvents.push_back(new MidiPortEvent(this, absTime, port));
+  addEvent<MidiPortEvent>(this, absTime, port);
 }
 
 void MidiTrack::addTimeSig(u8 numer, u8 denom, u8 ticksPerQuarter) {
-  aEvents.push_back(new TimeSigEvent(this, getDelta(), numer, denom, ticksPerQuarter));
+  addEvent<TimeSigEvent>(this, getDelta(), numer, denom, ticksPerQuarter);
   //bAddedTimeSig = true;
 }
 
 void MidiTrack::insertTimeSig(u8 numer, u8 denom, u8 ticksPerQuarter, u32 absTime) {
-  aEvents.push_back(new TimeSigEvent(this, absTime, numer, denom, ticksPerQuarter));
+  addEvent<TimeSigEvent>(this, absTime, numer, denom, ticksPerQuarter);
   //bAddedTimeSig = true;
 }
 
 void MidiTrack::addEndOfTrack() {
-  aEvents.push_back(new EndOfTrackEvent(this, getDelta()));
+  addEvent<EndOfTrackEvent>(this, getDelta());
   bHasEndOfTrack = true;
 }
 
 void MidiTrack::insertEndOfTrack(u32 absTime) {
-  aEvents.push_back(new EndOfTrackEvent(this, absTime));
+  addEvent<EndOfTrackEvent>(this, absTime);
   bHasEndOfTrack = true;
 }
 
 void MidiTrack::addText(const std::string &str) {
-  aEvents.push_back(new TextEvent(this, getDelta(), str));
+  addEvent<TextEvent>(this, getDelta(), str);
 }
 
 void MidiTrack::insertText(const std::string &str, u32 absTime) {
-  aEvents.push_back(new TextEvent(this, absTime, str));
+  addEvent<TextEvent>(this, absTime, str);
 }
 
 void MidiTrack::addSeqName(const std::string &str) {
-  aEvents.push_back(new SeqNameEvent(this, getDelta(), str));
+  addEvent<SeqNameEvent>(this, getDelta(), str);
 }
 
 void MidiTrack::insertSeqName(const std::string &str, u32 absTime) {
-  aEvents.push_back(new SeqNameEvent(this, absTime, str));
+  addEvent<SeqNameEvent>(this, absTime, str);
 }
 
 void MidiTrack::addTrackName(const std::string &str) {
-  aEvents.push_back(new TrackNameEvent(this, getDelta(), str));
+  addEvent<TrackNameEvent>(this, getDelta(), str);
 }
 
 void MidiTrack::insertTrackName(const std::string &str, u32 absTime) {
-  aEvents.push_back(new TrackNameEvent(this, absTime, str));
+  addEvent<TrackNameEvent>(this, absTime, str);
 }
 
 void MidiTrack::addGMReset() {
-  aEvents.push_back(new GMResetEvent(this, getDelta()));
+  addEvent<GMResetEvent>(this, getDelta());
 }
 
 void MidiTrack::insertGMReset(u32 absTime) {
-  aEvents.push_back(new GMResetEvent(this, absTime));
+  addEvent<GMResetEvent>(this, absTime);
 }
 
 void MidiTrack::addGM2Reset() {
-  aEvents.push_back(new GM2ResetEvent(this, getDelta()));
+  addEvent<GM2ResetEvent>(this, getDelta());
 }
 
 void MidiTrack::insertGM2Reset(u32 absTime) {
-  aEvents.push_back(new GM2ResetEvent(this, absTime));
+  addEvent<GM2ResetEvent>(this, absTime);
 }
 
 void MidiTrack::addGSReset() {
-  aEvents.push_back(new GSResetEvent(this, getDelta()));
+  addEvent<GSResetEvent>(this, getDelta());
 }
 
 void MidiTrack::insertGSReset(u32 absTime) {
-  aEvents.push_back(new GSResetEvent(this, absTime));
+  addEvent<GSResetEvent>(this, absTime);
 }
 
 void MidiTrack::addXGReset() {
-  aEvents.push_back(new XGResetEvent(this, getDelta()));
+  addEvent<XGResetEvent>(this, getDelta());
 }
 
 void MidiTrack::insertXGReset(u32 absTime) {
-  aEvents.push_back(new XGResetEvent(this, absTime));
+  addEvent<XGResetEvent>(this, absTime);
 }
 
 // SPECIAL NON-MIDI EVENTS
@@ -650,11 +700,11 @@ void MidiTrack::insertXGReset(u32 absTime) {
 
 //void MidiTrack::AddTranspose(s8 semitones)
 //{
-//	aEvents.push_back(new TransposeEvent(this, GetDelta(), semitones));
+//	addEvent<TransposeEvent>(this, GetDelta(), semitones);
 //}
 
 void MidiTrack::insertGlobalTranspose(u32 absTime, s8 semitones) {
-  aEvents.push_back(new GlobalTransposeEvent(this, absTime, semitones));
+  addEvent<GlobalTransposeEvent>(this, absTime, semitones);
 }
 
 
@@ -663,7 +713,7 @@ void MidiTrack::addMarker(u8 channel,
                           u8 databyte1,
                           u8 databyte2,
                           s8 priority) {
-  aEvents.push_back(new MarkerEvent(this, channel, getDelta(), markername, databyte1, databyte2, priority));
+  addEvent<MarkerEvent>(this, channel, getDelta(), markername, databyte1, databyte2, priority);
 }
 
 void MidiTrack::insertMarker(u8 channel,
@@ -672,7 +722,7 @@ void MidiTrack::insertMarker(u8 channel,
                   u8 databyte2,
                   s8 priority,
                   u32 absTime) {
-  aEvents.push_back(new MarkerEvent(this, channel, absTime, markername, databyte1, databyte2, priority));
+  addEvent<MarkerEvent>(this, channel, absTime, markername, databyte1, databyte2, priority);
 }
 
 //  *********
@@ -822,8 +872,8 @@ DurNoteEvent* DurNoteEvent::MakeCopy()
 
 /*void DurNoteEvent::PrepareWrite(vector<MidiEvent*> & aEvents)
 {
-	prntTrk->aEvents.push_back(new NoteEvent(prntTrk, channel, AbsTime, true, key, vel));	//add note on
-	prntTrk->aEvents.push_back(new NoteEvent(prntTrk, channel, AbsTime+duration, false, key, vel));  //add note off at end of dur
+	prntTrk->addEvent<NoteEvent>(prntTrk, channel, AbsTime, true, key, vel);	//add note on
+	prntTrk->addEvent<NoteEvent>(prntTrk, channel, AbsTime+duration, false, key, vel);  //add note off at end of dur
 }*/
 
 //u32 DurNoteEvent::WriteEvent(vector<u8> & buf, u32 time)		//we do note use WriteEvent on DurNoteEvents... this is what PrepareWrite is for, to create NoteEvents in substitute

--- a/src/main/conversion/MidiFile.cpp
+++ b/src/main/conversion/MidiFile.cpp
@@ -29,7 +29,7 @@ MidiFile::MidiFile(VGMSeq *assocSeq)
 MidiFile::~MidiFile() = default;
 
 MidiTrack *MidiFile::addTrack() {
-  return adoptTrack(std::make_unique<MidiTrack>(this, bMonophonicTracks));
+  return sinkTrack(std::make_unique<MidiTrack>(this, bMonophonicTracks));
 }
 
 MidiTrack *MidiFile::insertTrack(u32 trackNum) {
@@ -49,7 +49,7 @@ MidiTrack *MidiFile::insertTrack(u32 trackNum) {
   return rawTrack;
 }
 
-MidiTrack* MidiFile::adoptTrack(std::unique_ptr<MidiTrack> track) {
+MidiTrack* MidiFile::sinkTrack(std::unique_ptr<MidiTrack>&& track) {
   if (!track) {
     return nullptr;
   }
@@ -147,7 +147,7 @@ MidiTrack::MidiTrack(MidiFile *parentSeq, bool monophonic)
 
 MidiTrack::~MidiTrack() = default;
 
-MidiEvent* MidiTrack::adoptEvent(std::unique_ptr<MidiEvent> event) {
+MidiEvent* MidiTrack::sinkEvent(std::unique_ptr<MidiEvent>&& event) {
   if (!event) {
     return nullptr;
   }

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -78,6 +78,9 @@ class MidiTrack {
   MidiEvent* adoptEvent(std::unique_ptr<MidiEvent> event);
   void prependEvents(std::vector<std::unique_ptr<MidiEvent>> events);
   std::vector<std::unique_ptr<MidiEvent>> releaseEvents();
+  [[nodiscard]] const std::vector<MidiEvent*>& events() const { return m_events; }
+  [[nodiscard]] bool hasEvents() const { return !m_events.empty(); }
+  [[nodiscard]] const std::vector<NoteEvent*>& previousDurNoteOffs() const { return m_prevDurNoteOffs; }
 
   template <class EventType, class... Args>
   EventType* addEvent(Args&&... args) {
@@ -214,10 +217,8 @@ class MidiTrack {
   // state
   u32 DeltaTime;            //a time value to be used for AddEvent
   DurNoteEvent *prevDurEvent;
-  std::vector<NoteEvent *> prevDurNoteOffs;
   bool bSustain;
 
-  std::vector<MidiEvent *> aEvents;
   // activeNotes tracks which keys are on during conversion. It maps the note's original key to the
   // final realized key, which will be different when a global transpose is set. It helps us resolve
   // the correct note off events when a global transpose event occurs amidst live note on events,
@@ -226,6 +227,8 @@ class MidiTrack {
 
  private:
   std::vector<std::unique_ptr<MidiEvent>> m_ownedEvents;
+  std::vector<MidiEvent *> m_events;
+  std::vector<NoteEvent *> m_prevDurNoteOffs;
 };
 
 class MidiFile {
@@ -237,6 +240,9 @@ class MidiFile {
   MidiTrack* adoptTrack(std::unique_ptr<MidiTrack> track);
   std::vector<std::unique_ptr<MidiTrack>> releaseTracks();
   int getMidiTrackIndex(const MidiTrack *midiTrack);
+  [[nodiscard]] const std::vector<MidiTrack*>& tracks() const { return m_tracks; }
+  [[nodiscard]] size_t trackCount() const { return m_tracks.size(); }
+  MidiTrack* track(size_t index) const { return m_tracks.at(index); }
   void setPPQN(u16 ppqn);
   u32 ppqn() const;
   void writeMidiToBuffer(std::vector<u8> &buf);
@@ -250,7 +256,6 @@ class MidiFile {
  public:
   VGMSeq *assocSeq;
 
-  std::vector<MidiTrack *> aTracks;
   MidiTrack globalTrack;            //events in the globalTrack will be copied into every other track
   s8 globalTranspose;
   bool bMonophonicTracks;
@@ -258,6 +263,7 @@ class MidiFile {
 private:
   u16 m_ppqn;
   std::vector<std::unique_ptr<MidiTrack>> m_ownedTracks;
+  std::vector<MidiTrack *> m_tracks;
 };
 
 class MidiEvent {
@@ -317,7 +323,7 @@ class NoteEvent
 //{
 //public:
 //	DurNoteEvent(MidiTrack* prntTrk, u8 channel, u32 absoluteTime, u8 theKey, u8 theVel, u32 theDur);
-//	//virtual void PrepareWrite(std::vector<MidiEvent*> & aEvents);
+//	//virtual void PrepareWrite(std::vector<MidiEvent*> & events);
 //	virtual u32 WriteEvent(std::vector<u8> & buf, u32 time);
 //
 //	bool bNoteDown;

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -8,8 +8,10 @@
 
 #include <filesystem>
 #include <list>
+#include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 class VGMSeq;
@@ -73,6 +75,14 @@ class MidiTrack {
 
   void sort();
   void writeTrack(std::vector<u8> &buf) const;
+  MidiEvent* adoptEvent(std::unique_ptr<MidiEvent> event);
+  void prependEvents(std::vector<std::unique_ptr<MidiEvent>> events);
+  std::vector<std::unique_ptr<MidiEvent>> releaseEvents();
+
+  template <class EventType, class... Args>
+  EventType* addEvent(Args&&... args) {
+    return static_cast<EventType*>(adoptEvent(std::make_unique<EventType>(std::forward<Args>(args)...)));
+  }
 
   //void setChannel(int theChannel);
   void setChannelGroup(int theChannelGroup);
@@ -213,6 +223,9 @@ class MidiTrack {
   // the correct note off events when a global transpose event occurs amidst live note on events,
   // and also allows us to warn about unpaired note on/off events.
   std::unordered_map<u8, u8> activeNotes;
+
+ private:
+  std::vector<std::unique_ptr<MidiEvent>> m_ownedEvents;
 };
 
 class MidiFile {
@@ -221,6 +234,8 @@ class MidiFile {
   ~MidiFile();
   MidiTrack *addTrack();
   MidiTrack *insertTrack(u32 trackNum);
+  MidiTrack* adoptTrack(std::unique_ptr<MidiTrack> track);
+  std::vector<std::unique_ptr<MidiTrack>> releaseTracks();
   int getMidiTrackIndex(const MidiTrack *midiTrack);
   void setPPQN(u16 ppqn);
   u32 ppqn() const;
@@ -242,6 +257,7 @@ class MidiFile {
 
 private:
   u16 m_ppqn;
+  std::vector<std::unique_ptr<MidiTrack>> m_ownedTracks;
 };
 
 class MidiEvent {

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -75,7 +75,7 @@ class MidiTrack {
 
   void sort();
   void writeTrack(std::vector<u8> &buf) const;
-  MidiEvent* adoptEvent(std::unique_ptr<MidiEvent> event);
+  MidiEvent* sinkEvent(std::unique_ptr<MidiEvent>&& event);
   void prependEvents(std::vector<std::unique_ptr<MidiEvent>> events);
   std::vector<std::unique_ptr<MidiEvent>> releaseEvents();
   [[nodiscard]] const std::vector<MidiEvent*>& events() const { return m_events; }
@@ -84,7 +84,7 @@ class MidiTrack {
 
   template <class EventType, class... Args>
   EventType* addEvent(Args&&... args) {
-    return static_cast<EventType*>(adoptEvent(std::make_unique<EventType>(std::forward<Args>(args)...)));
+    return static_cast<EventType*>(sinkEvent(std::make_unique<EventType>(std::forward<Args>(args)...)));
   }
 
   //void setChannel(int theChannel);
@@ -237,7 +237,7 @@ class MidiFile {
   ~MidiFile();
   MidiTrack *addTrack();
   MidiTrack *insertTrack(u32 trackNum);
-  MidiTrack* adoptTrack(std::unique_ptr<MidiTrack> track);
+  MidiTrack* sinkTrack(std::unique_ptr<MidiTrack>&& track);
   std::vector<std::unique_ptr<MidiTrack>> releaseTracks();
   int getMidiTrackIndex(const MidiTrack *midiTrack);
   [[nodiscard]] const std::vector<MidiTrack*>& tracks() const { return m_tracks; }

--- a/src/main/conversion/MidiMerge.cpp
+++ b/src/main/conversion/MidiMerge.cpp
@@ -51,19 +51,19 @@ u64 rescaleTick(u32 tick, u16 srcPPQN, u16 dstPPQN) {
 u32 getMidiDurationTicks(const MidiFile& midi) {
   u32 maxTick = 0;
 
-  for (const MidiTrack* track : midi.aTracks) {
+  for (const MidiTrack* track : midi.tracks()) {
     if (!track) {
       continue;
     }
 
-    for (const MidiEvent* event : track->aEvents) {
+    for (const MidiEvent* event : track->events()) {
       if (event) {
         maxTick = std::max(maxTick, event->absTime);
       }
     }
   }
 
-  for (const MidiEvent* event : midi.globalTrack.aEvents) {
+  for (const MidiEvent* event : midi.globalTrack.events()) {
     if (event) {
       maxTick = std::max(maxTick, event->absTime);
     }
@@ -77,7 +77,7 @@ void retimeTrack(MidiTrack* track, u16 srcPPQN, u16 dstPPQN, u32 startTick) {
     return;
   }
 
-  for (MidiEvent* event : track->aEvents) {
+  for (MidiEvent* event : track->events()) {
     if (!event) {
       continue;
     }
@@ -135,7 +135,7 @@ bool applyBankOffsetToTrack(MidiTrack* track,
     return true;
   };
 
-  for (MidiEvent* event : track->aEvents) {
+  for (MidiEvent* event : track->events()) {
     if (!event) {
       continue;
     }
@@ -503,13 +503,13 @@ bool saveMergedSoundfont(const std::vector<MidiMergeEntry>& entries,
       instr->ulBank = remapped;
     }
 
-    const u32 waveOffset = static_cast<u32>(mergedSynth->vWaves.size());
+    const u32 waveOffset = static_cast<u32>(mergedSynth->waveCount());
 
     for (auto& instr : partInstrs) {
       if (!instr) {
         continue;
       }
-      for (SynthRgn* rgn : instr->vRgns) {
+      for (SynthRgn* rgn : instr->regions()) {
         if (rgn) {
           rgn->tableIndex += waveOffset;
         }
@@ -523,7 +523,7 @@ bool saveMergedSoundfont(const std::vector<MidiMergeEntry>& entries,
     }
   }
 
-  if (mergedSynth->vInstrs.empty() || mergedSynth->vWaves.empty()) {
+  if (!mergedSynth->hasInstrs() || !mergedSynth->hasWaves()) {
     L_ERROR("Merged SF2 has no instruments or no samples.");
     return false;
   }

--- a/src/main/conversion/MidiMerge.cpp
+++ b/src/main/conversion/MidiMerge.cpp
@@ -161,7 +161,7 @@ bool applyBankOffsetToTrack(MidiTrack* track,
     }
   }
 
-  std::vector<MidiEvent*> injectedBankEvents;
+  std::vector<std::unique_ptr<MidiEvent>> injectedBankEvents;
   injectedBankEvents.reserve(32);
   u8 remappedBankMsb = 0;
   u8 remappedBankLsb = 0;
@@ -174,12 +174,12 @@ bool applyBankOffsetToTrack(MidiTrack* track,
     if (!usedChannels[channel]) {
       continue;
     }
-    injectedBankEvents.push_back(new BankSelectEvent(track, channel, startTick, remappedBankMsb));
-    injectedBankEvents.push_back(new BankSelectFineEvent(track, channel, startTick, remappedBankLsb));
+    injectedBankEvents.push_back(std::make_unique<BankSelectEvent>(track, channel, startTick, remappedBankMsb));
+    injectedBankEvents.push_back(std::make_unique<BankSelectFineEvent>(track, channel, startTick, remappedBankLsb));
   }
 
   // Keep injected bank selects ahead of same-tick program changes when priorities are equal
-  track->aEvents.insert(track->aEvents.begin(), injectedBankEvents.begin(), injectedBankEvents.end());
+  track->prependEvents(std::move(injectedBankEvents));
 
   return true;
 }
@@ -342,7 +342,7 @@ std::unique_ptr<MidiFile> mergeMidiSequences(const std::vector<MidiMergeEntry>& 
       return nullptr;
     }
 
-    std::unique_ptr<MidiFile> midi(seq->convertToMidi(coll, context));
+    auto midi = seq->convertToMidi(coll, context);
     if (!midi) {
       L_ERROR("Failed to convert one of the source sequences to MIDI.");
       return nullptr;
@@ -407,32 +407,31 @@ std::unique_ptr<MidiFile> mergeMidiSequences(const std::vector<MidiMergeEntry>& 
     const u8 bankOffset = options.bankOffsets.empty() ? 0 : options.bankOffsets[i];
 
     retimeTrack(&source->globalTrack, sourcePPQN, targetPPQN, startTick);
-    for (MidiEvent* event : source->globalTrack.aEvents) {
+    auto globalEvents = source->globalTrack.releaseEvents();
+    for (auto& event : globalEvents) {
       if (!event) {
         continue;
       }
 
       event->prntTrk = &mergedMidi->globalTrack;
-      mergedMidi->globalTrack.aEvents.push_back(event);
+      mergedMidi->globalTrack.adoptEvent(std::move(event));
     }
-    source->globalTrack.aEvents.clear();
 
-    for (MidiTrack*& track : source->aTracks) {
+    auto tracks = source->releaseTracks();
+    for (auto& track : tracks) {
       if (!track) {
         continue;
       }
 
-      retimeTrack(track, sourcePPQN, targetPPQN, startTick);
+      retimeTrack(track.get(), sourcePPQN, targetPPQN, startTick);
       if (!options.bankOffsets.empty() &&
-          !applyBankOffsetToTrack(track, bankOffset, startTick, context)) {
+          !applyBankOffsetToTrack(track.get(), bankOffset, startTick, context)) {
         return nullptr;
       }
 
       track->parentSeq = mergedMidi.get();
-      mergedMidi->aTracks.push_back(track);
-      track = nullptr;
+      mergedMidi->adoptTrack(std::move(track));
     }
-    source->aTracks.clear();
   }
 
   if (result) {
@@ -482,14 +481,17 @@ bool saveMergedSoundfont(const std::vector<MidiMergeEntry>& entries,
     }
 
     ExportPrepGuard guard(instrsets, coll);
-    std::unique_ptr<SynthFile> partSynth(createSynthFile(instrsets, sampcolls));
+    auto partSynth = createSynthFile(instrsets, sampcolls);
     if (!partSynth) {
       L_ERROR("Failed to build a temporary SynthFile for one stitched chunk.");
       return false;
     }
 
     const u8 bankOffset = bankOffsets[i];
-    for (SynthInstr* instr : partSynth->vInstrs) {
+    auto partInstrs = partSynth->releaseInstrs();
+    auto partWaves = partSynth->releaseWaves();
+
+    for (const auto& instr : partInstrs) {
       if (!instr) {
         continue;
       }
@@ -503,7 +505,7 @@ bool saveMergedSoundfont(const std::vector<MidiMergeEntry>& entries,
 
     const u32 waveOffset = static_cast<u32>(mergedSynth->vWaves.size());
 
-    for (SynthInstr* instr : partSynth->vInstrs) {
+    for (auto& instr : partInstrs) {
       if (!instr) {
         continue;
       }
@@ -512,15 +514,13 @@ bool saveMergedSoundfont(const std::vector<MidiMergeEntry>& entries,
           rgn->tableIndex += waveOffset;
         }
       }
-      mergedSynth->vInstrs.push_back(instr);
+      mergedSynth->adoptInstr(std::move(instr));
     }
-    for (SynthWave* wave : partSynth->vWaves) {
+    for (auto& wave : partWaves) {
       if (wave) {
-        mergedSynth->vWaves.push_back(wave);
+        mergedSynth->adoptWave(std::move(wave));
       }
     }
-    partSynth->vInstrs.clear();
-    partSynth->vWaves.clear();
   }
 
   if (mergedSynth->vInstrs.empty() || mergedSynth->vWaves.empty()) {

--- a/src/main/conversion/MidiMerge.cpp
+++ b/src/main/conversion/MidiMerge.cpp
@@ -414,7 +414,7 @@ std::unique_ptr<MidiFile> mergeMidiSequences(const std::vector<MidiMergeEntry>& 
       }
 
       event->prntTrk = &mergedMidi->globalTrack;
-      mergedMidi->globalTrack.adoptEvent(std::move(event));
+      mergedMidi->globalTrack.sinkEvent(std::move(event));
     }
 
     auto tracks = source->releaseTracks();
@@ -430,7 +430,7 @@ std::unique_ptr<MidiFile> mergeMidiSequences(const std::vector<MidiMergeEntry>& 
       }
 
       track->parentSeq = mergedMidi.get();
-      mergedMidi->adoptTrack(std::move(track));
+      mergedMidi->sinkTrack(std::move(track));
     }
   }
 
@@ -514,11 +514,11 @@ bool saveMergedSoundfont(const std::vector<MidiMergeEntry>& entries,
           rgn->tableIndex += waveOffset;
         }
       }
-      mergedSynth->adoptInstr(std::move(instr));
+      mergedSynth->sinkInstr(std::move(instr));
     }
     for (auto& wave : partWaves) {
       if (wave) {
-        mergedSynth->adoptWave(std::move(wave));
+        mergedSynth->sinkWave(std::move(wave));
       }
     }
   }

--- a/src/main/conversion/RiffFile.cpp
+++ b/src/main/conversion/RiffFile.cpp
@@ -38,9 +38,10 @@ void Chunk::write(u8 *buffer) {
   memcpy(buffer + 8, data.get(), paddedSize(m_size));
 }
 
-Chunk *ListTypeChunk::addChildChunk(Chunk *ck) {
-  childChunks.emplace_back(ck);
-  return ck;
+Chunk *ListTypeChunk::addChildChunk(std::unique_ptr<Chunk> ck) {
+  auto* rawChunk = ck.get();
+  childChunks.emplace_back(std::move(ck));
+  return rawChunk;
 }
 
 u32 ListTypeChunk::size() {

--- a/src/main/conversion/RiffFile.cpp
+++ b/src/main/conversion/RiffFile.cpp
@@ -38,7 +38,7 @@ void Chunk::write(u8 *buffer) {
   memcpy(buffer + 8, data.get(), paddedSize(m_size));
 }
 
-Chunk *ListTypeChunk::adoptChildChunk(std::unique_ptr<Chunk> ck) {
+Chunk *ListTypeChunk::sinkChildChunk(std::unique_ptr<Chunk>&& ck) {
   auto* rawChunk = ck.get();
   childChunks.emplace_back(std::move(ck));
   return rawChunk;

--- a/src/main/conversion/RiffFile.cpp
+++ b/src/main/conversion/RiffFile.cpp
@@ -17,17 +17,13 @@ void Chunk::setData(const void *src, u32 datasize) {
 
   // set the size and copy from the data source
   datasize = paddedSize(m_size);
-  if (data != nullptr) {
-    delete[] data;
-    data = nullptr;
-  }
-  data = new u8[datasize];
-  memcpy(data, src, m_size);
+  data = std::make_unique<u8[]>(datasize);
+  memcpy(data.get(), src, m_size);
 
   // Add pad byte
   u32 padsize = datasize - m_size;
   if (padsize != 0) {
-    memset(data + m_size, 0, padsize);
+    memset(data.get() + m_size, 0, padsize);
   }
 }
 
@@ -39,11 +35,11 @@ void Chunk::write(u8 *buffer) {
   u32 value = m_size + padsize;
   memcpy(buffer + 4, &value, sizeof(value));
 
-  memcpy(buffer + 8, data, paddedSize(m_size));
+  memcpy(buffer + 8, data.get(), paddedSize(m_size));
 }
 
 Chunk *ListTypeChunk::addChildChunk(Chunk *ck) {
-  childChunks.push_back(ck);
+  childChunks.emplace_back(ck);
   return ck;
 }
 

--- a/src/main/conversion/RiffFile.cpp
+++ b/src/main/conversion/RiffFile.cpp
@@ -38,7 +38,7 @@ void Chunk::write(u8 *buffer) {
   memcpy(buffer + 8, data.get(), paddedSize(m_size));
 }
 
-Chunk *ListTypeChunk::addChildChunk(std::unique_ptr<Chunk> ck) {
+Chunk *ListTypeChunk::adoptChildChunk(std::unique_ptr<Chunk> ck) {
   auto* rawChunk = ck.get();
   childChunks.emplace_back(std::move(ck));
   return rawChunk;

--- a/src/main/conversion/RiffFile.h
+++ b/src/main/conversion/RiffFile.h
@@ -5,8 +5,10 @@
 
 #include <cassert>
 #include <cstring>
+#include <list>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 //////////////////////////////////////////////
@@ -57,7 +59,14 @@ class ListTypeChunk: public Chunk {
   }
   ~ListTypeChunk() override = default;
 
-  Chunk *addChildChunk(Chunk *ck);
+  Chunk *addChildChunk(std::unique_ptr<Chunk> ck);
+  template <class ChunkType, class... Args>
+  ChunkType* emplaceChildChunk(Args&&... args) {
+    auto ck = std::make_unique<ChunkType>(std::forward<Args>(args)...);
+    auto* rawChunk = ck.get();
+    addChildChunk(std::move(ck));
+    return rawChunk;
+  }
   u32 size() override;    //  Returns the size of the chunk in bytes, including any pad byte.
   void write(u8 *buffer) override;
 };

--- a/src/main/conversion/RiffFile.h
+++ b/src/main/conversion/RiffFile.h
@@ -5,6 +5,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -14,7 +15,7 @@
 class Chunk {
  public:
   char id[4];        //  A chunk ID identifies the type of data within the chunk.
-  u8 *data;        //  The actual data not including a possible pad byte to word align
+  std::unique_ptr<u8[]> data;        //  The actual data not including a possible pad byte to word align
 
  public:
   Chunk(const std::string& id)
@@ -22,12 +23,7 @@ class Chunk {
     assert(id.length() == 4);
     memcpy(this->id, id.c_str(), 4);
   }
-  virtual ~Chunk() {
-    if (data != nullptr) {
-      delete[] data;
-      data = nullptr;
-    }
-  }
+  virtual ~Chunk() = default;
   void setData(const void *src, u32 datasize);
   virtual u32 size();    //  Returns the size of the chunk in bytes, including any pad byte.
   void setSize(u32 size) { m_size = size; }
@@ -51,7 +47,7 @@ private:
 class ListTypeChunk: public Chunk {
  public:
   char type[4];    // 4 byte sig that begins the data field, "LIST" or "sfbk" for ex
-  std::list<Chunk *> childChunks;
+  std::list<std::unique_ptr<Chunk>> childChunks;
 
  public:
   ListTypeChunk(const std::string& id, const std::string& type)
@@ -59,9 +55,7 @@ class ListTypeChunk: public Chunk {
     assert(type.length() == 4);
     memcpy(this->type, type.c_str(), 4);
   }
-  ~ListTypeChunk() override {
-    deleteList(childChunks);
-  }
+  ~ListTypeChunk() override = default;
 
   Chunk *addChildChunk(Chunk *ck);
   u32 size() override;    //  Returns the size of the chunk in bytes, including any pad byte.

--- a/src/main/conversion/RiffFile.h
+++ b/src/main/conversion/RiffFile.h
@@ -59,12 +59,12 @@ class ListTypeChunk: public Chunk {
   }
   ~ListTypeChunk() override = default;
 
-  Chunk *addChildChunk(std::unique_ptr<Chunk> ck);
+  Chunk *adoptChildChunk(std::unique_ptr<Chunk> ck);
   template <class ChunkType, class... Args>
-  ChunkType* emplaceChildChunk(Args&&... args) {
+  ChunkType* addChildChunk(Args&&... args) {
     auto ck = std::make_unique<ChunkType>(std::forward<Args>(args)...);
     auto* rawChunk = ck.get();
-    addChildChunk(std::move(ck));
+    adoptChildChunk(std::move(ck));
     return rawChunk;
   }
   u32 size() override;    //  Returns the size of the chunk in bytes, including any pad byte.

--- a/src/main/conversion/RiffFile.h
+++ b/src/main/conversion/RiffFile.h
@@ -59,12 +59,12 @@ class ListTypeChunk: public Chunk {
   }
   ~ListTypeChunk() override = default;
 
-  Chunk *adoptChildChunk(std::unique_ptr<Chunk> ck);
+  Chunk *sinkChildChunk(std::unique_ptr<Chunk>&& ck);
   template <class ChunkType, class... Args>
   ChunkType* addChildChunk(Args&&... args) {
     auto ck = std::make_unique<ChunkType>(std::forward<Args>(args)...);
     auto* rawChunk = ck.get();
-    adoptChildChunk(std::move(ck));
+    sinkChildChunk(std::move(ck));
     return rawChunk;
   }
   u32 size() override;    //  Returns the size of the chunk in bytes, including any pad byte.

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<SynthFile> createSynthFile(
     }
   } else {
     for (auto & instrset : m_instrsets) {
-      if (auto instrset_sampcoll = instrset->sampColl) {
+      if (auto instrset_sampcoll = instrset->sampColl()) {
         finalSampColls.push_back(instrset_sampcoll);
         unpackSampColl(*synthfile, instrset_sampcoll, finalSamps);
       }
@@ -112,8 +112,8 @@ std::unique_ptr<SynthFile> createSynthFile(
         const VGMSampColl* sampColl = rgn->sampCollPtr;
         if (!sampColl) {
           // If rgn is of an InstrSet with an embedded SampColl, use that SampColl.
-          if (static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl)
-            sampColl = static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl;
+          if (static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl())
+            sampColl = static_cast<VGMInstrSet*>(rgn->vgmFile())->sampColl();
           // If that does not exist, assume the first SampColl
           else
             sampColl = finalSampColls[0];

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -105,7 +105,7 @@ std::unique_ptr<SynthFile> createSynthFile(
       }
       for (u32 j = 0; j < nRgns; j++) {
         VGMRgn* rgn = vgminstr->regions()[j];
-        //				if (rgn->sampNum+1 > sampColl->samples.size())	//does thereferenced sample exist?
+        //				if (rgn->sampNum+1 > sampColl->sampleCount())	//does thereferenced sample exist?
         //					continue;
 
         // Determine the SampColl associated with this rgn.  If there's an explicit pointer to it, use that.
@@ -125,8 +125,8 @@ std::unique_ptr<SynthFile> createSynthFile(
         // see sampOffset declaration in header file for more info.
         if (rgn->sampOffset != -1) {
           bool bFoundIt = false;
-          for (u32 s = 0; s < sampColl->samples.size(); s++) {  //for every sample
-            auto sample = sampColl->samples[s];
+          for (u32 s = 0; s < sampColl->sampleCount(); s++) {  //for every sample
+            auto sample = sampColl->sample(s);
             if (std::cmp_equal(rgn->sampOffset, sample->offset()) ||
                 std::cmp_equal(rgn->sampOffset, sample->offset() - sampColl->offset() - sampColl->sampDataOffset)) {
               if (rgn->sampDataLength != -1 && !std::cmp_equal(rgn->sampDataLength, sample->dataLength)) {
@@ -135,8 +135,6 @@ std::unique_ptr<SynthFile> createSynthFile(
 
               realSampNum = s;
 
-              //samples[m]->loop.loopStart = parInstrSet->aInstrs[i]->aRgns[k]->loop.loopStart;
-              //samples[m]->loop.loopLength = (samples[m]->dataLength) - (parInstrSet->aInstrs[i]->aRgns[k]->loop.loopStart); //[aInstrs[i]->aRegions[k]->sample_num]->dwUncompSize/2) - ((aInstrs[i]->aRegions[k]->loop_point*28)/16); //to end of sample
               bFoundIt = true;
               break;
             }
@@ -165,7 +163,7 @@ std::unique_ptr<SynthFile> createSynthFile(
         // now we add the number of samples from the preceding SampColls to the value to
         // get the real sampNum in the final DLS file.
         for (u32 k = 0; k < sampCollNum; k++)
-          realSampNum += finalSampColls[k]->samples.size();
+          realSampNum += finalSampColls[k]->sampleCount();
 
         if (realSampNum >= finalSamps.size()) {
           L_ERROR("Region has an explicit sample number that exceeds sample count. Sample Num: {:d} (Instrset "
@@ -187,7 +185,7 @@ std::unique_ptr<SynthFile> createSynthFile(
           realSampNum = finalSamps.size() - 1;
         }
 
-        VGMSamp* samp = finalSamps[realSampNum];  // sampColl->samples[rgn->sampNum];
+        VGMSamp* samp = finalSamps[realSampNum];  // sampColl->sample(rgn->sampNum);
         SynthSampInfo* sampInfo = newRgn->addSampInfo();
 
         // This is a really loopy way of determining the loop information, pardon the pun.  However, it works.
@@ -251,9 +249,9 @@ std::unique_ptr<SynthFile> createSynthFile(
 void unpackSampColl(SynthFile &synthfile, const VGMSampColl *sampColl, std::vector<VGMSamp *> &finalSamps) {
   assert(sampColl != nullptr);
 
-  size_t nSamples = sampColl->samples.size();
+  size_t nSamples = sampColl->sampleCount();
   for (size_t i = 0; i < nSamples; i++) {
-    VGMSamp *samp = sampColl->samples[i];
+    VGMSamp *samp = sampColl->sample(i);
 
     std::vector<u8> uncompSampBuf = samp->toPcm(Signedness::Signed, Endianness::Little, BPS::PCM16);
 

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -22,16 +22,16 @@
 
 namespace conversion {
 
-SF2File* createSF2File(const VGMColl& coll) {
+std::unique_ptr<SF2File> createSF2File(const VGMColl& coll) {
   const auto context = ConversionContext::fromOptions(ConversionOptions::the(), SynthTarget::SoundFont);
   return createSF2File(coll, context);
 }
 
-SF2File* createSF2File(const VGMColl& coll, const ConversionContext& context) {
+std::unique_ptr<SF2File> createSF2File(const VGMColl& coll, const ConversionContext& context) {
   return createSF2File(coll.instrSets(), coll.sampColls(), &coll, context);
 }
 
-SF2File* createSF2File(
+std::unique_ptr<SF2File> createSF2File(
   const std::vector<VGMInstrSet*>& instrsets,
   const std::vector<VGMSampColl*>& sampcolls,
   const VGMColl* coll,
@@ -41,7 +41,7 @@ SF2File* createSF2File(
     instrset->prepareForExport(coll);
   }
 
-  SynthFile *synthfile = createSynthFile(instrsets, sampcolls);
+  auto synthfile = createSynthFile(instrsets, sampcolls);
 
   for (auto* instrset : instrsets) {
     instrset->cleanupAfterExport();
@@ -50,12 +50,10 @@ SF2File* createSF2File(
     L_ERROR("SF2 conversion failed");
     return nullptr;
   }
-  SF2File *sf2file = new SF2File(synthfile, context);
-  delete synthfile;
-  return sf2file;
+  return std::make_unique<SF2File>(synthfile.get(), context);
 }
 
-SynthFile* createSynthFile(
+std::unique_ptr<SynthFile> createSynthFile(
   const std::vector<VGMInstrSet*>& m_instrsets,
   const std::vector<VGMSampColl*>& m_sampcolls
 ) {
@@ -64,8 +62,7 @@ SynthFile* createSynthFile(
     return nullptr;
   }
 
-  /* FIXME: shared_ptr eventually */
-  SynthFile *synthfile = new SynthFile("SynthFile");
+  auto synthfile = std::make_unique<SynthFile>("SynthFile");
 
   std::vector<VGMSamp *> finalSamps;
   std::vector<const VGMSampColl *> finalSampColls;
@@ -87,7 +84,6 @@ SynthFile* createSynthFile(
 
   if (finalSamps.empty()) {
     L_ERROR("No sample collection available to create a SynthFile.");
-    delete synthfile;
     return nullptr;
   }
 
@@ -208,7 +204,6 @@ SynthFile* createSynthFile(
               sampInfo->setLoopInfo(rgn->loop, samp);
             }
           } else {
-            delete synthfile;
             throw;
           }
         }
@@ -218,7 +213,6 @@ SynthFile* createSynthFile(
           if (samp->loop.loopStatus != -1)
             sampInfo->setLoopInfo(samp->loop, samp);
           else {
-            delete synthfile;
             throw;
           }
         } else

--- a/src/main/conversion/SF2Conversion.h
+++ b/src/main/conversion/SF2Conversion.h
@@ -5,6 +5,7 @@
 */
 #pragma once
 
+#include <memory>
 #include <vector>
 
 class SF2File;
@@ -17,15 +18,15 @@ struct ConversionContext;
 
 namespace conversion {
 
-SF2File* createSF2File(const VGMColl& coll);
-SF2File* createSF2File(const VGMColl& coll, const ConversionContext& context);
-SF2File* createSF2File(
+std::unique_ptr<SF2File> createSF2File(const VGMColl& coll);
+std::unique_ptr<SF2File> createSF2File(const VGMColl& coll, const ConversionContext& context);
+std::unique_ptr<SF2File> createSF2File(
   const std::vector<VGMInstrSet*>& instrsets,
   const std::vector<VGMSampColl*>& sampcolls,
   const VGMColl* coll,
   const ConversionContext& context
 );
-SynthFile* createSynthFile(
+std::unique_ptr<SynthFile> createSynthFile(
   const std::vector<VGMInstrSet*>& instrsets,
   const std::vector<VGMSampColl*>& sampcolls
 );

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -106,16 +106,15 @@ SF2InfoListChunk::SF2InfoListChunk(const std::string& name)
   char *c_time_string = ctime(&current_time);
 
   // Add the child info chunks
-  Chunk *ifilCk = new Chunk("ifil");
+  auto* ifilCk = emplaceChildChunk<Chunk>("ifil");
   sfVersionTag versionTag;        //soundfont version 2.01
   versionTag.wMajor = 2;
   versionTag.wMinor = 1;
   ifilCk->setData(&versionTag, sizeof(versionTag));
-  addChildChunk(ifilCk);
-  addChildChunk(new SF2StringChunk("isng", "EMU8000"));
-  addChildChunk(new SF2StringChunk("INAM", name));
-  addChildChunk(new SF2StringChunk("ICRD", std::string(c_time_string)));
-  addChildChunk(new SF2StringChunk("ISFT", std::string("VGMTrans " + std::string(VGMTRANS_VERSION))));
+  emplaceChildChunk<SF2StringChunk>("isng", "EMU8000");
+  emplaceChildChunk<SF2StringChunk>("INAM", name);
+  emplaceChildChunk<SF2StringChunk>("ICRD", std::string(c_time_string));
+  emplaceChildChunk<SF2StringChunk>("ISFT", std::string("VGMTrans " + std::string(VGMTRANS_VERSION)));
 }
 
 
@@ -139,49 +138,46 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   //***********
   // INFO chunk
   //***********
-  addChildChunk(new SF2InfoListChunk(name));
+  emplaceChildChunk<SF2InfoListChunk>(name);
 
   // sdta chunk and its child smpl chunk containing all samples
-  LISTChunk *sdtaCk = new LISTChunk("sdta");
-  Chunk *smplCk = new Chunk("smpl");
+  auto* sdtaCk = emplaceChildChunk<LISTChunk>("sdta");
+  auto* smplCk = sdtaCk->emplaceChildChunk<Chunk>("smpl");
 
   // Concatanate all of the samples together and add the result to the smpl chunk data
-  size_t numWaves = synthfile->vWaves.size();
+  size_t numWaves = synthfile->waveCount();
   u32 smplCkSize = 0;
   for (size_t i = 0; i < numWaves; i++) {
-    SynthWave *wave = synthfile->vWaves[i];
+    SynthWave *wave = synthfile->waves()[i];
     smplCkSize += wave->dataSize + (46 * 2);    // plus the 46 padding samples required by sf2 spec
   }
   smplCk->setSize(smplCkSize);
   smplCk->data = std::make_unique<u8[]>(smplCkSize);
   u32 bufPtr = 0;
   for (size_t i = 0; i < numWaves; i++) {
-    SynthWave *wave = synthfile->vWaves[i];
+    SynthWave *wave = synthfile->waves()[i];
 
     memcpy(smplCk->data.get() + bufPtr, wave->data.data(), wave->dataSize);
     memset(smplCk->data.get() + bufPtr + wave->dataSize, 0, 46 * 2);
     bufPtr += wave->dataSize + (46 * 2);        // plus the 46 padding samples required by sf2 spec
   }
 
-  sdtaCk->addChildChunk(smplCk);
-  this->addChildChunk(sdtaCk);
-
   //***********
   // pdta chunk
   //***********
 
-  LISTChunk *pdtaCk = new LISTChunk("pdta");
+  auto* pdtaCk = emplaceChildChunk<LISTChunk>("pdta");
 
   //***********
   // phdr chunk
   //***********
-  Chunk *phdrCk = new Chunk("phdr");
-  size_t numInstrs = synthfile->vInstrs.size();
+  auto* phdrCk = pdtaCk->emplaceChildChunk<Chunk>("phdr");
+  size_t numInstrs = synthfile->instrCount();
   phdrCk->setSize(static_cast<u32>((numInstrs + 1) * sizeof(sfPresetHeader)));
   phdrCk->data = std::make_unique<u8[]>(phdrCk->size());
 
   for (size_t i = 0; i < numInstrs; i++) {
-    SynthInstr *instr = synthfile->vInstrs[i];
+    SynthInstr *instr = synthfile->instrs()[i];
 
     sfPresetHeader presetHdr{};
     memcpy(presetHdr.achPresetName, instr->name.c_str(), std::min(instr->name.length(), static_cast<size_t>(20)));
@@ -208,12 +204,10 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   sfPresetHeader presetHdr{};
   presetHdr.wPresetBagNdx = static_cast<u16>(numInstrs);
   memcpy(phdrCk->data.get() + (numInstrs * sizeof(sfPresetHeader)), &presetHdr, sizeof(sfPresetHeader));
-  pdtaCk->addChildChunk(phdrCk);
-
   //***********
   // pbag chunk
   //***********
-  Chunk *pbagCk = new Chunk("pbag");
+  auto* pbagCk = pdtaCk->emplaceChildChunk<Chunk>("pbag");
   constexpr size_t ITEMS_IN_PGEN = 2;
   pbagCk->setSize(static_cast<u32>((numInstrs + 1) * sizeof(sfPresetBag)));
   pbagCk->data = std::make_unique<u8[]>(pbagCk->size());
@@ -228,12 +222,10 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   sfPresetBag presetBag{};
   presetBag.wGenNdx = static_cast<u16>(numInstrs * ITEMS_IN_PGEN);
   memcpy(pbagCk->data.get() + (numInstrs * sizeof(sfPresetBag)), &presetBag, sizeof(sfPresetBag));
-  pdtaCk->addChildChunk(pbagCk);
-
   //***********
   // pmod chunk
   //***********
-  Chunk *pmodCk = new Chunk("pmod");
+  auto* pmodCk = pdtaCk->emplaceChildChunk<Chunk>("pmod");
   //  create the terminal field
   sfModList modList{};
   pmodCk->setData(&modList, sizeof(sfModList));
@@ -242,18 +234,16 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   //modList.modAmount = 0;
   //modList.sfModAmtSrcOper = cc1_Mod;
   //modList.sfModTransOper = linear;
-  pdtaCk->addChildChunk(pmodCk);
-
   //***********
   // pgen chunk
   //***********
-  Chunk *pgenCk = new Chunk("pgen");
-  //pgenCk->size = (synthfile->vInstrs.size()+1) * sizeof(sfGenList);
-  pgenCk->setSize(static_cast<u32>((synthfile->vInstrs.size() * sizeof(sfGenList) * ITEMS_IN_PGEN) + sizeof(sfGenList)));
+  auto* pgenCk = pdtaCk->emplaceChildChunk<Chunk>("pgen");
+  //pgenCk->size = (synthfile->instrCount()+1) * sizeof(sfGenList);
+  pgenCk->setSize(static_cast<u32>((synthfile->instrCount() * sizeof(sfGenList) * ITEMS_IN_PGEN) + sizeof(sfGenList)));
   pgenCk->data = std::make_unique<u8[]>(pgenCk->size());
   u32 dataPtr = 0;
   for (size_t i = 0; i < numInstrs; i++) {
-    SynthInstr *instr = synthfile->vInstrs[i];
+    SynthInstr *instr = synthfile->instrs()[i];
 
     sfGenList genList{};
 
@@ -272,22 +262,20 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   sfGenList genList{};
   memcpy(pgenCk->data.get() + dataPtr, &genList, sizeof(sfGenList));
 
-  pdtaCk->addChildChunk(pgenCk);
-
   //***********
   // inst chunk
   //***********
-  Chunk *instCk = new Chunk("inst");
-  instCk->setSize(static_cast<u32>((synthfile->vInstrs.size() + 1) * sizeof(sfInst)));
+  auto* instCk = pdtaCk->emplaceChildChunk<Chunk>("inst");
+  instCk->setSize(static_cast<u32>((synthfile->instrCount() + 1) * sizeof(sfInst)));
   instCk->data = std::make_unique<u8[]>(instCk->size());
   u16 instBagCounter = 0;
   for (size_t i = 0; i < numInstrs; i++) {
-    SynthInstr *instr = synthfile->vInstrs[i];
+    SynthInstr *instr = synthfile->instrs()[i];
 
     sfInst inst{};
     memcpy(inst.achInstName, instr->name.c_str(), std::min(instr->name.length(), static_cast<size_t>(20)));
     inst.wInstBagNdx = instBagCounter;
-    instBagCounter += static_cast<u16>(instr->vRgns.size());
+    instBagCounter += static_cast<u16>(instr->regions().size());
     if (hasInstrumentGlobalZone(instr, context)) {
       instBagCounter++;
     }
@@ -298,17 +286,15 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   sfInst inst{};
   inst.wInstBagNdx = instBagCounter;
   memcpy(instCk->data.get() + (numInstrs * sizeof(sfInst)), &inst, sizeof(sfInst));
-  pdtaCk->addChildChunk(instCk);
-
   //***********
   // ibag chunk - stores all zones (regions) for instruments
   //***********
-  Chunk *ibagCk = new Chunk("ibag");
+  auto* ibagCk = pdtaCk->emplaceChildChunk<Chunk>("ibag");
 
   u32 numTotalInstBags = 0;
   for (size_t i = 0; i < numInstrs; i++) {
-    SynthInstr *instr = synthfile->vInstrs[i];
-    numTotalInstBags += static_cast<u32>(instr->vRgns.size());
+    SynthInstr *instr = synthfile->instrs()[i];
+    numTotalInstBags += static_cast<u32>(instr->regions().size());
     if (hasInstrumentGlobalZone(instr, context)) {
       numTotalInstBags++;
     }
@@ -321,7 +307,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   int instGenCounter = 0;
   int instModCounter = 0;
   for (size_t i = 0; i < numInstrs; i++) {
-    SynthInstr *instr = synthfile->vInstrs[i];
+    SynthInstr *instr = synthfile->instrs()[i];
 
     if (hasInstrumentGlobalZone(instr, context)) {
       sfInstBag globalInstBag{};
@@ -332,11 +318,11 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
       memcpy(ibagCk->data.get() + (instBagCounter++ * sizeof(sfInstBag)), &globalInstBag, sizeof(sfInstBag));
     }
 
-    size_t numRgns = instr->vRgns.size();
+    size_t numRgns = instr->regions().size();
     for (size_t j = 0; j < numRgns; j++) {
       sfInstBag instBag{};
       instBag.wInstGenNdx = static_cast<u16>(instGenCounter);
-      instGenCounter += numOfGeneratorsForRgn(instr->vRgns[j]);
+      instGenCounter += numOfGeneratorsForRgn(instr->regions()[j]);
       instBag.wInstModNdx = static_cast<u16>(instModCounter);
 
       memcpy(ibagCk->data.get() + (instBagCounter++ * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
@@ -347,23 +333,22 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   instBag.wInstGenNdx = static_cast<u16>(instGenCounter);
   instBag.wInstModNdx = static_cast<u16>(instModCounter);
   memcpy(ibagCk->data.get() + (instBagCounter * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
-  pdtaCk->addChildChunk(ibagCk);
 
   //***********
   // imod chunk
   //***********
   u32 numTotalMods = 1;
-  for (const auto instr : synthfile->vInstrs) {
+  for (const auto instr : synthfile->instrs()) {
     if (hasInstrumentGlobalZone(instr, context)) {
       numTotalMods += static_cast<u32>(numSf2ModulatorsForInstr(instr, context));
     }
   }
 
-  Chunk *imodCk = new Chunk("imod");
+  auto* imodCk = pdtaCk->emplaceChildChunk<Chunk>("imod");
   imodCk->setSize(numTotalMods * sizeof(sfInstModList));
   imodCk->data = std::make_unique<u8[]>(imodCk->size());
   dataPtr = 0;
-  for (const auto instr : synthfile->vInstrs) {
+  for (const auto instr : synthfile->instrs()) {
     for (const auto& modulator : instr->modulators()) {
       const auto source = sf2SourceForModulator(modulator, context);
       if (!source.has_value()) {
@@ -382,25 +367,24 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   }
   sfInstModList instModList{};
   memcpy(imodCk->data.get() + dataPtr, &instModList, sizeof(sfInstModList));
-  pdtaCk->addChildChunk(imodCk);
 
   //***********
   // igen chunk
   //***********
   u32 numTotalGens = 1;
-  for (const auto instr : synthfile->vInstrs) {
+  for (const auto instr : synthfile->instrs()) {
     numTotalGens += static_cast<u32>(instr->generators().size());
-    for (const auto rgn : instr->vRgns) {
+    for (const auto rgn : instr->regions()) {
       numTotalGens += numOfGeneratorsForRgn(rgn);
     }
   }
 
-  Chunk *igenCk = new Chunk("igen");
+  auto* igenCk = pdtaCk->emplaceChildChunk<Chunk>("igen");
   igenCk->setSize(numTotalGens * sizeof(sfInstGenList));
   igenCk->data = std::make_unique<u8[]>(igenCk->size());
   dataPtr = 0;
   for (size_t i = 0; i < numInstrs; i++) {
-    SynthInstr *instr = synthfile->vInstrs[i];
+    SynthInstr *instr = synthfile->instrs()[i];
 
     for (const auto& generator : instr->generators()) {
       sfInstGenList instGenList{};
@@ -410,9 +394,9 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
       dataPtr += sizeof(sfInstGenList);
     }
 
-    size_t numRgns = instr->vRgns.size();
+    size_t numRgns = instr->regions().size();
     for (size_t j = 0; j < numRgns; j++) {
-      SynthRgn *rgn = instr->vRgns[j];
+      SynthRgn *rgn = instr->regions()[j];
 
       sfInstGenList instGenList;
       // Key range. This must be the first chunk
@@ -551,20 +535,19 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
   //memset(ibagCk->data + (numRgns*sizeof(sfInstBag)), 0, sizeof(sfInstBag));
   //igenCk->SetData(&genList, sizeof(sfGenList));
-  pdtaCk->addChildChunk(igenCk);
 
   //***********
   // shdr chunk
   //***********
-  Chunk *shdrCk = new Chunk("shdr");
+  auto* shdrCk = pdtaCk->emplaceChildChunk<Chunk>("shdr");
 
-  size_t numSamps = synthfile->vWaves.size();
+  size_t numSamps = synthfile->waveCount();
   shdrCk->setSize(static_cast<u32>((numSamps + 1) * sizeof(sfSample)));
   shdrCk->data = std::make_unique<u8[]>(shdrCk->size());
 
   u32 sampOffset = 0;
   for (size_t i = 0; i < numSamps; i++) {
-    SynthWave *wave = synthfile->vWaves[i];
+    SynthWave *wave = synthfile->waves()[i];
 
     sfSample samp{};
     memcpy(samp.achSampleName, wave->name.c_str(), std::min(wave->name.length(), static_cast<size_t>(20)));
@@ -575,11 +558,11 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
     // Search through all regions for an associated sampInfo structure with this sample
     SynthSampInfo *sampInfo = nullptr;
     for (size_t j = 0; j < numInstrs; j++) {
-      SynthInstr *instr = synthfile->vInstrs[j];
+      SynthInstr *instr = synthfile->instrs()[j];
 
-      size_t numRgns = instr->vRgns.size();
+      size_t numRgns = instr->regions().size();
       for (size_t k = 0; k < numRgns; k++) {
-        SynthRgn *rgn = instr->vRgns[k];
+        SynthRgn *rgn = instr->regions()[k];
         if (rgn->tableIndex == i && rgn->sampinfo != nullptr) {
           sampInfo = rgn->sampinfo;
           break;
@@ -609,9 +592,6 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
 
   //  add terminal sfSample
   memset(shdrCk->data.get() + (numSamps * sizeof(sfSample)), 0, sizeof(sfSample));
-  pdtaCk->addChildChunk(shdrCk);
-
-  this->addChildChunk(pdtaCk);
 }
 
 std::vector<u8> SF2File::saveToMem() {

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -106,15 +106,15 @@ SF2InfoListChunk::SF2InfoListChunk(const std::string& name)
   char *c_time_string = ctime(&current_time);
 
   // Add the child info chunks
-  auto* ifilCk = emplaceChildChunk<Chunk>("ifil");
+  auto* ifilCk = addChildChunk<Chunk>("ifil");
   sfVersionTag versionTag;        //soundfont version 2.01
   versionTag.wMajor = 2;
   versionTag.wMinor = 1;
   ifilCk->setData(&versionTag, sizeof(versionTag));
-  emplaceChildChunk<SF2StringChunk>("isng", "EMU8000");
-  emplaceChildChunk<SF2StringChunk>("INAM", name);
-  emplaceChildChunk<SF2StringChunk>("ICRD", std::string(c_time_string));
-  emplaceChildChunk<SF2StringChunk>("ISFT", std::string("VGMTrans " + std::string(VGMTRANS_VERSION)));
+  addChildChunk<SF2StringChunk>("isng", "EMU8000");
+  addChildChunk<SF2StringChunk>("INAM", name);
+  addChildChunk<SF2StringChunk>("ICRD", std::string(c_time_string));
+  addChildChunk<SF2StringChunk>("ISFT", std::string("VGMTrans " + std::string(VGMTRANS_VERSION)));
 }
 
 
@@ -138,11 +138,11 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   //***********
   // INFO chunk
   //***********
-  emplaceChildChunk<SF2InfoListChunk>(name);
+  addChildChunk<SF2InfoListChunk>(name);
 
   // sdta chunk and its child smpl chunk containing all samples
-  auto* sdtaCk = emplaceChildChunk<LISTChunk>("sdta");
-  auto* smplCk = sdtaCk->emplaceChildChunk<Chunk>("smpl");
+  auto* sdtaCk = addChildChunk<LISTChunk>("sdta");
+  auto* smplCk = sdtaCk->addChildChunk<Chunk>("smpl");
 
   // Concatanate all of the samples together and add the result to the smpl chunk data
   size_t numWaves = synthfile->waveCount();
@@ -166,12 +166,12 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   // pdta chunk
   //***********
 
-  auto* pdtaCk = emplaceChildChunk<LISTChunk>("pdta");
+  auto* pdtaCk = addChildChunk<LISTChunk>("pdta");
 
   //***********
   // phdr chunk
   //***********
-  auto* phdrCk = pdtaCk->emplaceChildChunk<Chunk>("phdr");
+  auto* phdrCk = pdtaCk->addChildChunk<Chunk>("phdr");
   size_t numInstrs = synthfile->instrCount();
   phdrCk->setSize(static_cast<u32>((numInstrs + 1) * sizeof(sfPresetHeader)));
   phdrCk->data = std::make_unique<u8[]>(phdrCk->size());
@@ -207,7 +207,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   //***********
   // pbag chunk
   //***********
-  auto* pbagCk = pdtaCk->emplaceChildChunk<Chunk>("pbag");
+  auto* pbagCk = pdtaCk->addChildChunk<Chunk>("pbag");
   constexpr size_t ITEMS_IN_PGEN = 2;
   pbagCk->setSize(static_cast<u32>((numInstrs + 1) * sizeof(sfPresetBag)));
   pbagCk->data = std::make_unique<u8[]>(pbagCk->size());
@@ -225,7 +225,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   //***********
   // pmod chunk
   //***********
-  auto* pmodCk = pdtaCk->emplaceChildChunk<Chunk>("pmod");
+  auto* pmodCk = pdtaCk->addChildChunk<Chunk>("pmod");
   //  create the terminal field
   sfModList modList{};
   pmodCk->setData(&modList, sizeof(sfModList));
@@ -237,7 +237,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   //***********
   // pgen chunk
   //***********
-  auto* pgenCk = pdtaCk->emplaceChildChunk<Chunk>("pgen");
+  auto* pgenCk = pdtaCk->addChildChunk<Chunk>("pgen");
   //pgenCk->size = (synthfile->instrCount()+1) * sizeof(sfGenList);
   pgenCk->setSize(static_cast<u32>((synthfile->instrCount() * sizeof(sfGenList) * ITEMS_IN_PGEN) + sizeof(sfGenList)));
   pgenCk->data = std::make_unique<u8[]>(pgenCk->size());
@@ -265,7 +265,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   //***********
   // inst chunk
   //***********
-  auto* instCk = pdtaCk->emplaceChildChunk<Chunk>("inst");
+  auto* instCk = pdtaCk->addChildChunk<Chunk>("inst");
   instCk->setSize(static_cast<u32>((synthfile->instrCount() + 1) * sizeof(sfInst)));
   instCk->data = std::make_unique<u8[]>(instCk->size());
   u16 instBagCounter = 0;
@@ -289,7 +289,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   //***********
   // ibag chunk - stores all zones (regions) for instruments
   //***********
-  auto* ibagCk = pdtaCk->emplaceChildChunk<Chunk>("ibag");
+  auto* ibagCk = pdtaCk->addChildChunk<Chunk>("ibag");
 
   u32 numTotalInstBags = 0;
   for (size_t i = 0; i < numInstrs; i++) {
@@ -344,7 +344,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
     }
   }
 
-  auto* imodCk = pdtaCk->emplaceChildChunk<Chunk>("imod");
+  auto* imodCk = pdtaCk->addChildChunk<Chunk>("imod");
   imodCk->setSize(numTotalMods * sizeof(sfInstModList));
   imodCk->data = std::make_unique<u8[]>(imodCk->size());
   dataPtr = 0;
@@ -379,7 +379,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
     }
   }
 
-  auto* igenCk = pdtaCk->emplaceChildChunk<Chunk>("igen");
+  auto* igenCk = pdtaCk->addChildChunk<Chunk>("igen");
   igenCk->setSize(numTotalGens * sizeof(sfInstGenList));
   igenCk->data = std::make_unique<u8[]>(igenCk->size());
   dataPtr = 0;
@@ -539,7 +539,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   //***********
   // shdr chunk
   //***********
-  auto* shdrCk = pdtaCk->emplaceChildChunk<Chunk>("shdr");
+  auto* shdrCk = pdtaCk->addChildChunk<Chunk>("shdr");
 
   size_t numSamps = synthfile->waveCount();
   shdrCk->setSize(static_cast<u32>((numSamps + 1) * sizeof(sfSample)));

--- a/src/main/conversion/SF2File.cpp
+++ b/src/main/conversion/SF2File.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <optional>
 
 namespace {
@@ -152,13 +153,13 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
     smplCkSize += wave->dataSize + (46 * 2);    // plus the 46 padding samples required by sf2 spec
   }
   smplCk->setSize(smplCkSize);
-  smplCk->data = new u8[smplCkSize];
+  smplCk->data = std::make_unique<u8[]>(smplCkSize);
   u32 bufPtr = 0;
   for (size_t i = 0; i < numWaves; i++) {
     SynthWave *wave = synthfile->vWaves[i];
 
-    memcpy(smplCk->data + bufPtr, wave->data.data(), wave->dataSize);
-    memset(smplCk->data + bufPtr + wave->dataSize, 0, 46 * 2);
+    memcpy(smplCk->data.get() + bufPtr, wave->data.data(), wave->dataSize);
+    memset(smplCk->data.get() + bufPtr + wave->dataSize, 0, 46 * 2);
     bufPtr += wave->dataSize + (46 * 2);        // plus the 46 padding samples required by sf2 spec
   }
 
@@ -177,7 +178,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   Chunk *phdrCk = new Chunk("phdr");
   size_t numInstrs = synthfile->vInstrs.size();
   phdrCk->setSize(static_cast<u32>((numInstrs + 1) * sizeof(sfPresetHeader)));
-  phdrCk->data = new u8[phdrCk->size()];
+  phdrCk->data = std::make_unique<u8[]>(phdrCk->size());
 
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
@@ -201,12 +202,12 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
     presetHdr.dwGenre = 0;
     presetHdr.dwMorphology = 0;
 
-    memcpy(phdrCk->data + (i * sizeof(sfPresetHeader)), &presetHdr, sizeof(sfPresetHeader));
+    memcpy(phdrCk->data.get() + (i * sizeof(sfPresetHeader)), &presetHdr, sizeof(sfPresetHeader));
   }
   //  add terminal sfPresetBag
   sfPresetHeader presetHdr{};
   presetHdr.wPresetBagNdx = static_cast<u16>(numInstrs);
-  memcpy(phdrCk->data + (numInstrs * sizeof(sfPresetHeader)), &presetHdr, sizeof(sfPresetHeader));
+  memcpy(phdrCk->data.get() + (numInstrs * sizeof(sfPresetHeader)), &presetHdr, sizeof(sfPresetHeader));
   pdtaCk->addChildChunk(phdrCk);
 
   //***********
@@ -215,18 +216,18 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   Chunk *pbagCk = new Chunk("pbag");
   constexpr size_t ITEMS_IN_PGEN = 2;
   pbagCk->setSize(static_cast<u32>((numInstrs + 1) * sizeof(sfPresetBag)));
-  pbagCk->data = new u8[pbagCk->size()];
+  pbagCk->data = std::make_unique<u8[]>(pbagCk->size());
   for (size_t i = 0; i < numInstrs; i++) {
     sfPresetBag presetBag{};
     presetBag.wGenNdx = static_cast<u16>(i * ITEMS_IN_PGEN);
     presetBag.wModNdx = 0;
 
-    memcpy(pbagCk->data + (i * sizeof(sfPresetBag)), &presetBag, sizeof(sfPresetBag));
+    memcpy(pbagCk->data.get() + (i * sizeof(sfPresetBag)), &presetBag, sizeof(sfPresetBag));
   }
   //  add terminal sfPresetBag
   sfPresetBag presetBag{};
   presetBag.wGenNdx = static_cast<u16>(numInstrs * ITEMS_IN_PGEN);
-  memcpy(pbagCk->data + (numInstrs * sizeof(sfPresetBag)), &presetBag, sizeof(sfPresetBag));
+  memcpy(pbagCk->data.get() + (numInstrs * sizeof(sfPresetBag)), &presetBag, sizeof(sfPresetBag));
   pdtaCk->addChildChunk(pbagCk);
 
   //***********
@@ -249,7 +250,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   Chunk *pgenCk = new Chunk("pgen");
   //pgenCk->size = (synthfile->vInstrs.size()+1) * sizeof(sfGenList);
   pgenCk->setSize(static_cast<u32>((synthfile->vInstrs.size() * sizeof(sfGenList) * ITEMS_IN_PGEN) + sizeof(sfGenList)));
-  pgenCk->data = new u8[pgenCk->size()];
+  pgenCk->data = std::make_unique<u8[]>(pgenCk->size());
   u32 dataPtr = 0;
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
@@ -259,17 +260,17 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
     // reverbEffectsSend - Value is in 0.1% units, so multiply by 1000. Ex: 250 == 25%.
     genList.sfGenOper = reverbEffectsSend;
     genList.genAmount.shAmount = instr->reverb * 1000;
-    memcpy(pgenCk->data + dataPtr, &genList, sizeof(sfGenList));
+    memcpy(pgenCk->data.get() + dataPtr, &genList, sizeof(sfGenList));
     dataPtr += sizeof(sfGenList);
 
     genList.sfGenOper = instrument;
     genList.genAmount.wAmount = static_cast<u16>(i);
-    memcpy(pgenCk->data + dataPtr, &genList, sizeof(sfGenList));
+    memcpy(pgenCk->data.get() + dataPtr, &genList, sizeof(sfGenList));
     dataPtr += sizeof(sfGenList);
   }
   //  add terminal sfGenList
   sfGenList genList{};
-  memcpy(pgenCk->data + dataPtr, &genList, sizeof(sfGenList));
+  memcpy(pgenCk->data.get() + dataPtr, &genList, sizeof(sfGenList));
 
   pdtaCk->addChildChunk(pgenCk);
 
@@ -278,7 +279,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   //***********
   Chunk *instCk = new Chunk("inst");
   instCk->setSize(static_cast<u32>((synthfile->vInstrs.size() + 1) * sizeof(sfInst)));
-  instCk->data = new u8[instCk->size()];
+  instCk->data = std::make_unique<u8[]>(instCk->size());
   u16 instBagCounter = 0;
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
@@ -291,12 +292,12 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
       instBagCounter++;
     }
 
-    memcpy(instCk->data + (i * sizeof(sfInst)), &inst, sizeof(sfInst));
+    memcpy(instCk->data.get() + (i * sizeof(sfInst)), &inst, sizeof(sfInst));
   }
   //  add terminal sfInst
   sfInst inst{};
   inst.wInstBagNdx = instBagCounter;
-  memcpy(instCk->data + (numInstrs * sizeof(sfInst)), &inst, sizeof(sfInst));
+  memcpy(instCk->data.get() + (numInstrs * sizeof(sfInst)), &inst, sizeof(sfInst));
   pdtaCk->addChildChunk(instCk);
 
   //***********
@@ -314,7 +315,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   }
 
   ibagCk->setSize((numTotalInstBags + 1) * sizeof(sfInstBag));
-  ibagCk->data = new u8[ibagCk->size()];
+  ibagCk->data = std::make_unique<u8[]>(ibagCk->size());
 
   instBagCounter = 0;
   int instGenCounter = 0;
@@ -328,7 +329,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
       globalInstBag.wInstModNdx = static_cast<u16>(instModCounter);
       instGenCounter += static_cast<int>(instr->generators().size());
       instModCounter += static_cast<int>(numSf2ModulatorsForInstr(instr, context));
-      memcpy(ibagCk->data + (instBagCounter++ * sizeof(sfInstBag)), &globalInstBag, sizeof(sfInstBag));
+      memcpy(ibagCk->data.get() + (instBagCounter++ * sizeof(sfInstBag)), &globalInstBag, sizeof(sfInstBag));
     }
 
     size_t numRgns = instr->vRgns.size();
@@ -338,14 +339,14 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
       instGenCounter += numOfGeneratorsForRgn(instr->vRgns[j]);
       instBag.wInstModNdx = static_cast<u16>(instModCounter);
 
-      memcpy(ibagCk->data + (instBagCounter++ * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
+      memcpy(ibagCk->data.get() + (instBagCounter++ * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
     }
   }
   //  add terminal sfInstBag
   sfInstBag instBag{};
   instBag.wInstGenNdx = static_cast<u16>(instGenCounter);
   instBag.wInstModNdx = static_cast<u16>(instModCounter);
-  memcpy(ibagCk->data + (instBagCounter * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
+  memcpy(ibagCk->data.get() + (instBagCounter * sizeof(sfInstBag)), &instBag, sizeof(sfInstBag));
   pdtaCk->addChildChunk(ibagCk);
 
   //***********
@@ -360,7 +361,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
 
   Chunk *imodCk = new Chunk("imod");
   imodCk->setSize(numTotalMods * sizeof(sfInstModList));
-  imodCk->data = new u8[imodCk->size()];
+  imodCk->data = std::make_unique<u8[]>(imodCk->size());
   dataPtr = 0;
   for (const auto instr : synthfile->vInstrs) {
     for (const auto& modulator : instr->modulators()) {
@@ -375,12 +376,12 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
       instModList.modAmount = sf2AmountForModulator(modulator);
       instModList.sfModAmtSrcOper = 0;
       instModList.sfModTransOper = linear;
-      memcpy(imodCk->data + dataPtr, &instModList, sizeof(sfInstModList));
+      memcpy(imodCk->data.get() + dataPtr, &instModList, sizeof(sfInstModList));
       dataPtr += sizeof(sfInstModList);
     }
   }
   sfInstModList instModList{};
-  memcpy(imodCk->data + dataPtr, &instModList, sizeof(sfInstModList));
+  memcpy(imodCk->data.get() + dataPtr, &instModList, sizeof(sfInstModList));
   pdtaCk->addChildChunk(imodCk);
 
   //***********
@@ -396,7 +397,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
 
   Chunk *igenCk = new Chunk("igen");
   igenCk->setSize(numTotalGens * sizeof(sfInstGenList));
-  igenCk->data = new u8[igenCk->size()];
+  igenCk->data = std::make_unique<u8[]>(igenCk->size());
   dataPtr = 0;
   for (size_t i = 0; i < numInstrs; i++) {
     SynthInstr *instr = synthfile->vInstrs[i];
@@ -405,7 +406,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
       sfInstGenList instGenList{};
       instGenList.sfGenOper = sf2GeneratorForModDestination(generator.destination);
       instGenList.genAmount.shAmount = sf2AmountForGenerator(generator);
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
     }
 
@@ -418,14 +419,14 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
       instGenList.sfGenOper = keyRange;
       instGenList.genAmount.ranges.byLo = static_cast<u8>(rgn->usKeyLow);
       instGenList.genAmount.ranges.byHi = static_cast<u8>(rgn->usKeyHigh);
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // Velocity range. This must be the next chunk
       instGenList.sfGenOper = velRange;
       instGenList.genAmount.ranges.byLo = static_cast<u8>(rgn->usVelLow);
       instGenList.genAmount.ranges.byHi = static_cast<u8>(rgn->usVelHigh);
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // initialAttenuation
@@ -439,55 +440,55 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
                    kEmu8000InitialAttenuationScale),
         0.0, kSoundFontMaxInitialAttenuationCentibels));
       instGenList.genAmount.wAmount = atten;
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // pan
       instGenList.sfGenOper = pan;
       instGenList.genAmount.shAmount = static_cast<s16>(convertPercentPanTo10thPercentUnits(rgn->art->pan));
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // sampleModes
       instGenList.sfGenOper = sampleModes;
       instGenList.genAmount.wAmount = rgn->sampinfo->cSampleLoops;
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // overridingRootKey
       instGenList.sfGenOper = overridingRootKey;
       instGenList.genAmount.wAmount = rgn->sampinfo->usUnityNote;
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // coarseTune
       instGenList.sfGenOper = coarseTune;
       instGenList.genAmount.shAmount = rgn->coarseTuneSemitones;
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // fineTune
       instGenList.sfGenOper = fineTune;
       instGenList.genAmount.shAmount = rgn->fineTuneCents;
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // attackVolEnv
       instGenList.sfGenOper = attackVolEnv;
       instGenList.genAmount.shAmount = secondsToSf2Timecents(rgn->art->attack_time);
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // holdVolEnv
       instGenList.sfGenOper = holdVolEnv;
       instGenList.genAmount.shAmount = secondsToSf2Timecents(rgn->art->hold_time);
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // decayVolEnv
       instGenList.sfGenOper = decayVolEnv;
       instGenList.genAmount.shAmount = secondsToSf2Timecents(rgn->art->decay_time);
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // sustainVolEnv
@@ -495,13 +496,13 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
       if (rgn->art->sustain_lev > 100.0)
         rgn->art->sustain_lev = 100.0;
       instGenList.genAmount.shAmount = static_cast<s16>(rgn->art->sustain_lev * 10);
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // releaseVolEnv
       instGenList.sfGenOper = releaseVolEnv;
       instGenList.genAmount.shAmount = secondsToSf2Timecents(rgn->art->release_time);
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       // reverbEffectsSend
@@ -513,20 +514,20 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
       if (rgn->lfoVibDepthCents() > 0 && rgn->lfoVibFreqHz() > 0) {
         instGenList.sfGenOper = vibLfoToPitch;
         instGenList.genAmount.shAmount = round(rgn->lfoVibDepthCents());
-        memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+        memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
         dataPtr += sizeof(sfInstGenList);
 
         instGenList.sfGenOper = freqVibLFO;
         double hz = rgn->lfoVibFreqHz();
         instGenList.genAmount.shAmount = round( 1200 * log2( hz / 8.176 ) );
-        memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+        memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
         dataPtr += sizeof(sfInstGenList);
 
         if (rgn->lfoVibDelaySeconds() > 0) {
           instGenList.sfGenOper = delayVibLFO;
           double delaySeconds = rgn->lfoVibDelaySeconds();
           instGenList.genAmount.shAmount = round( 1200 * log2( delaySeconds ) );
-          memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+          memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
           dataPtr += sizeof(sfInstGenList);
         }
       }
@@ -534,7 +535,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
       // sampleID - this is the terminal chunk
       instGenList.sfGenOper = sampleID;
       instGenList.genAmount.wAmount = static_cast<u16>(rgn->tableIndex);
-      memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+      memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
       dataPtr += sizeof(sfInstGenList);
 
       //int numConnBlocks = rgn->art->vConnBlocks.size();
@@ -547,7 +548,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
   }
   //  add terminal sfInstBag
   sfInstGenList instGenList{};
-  memcpy(igenCk->data + dataPtr, &instGenList, sizeof(sfInstGenList));
+  memcpy(igenCk->data.get() + dataPtr, &instGenList, sizeof(sfInstGenList));
   //memset(ibagCk->data + (numRgns*sizeof(sfInstBag)), 0, sizeof(sfInstBag));
   //igenCk->SetData(&genList, sizeof(sfGenList));
   pdtaCk->addChildChunk(igenCk);
@@ -559,7 +560,7 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
 
   size_t numSamps = synthfile->vWaves.size();
   shdrCk->setSize(static_cast<u32>((numSamps + 1) * sizeof(sfSample)));
-  shdrCk->data = new u8[shdrCk->size()];
+  shdrCk->data = std::make_unique<u8[]>(shdrCk->size());
 
   u32 sampOffset = 0;
   for (size_t i = 0; i < numSamps; i++) {
@@ -603,11 +604,11 @@ SF2File::SF2File(SynthFile* synthfile, const ConversionContext& context)
     samp.wSampleLink = 0;
     samp.sfSampleType = monoSample;
 
-    memcpy(shdrCk->data + (i * sizeof(sfSample)), &samp, sizeof(sfSample));
+    memcpy(shdrCk->data.get() + (i * sizeof(sfSample)), &samp, sizeof(sfSample));
   }
 
   //  add terminal sfSample
-  memset(shdrCk->data + (numSamps * sizeof(sfSample)), 0, sizeof(sfSample));
+  memset(shdrCk->data.get() + (numSamps * sizeof(sfSample)), 0, sizeof(sfSample));
   pdtaCk->addChildChunk(shdrCk);
 
   this->addChildChunk(pdtaCk);

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -39,12 +39,12 @@ SynthInstr *SynthFile::addInstr(u32 bank, u32 instrNum, std::string name, float 
 }
 
 void SynthFile::adoptInstr(std::unique_ptr<SynthInstr> instr) {
-  vInstrs.push_back(instr.get());
+  m_instrObservers.push_back(instr.get());
   m_instrs.push_back(std::move(instr));
 }
 
 std::vector<std::unique_ptr<SynthInstr>> SynthFile::releaseInstrs() {
-  vInstrs.clear();
+  m_instrObservers.clear();
   return std::exchange(m_instrs, {});
 }
 
@@ -72,12 +72,12 @@ SynthWave *SynthFile::addWave(u16 formatTag,
 }
 
 void SynthFile::adoptWave(std::unique_ptr<SynthWave> wave) {
-  vWaves.push_back(wave.get());
+  m_waveObservers.push_back(wave.get());
   m_waves.push_back(std::move(wave));
 }
 
 std::vector<std::unique_ptr<SynthWave>> SynthFile::releaseWaves() {
-  vWaves.clear();
+  m_waveObservers.clear();
   return std::exchange(m_waves, {});
 }
 
@@ -97,15 +97,6 @@ SynthInstr::SynthInstr(u32 bank, u32 instrument, std::string instrName, float re
   //RiffFile::AlignName(name);
 }
 
-SynthInstr::SynthInstr(u32 bank, u32 instrument, std::string instrName,
-                       const std::vector<SynthRgn *>& listRgns, float reverb)
-    : ulBank(bank), ulInstrument(instrument), name(std::move(instrName)), reverb(reverb)  {
-  //RiffFile::AlignName(name);
-  for (auto *rgn : listRgns) {
-    adoptRgn(std::unique_ptr<SynthRgn>(rgn));
-  }
-}
-
 SynthInstr::~SynthInstr() = default;
 
 SynthRgn *SynthInstr::addRgn() {
@@ -123,7 +114,7 @@ SynthRgn *SynthInstr::addRgn(const SynthRgn& rgn) {
 }
 
 void SynthInstr::adoptRgn(std::unique_ptr<SynthRgn> rgn) {
-  vRgns.push_back(rgn.get());
+  m_regionObservers.push_back(rgn.get());
   m_regions.push_back(std::move(rgn));
 }
 

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -9,6 +9,8 @@
 #include "base/Types.h"
 #include "VGMSamp.h"
 
+#include <utility>
+
 #include <spdlog/fmt/fmt.h>
 
 //  **********************************************************************************
@@ -19,20 +21,31 @@
 SynthFile::SynthFile(std::string name)
     : m_name(std::move(name)) {}
 
-SynthFile::~SynthFile() {
-  deleteVect(vInstrs);
-  deleteVect(vWaves);
-}
+SynthFile::~SynthFile() = default;
 
 SynthInstr *SynthFile::addInstr(u32 bank, u32 instrNum, float reverb) {
   auto str = fmt::format("Instr bnk {} num {}", bank, instrNum);
-  vInstrs.insert(vInstrs.end(), new SynthInstr(bank, instrNum, str, reverb));
-  return vInstrs.back();
+  auto instr = std::make_unique<SynthInstr>(bank, instrNum, str, reverb);
+  auto *rawInstr = instr.get();
+  adoptInstr(std::move(instr));
+  return rawInstr;
 }
 
 SynthInstr *SynthFile::addInstr(u32 bank, u32 instrNum, std::string name, float reverb) {
-  vInstrs.insert(vInstrs.end(), new SynthInstr(bank, instrNum, std::move(name), reverb));
-  return vInstrs.back();
+  auto instr = std::make_unique<SynthInstr>(bank, instrNum, std::move(name), reverb);
+  auto *rawInstr = instr.get();
+  adoptInstr(std::move(instr));
+  return rawInstr;
+}
+
+void SynthFile::adoptInstr(std::unique_ptr<SynthInstr> instr) {
+  vInstrs.push_back(instr.get());
+  m_instrs.push_back(std::move(instr));
+}
+
+std::vector<std::unique_ptr<SynthInstr>> SynthFile::releaseInstrs() {
+  vInstrs.clear();
+  return std::exchange(m_instrs, {});
 }
 
 SynthWave *SynthFile::addWave(u16 formatTag,
@@ -44,17 +57,28 @@ SynthWave *SynthFile::addWave(u16 formatTag,
                               u32 waveDataSize,
                               std::vector<u8> waveData,
                               std::string name) {
-  vWaves.insert(vWaves.end(),
-                new SynthWave(formatTag,
-                              channels,
-                              samplesPerSec,
-                              aveBytesPerSec,
-                              blockAlign,
-                              bitsPerSample,
-                              waveDataSize,
-                              std::move(waveData),
-                              std::move(name)));
-  return vWaves.back();
+  auto wave = std::make_unique<SynthWave>(formatTag,
+                                          channels,
+                                          samplesPerSec,
+                                          aveBytesPerSec,
+                                          blockAlign,
+                                          bitsPerSample,
+                                          waveDataSize,
+                                          std::move(waveData),
+                                          std::move(name));
+  auto *rawWave = wave.get();
+  adoptWave(std::move(wave));
+  return rawWave;
+}
+
+void SynthFile::adoptWave(std::unique_ptr<SynthWave> wave) {
+  vWaves.push_back(wave.get());
+  m_waves.push_back(std::move(wave));
+}
+
+std::vector<std::unique_ptr<SynthWave>> SynthFile::releaseWaves() {
+  vWaves.clear();
+  return std::exchange(m_waves, {});
 }
 
 //  **********
@@ -77,16 +101,30 @@ SynthInstr::SynthInstr(u32 bank, u32 instrument, std::string instrName,
                        const std::vector<SynthRgn *>& listRgns, float reverb)
     : ulBank(bank), ulInstrument(instrument), name(std::move(instrName)), reverb(reverb)  {
   //RiffFile::AlignName(name);
-  vRgns = listRgns;
+  for (auto *rgn : listRgns) {
+    adoptRgn(std::unique_ptr<SynthRgn>(rgn));
+  }
 }
 
-SynthInstr::~SynthInstr() {
-  deleteVect(vRgns);
-}
+SynthInstr::~SynthInstr() = default;
 
 SynthRgn *SynthInstr::addRgn() {
-  vRgns.insert(vRgns.end(), new SynthRgn());
-  return vRgns.back();
+  auto rgn = std::make_unique<SynthRgn>();
+  auto *rawRgn = rgn.get();
+  adoptRgn(std::move(rgn));
+  return rawRgn;
+}
+
+SynthRgn *SynthInstr::addRgn(const SynthRgn& rgn) {
+  auto newRgn = std::make_unique<SynthRgn>(rgn);
+  auto *rawRgn = newRgn.get();
+  adoptRgn(std::move(newRgn));
+  return rawRgn;
+}
+
+void SynthInstr::adoptRgn(std::unique_ptr<SynthRgn> rgn) {
+  vRgns.push_back(rgn.get());
+  m_regions.push_back(std::move(rgn));
 }
 
 void SynthInstr::addModulator(const SynthModulator& modulator) {
@@ -127,18 +165,120 @@ void SynthInstr::addGenerator(ModDest destination, ModAmount amount) {
 //  SynthRgn
 //  ********
 
-SynthRgn::~SynthRgn() {
-  delete sampinfo;
-  delete art;
+SynthRgn::SynthRgn(const SynthRgn& other)
+    : usKeyLow(other.usKeyLow),
+      usKeyHigh(other.usKeyHigh),
+      usVelLow(other.usVelLow),
+      usVelHigh(other.usVelHigh),
+      fusOptions(other.fusOptions),
+      usPhaseGroup(other.usPhaseGroup),
+      channel(other.channel),
+      tableIndex(other.tableIndex),
+      coarseTuneSemitones(other.coarseTuneSemitones),
+      fineTuneCents(other.fineTuneCents),
+      attenDb(other.attenDb),
+      m_lfoVibFreqHz(other.m_lfoVibFreqHz),
+      m_lfoVibDepthCents(other.m_lfoVibDepthCents),
+      m_lfoVibDelaySeconds(other.m_lfoVibDelaySeconds) {
+  if (other.sampinfo) {
+    m_sampinfo = std::make_unique<SynthSampInfo>(*other.sampinfo);
+    sampinfo = m_sampinfo.get();
+  }
+  if (other.art) {
+    m_art = std::make_unique<SynthArt>(*other.art);
+    art = m_art.get();
+  }
+}
+
+SynthRgn::SynthRgn(SynthRgn&& other) noexcept
+    : usKeyLow(other.usKeyLow),
+      usKeyHigh(other.usKeyHigh),
+      usVelLow(other.usVelLow),
+      usVelHigh(other.usVelHigh),
+      fusOptions(other.fusOptions),
+      usPhaseGroup(other.usPhaseGroup),
+      channel(other.channel),
+      tableIndex(other.tableIndex),
+      coarseTuneSemitones(other.coarseTuneSemitones),
+      fineTuneCents(other.fineTuneCents),
+      attenDb(other.attenDb),
+      m_sampinfo(std::move(other.m_sampinfo)),
+      m_art(std::move(other.m_art)),
+      m_lfoVibFreqHz(other.m_lfoVibFreqHz),
+      m_lfoVibDepthCents(other.m_lfoVibDepthCents),
+      m_lfoVibDelaySeconds(other.m_lfoVibDelaySeconds) {
+  sampinfo = m_sampinfo.get();
+  art = m_art.get();
+  other.sampinfo = nullptr;
+  other.art = nullptr;
+}
+
+SynthRgn& SynthRgn::operator=(const SynthRgn& other) {
+  if (this == &other) {
+    return *this;
+  }
+
+  usKeyLow = other.usKeyLow;
+  usKeyHigh = other.usKeyHigh;
+  usVelLow = other.usVelLow;
+  usVelHigh = other.usVelHigh;
+  fusOptions = other.fusOptions;
+  usPhaseGroup = other.usPhaseGroup;
+  channel = other.channel;
+  tableIndex = other.tableIndex;
+  coarseTuneSemitones = other.coarseTuneSemitones;
+  fineTuneCents = other.fineTuneCents;
+  attenDb = other.attenDb;
+  m_lfoVibFreqHz = other.m_lfoVibFreqHz;
+  m_lfoVibDepthCents = other.m_lfoVibDepthCents;
+  m_lfoVibDelaySeconds = other.m_lfoVibDelaySeconds;
+
+  m_sampinfo = other.sampinfo ? std::make_unique<SynthSampInfo>(*other.sampinfo) : nullptr;
+  sampinfo = m_sampinfo.get();
+  m_art = other.art ? std::make_unique<SynthArt>(*other.art) : nullptr;
+  art = m_art.get();
+
+  return *this;
+}
+
+SynthRgn& SynthRgn::operator=(SynthRgn&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+
+  usKeyLow = other.usKeyLow;
+  usKeyHigh = other.usKeyHigh;
+  usVelLow = other.usVelLow;
+  usVelHigh = other.usVelHigh;
+  fusOptions = other.fusOptions;
+  usPhaseGroup = other.usPhaseGroup;
+  channel = other.channel;
+  tableIndex = other.tableIndex;
+  coarseTuneSemitones = other.coarseTuneSemitones;
+  fineTuneCents = other.fineTuneCents;
+  attenDb = other.attenDb;
+  m_lfoVibFreqHz = other.m_lfoVibFreqHz;
+  m_lfoVibDepthCents = other.m_lfoVibDepthCents;
+  m_lfoVibDelaySeconds = other.m_lfoVibDelaySeconds;
+  m_sampinfo = std::move(other.m_sampinfo);
+  m_art = std::move(other.m_art);
+  sampinfo = m_sampinfo.get();
+  art = m_art.get();
+  other.sampinfo = nullptr;
+  other.art = nullptr;
+
+  return *this;
 }
 
 SynthArt *SynthRgn::addArt() {
-  art = new SynthArt();
+  m_art = std::make_unique<SynthArt>();
+  art = m_art.get();
   return art;
 }
 
 SynthSampInfo *SynthRgn::addSampInfo() {
-  sampinfo = new SynthSampInfo();
+  m_sampinfo = std::make_unique<SynthSampInfo>();
+  sampinfo = m_sampinfo.get();
   return sampinfo;
 }
 
@@ -232,11 +372,8 @@ void SynthWave::convertTo16bit() {
   }
 }
 
-SynthWave::~SynthWave() {
-  delete sampinfo;
-}
-
 SynthSampInfo *SynthWave::addSampInfo() {
-  sampinfo = new SynthSampInfo();
+  m_sampinfo = std::make_unique<SynthSampInfo>();
+  sampinfo = m_sampinfo.get();
   return sampinfo;
 }

--- a/src/main/conversion/SynthFile.cpp
+++ b/src/main/conversion/SynthFile.cpp
@@ -27,18 +27,18 @@ SynthInstr *SynthFile::addInstr(u32 bank, u32 instrNum, float reverb) {
   auto str = fmt::format("Instr bnk {} num {}", bank, instrNum);
   auto instr = std::make_unique<SynthInstr>(bank, instrNum, str, reverb);
   auto *rawInstr = instr.get();
-  adoptInstr(std::move(instr));
+  sinkInstr(std::move(instr));
   return rawInstr;
 }
 
 SynthInstr *SynthFile::addInstr(u32 bank, u32 instrNum, std::string name, float reverb) {
   auto instr = std::make_unique<SynthInstr>(bank, instrNum, std::move(name), reverb);
   auto *rawInstr = instr.get();
-  adoptInstr(std::move(instr));
+  sinkInstr(std::move(instr));
   return rawInstr;
 }
 
-void SynthFile::adoptInstr(std::unique_ptr<SynthInstr> instr) {
+void SynthFile::sinkInstr(std::unique_ptr<SynthInstr>&& instr) {
   m_instrObservers.push_back(instr.get());
   m_instrs.push_back(std::move(instr));
 }
@@ -67,11 +67,11 @@ SynthWave *SynthFile::addWave(u16 formatTag,
                                           std::move(waveData),
                                           std::move(name));
   auto *rawWave = wave.get();
-  adoptWave(std::move(wave));
+  sinkWave(std::move(wave));
   return rawWave;
 }
 
-void SynthFile::adoptWave(std::unique_ptr<SynthWave> wave) {
+void SynthFile::sinkWave(std::unique_ptr<SynthWave>&& wave) {
   m_waveObservers.push_back(wave.get());
   m_waves.push_back(std::move(wave));
 }
@@ -102,18 +102,18 @@ SynthInstr::~SynthInstr() = default;
 SynthRgn *SynthInstr::addRgn() {
   auto rgn = std::make_unique<SynthRgn>();
   auto *rawRgn = rgn.get();
-  adoptRgn(std::move(rgn));
+  sinkRgn(std::move(rgn));
   return rawRgn;
 }
 
 SynthRgn *SynthInstr::addRgn(const SynthRgn& rgn) {
   auto newRgn = std::make_unique<SynthRgn>(rgn);
   auto *rawRgn = newRgn.get();
-  adoptRgn(std::move(newRgn));
+  sinkRgn(std::move(newRgn));
   return rawRgn;
 }
 
-void SynthInstr::adoptRgn(std::unique_ptr<SynthRgn> rgn) {
+void SynthInstr::sinkRgn(std::unique_ptr<SynthRgn>&& rgn) {
   m_regionObservers.push_back(rgn.get());
   m_regions.push_back(std::move(rgn));
 }

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -4,6 +4,7 @@
 #include "Modulation.h"
 #include "RiffFile.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -29,14 +30,22 @@ class SynthFile {
 
   SynthInstr *addInstr(u32 bank, u32 instrNum, float reverb);
   SynthInstr *addInstr(u32 bank, u32 instrNum, std::string Name, float reverb);
+  void adoptInstr(std::unique_ptr<SynthInstr> instr);
+  std::vector<std::unique_ptr<SynthInstr>> releaseInstrs();
   SynthWave *addWave(u16 formatTag, u16 channels, int samplesPerSec, int aveBytesPerSec,
                      u16 blockAlign, u16 bitsPerSample, u32 waveDataSize,
                      std::vector<u8> waveData,
                      std::string name = "Unnamed Wave");
+  void adoptWave(std::unique_ptr<SynthWave> wave);
+  std::vector<std::unique_ptr<SynthWave>> releaseWaves();
 
   std::vector<SynthInstr *> vInstrs;
   std::vector<SynthWave *> vWaves;
   std::string m_name;
+
+private:
+  std::vector<std::unique_ptr<SynthInstr>> m_instrs;
+  std::vector<std::unique_ptr<SynthWave>> m_waves;
 };
 
 class SynthInstr {
@@ -48,6 +57,8 @@ class SynthInstr {
   ~SynthInstr();
 
   SynthRgn *addRgn();
+  SynthRgn *addRgn(const SynthRgn& rgn);
+  void adoptRgn(std::unique_ptr<SynthRgn> rgn);
 
   void addModulator(const SynthModulator& modulator);
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
@@ -65,6 +76,7 @@ class SynthInstr {
   std::vector<SynthRgn *> vRgns;
 
 private:
+  std::vector<std::unique_ptr<SynthRgn>> m_regions;
   std::vector<SynthModulator> m_modulators;
   std::vector<SynthGenerator> m_generators;
 };
@@ -101,7 +113,11 @@ class SynthRgn {
   SynthRgn() = default;
   SynthRgn(u16 keyLow, u16 keyHigh, u16 velLow, u16 velHigh)
       : usKeyLow(keyLow), usKeyHigh(keyHigh), usVelLow(velLow), usVelHigh(velHigh) {}
-  ~SynthRgn();
+  SynthRgn(const SynthRgn& other);
+  SynthRgn(SynthRgn&& other) noexcept;
+  SynthRgn& operator=(const SynthRgn& other);
+  SynthRgn& operator=(SynthRgn&& other) noexcept;
+  ~SynthRgn() = default;
 
   SynthArt *addArt();
   SynthSampInfo *addSampInfo();
@@ -136,6 +152,8 @@ class SynthRgn {
   SynthArt *art {nullptr};
 
 private:
+  std::unique_ptr<SynthSampInfo> m_sampinfo;
+  std::unique_ptr<SynthArt> m_art;
   double m_lfoVibFreqHz       {0};
   double m_lfoVibDepthCents   {0};
   double m_lfoVibDelaySeconds {0};
@@ -166,8 +184,7 @@ class SynthWave {
   SynthWave(u16 formatTag, u16 channels, int samplesPerSec, int aveBytesPerSec, u16 blockAlign,
             u16 bitsPerSample, u32 waveDataSize, std::vector<u8> waveData,
             std::string waveName = "Untitled Wave")
-      : sampinfo(nullptr),
-        wFormatTag(formatTag),
+      : wFormatTag(formatTag),
         wChannels(channels),
         dwSamplesPerSec(samplesPerSec),
         dwAveBytesPerSec(aveBytesPerSec),
@@ -179,14 +196,14 @@ class SynthWave {
     RiffFile::alignName(name);
     dataSize = static_cast<u32>(data.size());
   }
-  ~SynthWave();
+  ~SynthWave() = default;
 
   SynthSampInfo *addSampInfo();
 
   void convertTo16bit();
 
- public:
-  SynthSampInfo *sampinfo;
+public:
+  SynthSampInfo *sampinfo {nullptr};
 
   u16 wFormatTag;
   u16 wChannels;
@@ -199,4 +216,7 @@ class SynthWave {
   std::vector<u8> data;
 
   std::string name;
+
+private:
+  std::unique_ptr<SynthSampInfo> m_sampinfo;
 };

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -39,26 +39,32 @@ class SynthFile {
   void adoptWave(std::unique_ptr<SynthWave> wave);
   std::vector<std::unique_ptr<SynthWave>> releaseWaves();
 
-  std::vector<SynthInstr *> vInstrs;
-  std::vector<SynthWave *> vWaves;
+  [[nodiscard]] const std::vector<SynthInstr*>& instrs() const { return m_instrObservers; }
+  [[nodiscard]] const std::vector<SynthWave*>& waves() const { return m_waveObservers; }
+  [[nodiscard]] bool hasInstrs() const { return !m_instrObservers.empty(); }
+  [[nodiscard]] bool hasWaves() const { return !m_waveObservers.empty(); }
+  [[nodiscard]] size_t instrCount() const { return m_instrObservers.size(); }
+  [[nodiscard]] size_t waveCount() const { return m_waveObservers.size(); }
+
   std::string m_name;
 
 private:
   std::vector<std::unique_ptr<SynthInstr>> m_instrs;
   std::vector<std::unique_ptr<SynthWave>> m_waves;
+  std::vector<SynthInstr *> m_instrObservers;
+  std::vector<SynthWave *> m_waveObservers;
 };
 
 class SynthInstr {
  public:
   SynthInstr(u32 bank, u32 instrument, float reverb);
   SynthInstr(u32 bank, u32 instrument, std::string instrName, float reverb);
-  SynthInstr(u32 bank, u32 instrument, std::string instrName,
-             const std::vector<SynthRgn *>& listRgns, float reverb);
   ~SynthInstr();
 
   SynthRgn *addRgn();
   SynthRgn *addRgn(const SynthRgn& rgn);
   void adoptRgn(std::unique_ptr<SynthRgn> rgn);
+  [[nodiscard]] const std::vector<SynthRgn*>& regions() const { return m_regionObservers; }
 
   void addModulator(const SynthModulator& modulator);
   void addModulator(ModSource source, ModDest destination, ModAmount amount);
@@ -73,10 +79,9 @@ class SynthInstr {
   std::string name;
   float reverb;
 
-  std::vector<SynthRgn *> vRgns;
-
 private:
   std::vector<std::unique_ptr<SynthRgn>> m_regions;
+  std::vector<SynthRgn *> m_regionObservers;
   std::vector<SynthModulator> m_modulators;
   std::vector<SynthGenerator> m_generators;
 };

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -30,13 +30,13 @@ class SynthFile {
 
   SynthInstr *addInstr(u32 bank, u32 instrNum, float reverb);
   SynthInstr *addInstr(u32 bank, u32 instrNum, std::string Name, float reverb);
-  void adoptInstr(std::unique_ptr<SynthInstr> instr);
+  void sinkInstr(std::unique_ptr<SynthInstr>&& instr);
   std::vector<std::unique_ptr<SynthInstr>> releaseInstrs();
   SynthWave *addWave(u16 formatTag, u16 channels, int samplesPerSec, int aveBytesPerSec,
                      u16 blockAlign, u16 bitsPerSample, u32 waveDataSize,
                      std::vector<u8> waveData,
                      std::string name = "Unnamed Wave");
-  void adoptWave(std::unique_ptr<SynthWave> wave);
+  void sinkWave(std::unique_ptr<SynthWave>&& wave);
   std::vector<std::unique_ptr<SynthWave>> releaseWaves();
 
   [[nodiscard]] const std::vector<SynthInstr*>& instrs() const { return m_instrObservers; }
@@ -63,7 +63,7 @@ class SynthInstr {
 
   SynthRgn *addRgn();
   SynthRgn *addRgn(const SynthRgn& rgn);
-  void adoptRgn(std::unique_ptr<SynthRgn> rgn);
+  void sinkRgn(std::unique_ptr<SynthRgn>&& rgn);
   [[nodiscard]] const std::vector<SynthRgn*>& regions() const { return m_regionObservers; }
 
   void addModulator(const SynthModulator& modulator);

--- a/src/main/conversion/VGMExport.cpp
+++ b/src/main/conversion/VGMExport.cpp
@@ -61,7 +61,6 @@ bool saveAsSF2(VGMInstrSet &set, const fs::path &filepath) {
 
   if (auto sf2file = createSF2File(instrsets, sampcolls, coll, context); sf2file) {
     bool bResult = sf2file->saveSF2File(filepath);
-    delete sf2file;
     return bResult;
   }
 
@@ -72,7 +71,6 @@ bool saveAsSF2(const VGMColl &coll, const fs::path &filepath) {
   const auto context = ConversionContext::fromOptions(ConversionOptions::the(), SynthTarget::SoundFont);
   if (auto sf2file = createSF2File(coll.instrSets(), coll.sampColls(), &coll, context); sf2file) {
     bool bResult = sf2file->saveSF2File(filepath);
-    delete sf2file;
     return bResult;
   }
 

--- a/src/main/conversion/VGMExport.cpp
+++ b/src/main/conversion/VGMExport.cpp
@@ -24,7 +24,7 @@ namespace conversion {
 
 bool saveAsDLS(VGMInstrSet &set, const fs::path &filepath) {
   const auto context = ConversionContext::fromOptions(ConversionOptions::the(), SynthTarget::DLS);
-  VGMColl* coll = !set.assocColls.empty() ? set.assocColls.front() : nullptr;
+  VGMColl* coll = set.hasAssocColls() ? set.assocColls().front() : nullptr;
   if (!coll && !set.sampColl)
     return false;
 
@@ -46,7 +46,7 @@ bool saveAsDLS(VGMInstrSet &set, const fs::path &filepath) {
 
 bool saveAsSF2(VGMInstrSet &set, const fs::path &filepath) {
   const auto context = ConversionContext::fromOptions(ConversionOptions::the(), SynthTarget::SoundFont);
-  VGMColl* coll = !set.assocColls.empty() ? set.assocColls.front() : nullptr;
+  VGMColl* coll = set.hasAssocColls() ? set.assocColls().front() : nullptr;
   if (!coll && !set.sampColl)
     return false;
 
@@ -79,7 +79,7 @@ bool saveAsSF2(const VGMColl &coll, const fs::path &filepath) {
 
 void saveAllAsWav(const VGMSampColl &coll, const fs::path &save_dir) {
   const auto sampCollName = makeSafeFileName(coll.name()).u8string();
-  for (auto &sample : coll.samples) {
+  for (auto* sample : coll.samples()) {
     std::u8string filename = sampCollName + u8" - " + makeSafeFileName(sample->name()).u8string() + u8".wav";
     sample->saveAsWav(save_dir / filename);
   }

--- a/src/main/conversion/VGMExport.cpp
+++ b/src/main/conversion/VGMExport.cpp
@@ -25,7 +25,7 @@ namespace conversion {
 bool saveAsDLS(VGMInstrSet &set, const fs::path &filepath) {
   const auto context = ConversionContext::fromOptions(ConversionOptions::the(), SynthTarget::DLS);
   VGMColl* coll = set.hasAssocColls() ? set.assocColls().front() : nullptr;
-  if (!coll && !set.sampColl)
+  if (!coll && !set.sampColl())
     return false;
 
   std::vector<VGMInstrSet*> instrsets;
@@ -47,7 +47,7 @@ bool saveAsDLS(VGMInstrSet &set, const fs::path &filepath) {
 bool saveAsSF2(VGMInstrSet &set, const fs::path &filepath) {
   const auto context = ConversionContext::fromOptions(ConversionOptions::the(), SynthTarget::SoundFont);
   VGMColl* coll = set.hasAssocColls() ? set.assocColls().front() : nullptr;
-  if (!coll && !set.sampColl)
+  if (!coll && !set.sampColl())
     return false;
 
   std::vector<VGMInstrSet*> instrsets;

--- a/src/main/conversion/VGMExport.h
+++ b/src/main/conversion/VGMExport.h
@@ -75,11 +75,10 @@ void saveAs(const VGMColl &coll, const std::filesystem::path &dir_path) {
   }
 
   if constexpr (hasTarget(options, Target::SF2)) {
-    if (SF2File *sf2file = createSF2File(coll, context)) {
+    if (auto sf2file = createSF2File(coll, context)) {
       auto sf2Path = filepath;
       sf2Path.replace_extension(".sf2");
       sf2file->saveSF2File(sf2Path);
-      delete sf2file;
     }
   }
 }

--- a/src/main/formats/Akao/AkaoFormat.cpp
+++ b/src/main/formats/Akao/AkaoFormat.cpp
@@ -38,7 +38,7 @@ AkaoColl::mapSampleCollections() const {
       artIdToSampleNumMap[artId] = sampcoll->akArts[i].sample_num + cumulativeSamples;
       artIdToSampCollMap[artId] = sampcoll;
     }
-    cumulativeSamples += sampcoll->samples.size();
+    cumulativeSamples += static_cast<int>(sampcoll->sampleCount());
   }
 
   return std::make_tuple(std::move(artIdToArtMap), std::move(artIdToSampleNumMap), std::move(artIdToSampCollMap));
@@ -49,7 +49,7 @@ bool AkaoColl::loadMain() {
 
   auto [artIdToArtMap, artIdToSampleNumMap, artIdToSampCollMap] = mapSampleCollections();
 
-  for (auto *vgminstr : instrset->aInstrs) {
+  for (auto *vgminstr : instrset->instrs()) {
     auto* instr = dynamic_cast<AkaoInstr*>(vgminstr);
     if (!instr) {
       L_ERROR("AkaoInstrSet contained an instrument that wasn't an AkaoInstr.");
@@ -73,9 +73,9 @@ bool AkaoColl::loadMain() {
 
       if (art->loop_point != 0) {
         AkaoSampColl *sampColl = artIdToSampCollMap[rgn->artNum];
-        if (rgn->sampNum < sampColl->samples.size()) {
+        if (art->sample_num >= 0 && static_cast<size_t>(art->sample_num) < sampColl->sampleCount()) {
           rgn->setLoopInfo(1, art->loop_point,
-                           sampColl->samples[art->sample_num]->dataLength - art->loop_point);
+                           sampColl->sample(static_cast<size_t>(art->sample_num))->dataLength - art->loop_point);
         } else
           L_ERROR("Akao region points to out-of-range sample (#{:d}) in {}.", rgn->sampNum, sampColl->name());
       }

--- a/src/main/formats/Akao/AkaoInstr.cpp
+++ b/src/main/formats/Akao/AkaoInstr.cpp
@@ -12,6 +12,8 @@
 #include "VGMColl.h"
 #include "VGMSamp.h"
 
+#include <memory>
+
 // ************
 // AkaoInstrSet
 // ************
@@ -80,23 +82,23 @@ bool AkaoInstrSet::parseInstrPointers() {
       if (instrPtr == 0xFFFF || (instrPtr == 0 && i != 0))
         continue;
       SSEQHdr->addChild(ptrOff, 2, "Instr Pointer");
-      aInstrs.push_back(new AkaoInstr(this, instrSetOff + 0x20 + instrPtr, 0, 1, i));
+      emplaceInstr<AkaoInstr>(this, instrSetOff + 0x20 + instrPtr, 0, 1, i);
     }
   }
   else if (!custom_instrument_addresses.empty()) {
     u32 instrNum = 0;
     for (const u32 instrOff : custom_instrument_addresses) {
-      aInstrs.push_back(new AkaoInstr(this, instrOff, 0, 1, instrNum++));
+      emplaceInstr<AkaoInstr>(this, instrOff, 0, 1, instrNum++);
     }
   }
 
   if (bDrumKit) {
-    aInstrs.push_back(new AkaoDrumKit(this, drumkitOff, 0, 127, 127));
+    emplaceInstr<AkaoDrumKit>(this, drumkitOff, 0, 127, 127);
   }
   else if (!drum_instrument_addresses.empty()) {
     u32 instrNum = 127;
     for (const u32 instrOff : drum_instrument_addresses) {
-      aInstrs.push_back(new AkaoDrumKit(this, instrOff, 0, 127, instrNum--));
+      emplaceInstr<AkaoDrumKit>(this, instrOff, 0, 127, instrNum--);
     }
   }
 
@@ -125,12 +127,13 @@ void AkaoInstrSet::useColl(const VGMColl* coll) {
 
     for (size_t i = 0; i < sampcoll->akArts.size(); i++) {
       const AkaoArt* art = &sampcoll->akArts[i];
-      auto* newInstr = new AkaoInstr(this, 0, 0, 0, sampcoll->starting_art_id + static_cast<u32>(i));
-      auto* rgn = new AkaoRgn(newInstr, 0, 0);
+      auto newInstr = std::make_unique<AkaoInstr>(this, 0, 0, 0, sampcoll->starting_art_id + static_cast<u32>(i));
+      auto* rawInstr = newInstr.get();
+      auto* rgn = rawInstr->emplaceRgn<AkaoRgn>(rawInstr, 0, 0);
 
       if (art->loop_point != 0) {
         rgn->setLoopInfo(1, art->loop_point,
-                         sampcoll->samples[art->sample_num]->dataLength - art->loop_point);
+                         sampcoll->sample(static_cast<size_t>(art->sample_num))->dataLength - art->loop_point);
       }
 
       if (auto itSampleNum = artIdToSampleNumMap.find(art->artID); itSampleNum != artIdToSampleNumMap.end()) {
@@ -141,8 +144,7 @@ void AkaoInstrSet::useColl(const VGMColl* coll) {
       rgn->unityKey = art->unityKey;
       rgn->fineTune = art->fineTune;
 
-      newInstr->addRgn(rgn);
-      addTempInstr(newInstr);
+      addTempInstr(std::move(newInstr));
     }
   }
 }
@@ -171,27 +173,27 @@ bool AkaoInstr::loadInstr() {
       }
     }
 
-    auto rgn = new AkaoRgn(this, offset() + k * 8, 8);
+    auto rgn = std::make_unique<AkaoRgn>(this, offset() + k * 8, 8);
     if (!rgn->loadRgn()) {
-      delete rgn;
       return false;
     }
+    auto* rawRgn = rgn.get();
     if (k > 0) {
       // Some tracks have apparently malformed key low / key high regions, where sections of the
       // keyboard are left unaccounted for, but notes still play in these regions.
       // For ex: Saga Frontier 2 - Thema instrument 0 (harp). The logic below ensures
       // all keys are covered, though it is imperfect as the wrong regions are being extended.
       auto prevRgn = regions().back();
-      if (rgn->keyHigh > prevRgn->keyHigh && rgn->keyLow > prevRgn->keyHigh) {
-        addRgn(rgn);
-      } else if (rgn->keyHigh == prevRgn->keyHigh) {
+      if (rawRgn->keyHigh > prevRgn->keyHigh && rawRgn->keyLow > prevRgn->keyHigh) {
+        addRgn(std::move(rgn));
+      } else if (rawRgn->keyHigh == prevRgn->keyHigh) {
         // TODO: replace the last region with this one?
       }
-      if (rgn->keyLow - prevRgn->keyHigh > 1) {
-        rgn->keyLow = prevRgn->keyHigh + 1;
+      if (rawRgn->keyLow - prevRgn->keyHigh > 1) {
+        rawRgn->keyLow = prevRgn->keyHigh + 1;
       }
     } else {
-      addRgn(rgn);
+      addRgn(std::move(rgn));
     }
   }
   if (!regions().empty()) {
@@ -235,8 +237,7 @@ bool AkaoDrumKit::loadInstr() {
         break;
 
       const u8 assoc_art_id = readByte(rgn_offset + 0);
-      auto *rgn = new AkaoRgn(this, rgn_offset, kRgnLength, drum_note_number, drum_note_number, assoc_art_id);
-      addRgn(rgn);
+      auto *rgn = emplaceRgn<AkaoRgn>(this, rgn_offset, kRgnLength, drum_note_number, drum_note_number, assoc_art_id);
       rgn->drumRelUnityKey = readByte(rgn_offset + 1);
       const u8 raw_volume = readByte(rgn_offset + 6);
       const double volume = raw_volume == 0 ? 1.0 : raw_volume / 128.0;
@@ -275,8 +276,7 @@ bool AkaoDrumKit::loadInstr() {
 
       const u8 assoc_art_id = readByte(rgn_offset + 0);
       const u8 drum_note_number = drum_octave * 12 + drum_key;
-      auto *rgn = new AkaoRgn(this, rgn_offset, kRgnLength, drum_note_number, drum_note_number, assoc_art_id);
-      addRgn(rgn);
+      auto *rgn = emplaceRgn<AkaoRgn>(this, rgn_offset, kRgnLength, drum_note_number, drum_note_number, assoc_art_id);
       rgn->drumRelUnityKey = readByte(rgn_offset + 1);
       const u16 raw_volume = getWord(rgn_offset + 2);
       rgn->setVolume(raw_volume / (127 * 128.0));
@@ -715,21 +715,19 @@ bool AkaoSampColl::parseSampleInfo() {
     }
 
     const u32 length = PSXSamp::getSampleLength(rawFile(), offset, sample_section_offset + sample_section_size, loop);
-    auto *samp = new PSXSamp(this, offset, length, offset, length, 1, BPS::PCM16, 44100,
-      fmt::format("Sample {}", samples.size()));
-
-    samples.push_back(samp);
+    emplaceSamp<PSXSamp>(this, offset, length, offset, length, 1, BPS::PCM16, 44100,
+                         fmt::format("Sample {}", sampleCount()));
   }
 
-  if (samples.empty())
+  if (!hasSamples())
     return false;
 
   // now to verify and associate each articulation with a sample index value
   // for every sample of every instrument, we add sample_section offset, because those values
   //  are relative to the beginning of the sample section
   for (auto& akArt : akArts) {
-    for (u32 l = 0; l < samples.size(); l++) {
-      if (akArt.sample_offset + sample_section_offset == samples[l]->offset()) {
+    for (u32 l = 0; l < sampleCount(); l++) {
+      if (akArt.sample_offset + sample_section_offset == sample(l)->offset()) {
         akArt.sample_num = l;
         break;
       }

--- a/src/main/formats/Akao/AkaoInstr.cpp
+++ b/src/main/formats/Akao/AkaoInstr.cpp
@@ -82,23 +82,23 @@ bool AkaoInstrSet::parseInstrPointers() {
       if (instrPtr == 0xFFFF || (instrPtr == 0 && i != 0))
         continue;
       SSEQHdr->addChild(ptrOff, 2, "Instr Pointer");
-      emplaceInstr<AkaoInstr>(this, instrSetOff + 0x20 + instrPtr, 0, 1, i);
+      addInstr<AkaoInstr>(this, instrSetOff + 0x20 + instrPtr, 0, 1, i);
     }
   }
   else if (!custom_instrument_addresses.empty()) {
     u32 instrNum = 0;
     for (const u32 instrOff : custom_instrument_addresses) {
-      emplaceInstr<AkaoInstr>(this, instrOff, 0, 1, instrNum++);
+      addInstr<AkaoInstr>(this, instrOff, 0, 1, instrNum++);
     }
   }
 
   if (bDrumKit) {
-    emplaceInstr<AkaoDrumKit>(this, drumkitOff, 0, 127, 127);
+    addInstr<AkaoDrumKit>(this, drumkitOff, 0, 127, 127);
   }
   else if (!drum_instrument_addresses.empty()) {
     u32 instrNum = 127;
     for (const u32 instrOff : drum_instrument_addresses) {
-      emplaceInstr<AkaoDrumKit>(this, instrOff, 0, 127, instrNum--);
+      addInstr<AkaoDrumKit>(this, instrOff, 0, 127, instrNum--);
     }
   }
 
@@ -129,7 +129,7 @@ void AkaoInstrSet::useColl(const VGMColl* coll) {
       const AkaoArt* art = &sampcoll->akArts[i];
       auto newInstr = std::make_unique<AkaoInstr>(this, 0, 0, 0, sampcoll->starting_art_id + static_cast<u32>(i));
       auto* rawInstr = newInstr.get();
-      auto* rgn = rawInstr->emplaceRgn<AkaoRgn>(rawInstr, 0, 0);
+      auto* rgn = rawInstr->addRgn<AkaoRgn>(rawInstr, 0, 0);
 
       if (art->loop_point != 0) {
         rgn->setLoopInfo(1, art->loop_point,
@@ -144,7 +144,7 @@ void AkaoInstrSet::useColl(const VGMColl* coll) {
       rgn->unityKey = art->unityKey;
       rgn->fineTune = art->fineTune;
 
-      addTempInstr(std::move(newInstr));
+      adoptTempInstr(std::move(newInstr));
     }
   }
 }
@@ -185,7 +185,7 @@ bool AkaoInstr::loadInstr() {
       // all keys are covered, though it is imperfect as the wrong regions are being extended.
       auto prevRgn = regions().back();
       if (rawRgn->keyHigh > prevRgn->keyHigh && rawRgn->keyLow > prevRgn->keyHigh) {
-        addRgn(std::move(rgn));
+        adoptRgn(std::move(rgn));
       } else if (rawRgn->keyHigh == prevRgn->keyHigh) {
         // TODO: replace the last region with this one?
       }
@@ -193,7 +193,7 @@ bool AkaoInstr::loadInstr() {
         rawRgn->keyLow = prevRgn->keyHigh + 1;
       }
     } else {
-      addRgn(std::move(rgn));
+      adoptRgn(std::move(rgn));
     }
   }
   if (!regions().empty()) {
@@ -237,7 +237,7 @@ bool AkaoDrumKit::loadInstr() {
         break;
 
       const u8 assoc_art_id = readByte(rgn_offset + 0);
-      auto *rgn = emplaceRgn<AkaoRgn>(this, rgn_offset, kRgnLength, drum_note_number, drum_note_number, assoc_art_id);
+      auto *rgn = addRgn<AkaoRgn>(this, rgn_offset, kRgnLength, drum_note_number, drum_note_number, assoc_art_id);
       rgn->drumRelUnityKey = readByte(rgn_offset + 1);
       const u8 raw_volume = readByte(rgn_offset + 6);
       const double volume = raw_volume == 0 ? 1.0 : raw_volume / 128.0;
@@ -276,7 +276,7 @@ bool AkaoDrumKit::loadInstr() {
 
       const u8 assoc_art_id = readByte(rgn_offset + 0);
       const u8 drum_note_number = drum_octave * 12 + drum_key;
-      auto *rgn = emplaceRgn<AkaoRgn>(this, rgn_offset, kRgnLength, drum_note_number, drum_note_number, assoc_art_id);
+      auto *rgn = addRgn<AkaoRgn>(this, rgn_offset, kRgnLength, drum_note_number, drum_note_number, assoc_art_id);
       rgn->drumRelUnityKey = readByte(rgn_offset + 1);
       const u16 raw_volume = getWord(rgn_offset + 2);
       rgn->setVolume(raw_volume / (127 * 128.0));
@@ -715,7 +715,7 @@ bool AkaoSampColl::parseSampleInfo() {
     }
 
     const u32 length = PSXSamp::getSampleLength(rawFile(), offset, sample_section_offset + sample_section_size, loop);
-    emplaceSamp<PSXSamp>(this, offset, length, offset, length, 1, BPS::PCM16, 44100,
+    addSamp<PSXSamp>(this, offset, length, offset, length, 1, BPS::PCM16, 44100,
                          fmt::format("Sample {}", sampleCount()));
   }
 

--- a/src/main/formats/Akao/AkaoInstr.cpp
+++ b/src/main/formats/Akao/AkaoInstr.cpp
@@ -144,7 +144,7 @@ void AkaoInstrSet::useColl(const VGMColl* coll) {
       rgn->unityKey = art->unityKey;
       rgn->fineTune = art->fineTune;
 
-      adoptTempInstr(std::move(newInstr));
+      sinkTempInstr(std::move(newInstr));
     }
   }
 }
@@ -185,7 +185,7 @@ bool AkaoInstr::loadInstr() {
       // all keys are covered, though it is imperfect as the wrong regions are being extended.
       auto prevRgn = regions().back();
       if (rawRgn->keyHigh > prevRgn->keyHigh && rawRgn->keyLow > prevRgn->keyHigh) {
-        adoptRgn(std::move(rgn));
+        sinkRgn(std::move(rgn));
       } else if (rawRgn->keyHigh == prevRgn->keyHigh) {
         // TODO: replace the last region with this one?
       }
@@ -193,7 +193,7 @@ bool AkaoInstr::loadInstr() {
         rawRgn->keyLow = prevRgn->keyHigh + 1;
       }
     } else {
-      adoptRgn(std::move(rgn));
+      sinkRgn(std::move(rgn));
     }
   }
   if (!regions().empty()) {

--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -160,8 +160,8 @@ bool AkaoMatcher::tryCreateCollection(int id) {
       if (!coll) return false;
 
       coll->setName(seq->name());
-      coll->useSeq(seq);
-      coll->addInstrSet(instrSet);
+      coll->attachSeq(seq);
+      coll->attachInstrSet(instrSet);
 
       // Sort the vector by starting_art_id in ascending order
       std::sort(matchingSampColls.begin(), matchingSampColls.end(),
@@ -169,7 +169,7 @@ bool AkaoMatcher::tryCreateCollection(int id) {
           return a->starting_art_id < b->starting_art_id;
       });
       for (auto *sc : matchingSampColls) {
-        coll->addSampColl(sc);
+        coll->attachSampColl(sc);
       }
 
       seqs.erase(seq->seq_id);

--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -2,6 +2,9 @@
 
 #include "AkaoInstr.h"
 #include "AkaoSeq.h"
+#include "Root.h"
+
+#include <ranges>
 
 bool isPsfFile(RawFile* file) {
   return file->extension() == "psf" ||
@@ -115,7 +118,7 @@ bool AkaoMatcher::tryCreateCollection(int id) {
     }
 
     std::vector<u32> requiredArtIds;
-    for (const auto &instr : instrSet->aInstrs) {
+    for (const auto &instr : instrSet->instrs()) {
       for (const auto &region : instr->regions()) {
         AkaoRgn* akaoRegion = static_cast<AkaoRgn*>(region);
         // We will exclude articulation id 0, as it often just indicates an unused region
@@ -171,8 +174,7 @@ bool AkaoMatcher::tryCreateCollection(int id) {
 
       seqs.erase(seq->seq_id);
 
-      if (!coll->load()) {
-        delete coll;
+      if (!pRoot->loadVGMColl(std::move(coll))) {
         return false;
       }
 

--- a/src/main/formats/Akao/AkaoScanner.cpp
+++ b/src/main/formats/Akao/AkaoScanner.cpp
@@ -34,7 +34,7 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
       u16 id = file->readShort(offset + 4);
       auto name = fmt::format("Akao Seq {:02X}", id);
 
-      auto* seq = pRoot->emplaceVGMFile<AkaoSeq>(file, offset, version, name);
+      auto* seq = pRoot->loadVGMFile<AkaoSeq>(file, offset, version, name);
       if (!seq) {
         continue;
       }
@@ -56,7 +56,7 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
       u16 id = file->readShort(offset + 4);
       auto name = fmt::format("Akao Sample Collection {:02X}", id);
 
-      pRoot->emplaceVGMFile<AkaoSampColl>(file, offset, version, name);
+      pRoot->loadVGMFile<AkaoSampColl>(file, offset, version, name);
     }
   }
 
@@ -79,7 +79,7 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
 
     if (!instrLocations.empty()) {
       for (const auto & loc : instrLocations) {
-        pRoot->emplaceVGMFile<AkaoSampColl>(file, loc);
+        pRoot->loadVGMFile<AkaoSampColl>(file, loc);
       }
     }
   }

--- a/src/main/formats/Akao/AkaoScanner.cpp
+++ b/src/main/formats/Akao/AkaoScanner.cpp
@@ -34,17 +34,15 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
       u16 id = file->readShort(offset + 4);
       auto name = fmt::format("Akao Seq {:02X}", id);
 
-      AkaoSeq *seq = new AkaoSeq(file, offset, version, name);
-      if (!seq->loadVGMFile()) {
-        delete seq;
+      auto* seq = pRoot->emplaceVGMFile<AkaoSeq>(file, offset, version, name);
+      if (!seq) {
         continue;
       }
 
-      AkaoInstrSet* instrset = seq->newInstrSet();
-      if (instrset == nullptr)
+      auto instrset = seq->newInstrSet();
+      if (!instrset)
         continue;
-      if (!instrset->loadVGMFile())
-        delete instrset;
+      pRoot->loadVGMFile(std::move(instrset));
     }
     else {
       // Samples
@@ -58,9 +56,7 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
       u16 id = file->readShort(offset + 4);
       auto name = fmt::format("Akao Sample Collection {:02X}", id);
 
-      AkaoSampColl *sampColl = new AkaoSampColl(file, offset, version, name);
-      if (!sampColl->loadVGMFile())
-        delete sampColl;
+      pRoot->emplaceVGMFile<AkaoSampColl>(file, offset, version, name);
     }
   }
 
@@ -83,9 +79,7 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
 
     if (!instrLocations.empty()) {
       for (const auto & loc : instrLocations) {
-        auto *sampColl = new AkaoSampColl(file, loc);
-        if (!sampColl->loadVGMFile())
-          delete sampColl;
+        pRoot->emplaceVGMFile<AkaoSampColl>(file, loc);
       }
     }
   }

--- a/src/main/formats/Akao/AkaoSeq.cpp
+++ b/src/main/formats/Akao/AkaoSeq.cpp
@@ -183,7 +183,7 @@ bool AkaoSeq::parseTrackPointers() {
     const u32 base = p + (version() >= AkaoPs1Version::VERSION_3_0 ? 0 : 2);
     const u32 relative_offset = readShort(offset() + p);
     const u32 track_offset = base + relative_offset;
-    aTracks.push_back(new AkaoTrack(this, offset() + track_offset));
+    addTrack<AkaoTrack>(this, offset() + track_offset);
   }
   return true;
 }
@@ -219,7 +219,7 @@ double AkaoSeq::getTempoInBPM(u16 tempo) const {
   }
 }
 
-AkaoInstrSet* AkaoSeq::newInstrSet() const {
+std::unique_ptr<AkaoInstrSet> AkaoSeq::newInstrSet() const {
   if (version() >= AkaoPs1Version::VERSION_3_0) {
     u32 instrSetLen = 0;
     if (has_instrument_set_offset())
@@ -228,10 +228,12 @@ AkaoInstrSet* AkaoSeq::newInstrSet() const {
       instrSetLen = length() - (drum_set_offset() - offset());
 
     return instrSetLen != 0
-      ? new AkaoInstrSet(rawFile(), instrSetLen, version(), instrument_set_offset(), drum_set_offset(), seq_id, "Akao Instr Set")
-      : new AkaoInstrSet(rawFile(), offset(), offset() + length(), version(), seq_id);
+      ? std::make_unique<AkaoInstrSet>(
+            rawFile(), instrSetLen, version(), instrument_set_offset(), drum_set_offset(), seq_id, "Akao Instr Set")
+      : std::make_unique<AkaoInstrSet>(rawFile(), offset(), offset() + length(), version(), seq_id);
   } else {
-    return new AkaoInstrSet(rawFile(), offset() + length(), version(), custom_instrument_addresses, drum_instrument_addresses, seq_id);
+    return std::make_unique<AkaoInstrSet>(
+        rawFile(), offset() + length(), version(), custom_instrument_addresses, drum_instrument_addresses, seq_id);
   }
 }
 

--- a/src/main/formats/Akao/AkaoSeq.h
+++ b/src/main/formats/Akao/AkaoSeq.h
@@ -13,6 +13,7 @@
 
 #include <array>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -160,7 +161,7 @@ class AkaoSeq final :
   [[nodiscard]] double getTempoInBPM(u16 tempo) const;
   [[nodiscard]] bool usesIndividualArts() const noexcept { return bUsesIndividualArts; }
 
-  [[nodiscard]] AkaoInstrSet* newInstrSet() const;
+  [[nodiscard]] std::unique_ptr<AkaoInstrSet> newInstrSet() const;
 
   [[nodiscard]] static bool isPossibleAkaoSeq(const RawFile *file, u32 offset);
   [[nodiscard]] static AkaoPs1Version guessVersion(const RawFile *file, u32 offset);

--- a/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
@@ -89,7 +89,7 @@ bool AkaoSnesInstrSet::parseInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    emplaceInstr<AkaoSnesInstr>(
+    addInstr<AkaoSnesInstr>(
       this, version, srcn, spcDirAddr, addrTuningTable, addrADSRTable,
       fmt::format("Instrument: {:#x}", srcn));
   }
@@ -99,7 +99,7 @@ bool AkaoSnesInstrSet::parseInstrPointers() {
 
   if (addrDrumKitTable) {
     // One percussion instrument covers all percussion sounds
-    emplaceInstr<AkaoSnesDrumKit>(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrTuningTable,
+    addInstr<AkaoSnesDrumKit>(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrTuningTable,
                                   addrADSRTable, addrDrumKitTable, "Drum Kit");
   }
 
@@ -144,7 +144,7 @@ bool AkaoSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  AkaoSnesRgn *rgn = emplaceRgn<AkaoSnesRgn>(this, version, addrTuningTable);
+  AkaoSnesRgn *rgn = addRgn<AkaoSnesRgn>(this, version, addrTuningTable);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   rgn->initializeRegion(instrNum, spcDirAddr, addrADSRTable);
   rgn->loadRgn();
@@ -219,7 +219,7 @@ bool AkaoSnesDrumKit::loadInstr() {
 
     rgn->sampOffset = addrSampStart - spcDirAddr;
 
-    addRgn(std::move(rgn));
+    adoptRgn(std::move(rgn));
   }
 
   setGuessedLength();

--- a/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
@@ -219,7 +219,7 @@ bool AkaoSnesDrumKit::loadInstr() {
 
     rgn->sampOffset = addrSampStart - spcDirAddr;
 
-    adoptRgn(std::move(rgn));
+    sinkRgn(std::move(rgn));
   }
 
   setGuessedLength();

--- a/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesInstr.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 
 #include <spdlog/fmt/fmt.h>
 
@@ -88,25 +89,22 @@ bool AkaoSnesInstrSet::parseInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    AkaoSnesInstr *newInstr = new AkaoSnesInstr(
+    emplaceInstr<AkaoSnesInstr>(
       this, version, srcn, spcDirAddr, addrTuningTable, addrADSRTable,
       fmt::format("Instrument: {:#x}", srcn));
-    aInstrs.push_back(newInstr);
   }
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   if (addrDrumKitTable) {
     // One percussion instrument covers all percussion sounds
-    AkaoSnesDrumKit *newDrumKitInstr = new AkaoSnesDrumKit(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrTuningTable, addrADSRTable, addrDrumKitTable, "Drum Kit");
-    aInstrs.push_back(newDrumKitInstr);
+    emplaceInstr<AkaoSnesDrumKit>(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrTuningTable,
+                                  addrADSRTable, addrDrumKitTable, "Drum Kit");
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(AkaoSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(AkaoSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -146,11 +144,10 @@ bool AkaoSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  AkaoSnesRgn *rgn = new AkaoSnesRgn(this, version, addrTuningTable);
+  AkaoSnesRgn *rgn = emplaceRgn<AkaoSnesRgn>(this, version, addrTuningTable);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   rgn->initializeRegion(instrNum, spcDirAddr, addrADSRTable);
   rgn->loadRgn();
-  addRgn(rgn);
 
   setGuessedLength();
   return true;
@@ -204,20 +201,17 @@ bool AkaoSnesDrumKit::loadInstr() {
 
   // A new region for every instrument
   for (u8 i = 0; i < NOTE_DUR_TABLE_SIZE; ++i) {
-    AkaoSnesDrumKitRgn *rgn = new AkaoSnesDrumKitRgn(this, version, addrTuningTable);
+    auto rgn = std::make_unique<AkaoSnesDrumKitRgn>(this, version, addrTuningTable);
 
     if (!rgn->initializePercussionRegion(i, spcDirAddr, addrADSRTable, addrDrumKitTable)) {
-      delete rgn;
       continue;
     }
     if (!rgn->loadRgn()) {
-      delete rgn;
       return false;
     }
 
     u32 rgnOffDirEnt = spcDirAddr + (rgn->sampNum * 4);
     if (rgnOffDirEnt + 4 > 0x10000) {
-      delete rgn;
       return false;
     }
 
@@ -225,7 +219,7 @@ bool AkaoSnesDrumKit::loadInstr() {
 
     rgn->sampOffset = addrSampStart - spcDirAddr;
 
-    addRgn(rgn);
+    addRgn(std::move(rgn));
   }
 
   setGuessedLength();

--- a/src/main/formats/AkaoSnes/AkaoSnesScanner.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesScanner.cpp
@@ -533,7 +533,7 @@ void AkaoSnesScanner::searchForAkaoSnesFromARAM(RawFile *file) {
   }
 
   // load sequence
-  auto* newSeq = pRoot->emplaceVGMFile<AkaoSnesSeq>(file, version, minorVersion, addrSeqHeader, addrAPURelocBase, name);
+  auto* newSeq = pRoot->loadVGMFile<AkaoSnesSeq>(file, version, minorVersion, addrSeqHeader, addrAPURelocBase, name);
   if (!newSeq) {
     return;
   }
@@ -581,7 +581,7 @@ void AkaoSnesScanner::searchForAkaoSnesFromARAM(RawFile *file) {
   }
 
   auto* newInstrSet =
-      pRoot->emplaceVGMFile<AkaoSnesInstrSet>(file, version, spcDirAddr, addrTuningTable, addrADSRTable, addrPercussionTable);
+      pRoot->loadVGMFile<AkaoSnesInstrSet>(file, version, spcDirAddr, addrTuningTable, addrADSRTable, addrPercussionTable);
   if (!newInstrSet) {
     return;
   }

--- a/src/main/formats/AkaoSnes/AkaoSnesScanner.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesScanner.cpp
@@ -533,9 +533,8 @@ void AkaoSnesScanner::searchForAkaoSnesFromARAM(RawFile *file) {
   }
 
   // load sequence
-  AkaoSnesSeq *newSeq = new AkaoSnesSeq(file, version, minorVersion, addrSeqHeader, addrAPURelocBase, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<AkaoSnesSeq>(file, version, minorVersion, addrSeqHeader, addrAPURelocBase, name);
+  if (!newSeq) {
     return;
   }
 
@@ -581,9 +580,9 @@ void AkaoSnesScanner::searchForAkaoSnesFromARAM(RawFile *file) {
     addrPercussionTable = 0;
   }
 
-  AkaoSnesInstrSet *newInstrSet = new AkaoSnesInstrSet(file, version, spcDirAddr, addrTuningTable, addrADSRTable, addrPercussionTable);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  auto* newInstrSet =
+      pRoot->emplaceVGMFile<AkaoSnesInstrSet>(file, version, spcDirAddr, addrTuningTable, addrADSRTable, addrPercussionTable);
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesSeq.cpp
@@ -125,8 +125,7 @@ bool AkaoSnesSeq::parseTrackPointers(void) {
   for (u8 trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     u16 addrTrackStart = getShortAddress(curOffset);
     if (addrTrackStart != addrSequenceEnd) {
-      AkaoSnesTrack *track = new AkaoSnesTrack(this, addrTrackStart);
-      aTracks.push_back(track);
+      addTrack<AkaoSnesTrack>(this, addrTrackStart);
     }
     curOffset += 2;
   }

--- a/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
+++ b/src/main/formats/AkaoSnes/AkaoSnesTrackLfo.cpp
@@ -26,7 +26,7 @@
  */
 
 void AkaoSnesSeq::syncTempoDependentTracks() {
-  for (auto *track : aTracks) {
+  for (auto *track : tracks()) {
     static_cast<AkaoSnesTrack*>(track)->syncTempoDependentLfos();
   }
 }

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesInstr.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesInstr.cpp
@@ -48,7 +48,7 @@ bool AsciiShuichiSnesInstrSet::parseInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    emplaceInstr<AsciiShuichiSnesInstr>(
+    addInstr<AsciiShuichiSnesInstr>(
       this, instrHeaderAddress, instr >> 7, instr & 0x7f, spcDirAddress, fineTuningTableAddress,
       fmt::format("Instrument {}", instr));
   }
@@ -94,7 +94,7 @@ bool AsciiShuichiSnesInstr::loadInstr() {
   }
   const auto spcFineTuning = static_cast<s8>(readByte(fineTuningTableAddress + srcn));
 
-  const auto rgn = emplaceRgn<AsciiShuichiSnesRgn>(this, offset(), spcFineTuning);
+  const auto rgn = addRgn<AsciiShuichiSnesRgn>(this, offset(), spcFineTuning);
   rgn->sampOffset = sampleStartAddress - spcDirAddress;
 
   return true;

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesInstr.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesInstr.cpp
@@ -48,19 +48,16 @@ bool AsciiShuichiSnesInstrSet::parseInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    const auto newInstr = new AsciiShuichiSnesInstr(
+    emplaceInstr<AsciiShuichiSnesInstr>(
       this, instrHeaderAddress, instr >> 7, instr & 0x7f, spcDirAddress, fineTuningTableAddress,
       fmt::format("Instrument {}", instr));
-    aInstrs.push_back(newInstr);
   }
-  if (aInstrs.empty()) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::ranges::sort(usedSRCNs);
-  auto newSampColl = new SNESSampColl(AsciiShuichiSnesFormat::name, this->rawFile(), spcDirAddress, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(AsciiShuichiSnesFormat::name, rawFile(), spcDirAddress, usedSRCNs)) {
     return false;
   }
 
@@ -97,9 +94,8 @@ bool AsciiShuichiSnesInstr::loadInstr() {
   }
   const auto spcFineTuning = static_cast<s8>(readByte(fineTuningTableAddress + srcn));
 
-  const auto rgn = new AsciiShuichiSnesRgn(this, offset(), spcFineTuning);
+  const auto rgn = emplaceRgn<AsciiShuichiSnesRgn>(this, offset(), spcFineTuning);
   rgn->sampOffset = sampleStartAddress - spcDirAddress;
-  addRgn(rgn);
 
   return true;
 }

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesScanner.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesScanner.cpp
@@ -89,7 +89,7 @@ void AsciiShuichiSnesScanner::scanFromARAM(RawFile *file) {
     return;
   const u16 seqHeaderAddress = file->readShort(ofsLoadSeq + 6);
 
-  const auto newSeq = pRoot->emplaceVGMFile<AsciiShuichiSnesSeq>(file, seqHeaderAddress, name);
+  const auto newSeq = pRoot->loadVGMFile<AsciiShuichiSnesSeq>(file, seqHeaderAddress, name);
   if (!newSeq) {
     return;
   }
@@ -115,7 +115,7 @@ void AsciiShuichiSnesScanner::scanFromARAM(RawFile *file) {
   const auto sampleDirAddress = static_cast<u16>(file->readByte(ofsLoadDIR + 3) << 8);
   L_DEBUG("{}: found sample DIR address {:#04x}", "AsciiShuichiSnesScanner", sampleDirAddress);
 
-  const auto newInstrSet = pRoot->emplaceVGMFile<AsciiShuichiSnesInstrSet>(file, instrTableAddress,
+  const auto newInstrSet = pRoot->loadVGMFile<AsciiShuichiSnesInstrSet>(file, instrTableAddress,
                                                                     instrTuningTableAddress, sampleDirAddress);
   if (!newInstrSet) {
     return;

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesScanner.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesScanner.cpp
@@ -89,9 +89,8 @@ void AsciiShuichiSnesScanner::scanFromARAM(RawFile *file) {
     return;
   const u16 seqHeaderAddress = file->readShort(ofsLoadSeq + 6);
 
-  const auto newSeq = new AsciiShuichiSnesSeq(file, seqHeaderAddress, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  const auto newSeq = pRoot->emplaceVGMFile<AsciiShuichiSnesSeq>(file, seqHeaderAddress, name);
+  if (!newSeq) {
     return;
   }
 
@@ -116,10 +115,9 @@ void AsciiShuichiSnesScanner::scanFromARAM(RawFile *file) {
   const auto sampleDirAddress = static_cast<u16>(file->readByte(ofsLoadDIR + 3) << 8);
   L_DEBUG("{}: found sample DIR address {:#04x}", "AsciiShuichiSnesScanner", sampleDirAddress);
 
-  const auto newInstrSet = new AsciiShuichiSnesInstrSet(file, instrTableAddress,
-                                                        instrTuningTableAddress, sampleDirAddress);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  const auto newInstrSet = pRoot->emplaceVGMFile<AsciiShuichiSnesInstrSet>(file, instrTableAddress,
+                                                                    instrTuningTableAddress, sampleDirAddress);
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
@@ -11,6 +11,7 @@
 #include "SeqEvent.h"
 
 #include <iterator>
+#include <memory>
 
 using namespace std;
 
@@ -75,8 +76,7 @@ bool AsciiShuichiSnesSeq::parseTrackPointers() {
     const u8 hi = readByte(offset() + MAX_TRACKS + trackIndex);
     const auto trackStartAddress = static_cast<u16>(lo | (hi << 8));
 
-    const auto track = new AsciiShuichiSnesTrack(this, trackStartAddress);
-    aTracks.push_back(track);
+    addTrack<AsciiShuichiSnesTrack>(this, trackStartAddress);
   }
 
   return true;
@@ -272,9 +272,11 @@ bool AsciiShuichiSnesTrack::readEvent() {
           makePrevDurNoteEnd(getTime() + actualDur);
 
           // add event without midi event
-          if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(beginOffset, true))
-            addEvent(new DurNoteSeqEvent(this, key + cKeyCorrection, 100, noteDuration, beginOffset,
-                                         curOffset - beginOffset, "Note with Duration"));
+          if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(beginOffset, true)) {
+            addEvent(std::make_unique<DurNoteSeqEvent>(
+                this, key + cKeyCorrection, 100, noteDuration, beginOffset,
+                curOffset - beginOffset, "Note with Duration"));
+          }
         } else {
           if (slurDeferred) {
             makePrevDurNoteEnd(getTime());

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
@@ -273,7 +273,7 @@ bool AsciiShuichiSnesTrack::readEvent() {
 
           // add event without midi event
           if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(beginOffset, true)) {
-            adoptEvent(std::make_unique<DurNoteSeqEvent>(
+            sinkEvent(std::make_unique<DurNoteSeqEvent>(
                 this, key + cKeyCorrection, 100, noteDuration, beginOffset,
                 curOffset - beginOffset, "Note with Duration"));
           }

--- a/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
+++ b/src/main/formats/AsciiShuichiSnes/AsciiShuichiSnesSeq.cpp
@@ -273,7 +273,7 @@ bool AsciiShuichiSnesTrack::readEvent() {
 
           // add event without midi event
           if (readMode == READMODE_ADD_TO_UI && !isItemAtOffset(beginOffset, true)) {
-            addEvent(std::make_unique<DurNoteSeqEvent>(
+            adoptEvent(std::make_unique<DurNoteSeqEvent>(
                 this, key + cKeyCorrection, 100, noteDuration, beginOffset,
                 curOffset - beginOffset, "Note with Duration"));
           }

--- a/src/main/formats/CPS/CPS1Instr.cpp
+++ b/src/main/formats/CPS/CPS1Instr.cpp
@@ -115,7 +115,7 @@ bool CPS1SampColl::parseSampleInfo() {
     rawSample->setBPS(BPS::PCM16);
     rawSample->setLoopStatus(false);
     rawSample->unityKey = 0x3C;
-    adoptSamp(std::move(sample));
+    sinkSamp(std::move(sample));
   }
   return true;
 }

--- a/src/main/formats/CPS/CPS1Instr.cpp
+++ b/src/main/formats/CPS/CPS1Instr.cpp
@@ -6,6 +6,8 @@
 #include "version.h"
 #include "VGMRgn.h"
 
+#include <memory>
+
 #include <spdlog/fmt/fmt.h>
 
 // ******************
@@ -29,12 +31,10 @@ bool CPS1SampleInstrSet::parseInstrPointers() {
     case CPS1_V502:
       for (int i = 1; i < 128; ++i) {
         std::string name = fmt::format("Instrument {:03d}", i);
-        VGMInstr* instr = new VGMInstr(this, 0, 0, 0, i, name, 0);
-        VGMRgn* rgn = new VGMRgn(instr, 0);
+        VGMInstr* instr = emplaceInstr<VGMInstr>(this, 0, 0, 0, i, name, 0);
+        VGMRgn* rgn = instr->emplaceRgn<VGMRgn>(instr, 0);
         rgn->sampNum = i - 1;
         rgn->release_time = 10;
-        instr->addRgn(rgn);
-        aInstrs.push_back(instr);
       }
       break;
 
@@ -45,15 +45,13 @@ bool CPS1SampleInstrSet::parseInstrPointers() {
           break;
         }
         std::string name = fmt::format("Instrument {}", i);
-        VGMInstr* instr = new VGMInstr(this, instrOff, 4, 0, i, name, 0);
-        VGMRgn* rgn = new VGMRgn(instr, instrOff);
+        VGMInstr* instr = emplaceInstr<VGMInstr>(this, instrOff, 4, 0, i, name, 0);
+        VGMRgn* rgn = instr->emplaceRgn<VGMRgn>(instr, instrOff);
         instr->setLength(4);
         rgn->setLength(4);
         // subtract 1 to account for the first OKIM6295 sample ptr always being null
         rgn->sampNum = readByte(instrOff+1) - 1;
         rgn->release_time = 10;
-        instr->addRgn(rgn);
-        aInstrs.push_back(instr);
       }
       break;
     case CPS1_VERSION_UNDEFINED:
@@ -101,21 +99,23 @@ bool CPS1SampColl::parseSampleInfo() {
   for (int offset = 8; offset < 0x400; offset += 8) {
     auto sampAddr = readShort(offset);
 
-    VGMSamp* sample;
+    std::unique_ptr<VGMSamp> sample;
     if (sampAddr == 0xFFFF || sampAddr == 0) {
       auto name = fmt::format("Empty Sample {:03d}", i);
-      sample = new EmptySamp(this);
+      sample = std::make_unique<EmptySamp>(this);
     } else {
       auto name = fmt::format("Sample {:03d}", i);
       auto begin = readWordBE(offset) >> 8;
       auto end = readWordBE(offset+PTR_SIZE) >> 8;
-      sample = new DialogicAdpcmSamp(this, begin, end > begin ? end-begin : 0, CPS1_OKIMSM6295_SAMPLE_RATE, CPS1_OKI_GAIN, name);
+      sample = std::make_unique<DialogicAdpcmSamp>(this, begin, end > begin ? end-begin : 0,
+                                                   CPS1_OKIMSM6295_SAMPLE_RATE, CPS1_OKI_GAIN, name);
     }
     i += 1;
-    sample->setBPS(BPS::PCM16);
-    sample->setLoopStatus(false);
-    sample->unityKey = 0x3C;
-    samples.push_back(sample);
+    auto* rawSample = sample.get();
+    rawSample->setBPS(BPS::PCM16);
+    rawSample->setLoopStatus(false);
+    rawSample->unityKey = 0x3C;
+    addSamp(std::move(sample));
   }
   return true;
 }
@@ -168,8 +168,7 @@ bool CPS1OPMInstrSet::parseInstrPointers() {
       case CPS1_V200: {
         CPS1OPMInstrDataV2_00 instrData{};
         readBytes(instrOff, static_cast<u32>(instrSize), &instrData);
-        auto instr = new CPS1OPMInstr<CPS1OPMInstrDataV2_00>(this, masterVol, instrOff, instrSize, 0, i, name);
-        aInstrs.push_back(instr);
+        emplaceInstr<CPS1OPMInstr<CPS1OPMInstrDataV2_00>>(this, masterVol, instrOff, instrSize, 0, i, name);
         addOPMInstrument(instrData.convertToOPMData(masterVol, name));
         break;
       }
@@ -177,8 +176,7 @@ bool CPS1OPMInstrSet::parseInstrPointers() {
       case CPS1_V502: {
         CPS1OPMInstrDataV5_02 instrData{};
         readBytes(instrOff, static_cast<u32>(instrSize), &instrData);
-        auto instr = new CPS1OPMInstr<CPS1OPMInstrDataV5_02>(this, masterVol, instrOff, instrSize, 0, i, name);
-        aInstrs.push_back(instr);
+        emplaceInstr<CPS1OPMInstr<CPS1OPMInstrDataV5_02>>(this, masterVol, instrOff, instrSize, 0, i, name);
         addOPMInstrument(instrData.convertToOPMData(masterVol, name));
         break;
       }
@@ -187,8 +185,8 @@ bool CPS1OPMInstrSet::parseInstrPointers() {
       case CPS1_V425: {
         CPS1OPMInstrDataV4_25 instrData{};
         readBytes(instrOff, static_cast<u32>(instrSize), &instrData);
-        auto instr = new CPS1OPMInstr<CPS1OPMInstrDataV4_25>(this, masterVol, instrOff, instrSize, 0, i, name);
-        aInstrs.push_back(instr);
+        auto* instr = emplaceInstr<CPS1OPMInstr<CPS1OPMInstrDataV4_25>>(
+            this, masterVol, instrOff, instrSize, 0, i, name);
         std::vector<u8> driverData;
         u8 enableLfo = instrData.LFO_ENABLE_AND_WF >> 7;
         u8 resetLfo = (instrData.LFO_ENABLE_AND_WF >> 1) & 1;
@@ -200,20 +198,20 @@ bool CPS1OPMInstrSet::parseInstrPointers() {
         }
 
         addOPMInstrument(instrData.convertToOPMData(masterVol, name), "cps", std::move(driverData));
-        instr->addChild(new VGMItem(this, instrOff, 1, "Transpose"));
-        instr->addChild(new VGMItem(this, instrOff+1, 1, "LFO_ENABLE_AND_WF"));
-        instr->addChild(new VGMItem(this, instrOff+2, 1, "LFRQ"));
-        instr->addChild(new VGMItem(this, instrOff+3, 1, "PMD"));
-        instr->addChild(new VGMItem(this, instrOff+4, 1, "AMD"));
-        instr->addChild(new VGMItem(this, instrOff+5, 1, "FL_CON"));
-        instr->addChild(new VGMItem(this, instrOff+6, 1, "PMS_AMS"));
-        instr->addChild(new VGMItem(this, instrOff+7, 1, "SLOT_MASK"));
-        instr->addChild(new VGMItem(this, instrOff+8, 12, "Driver-specific Volume Params"));
-        instr->addChild(new VGMItem(this, instrOff+20, 4, "DT1_MUL"));
-        instr->addChild(new VGMItem(this, instrOff+24, 4, "KS_AR"));
-        instr->addChild(new VGMItem(this, instrOff+28, 4, "AMSEN_D1R"));
-        instr->addChild(new VGMItem(this, instrOff+32, 4, "DT2_D2R"));
-        instr->addChild(new VGMItem(this, instrOff+36, 4, "D1L_RR"));
+        instr->emplaceChild<VGMItem>(this, instrOff, 1, "Transpose");
+        instr->emplaceChild<VGMItem>(this, instrOff+1, 1, "LFO_ENABLE_AND_WF");
+        instr->emplaceChild<VGMItem>(this, instrOff+2, 1, "LFRQ");
+        instr->emplaceChild<VGMItem>(this, instrOff+3, 1, "PMD");
+        instr->emplaceChild<VGMItem>(this, instrOff+4, 1, "AMD");
+        instr->emplaceChild<VGMItem>(this, instrOff+5, 1, "FL_CON");
+        instr->emplaceChild<VGMItem>(this, instrOff+6, 1, "PMS_AMS");
+        instr->emplaceChild<VGMItem>(this, instrOff+7, 1, "SLOT_MASK");
+        instr->emplaceChild<VGMItem>(this, instrOff+8, 12, "Driver-specific Volume Params");
+        instr->emplaceChild<VGMItem>(this, instrOff+20, 4, "DT1_MUL");
+        instr->emplaceChild<VGMItem>(this, instrOff+24, 4, "KS_AR");
+        instr->emplaceChild<VGMItem>(this, instrOff+28, 4, "AMSEN_D1R");
+        instr->emplaceChild<VGMItem>(this, instrOff+32, 4, "DT2_D2R");
+        instr->emplaceChild<VGMItem>(this, instrOff+36, 4, "D1L_RR");
         break;
       }
       case CPS1_VERSION_UNDEFINED:

--- a/src/main/formats/CPS/CPS1Instr.cpp
+++ b/src/main/formats/CPS/CPS1Instr.cpp
@@ -31,8 +31,8 @@ bool CPS1SampleInstrSet::parseInstrPointers() {
     case CPS1_V502:
       for (int i = 1; i < 128; ++i) {
         std::string name = fmt::format("Instrument {:03d}", i);
-        VGMInstr* instr = emplaceInstr<VGMInstr>(this, 0, 0, 0, i, name, 0);
-        VGMRgn* rgn = instr->emplaceRgn<VGMRgn>(instr, 0);
+        VGMInstr* instr = addInstr<VGMInstr>(this, 0, 0, 0, i, name, 0);
+        VGMRgn* rgn = instr->addRgn<VGMRgn>(instr, 0);
         rgn->sampNum = i - 1;
         rgn->release_time = 10;
       }
@@ -45,8 +45,8 @@ bool CPS1SampleInstrSet::parseInstrPointers() {
           break;
         }
         std::string name = fmt::format("Instrument {}", i);
-        VGMInstr* instr = emplaceInstr<VGMInstr>(this, instrOff, 4, 0, i, name, 0);
-        VGMRgn* rgn = instr->emplaceRgn<VGMRgn>(instr, instrOff);
+        VGMInstr* instr = addInstr<VGMInstr>(this, instrOff, 4, 0, i, name, 0);
+        VGMRgn* rgn = instr->addRgn<VGMRgn>(instr, instrOff);
         instr->setLength(4);
         rgn->setLength(4);
         // subtract 1 to account for the first OKIM6295 sample ptr always being null
@@ -115,7 +115,7 @@ bool CPS1SampColl::parseSampleInfo() {
     rawSample->setBPS(BPS::PCM16);
     rawSample->setLoopStatus(false);
     rawSample->unityKey = 0x3C;
-    addSamp(std::move(sample));
+    adoptSamp(std::move(sample));
   }
   return true;
 }
@@ -168,7 +168,7 @@ bool CPS1OPMInstrSet::parseInstrPointers() {
       case CPS1_V200: {
         CPS1OPMInstrDataV2_00 instrData{};
         readBytes(instrOff, static_cast<u32>(instrSize), &instrData);
-        emplaceInstr<CPS1OPMInstr<CPS1OPMInstrDataV2_00>>(this, masterVol, instrOff, instrSize, 0, i, name);
+        addInstr<CPS1OPMInstr<CPS1OPMInstrDataV2_00>>(this, masterVol, instrOff, instrSize, 0, i, name);
         addOPMInstrument(instrData.convertToOPMData(masterVol, name));
         break;
       }
@@ -176,7 +176,7 @@ bool CPS1OPMInstrSet::parseInstrPointers() {
       case CPS1_V502: {
         CPS1OPMInstrDataV5_02 instrData{};
         readBytes(instrOff, static_cast<u32>(instrSize), &instrData);
-        emplaceInstr<CPS1OPMInstr<CPS1OPMInstrDataV5_02>>(this, masterVol, instrOff, instrSize, 0, i, name);
+        addInstr<CPS1OPMInstr<CPS1OPMInstrDataV5_02>>(this, masterVol, instrOff, instrSize, 0, i, name);
         addOPMInstrument(instrData.convertToOPMData(masterVol, name));
         break;
       }
@@ -185,7 +185,7 @@ bool CPS1OPMInstrSet::parseInstrPointers() {
       case CPS1_V425: {
         CPS1OPMInstrDataV4_25 instrData{};
         readBytes(instrOff, static_cast<u32>(instrSize), &instrData);
-        auto* instr = emplaceInstr<CPS1OPMInstr<CPS1OPMInstrDataV4_25>>(
+        auto* instr = addInstr<CPS1OPMInstr<CPS1OPMInstrDataV4_25>>(
             this, masterVol, instrOff, instrSize, 0, i, name);
         std::vector<u8> driverData;
         u8 enableLfo = instrData.LFO_ENABLE_AND_WF >> 7;
@@ -198,20 +198,20 @@ bool CPS1OPMInstrSet::parseInstrPointers() {
         }
 
         addOPMInstrument(instrData.convertToOPMData(masterVol, name), "cps", std::move(driverData));
-        instr->emplaceChild<VGMItem>(this, instrOff, 1, "Transpose");
-        instr->emplaceChild<VGMItem>(this, instrOff+1, 1, "LFO_ENABLE_AND_WF");
-        instr->emplaceChild<VGMItem>(this, instrOff+2, 1, "LFRQ");
-        instr->emplaceChild<VGMItem>(this, instrOff+3, 1, "PMD");
-        instr->emplaceChild<VGMItem>(this, instrOff+4, 1, "AMD");
-        instr->emplaceChild<VGMItem>(this, instrOff+5, 1, "FL_CON");
-        instr->emplaceChild<VGMItem>(this, instrOff+6, 1, "PMS_AMS");
-        instr->emplaceChild<VGMItem>(this, instrOff+7, 1, "SLOT_MASK");
-        instr->emplaceChild<VGMItem>(this, instrOff+8, 12, "Driver-specific Volume Params");
-        instr->emplaceChild<VGMItem>(this, instrOff+20, 4, "DT1_MUL");
-        instr->emplaceChild<VGMItem>(this, instrOff+24, 4, "KS_AR");
-        instr->emplaceChild<VGMItem>(this, instrOff+28, 4, "AMSEN_D1R");
-        instr->emplaceChild<VGMItem>(this, instrOff+32, 4, "DT2_D2R");
-        instr->emplaceChild<VGMItem>(this, instrOff+36, 4, "D1L_RR");
+        instr->addChild<VGMItem>(this, instrOff, 1, "Transpose");
+        instr->addChild<VGMItem>(this, instrOff+1, 1, "LFO_ENABLE_AND_WF");
+        instr->addChild<VGMItem>(this, instrOff+2, 1, "LFRQ");
+        instr->addChild<VGMItem>(this, instrOff+3, 1, "PMD");
+        instr->addChild<VGMItem>(this, instrOff+4, 1, "AMD");
+        instr->addChild<VGMItem>(this, instrOff+5, 1, "FL_CON");
+        instr->addChild<VGMItem>(this, instrOff+6, 1, "PMS_AMS");
+        instr->addChild<VGMItem>(this, instrOff+7, 1, "SLOT_MASK");
+        instr->addChild<VGMItem>(this, instrOff+8, 12, "Driver-specific Volume Params");
+        instr->addChild<VGMItem>(this, instrOff+20, 4, "DT1_MUL");
+        instr->addChild<VGMItem>(this, instrOff+24, 4, "KS_AR");
+        instr->addChild<VGMItem>(this, instrOff+28, 4, "AMSEN_D1R");
+        instr->addChild<VGMItem>(this, instrOff+32, 4, "DT2_D2R");
+        instr->addChild<VGMItem>(this, instrOff+36, 4, "D1L_RR");
         break;
       }
       case CPS1_VERSION_UNDEFINED:

--- a/src/main/formats/CPS/CPS1Scanner.cpp
+++ b/src/main/formats/CPS/CPS1Scanner.cpp
@@ -13,6 +13,7 @@
 #include "VGMColl.h"
 #include "VGMMiscFile.h"
 
+#include <memory>
 #include <string>
 
 class CPS1SampleInstrSet;
@@ -128,45 +129,46 @@ void CPS1Scanner::loadCPS1(MAMEGame *gameentry, CPS1FormatVer fmt_ver) {
   // Load the YM2151 Instrument Set
   auto opmInstrsetName = fmt::format("{} YM2151 instrument set", gameentry->name);
   int opmInstrsetLength;
+  std::unique_ptr<CPS1OPMInstrSet> opmInstrsetOwner;
 
   switch (fmt_ver) {
     case CPS1_V200:
       opmInstrsetLength = 127 * static_cast<u32>(sizeof(CPS1OPMInstrDataV2_00));
-      opmInstrset = new CPS1OPMInstrSet(programFile,
-                                        fmt_ver, masterVol, opm_instr_table_offset,
-                                        opmInstrsetLength,
-                                        opmInstrsetName);
+      opmInstrsetOwner = std::make_unique<CPS1OPMInstrSet>(programFile,
+                                                           fmt_ver, masterVol, opm_instr_table_offset,
+                                                           opmInstrsetLength,
+                                                           opmInstrsetName);
       break;
 
     case CPS1_V500:
     case CPS1_V502:
       opmInstrsetLength = 127 * static_cast<u32>(sizeof(CPS1OPMInstrDataV5_02));
-      opmInstrset = new CPS1OPMInstrSet(programFile,
-                                        fmt_ver, masterVol, opm_instr_table_offset,
-                                        opmInstrsetLength,
-                                        opmInstrsetName);
+      opmInstrsetOwner = std::make_unique<CPS1OPMInstrSet>(programFile,
+                                                           fmt_ver, masterVol, opm_instr_table_offset,
+                                                           opmInstrsetLength,
+                                                           opmInstrsetName);
       break;
 
     case CPS1_V100:
     case CPS1_V350:
       opmInstrsetLength = 127 * static_cast<u32>(sizeof(CPS1OPMInstrDataV4_25));
-      opmInstrset = new CPS1OPMInstrSet(programFile,
-                                      fmt_ver, masterVol, opm_instr_table_offset,
-                                      opmInstrsetLength,
-                                      opmInstrsetName);
+      opmInstrsetOwner = std::make_unique<CPS1OPMInstrSet>(programFile,
+                                                           fmt_ver, masterVol, opm_instr_table_offset,
+                                                           opmInstrsetLength,
+                                                           opmInstrsetName);
       break;
     case CPS1_V425:
       opmInstrsetLength = std::min(127 * static_cast<u32>(sizeof(CPS1OPMInstrDataV4_25)), sample_instr_table_offset);
-      opmInstrset = new CPS1OPMInstrSet(programFile,
-                                        fmt_ver, masterVol, opm_instr_table_offset,
-                                        opmInstrsetLength,
-                                        opmInstrsetName);
+      opmInstrsetOwner = std::make_unique<CPS1OPMInstrSet>(programFile,
+                                                           fmt_ver, masterVol, opm_instr_table_offset,
+                                                           opmInstrsetLength,
+                                                           opmInstrsetName);
       break;
     case CPS1_VERSION_UNDEFINED:
       return;
   }
-  if (!opmInstrset->loadVGMFile()) {
-    delete opmInstrset;
+  opmInstrset = opmInstrsetOwner.get();
+  if (!pRoot->loadVGMFile(std::move(opmInstrsetOwner))) {
     opmInstrset = nullptr;
   }
 
@@ -177,35 +179,32 @@ void CPS1Scanner::loadCPS1(MAMEGame *gameentry, CPS1FormatVer fmt_ver) {
     auto sampleInstrsetName = fmt::format("{} oki msm6295 instrument set", gameentry->name);
     auto sampcoll_name = fmt::format("{} sample collection", gameentry->name);
 
-    sampleInstrset = new CPS1SampleInstrSet(programFile,
-                                fmt_ver, sample_instr_table_offset,
-                                sampleInstrsetName);
-    if (!sampleInstrset->loadVGMFile()) {
-      delete sampleInstrset;
+    auto sampleInstrsetOwner = std::make_unique<CPS1SampleInstrSet>(programFile,
+                                                                    fmt_ver, sample_instr_table_offset,
+                                                                    sampleInstrsetName);
+    sampleInstrset = sampleInstrsetOwner.get();
+    if (!pRoot->loadVGMFile(std::move(sampleInstrsetOwner))) {
       sampleInstrset = nullptr;
     }
 
-    sampcoll = new CPS1SampColl(samplesFile, sampleInstrset, 0, static_cast<u32>(samplesFile->size()), sampcoll_name);
-    if (!sampcoll->loadVGMFile()) {
-      delete sampcoll;
-      sampcoll = nullptr;
-    }
+    sampcoll =
+        pRoot->emplaceVGMFile<CPS1SampColl>(samplesFile, sampleInstrset, 0, static_cast<u32>(samplesFile->size()), sampcoll_name);
   }
 
   std::string seq_table_name = fmt::format("{} sequence pointer table", gameentry->name);
 
   // Add SeqTable as Miscfile
-  VGMMiscFile *seqTable = new VGMMiscFile(CPS1Format::name, seqRomGroupEntry->file, seq_table_offset, seq_table_length, seq_table_name);
-  if (!seqTable->loadVGMFile()) {
-    delete seqTable;
+  auto* seqTable =
+      pRoot->emplaceVGMFile<VGMMiscFile>(CPS1Format::name, seqRomGroupEntry->file, seq_table_offset, seq_table_length, seq_table_name);
+  if (!seqTable) {
     return;
   }
 
   // Create instrument transpose table
   std::vector<s8> instrTransposeTable;
   if (opmInstrset && (fmt_ver == CPS1_V425 || fmt_ver == CPS1_V350 || fmt_ver == CPS1_V100)) {
-    instrTransposeTable.reserve(opmInstrset->aInstrs.size());
-    for (const auto instr : opmInstrset->aInstrs) {
+    instrTransposeTable.reserve(opmInstrset->instrCount());
+    for (const auto instr : opmInstrset->instrs()) {
       if (auto* opmInstr = dynamic_cast<CPS1OPMInstr<CPS1OPMInstrDataV4_25>*>(instr); opmInstr != nullptr) {
         instrTransposeTable.emplace_back(opmInstr->getTranspose());
       }
@@ -224,17 +223,14 @@ void CPS1Scanner::loadCPS1(MAMEGame *gameentry, CPS1FormatVer fmt_ver) {
     seqTable->addChild(seq_table_offset + (seqId * sizeof(u16)), sizeof(u16), "Sequence Pointer");
 
     auto seqName = fmt::format("{} seq {}", gameentry->name, seqId);
-    VGMSeq* newSeq;
-    newSeq = new CPS1Seq(programFile, seqPointer, fmt_ver, seqName, instrTransposeTable);
-
-    if (!newSeq->loadVGMFile()) {
-      delete newSeq;
+    auto* newSeq = pRoot->emplaceVGMFile<CPS1Seq>(programFile, seqPointer, fmt_ver, seqName, instrTransposeTable);
+    if (!newSeq) {
       continue;
     }
 
     if (opmInstrset) {
       auto collName = fmt::format("{} song {}", gameentry->name, seqId);
-      VGMColl* coll = new VGMColl(collName);
+      auto coll = std::make_unique<VGMColl>(collName);
 
       coll->useSeq(newSeq);
       coll->addInstrSet(opmInstrset);
@@ -242,9 +238,7 @@ void CPS1Scanner::loadCPS1(MAMEGame *gameentry, CPS1FormatVer fmt_ver) {
         coll->addInstrSet(sampleInstrset);
         coll->addSampColl(sampcoll);
       }
-      if (!coll->load()) {
-        delete coll;
-      }
+      pRoot->loadVGMColl(std::move(coll));
     }
   }
 }

--- a/src/main/formats/CPS/CPS1Scanner.cpp
+++ b/src/main/formats/CPS/CPS1Scanner.cpp
@@ -188,14 +188,14 @@ void CPS1Scanner::loadCPS1(MAMEGame *gameentry, CPS1FormatVer fmt_ver) {
     }
 
     sampcoll =
-        pRoot->emplaceVGMFile<CPS1SampColl>(samplesFile, sampleInstrset, 0, static_cast<u32>(samplesFile->size()), sampcoll_name);
+        pRoot->loadVGMFile<CPS1SampColl>(samplesFile, sampleInstrset, 0, static_cast<u32>(samplesFile->size()), sampcoll_name);
   }
 
   std::string seq_table_name = fmt::format("{} sequence pointer table", gameentry->name);
 
   // Add SeqTable as Miscfile
   auto* seqTable =
-      pRoot->emplaceVGMFile<VGMMiscFile>(CPS1Format::name, seqRomGroupEntry->file, seq_table_offset, seq_table_length, seq_table_name);
+      pRoot->loadVGMFile<VGMMiscFile>(CPS1Format::name, seqRomGroupEntry->file, seq_table_offset, seq_table_length, seq_table_name);
   if (!seqTable) {
     return;
   }
@@ -223,7 +223,7 @@ void CPS1Scanner::loadCPS1(MAMEGame *gameentry, CPS1FormatVer fmt_ver) {
     seqTable->addChild(seq_table_offset + (seqId * sizeof(u16)), sizeof(u16), "Sequence Pointer");
 
     auto seqName = fmt::format("{} seq {}", gameentry->name, seqId);
-    auto* newSeq = pRoot->emplaceVGMFile<CPS1Seq>(programFile, seqPointer, fmt_ver, seqName, instrTransposeTable);
+    auto* newSeq = pRoot->loadVGMFile<CPS1Seq>(programFile, seqPointer, fmt_ver, seqName, instrTransposeTable);
     if (!newSeq) {
       continue;
     }
@@ -232,11 +232,11 @@ void CPS1Scanner::loadCPS1(MAMEGame *gameentry, CPS1FormatVer fmt_ver) {
       auto collName = fmt::format("{} song {}", gameentry->name, seqId);
       auto coll = std::make_unique<VGMColl>(collName);
 
-      coll->useSeq(newSeq);
-      coll->addInstrSet(opmInstrset);
+      coll->attachSeq(newSeq);
+      coll->attachInstrSet(opmInstrset);
       if (sampleInstrset && sampcoll) {
-        coll->addInstrSet(sampleInstrset);
-        coll->addSampColl(sampcoll);
+        coll->attachInstrSet(sampleInstrset);
+        coll->attachSampColl(sampcoll);
       }
       pRoot->loadVGMColl(std::move(coll));
     }

--- a/src/main/formats/CPS/CPS1Seq.cpp
+++ b/src/main/formats/CPS/CPS1Seq.cpp
@@ -47,29 +47,27 @@ bool CPS1Seq::parseTrackPointers() {
       continue;
     }
 
-    SeqTrack *newTrack;
     switch (fmtVersion) {
       case CPS1_VERSION_UNDEFINED:
         return false;
       case CPS1_V100:
-        newTrack = new CPS1TrackV1(this, CPSSynth::YM2151, trkOff);
+        addTrack<CPS1TrackV1>(this, CPSSynth::YM2151, trkOff);
         break;
       case CPS1_V200:
       case CPS1_V350:
       case CPS1_V425:
-        newTrack = new CPS1TrackV2(this, i < 8 ? CPSSynth::YM2151 : CPSSynth::OKIM6295, trkOff);
+        addTrack<CPS1TrackV2>(this, i < 8 ? CPSSynth::YM2151 : CPSSynth::OKIM6295, trkOff);
         break;
       case CPS1_V500:
       case CPS1_V502:
-        newTrack = new CPS1TrackV2(this, i < 8 ? CPSSynth::YM2151 : CPSSynth::OKIM6295, trkOff + offset());
+        addTrack<CPS1TrackV2>(this, i < 8 ? CPSSynth::YM2151 : CPSSynth::OKIM6295, trkOff + offset());
         break;
       default:
         return false;
     }
-    aTracks.push_back(newTrack);
     header->addChild(offset() + 1 + (i * 2), 2, "Track Pointer");
   }
-  if (aTracks.size() == 0)
+  if (!hasTracks())
     return false;
 
   return true;

--- a/src/main/formats/CPS/CPS2Instr.cpp
+++ b/src/main/formats/CPS/CPS2Instr.cpp
@@ -35,14 +35,13 @@ bool CPSArticTable::loadMain() {
       continue;
 
     auto name = fmt::format("Articulation {:d}", i);
-    VGMItem *containerItem = new VGMItem(this, off, sizeof(qs_artic_info), name);
+    auto* containerItem = emplaceChild<VGMItem>(this, off, sizeof(qs_artic_info), name);
     containerItem->addChild(off, 1, "Attack Rate");
     containerItem->addChild(off + 1, 1, "Decay Rate");
     containerItem->addChild(off + 2, 1, "Sustain Level");
     containerItem->addChild(off + 3, 1, "Sustain Rate");
     containerItem->addChild(off + 4, 1, "Release Rate");
     containerItem->addChild(off + 5, 3, "Unknown");
-    addChild(containerItem);
   }
   //setLength(off - offset());
   int numArtics = length() / sizeof(qs_artic_info);
@@ -91,13 +90,12 @@ bool CPS2SampleInfoTable::loadMain() {
 
     auto name = fmt::format("Sample Info: {:d}", i);
 
-    VGMItem *containerItem = new VGMItem(this, off, sizeof(qs_samp_info_cps2), name);
+    auto* containerItem = emplaceChild<VGMItem>(this, off, sizeof(qs_samp_info_cps2), name);
     containerItem->addChild(off + 0, 1, "Bank");
     containerItem->addChild(off + 1, 2, "Offset");
     containerItem->addChild(off + 3, 2, "Loop Offset");
     containerItem->addChild(off + 5, 2, "End Offset");
     containerItem->addChild(off + 7, 1, "Unity Key");
-    addChild(containerItem);
   }
   setLength(off - 8 - offset());
   this->numSamples = length() / 8;
@@ -150,12 +148,11 @@ bool CPS3SampleInfoTable::loadMain() {
 
     auto name = fmt::format("Sample Info: {:d}", i);
 
-    VGMItem *containerItem = new VGMItem(this, off, 16, name);
+    auto* containerItem = emplaceChild<VGMItem>(this, off, 16, name);
     containerItem->addChild(off + 0, 4, "Offset");
     containerItem->addChild(off + 4, 4, "Loop Offset");
     containerItem->addChild(off + 8, 4, "End Offset");
     containerItem->addChild(off + 12, 4, "Unity Key");
-    addChild(containerItem);
 
     sample_info& info = infos[i];
     info.start_addr = readWordBE(off + 0);
@@ -203,12 +200,12 @@ bool CPS2InstrSet::parseInstrPointers() {
     for (u32 bank = 0; bank < num_instr_banks; bank++)
       for (u32 i = 0; i < 256; i++) {
         auto name = fmt::format("Instrument: bank {:d}  num {:d}", bank * 256, i);
-        aInstrs.push_back(new CPS2Instr(this,
-                                       offset() + i * 8 + (bank * 256 * 8),
-                                       8,
-                                       (bank * 2) + (i / 128),
-                                       i % 128,
-                                       name));
+        emplaceInstr<CPS2Instr>(this,
+                                offset() + i * 8 + (bank * 256 * 8),
+                                8,
+                                (bank * 2) + (i / 128),
+                                i % 128,
+                                name);
       }
   }
   else {
@@ -237,7 +234,7 @@ bool CPS2InstrSet::parseInstrPointers() {
         u32 bankOff = instr_table_ptrs[bank] - 0x6000000;
 
         auto pointersName = fmt::format("Bank {:d} Instrument Pointers", bank);
-        auto instrPointersItem = new VGMItem(vgmFile(), bankOff, 128*2, pointersName, Type::Header);
+        auto* instrPointersItem = emplaceChild<VGMItem>(vgmFile(), bankOff, 128*2, pointersName, Type::Header);
 
         // For each bank, iterate over all instr ptrs and create instruments
         for (u8 j = 0; j < 128; j++) {
@@ -255,10 +252,8 @@ bool CPS2InstrSet::parseInstrPointers() {
           instrPointersItem->addChild(bankOff + (j*2), 2, pointerStream.str());
 
           auto name = fmt::format("Instrument: {:d}  bank: {:d}", j, bank);
-          aInstrs.push_back(new CPS2Instr(this, instrPtr, instrLength, bank*2, j, name));
+          emplaceInstr<CPS2Instr>(this, instrPtr, instrLength, bank*2, j, name);
         }
-        addChild(instrPointersItem);
-
         continue;
       }
 
@@ -275,7 +270,7 @@ bool CPS2InstrSet::parseInstrPointers() {
           break;
 
         auto name = fmt::format("Instrument {:d}", k);
-        aInstrs.push_back(new CPS2Instr(this, j, instr_info_length, (i * 2) + (k / 128), (k % 128), name));
+        emplaceInstr<CPS2Instr>(this, j, instr_info_length, (i * 2) + (k / 128), (k % 128), name);
       }
     }
   }
@@ -309,7 +304,7 @@ bool CPS2Instr::loadInstr() {
   std::vector<CPSRgnInfo> rgns;
   const CPS2FormatVer formatVer = formatVersion();
   if (formatVer < CPS2_V103) {
-    VGMRgn* rgn = new VGMRgn(this, offset(), length());
+    VGMRgn* rgn = emplaceRgn<VGMRgn>(this, offset(), length());
     rgn->addChild(this->offset(),     1, "Sample Info Index");
     rgn->addChild(this->offset() + 1, 1, "Unknown / Ignored");
     rgn->addChild(this->offset() + 2, 1, "Attack Rate");
@@ -330,7 +325,7 @@ bool CPS2Instr::loadInstr() {
                     progInfo.release_rate});
   }
   else if (formatVer < CPS2_V130 || formatVer == CPS2_V200 || formatVer == CPS2_V201B) {
-    VGMRgn* rgn = new VGMRgn(this, offset(), length());
+    VGMRgn* rgn = emplaceRgn<VGMRgn>(this, offset(), length());
     qs_prog_info_ver_103 progInfo;
     readBytes(offset(), sizeof(qs_prog_info_ver_103), &progInfo);
 
@@ -356,7 +351,7 @@ bool CPS2Instr::loadInstr() {
       if (length() != 0 && off >= offset() + length())
         break;
 
-      VGMRgn* rgn = new VGMRgn(this, off, 12);
+      VGMRgn* rgn = emplaceRgn<VGMRgn>(this, off, 12);
 
       qs_prog_info_ver_cps3 progInfo;
       readBytes(off, sizeof(qs_prog_info_ver_cps3), &progInfo);
@@ -397,7 +392,7 @@ bool CPS2Instr::loadInstr() {
     setLength(off - offset());
   }
   else {
-    VGMRgn* rgn = new VGMRgn(this, offset(), length(), "Region");
+    VGMRgn* rgn = emplaceRgn<VGMRgn>(this, offset(), length(), "Region");
     qs_prog_info_ver_130 progInfo;
     readBytes(offset(), sizeof(qs_prog_info_ver_130), &progInfo);
 
@@ -482,7 +477,6 @@ bool CPS2Instr::loadInstr() {
       rgn->sampNum = 0;
 
     rgn->setUnityKey(instrSet->sampInfoTable->infos[rgn->sampNum].unity_key);
-    addRgn(rgn);
   }
   return true;
 }

--- a/src/main/formats/CPS/CPS2Instr.cpp
+++ b/src/main/formats/CPS/CPS2Instr.cpp
@@ -35,7 +35,7 @@ bool CPSArticTable::loadMain() {
       continue;
 
     auto name = fmt::format("Articulation {:d}", i);
-    auto* containerItem = emplaceChild<VGMItem>(this, off, sizeof(qs_artic_info), name);
+    auto* containerItem = addChild<VGMItem>(this, off, sizeof(qs_artic_info), name);
     containerItem->addChild(off, 1, "Attack Rate");
     containerItem->addChild(off + 1, 1, "Decay Rate");
     containerItem->addChild(off + 2, 1, "Sustain Level");
@@ -90,7 +90,7 @@ bool CPS2SampleInfoTable::loadMain() {
 
     auto name = fmt::format("Sample Info: {:d}", i);
 
-    auto* containerItem = emplaceChild<VGMItem>(this, off, sizeof(qs_samp_info_cps2), name);
+    auto* containerItem = addChild<VGMItem>(this, off, sizeof(qs_samp_info_cps2), name);
     containerItem->addChild(off + 0, 1, "Bank");
     containerItem->addChild(off + 1, 2, "Offset");
     containerItem->addChild(off + 3, 2, "Loop Offset");
@@ -148,7 +148,7 @@ bool CPS3SampleInfoTable::loadMain() {
 
     auto name = fmt::format("Sample Info: {:d}", i);
 
-    auto* containerItem = emplaceChild<VGMItem>(this, off, 16, name);
+    auto* containerItem = addChild<VGMItem>(this, off, 16, name);
     containerItem->addChild(off + 0, 4, "Offset");
     containerItem->addChild(off + 4, 4, "Loop Offset");
     containerItem->addChild(off + 8, 4, "End Offset");
@@ -200,7 +200,7 @@ bool CPS2InstrSet::parseInstrPointers() {
     for (u32 bank = 0; bank < num_instr_banks; bank++)
       for (u32 i = 0; i < 256; i++) {
         auto name = fmt::format("Instrument: bank {:d}  num {:d}", bank * 256, i);
-        emplaceInstr<CPS2Instr>(this,
+        addInstr<CPS2Instr>(this,
                                 offset() + i * 8 + (bank * 256 * 8),
                                 8,
                                 (bank * 2) + (i / 128),
@@ -234,7 +234,7 @@ bool CPS2InstrSet::parseInstrPointers() {
         u32 bankOff = instr_table_ptrs[bank] - 0x6000000;
 
         auto pointersName = fmt::format("Bank {:d} Instrument Pointers", bank);
-        auto* instrPointersItem = emplaceChild<VGMItem>(vgmFile(), bankOff, 128*2, pointersName, Type::Header);
+        auto* instrPointersItem = addChild<VGMItem>(vgmFile(), bankOff, 128*2, pointersName, Type::Header);
 
         // For each bank, iterate over all instr ptrs and create instruments
         for (u8 j = 0; j < 128; j++) {
@@ -252,7 +252,7 @@ bool CPS2InstrSet::parseInstrPointers() {
           instrPointersItem->addChild(bankOff + (j*2), 2, pointerStream.str());
 
           auto name = fmt::format("Instrument: {:d}  bank: {:d}", j, bank);
-          emplaceInstr<CPS2Instr>(this, instrPtr, instrLength, bank*2, j, name);
+          addInstr<CPS2Instr>(this, instrPtr, instrLength, bank*2, j, name);
         }
         continue;
       }
@@ -270,7 +270,7 @@ bool CPS2InstrSet::parseInstrPointers() {
           break;
 
         auto name = fmt::format("Instrument {:d}", k);
-        emplaceInstr<CPS2Instr>(this, j, instr_info_length, (i * 2) + (k / 128), (k % 128), name);
+        addInstr<CPS2Instr>(this, j, instr_info_length, (i * 2) + (k / 128), (k % 128), name);
       }
     }
   }
@@ -304,7 +304,7 @@ bool CPS2Instr::loadInstr() {
   std::vector<CPSRgnInfo> rgns;
   const CPS2FormatVer formatVer = formatVersion();
   if (formatVer < CPS2_V103) {
-    VGMRgn* rgn = emplaceRgn<VGMRgn>(this, offset(), length());
+    VGMRgn* rgn = addRgn<VGMRgn>(this, offset(), length());
     rgn->addChild(this->offset(),     1, "Sample Info Index");
     rgn->addChild(this->offset() + 1, 1, "Unknown / Ignored");
     rgn->addChild(this->offset() + 2, 1, "Attack Rate");
@@ -325,7 +325,7 @@ bool CPS2Instr::loadInstr() {
                     progInfo.release_rate});
   }
   else if (formatVer < CPS2_V130 || formatVer == CPS2_V200 || formatVer == CPS2_V201B) {
-    VGMRgn* rgn = emplaceRgn<VGMRgn>(this, offset(), length());
+    VGMRgn* rgn = addRgn<VGMRgn>(this, offset(), length());
     qs_prog_info_ver_103 progInfo;
     readBytes(offset(), sizeof(qs_prog_info_ver_103), &progInfo);
 
@@ -351,7 +351,7 @@ bool CPS2Instr::loadInstr() {
       if (length() != 0 && off >= offset() + length())
         break;
 
-      VGMRgn* rgn = emplaceRgn<VGMRgn>(this, off, 12);
+      VGMRgn* rgn = addRgn<VGMRgn>(this, off, 12);
 
       qs_prog_info_ver_cps3 progInfo;
       readBytes(off, sizeof(qs_prog_info_ver_cps3), &progInfo);
@@ -392,7 +392,7 @@ bool CPS2Instr::loadInstr() {
     setLength(off - offset());
   }
   else {
-    VGMRgn* rgn = emplaceRgn<VGMRgn>(this, offset(), length(), "Region");
+    VGMRgn* rgn = addRgn<VGMRgn>(this, offset(), length(), "Region");
     qs_prog_info_ver_130 progInfo;
     readBytes(offset(), sizeof(qs_prog_info_ver_130), &progInfo);
 

--- a/src/main/formats/CPS/CPS2Scanner.cpp
+++ b/src/main/formats/CPS/CPS2Scanner.cpp
@@ -133,26 +133,26 @@ void CPS2Scanner::scan(RawFile* /*file*/, void* info) {
   RawFile *samplesFile = sampsRomGroupEntry->file;
 
   if (fmt_ver == CPS3) {
-    sampInfoTable = pRoot->emplaceVGMFile<CPS3SampleInfoTable>(programFile, samp_info_table_name, samp_table_offset, samp_table_length);
+    sampInfoTable = pRoot->loadVGMFile<CPS3SampleInfoTable>(programFile, samp_info_table_name, samp_table_offset, samp_table_length);
   }
   else {
-    sampInfoTable = pRoot->emplaceVGMFile<CPS2SampleInfoTable>(programFile, samp_info_table_name, samp_table_offset, samp_table_length);
+    sampInfoTable = pRoot->loadVGMFile<CPS2SampleInfoTable>(programFile, samp_info_table_name, samp_table_offset, samp_table_length);
   }
   if (!sampInfoTable) {
     return;
   }
   if (artic_table_offset) {
-    articTable = pRoot->emplaceVGMFile<CPSArticTable>(programFile, artic_table_name, artic_table_offset, artic_table_length);
+    articTable = pRoot->loadVGMFile<CPSArticTable>(programFile, artic_table_name, artic_table_offset, artic_table_length);
   }
 
-  instrset = pRoot->emplaceVGMFile<CPS2InstrSet>(programFile,
+  instrset = pRoot->loadVGMFile<CPS2InstrSet>(programFile,
                                           fmt_ver,
                                           instr_table_offset,
                                           num_instr_banks,
                                           sampInfoTable,
                                           articTable,
                                           instrset_name);
-  sampcoll = pRoot->emplaceVGMFile<CPS2SampColl>(samplesFile, instrset, sampInfoTable, 0, 0, sampcoll_name);
+  sampcoll = pRoot->loadVGMFile<CPS2SampColl>(samplesFile, instrset, sampInfoTable, 0, 0, sampcoll_name);
 
 
   // LOAD SEQUENCES FROM SEQUENCE TABLE AND CREATE COLLECTIONS
@@ -171,7 +171,7 @@ void CPS2Scanner::scan(RawFile* /*file*/, void* info) {
 
   // Add SeqTable as Miscfile
   auto* seqTable =
-      pRoot->emplaceVGMFile<VGMMiscFile>(CPS2Format::name, seqRomGroupEntry->file, seq_table_offset, seq_table_length, seq_table_name);
+      pRoot->loadVGMFile<VGMMiscFile>(CPS2Format::name, seqRomGroupEntry->file, seq_table_offset, seq_table_length, seq_table_name);
   if (!seqTable) {
     return;
   }
@@ -195,18 +195,18 @@ void CPS2Scanner::scan(RawFile* /*file*/, void* info) {
 
     std::string collName = fmt::format("{} song {}", gameentry->name, k / 4);
     std::string seqName = fmt::format("{} seq {}", gameentry->name, k / 4);
-    auto* newSeq = pRoot->emplaceVGMFile<CPS2Seq>(programFile, seqPointer, fmt_ver, seqName);
+    auto* newSeq = pRoot->loadVGMFile<CPS2Seq>(programFile, seqPointer, fmt_ver, seqName);
     if (!newSeq) {
       continue;
     }
 
     auto coll = std::make_unique<VGMColl>(collName);
-    coll->useSeq(newSeq);
-    coll->addInstrSet(instrset);
-    coll->addSampColl(sampcoll);
-    coll->addMiscFile(sampInfoTable);
+    coll->attachSeq(newSeq);
+    coll->attachInstrSet(instrset);
+    coll->attachSampColl(sampcoll);
+    coll->attachMiscFile(sampInfoTable);
     if (articTable)
-      coll->addMiscFile(articTable);
+      coll->attachMiscFile(articTable);
     pRoot->loadVGMColl(std::move(coll));
   }
 

--- a/src/main/formats/CPS/CPS2Scanner.cpp
+++ b/src/main/formats/CPS/CPS2Scanner.cpp
@@ -13,6 +13,8 @@
 #include "Root.h"
 #include "VGMColl.h"
 
+#include <memory>
+
 CPS2FormatVer cps2VersionEnum(const std::string &versionStr) {
     static const std::unordered_map<std::string, CPS2FormatVer> versionMap = {
         {"CPS2_V1.00", CPS2_V100},
@@ -131,36 +133,26 @@ void CPS2Scanner::scan(RawFile* /*file*/, void* info) {
   RawFile *samplesFile = sampsRomGroupEntry->file;
 
   if (fmt_ver == CPS3) {
-    sampInfoTable = new CPS3SampleInfoTable(programFile, samp_info_table_name, samp_table_offset, samp_table_length);
+    sampInfoTable = pRoot->emplaceVGMFile<CPS3SampleInfoTable>(programFile, samp_info_table_name, samp_table_offset, samp_table_length);
   }
   else {
-    sampInfoTable = new CPS2SampleInfoTable(programFile, samp_info_table_name, samp_table_offset, samp_table_length);
+    sampInfoTable = pRoot->emplaceVGMFile<CPS2SampleInfoTable>(programFile, samp_info_table_name, samp_table_offset, samp_table_length);
   }
-  sampInfoTable->loadVGMFile();
+  if (!sampInfoTable) {
+    return;
+  }
   if (artic_table_offset) {
-    articTable = new CPSArticTable(programFile, artic_table_name, artic_table_offset, artic_table_length);
-    if (!articTable->loadVGMFile()) {
-      delete articTable;
-      articTable = nullptr;
-    }
+    articTable = pRoot->emplaceVGMFile<CPSArticTable>(programFile, artic_table_name, artic_table_offset, artic_table_length);
   }
 
-  instrset = new CPS2InstrSet(programFile,
-                             fmt_ver,
-                             instr_table_offset,
-                             num_instr_banks,
-                             sampInfoTable,
-                             articTable,
-                             instrset_name);
-  if (!instrset->loadVGMFile()) {
-    delete instrset;
-    instrset = nullptr;
-  }
-  sampcoll = new CPS2SampColl(samplesFile, instrset, sampInfoTable, 0, 0, sampcoll_name);
-  if (!sampcoll->loadVGMFile()) {
-    delete sampcoll;
-    sampcoll = nullptr;
-  }
+  instrset = pRoot->emplaceVGMFile<CPS2InstrSet>(programFile,
+                                          fmt_ver,
+                                          instr_table_offset,
+                                          num_instr_banks,
+                                          sampInfoTable,
+                                          articTable,
+                                          instrset_name);
+  sampcoll = pRoot->emplaceVGMFile<CPS2SampColl>(samplesFile, instrset, sampInfoTable, 0, 0, sampcoll_name);
 
 
   // LOAD SEQUENCES FROM SEQUENCE TABLE AND CREATE COLLECTIONS
@@ -178,9 +170,9 @@ void CPS2Scanner::scan(RawFile* /*file*/, void* info) {
   }
 
   // Add SeqTable as Miscfile
-  VGMMiscFile *seqTable = new VGMMiscFile(CPS2Format::name, seqRomGroupEntry->file, seq_table_offset, seq_table_length, seq_table_name);
-  if (!seqTable->loadVGMFile()) {
-    delete seqTable;
+  auto* seqTable =
+      pRoot->emplaceVGMFile<VGMMiscFile>(CPS2Format::name, seqRomGroupEntry->file, seq_table_offset, seq_table_length, seq_table_name);
+  if (!seqTable) {
     return;
   }
 
@@ -202,23 +194,20 @@ void CPS2Scanner::scan(RawFile* /*file*/, void* info) {
     seqTable->addChild(seq_table_offset + k, 4, "Sequence Pointer");
 
     std::string collName = fmt::format("{} song {}", gameentry->name, k / 4);
-    VGMColl *coll = new VGMColl(collName);
     std::string seqName = fmt::format("{} seq {}", gameentry->name, k / 4);
-    CPS2Seq *newSeq = new CPS2Seq(programFile, seqPointer, fmt_ver, seqName);
-    if (newSeq->loadVGMFile()) {
-      coll->useSeq(newSeq);
-      coll->addInstrSet(instrset);
-      coll->addSampColl(sampcoll);
-      coll->addMiscFile(sampInfoTable);
-      if (articTable)
-        coll->addMiscFile(articTable);
-      if (!coll->load()) {
-        delete coll;
-      }
-    } else {
-      delete newSeq;
-      delete coll;
+    auto* newSeq = pRoot->emplaceVGMFile<CPS2Seq>(programFile, seqPointer, fmt_ver, seqName);
+    if (!newSeq) {
+      continue;
     }
+
+    auto coll = std::make_unique<VGMColl>(collName);
+    coll->useSeq(newSeq);
+    coll->addInstrSet(instrset);
+    coll->addSampColl(sampcoll);
+    coll->addMiscFile(sampInfoTable);
+    if (articTable)
+      coll->addMiscFile(articTable);
+    pRoot->loadVGMColl(std::move(coll));
   }
 
   return;

--- a/src/main/formats/CPS/CPS2Seq.cpp
+++ b/src/main/formats/CPS/CPS2Seq.cpp
@@ -59,23 +59,20 @@ bool CPS2Seq::parseTrackPointers() {
     //if (GetShortBE(offset+offset()) == 0xE017)	//Rest, EndTrack (used by empty tracks)
     //	continue;
 
-    SeqTrack *newTrack;
-
     switch (fmt_version) {
       case CPS2_V200:
       case CPS2_V201B:
       case CPS2_V210:
       case CPS2_V211:
       case CPS3:
-        newTrack = new CPS2TrackV2(this, trkOff + offset());
+        addTrack<CPS2TrackV2>(this, trkOff + offset());
         break;
       default:
-        newTrack = new CPS2TrackV1(this, trkOff + offset());
+        addTrack<CPS2TrackV1>(this, trkOff + offset());
     }
-    aTracks.push_back(newTrack);
     header->addChild(offset() + 1 + (i * 2), 2, "Track Pointer");
   }
-  if (aTracks.size() == 0)
+  if (!hasTracks())
     return false;
 
   return true;
@@ -95,11 +92,12 @@ bool CPS2Seq::postLoad() {
   //  ticks in our sequence into absolute elapsed time, which means we also need to keep
   //  track of any tempo events that change the absolute time per tick.
   std::vector<MidiEvent *> tempoEvents;
-  std::vector<MidiTrack *> &miditracks = midi->aTracks;
+  const auto &miditracks = midi->tracks();
 
   // First get all tempo events, we assume they occur on track 1
-  for (unsigned int i = 0; i < miditracks[0]->aEvents.size(); i++) {
-    MidiEvent *event = miditracks[0]->aEvents[i];
+  const auto& firstTrackEvents = miditracks[0]->events();
+  for (unsigned int i = 0; i < firstTrackEvents.size(); i++) {
+    MidiEvent *event = firstTrackEvents[i];
     if (event->eventType() == MIDIEVENT_TEMPO)
       tempoEvents.push_back(event);
   }
@@ -108,10 +106,11 @@ bool CPS2Seq::postLoad() {
   for (unsigned int i = 0; i < miditracks.size(); i++) {
     std::vector<MidiEvent *> events(tempoEvents);
     MidiTrack *track = miditracks[i];
-    int channel = this->aTracks[i]->channel;
+    int channel = this->track(i)->channel;
 
-    for (unsigned int j = 0; j < track->aEvents.size(); j++) {
-      MidiEvent *event = miditracks[i]->aEvents[j];
+    const auto& trackEvents = track->events();
+    for (unsigned int j = 0; j < trackEvents.size(); j++) {
+      MidiEvent *event = trackEvents[j];
       MidiEventType type = event->eventType();
       if (type == MIDIEVENT_MARKER || type == MIDIEVENT_PITCHBEND || type == MIDIEVENT_ENDOFTRACK)
         events.push_back(event);

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -62,7 +62,7 @@ bool CapcomSnesInstrSet::parseInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    emplaceInstr<CapcomSnesInstr>(
+    addInstr<CapcomSnesInstr>(
       this, addrInstrHeader, instr >> 7, instr & 0x7f, spcDirAddr,
       fmt::format("Instrument {}", instr));
   }
@@ -110,7 +110,7 @@ bool CapcomSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  CapcomSnesRgn *rgn = emplaceRgn<CapcomSnesRgn>(this, offset());
+  CapcomSnesRgn *rgn = addRgn<CapcomSnesRgn>(this, offset());
   rgn->sampOffset = addrSampStart - spcDirAddr;
 
   return true;

--- a/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesInstr.cpp
@@ -62,19 +62,16 @@ bool CapcomSnesInstrSet::parseInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    CapcomSnesInstr *newInstr = new CapcomSnesInstr(
+    emplaceInstr<CapcomSnesInstr>(
       this, addrInstrHeader, instr >> 7, instr & 0x7f, spcDirAddr,
       fmt::format("Instrument {}", instr));
-    aInstrs.push_back(newInstr);
   }
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(CapcomSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(CapcomSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -113,9 +110,8 @@ bool CapcomSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  CapcomSnesRgn *rgn = new CapcomSnesRgn(this, offset());
+  CapcomSnesRgn *rgn = emplaceRgn<CapcomSnesRgn>(this, offset());
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   return true;
 }

--- a/src/main/formats/CapcomSnes/CapcomSnesScanner.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesScanner.cpp
@@ -161,7 +161,7 @@ void CapcomSnesScanner::searchForCapcomSnesFromARAM(RawFile *file) const {
 
   // load a sequence from BGM region
   if (bgmAtFixedAddress) {
-    auto* newSeq = pRoot->emplaceVGMFile<CapcomSnesSeq>(file, version, addrBGMHeader + 1, false, name);
+    auto* newSeq = pRoot->loadVGMFile<CapcomSnesSeq>(file, version, addrBGMHeader + 1, false, name);
     if (!newSeq) {
       return;
     }
@@ -180,7 +180,7 @@ void CapcomSnesScanner::searchForCapcomSnesFromARAM(RawFile *file) const {
       // load current song if possible
       if (guessedSongIndex != -1) {
         u16 addrSongHeader = file->readShortBE(addrSongList + guessedSongIndex * 2);
-        auto* newSeq = pRoot->emplaceVGMFile<CapcomSnesSeq>(file, version, addrSongHeader, true, name);
+        auto* newSeq = pRoot->loadVGMFile<CapcomSnesSeq>(file, version, addrSongHeader, true, name);
         if (!newSeq) {
           return;
         }
@@ -195,7 +195,7 @@ void CapcomSnesScanner::searchForCapcomSnesFromARAM(RawFile *file) const {
           continue;
         }
 
-        auto* newSeq = pRoot->emplaceVGMFile<CapcomSnesSeq>(
+        auto* newSeq = pRoot->loadVGMFile<CapcomSnesSeq>(
             file, version, addrSongHeader, true, (songIndex == guessedSongIndex) ? name : basefilename);
         if (!newSeq) {
           return;
@@ -221,7 +221,7 @@ void CapcomSnesScanner::searchForCapcomSnesFromARAM(RawFile *file) const {
   }
   u8 spcDIR = itSpcDIR->second;
 
-  auto* newInstrSet = pRoot->emplaceVGMFile<CapcomSnesInstrSet>(file, addrInstrTable, spcDIR << 8);
+  auto* newInstrSet = pRoot->loadVGMFile<CapcomSnesInstrSet>(file, addrInstrTable, spcDIR << 8);
   if (!newInstrSet) {
     return;
   }

--- a/src/main/formats/CapcomSnes/CapcomSnesScanner.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesScanner.cpp
@@ -161,9 +161,8 @@ void CapcomSnesScanner::searchForCapcomSnesFromARAM(RawFile *file) const {
 
   // load a sequence from BGM region
   if (bgmAtFixedAddress) {
-    CapcomSnesSeq *newSeq = new CapcomSnesSeq(file, version, addrBGMHeader + 1, false, name);
-    if (!newSeq->loadVGMFile()) {
-      delete newSeq;
+    auto* newSeq = pRoot->emplaceVGMFile<CapcomSnesSeq>(file, version, addrBGMHeader + 1, false, name);
+    if (!newSeq) {
       return;
     }
   }
@@ -181,9 +180,8 @@ void CapcomSnesScanner::searchForCapcomSnesFromARAM(RawFile *file) const {
       // load current song if possible
       if (guessedSongIndex != -1) {
         u16 addrSongHeader = file->readShortBE(addrSongList + guessedSongIndex * 2);
-        CapcomSnesSeq *newSeq = new CapcomSnesSeq(file, version, addrSongHeader, true, name);
-        if (!newSeq->loadVGMFile()) {
-          delete newSeq;
+        auto* newSeq = pRoot->emplaceVGMFile<CapcomSnesSeq>(file, version, addrSongHeader, true, name);
+        if (!newSeq) {
           return;
         }
       }
@@ -197,13 +195,9 @@ void CapcomSnesScanner::searchForCapcomSnesFromARAM(RawFile *file) const {
           continue;
         }
 
-        CapcomSnesSeq *newSeq = new CapcomSnesSeq(file,
-                                                  version,
-                                                  addrSongHeader,
-                                                  true,
-                                                  (songIndex == guessedSongIndex) ? name : basefilename);
-        if (!newSeq->loadVGMFile()) {
-          delete newSeq;
+        auto* newSeq = pRoot->emplaceVGMFile<CapcomSnesSeq>(
+            file, version, addrSongHeader, true, (songIndex == guessedSongIndex) ? name : basefilename);
+        if (!newSeq) {
           return;
         }
       }
@@ -227,9 +221,8 @@ void CapcomSnesScanner::searchForCapcomSnesFromARAM(RawFile *file) const {
   }
   u8 spcDIR = itSpcDIR->second;
 
-  CapcomSnesInstrSet *newInstrSet = new CapcomSnesInstrSet(file, addrInstrTable, spcDIR << 8);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  auto* newInstrSet = pRoot->emplaceVGMFile<CapcomSnesInstrSet>(file, addrInstrTable, spcDIR << 8);
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
+++ b/src/main/formats/CapcomSnes/CapcomSnesSeq.cpp
@@ -85,7 +85,7 @@ bool CapcomSnesSeq::parseTrackPointers() {
   for (int i = MAX_TRACKS - 1; i >= 0; i--) {
     u16 trkOff = readShortBE(offset() + (priorityInHeader ? 1 : 0) + i * 2);
     if (trkOff != 0)
-      aTracks.push_back(new CapcomSnesTrack(this, trkOff));
+      addTrack<CapcomSnesTrack>(this, trkOff);
   }
   return true;
 }

--- a/src/main/formats/ChunSnes/ChunSnesInstr.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesInstr.cpp
@@ -87,7 +87,7 @@ bool ChunSnesInstrSet::parseInstrPointers() {
         setOffset(addrInstr);
       }
 
-      emplaceInstr<ChunSnesInstr>(this, version, instrNum, addrInstr,
+      addInstr<ChunSnesInstr>(this, version, instrNum, addrInstr,
                                   addrSampleTable, spcDirAddr, instrName);
     }
   }
@@ -140,7 +140,7 @@ bool ChunSnesInstr::loadInstr() {
     return false;
   }
 
-  ChunSnesRgn *rgn = emplaceRgn<ChunSnesRgn>(this, version, srcn, addrRgn, spcDirAddr);
+  ChunSnesRgn *rgn = addRgn<ChunSnesRgn>(this, version, srcn, addrRgn, spcDirAddr);
   rgn->sampOffset = addrSampStart - spcDirAddr;
 
   setGuessedLength();

--- a/src/main/formats/ChunSnes/ChunSnesInstr.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesInstr.cpp
@@ -87,20 +87,17 @@ bool ChunSnesInstrSet::parseInstrPointers() {
         setOffset(addrInstr);
       }
 
-      ChunSnesInstr *newInstr = new ChunSnesInstr(this, version, instrNum, addrInstr,
-        addrSampleTable, spcDirAddr, instrName);
-      aInstrs.push_back(newInstr);
+      emplaceInstr<ChunSnesInstr>(this, version, instrNum, addrInstr,
+                                  addrSampleTable, spcDirAddr, instrName);
     }
   }
 
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(ChunSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(ChunSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -143,9 +140,8 @@ bool ChunSnesInstr::loadInstr() {
     return false;
   }
 
-  ChunSnesRgn *rgn = new ChunSnesRgn(this, version, srcn, addrRgn, spcDirAddr);
+  ChunSnesRgn *rgn = emplaceRgn<ChunSnesRgn>(this, version, srcn, addrRgn, spcDirAddr);
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   setGuessedLength();
   return true;

--- a/src/main/formats/ChunSnes/ChunSnesScanner.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesScanner.cpp
@@ -518,9 +518,8 @@ void ChunSnesScanner::searchForChunSnesFromARAM(RawFile *file) {
   }
 
   u16 addrSeqHeader = file->readShort(addrSeqEntry + CHUNSNES_SEQENT_OFFSET_OF_HEADER);
-  ChunSnesSeq *newSeq = new ChunSnesSeq(file, version, minorVersion, addrSeqHeader, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<ChunSnesSeq>(file, version, minorVersion, addrSeqHeader, name);
+  if (!newSeq) {
     return;
   }
 
@@ -588,9 +587,9 @@ void ChunSnesScanner::searchForChunSnesFromARAM(RawFile *file) {
     addrInstrSet += nNumInstrs;
   }
 
-  ChunSnesInstrSet *newInstrSet = new ChunSnesInstrSet(file, version, addrInstrSet, addrSampNumTable, addrSampleTable, spcDirAddr);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  auto* newInstrSet =
+      pRoot->emplaceVGMFile<ChunSnesInstrSet>(file, version, addrInstrSet, addrSampNumTable, addrSampleTable, spcDirAddr);
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/ChunSnes/ChunSnesScanner.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesScanner.cpp
@@ -518,7 +518,7 @@ void ChunSnesScanner::searchForChunSnesFromARAM(RawFile *file) {
   }
 
   u16 addrSeqHeader = file->readShort(addrSeqEntry + CHUNSNES_SEQENT_OFFSET_OF_HEADER);
-  auto* newSeq = pRoot->emplaceVGMFile<ChunSnesSeq>(file, version, minorVersion, addrSeqHeader, name);
+  auto* newSeq = pRoot->loadVGMFile<ChunSnesSeq>(file, version, minorVersion, addrSeqHeader, name);
   if (!newSeq) {
     return;
   }
@@ -588,7 +588,7 @@ void ChunSnesScanner::searchForChunSnesFromARAM(RawFile *file) {
   }
 
   auto* newInstrSet =
-      pRoot->emplaceVGMFile<ChunSnesInstrSet>(file, version, addrInstrSet, addrSampNumTable, addrSampleTable, spcDirAddr);
+      pRoot->loadVGMFile<ChunSnesInstrSet>(file, version, addrInstrSet, addrSampNumTable, addrSampleTable, spcDirAddr);
   if (!newInstrSet) {
     return;
   }

--- a/src/main/formats/ChunSnes/ChunSnesSeq.cpp
+++ b/src/main/formats/ChunSnes/ChunSnesSeq.cpp
@@ -82,9 +82,8 @@ bool ChunSnesSeq::parseHeader() {
     auto trackName = fmt::format("Track Pointer {}", trackIndex + 1);
     header->addChild(curOffset, 2, trackName);
 
-    ChunSnesTrack *track = new ChunSnesTrack(this, addrTrackStart);
-    track->index = static_cast<u8>(aTracks.size());
-    aTracks.push_back(track);
+    ChunSnesTrack *track = addTrack<ChunSnesTrack>(this, addrTrackStart);
+    track->index = static_cast<u8>(trackCount() - 1);
 
     curOffset += 2;
   }
@@ -799,8 +798,8 @@ bool ChunSnesTrack::readEvent() {
 }
 
 void ChunSnesTrack::syncNoteLengthWithPriorTrack() {
-  if (index != 0 && index < parentSeq->aTracks.size()) {
-    ChunSnesTrack *priorTrack = static_cast<ChunSnesTrack*>(parentSeq->aTracks[index - 1]);
+  if (index != 0 && index < parentSeq->trackCount()) {
+    auto *priorTrack = static_cast<ChunSnesTrack*>(parentSeq->track(index - 1));
     noteLength = priorTrack->noteLength;
     noteDurationRate = priorTrack->noteDurationRate;
   }

--- a/src/main/formats/CompileSnes/CompileSnesInstr.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesInstr.cpp
@@ -62,19 +62,16 @@ bool CompileSnesInstrSet::parseInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    CompileSnesInstr *newInstr = new CompileSnesInstr(
+    emplaceInstr<CompileSnesInstr>(
       this, version, ofsInstrEntry, addrPitchTablePtrs, srcn, spcDirAddr,
       fmt::format("Instrument: {:#x}", srcn));
-    aInstrs.push_back(newInstr);
   }
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(CompileSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(CompileSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -106,9 +103,8 @@ bool CompileSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  CompileSnesRgn *rgn = new CompileSnesRgn(this, version, offset(), addrPitchTablePtrs);
+  CompileSnesRgn *rgn = emplaceRgn<CompileSnesRgn>(this, version, offset(), addrPitchTablePtrs);
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   return true;
 }

--- a/src/main/formats/CompileSnes/CompileSnesInstr.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesInstr.cpp
@@ -62,7 +62,7 @@ bool CompileSnesInstrSet::parseInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    emplaceInstr<CompileSnesInstr>(
+    addInstr<CompileSnesInstr>(
       this, version, ofsInstrEntry, addrPitchTablePtrs, srcn, spcDirAddr,
       fmt::format("Instrument: {:#x}", srcn));
   }
@@ -103,7 +103,7 @@ bool CompileSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  CompileSnesRgn *rgn = emplaceRgn<CompileSnesRgn>(this, version, offset(), addrPitchTablePtrs);
+  CompileSnesRgn *rgn = addRgn<CompileSnesRgn>(this, version, offset(), addrPitchTablePtrs);
   rgn->sampOffset = addrSampStart - spcDirAddr;
 
   return true;

--- a/src/main/formats/CompileSnes/CompileSnesScanner.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesScanner.cpp
@@ -101,7 +101,7 @@ void CompileSnesScanner::searchForCompileSnesFromARAM(RawFile *file) {
     u16 addrSongHeader = file->readShort(addrSongHeaderPtr);
     u8 numTracks = file->readByte(addrSongHeader);
     if (numTracks > 0 && numTracks <= 8) {
-      auto* newSeq = pRoot->emplaceVGMFile<CompileSnesSeq>(file, version, addrSongHeader, name);
+      auto* newSeq = pRoot->loadVGMFile<CompileSnesSeq>(file, version, addrSongHeader, name);
       if (!newSeq) {
         return;
       }
@@ -116,7 +116,7 @@ void CompileSnesScanner::searchForCompileSnesFromARAM(RawFile *file) {
     addrPitchTablePtrs = file->readShort(addrEngineHeader + 0x16);
   }
 
-  auto* newInstrSet = pRoot->emplaceVGMFile<CompileSnesInstrSet>(file, version, addrTuningTable, addrPitchTablePtrs, spcDirAddr);
+  auto* newInstrSet = pRoot->loadVGMFile<CompileSnesInstrSet>(file, version, addrTuningTable, addrPitchTablePtrs, spcDirAddr);
   if (!newInstrSet) {
     return;
   }

--- a/src/main/formats/CompileSnes/CompileSnesScanner.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesScanner.cpp
@@ -101,9 +101,8 @@ void CompileSnesScanner::searchForCompileSnesFromARAM(RawFile *file) {
     u16 addrSongHeader = file->readShort(addrSongHeaderPtr);
     u8 numTracks = file->readByte(addrSongHeader);
     if (numTracks > 0 && numTracks <= 8) {
-      CompileSnesSeq *newSeq = new CompileSnesSeq(file, version, addrSongHeader, name);
-      if (!newSeq->loadVGMFile()) {
-        delete newSeq;
+      auto* newSeq = pRoot->emplaceVGMFile<CompileSnesSeq>(file, version, addrSongHeader, name);
+      if (!newSeq) {
         return;
       }
     }
@@ -117,9 +116,8 @@ void CompileSnesScanner::searchForCompileSnesFromARAM(RawFile *file) {
     addrPitchTablePtrs = file->readShort(addrEngineHeader + 0x16);
   }
 
-  CompileSnesInstrSet *newInstrSet = new CompileSnesInstrSet(file, version, addrTuningTable, addrPitchTablePtrs, spcDirAddr);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  auto* newInstrSet = pRoot->emplaceVGMFile<CompileSnesInstrSet>(file, version, addrTuningTable, addrPitchTablePtrs, spcDirAddr);
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/CompileSnes/CompileSnesSeq.cpp
+++ b/src/main/formats/CompileSnes/CompileSnesSeq.cpp
@@ -88,15 +88,13 @@ bool CompileSnesSeq::parseTrackPointers(void) {
   for (u8 trackIndex = 0; trackIndex < nNumTracks; trackIndex++) {
     u16 ofsTrackStart = readShort(curOffset + 8);
 
-    CompileSnesTrack *track = new CompileSnesTrack(this, ofsTrackStart);
+    CompileSnesTrack *track = addTrack<CompileSnesTrack>(this, ofsTrackStart);
     track->spcInitialFlags = readByte(curOffset + 1);
     track->spcInitialVolume = readByte(curOffset + 2);
     track->spcInitialTranspose = static_cast<s8>(readByte(curOffset + 5));
     track->spcInitialTempo = readByte(curOffset + 6);
     track->spcInitialSRCN = readByte(curOffset + 10);
     track->spcInitialPan = static_cast<s8>(readByte(curOffset + 12));
-    aTracks.push_back(track);
-
     if (trackIndex == 0) {
       setAlwaysWriteInitialTempo(getTempoInBPM(track->spcInitialTempo));
     }

--- a/src/main/formats/FFT/FFTInstr.cpp
+++ b/src/main/formats/FFT/FFTInstr.cpp
@@ -60,7 +60,7 @@ bool WdsInstrSet::parseHeader() {
   wdsHeader->addUnknownChild(offset() + 0x2C, sizeof(long));
 
   //波形objectの生成
-  adoptSampColl(new PSXSampColl(FFTFormat::name, this, offset() + hdr.szHeader1, hdr.szSampColl));
+  emplaceSampColl<PSXSampColl>(FFTFormat::name, this, offset() + hdr.szHeader1, hdr.szSampColl);
 //	sampColl->Load();				//VGMInstrSet::Load()関数内でやっている。
 //	sampColl->UseInstrSet(this);	//"WD.cpp"では、同様の事をやっている。
 
@@ -81,8 +81,7 @@ bool    WdsInstrSet::parseInstrPointers() {
   //音色数だけ繰り返す。
   for (unsigned int i = 0; i <= hdr.iNumInstrs; i++) {
     //WdsInstr* newInstr = new WdsInstr(this,iOffset,sizeof(WdsRgnData),hdr.iBank,i);		//0 … hdr.iBank
-    WdsInstr *newInstr = new WdsInstr(this, iOffset, sizeof(WdsRgnData), i / 128, i % 128);        //0 … hdr.iBank
-    aInstrs.push_back(newInstr);
+    emplaceInstr<WdsInstr>(this, iOffset, sizeof(WdsRgnData), i / 128, i % 128);        //0 … hdr.iBank
     //	newInstr->LoadInstr();		//VGMInstrSet::Load()関数内（LoadInstrs()）でやっている。
     iOffset += sizeof(WdsRgnData);    // size = 0x0010
   }
@@ -115,7 +114,7 @@ bool WdsInstr::loadInstr() {
   WdsInstrSet *parInstrSet = static_cast<WdsInstrSet*>(this->parInstrSet);
 
   readBytes(offset(), sizeof(WdsRgnData), &rgndata);
-  VGMRgn *rgn = new VGMRgn(this, offset(), length());
+  VGMRgn *rgn = emplaceRgn<VGMRgn>(this, offset(), length());
   rgn->sampOffset = rgndata.ptBody;
   if (parInstrSet->version == WdsInstrSet::VERSION_WDS) {
     rgn->sampOffset *= 8;
@@ -155,11 +154,9 @@ bool WdsInstr::loadInstr() {
     rgn->addUnknown(offset() + 0x0f, sizeof(u8));
 
     psxConvADSR(rgn, Am >> 2, Ar, Dr, Sl, Sm >> 2, (Sm >> 1) & 1, Sr, Rm >> 2, Rr, false);
-    addRgn(rgn);
   }
   else if (parInstrSet->version == WdsInstrSet::VERSION_DWDS) {
     psxConvADSR(rgn, rgndata.Am > 1, rgndata.Ar, rgndata.Dr, rgndata.Sl, 1, 1, rgndata.Sr, 1, rgndata.Rr, false);
-    addRgn(rgn);
 
     rgn->addADSRValue(offset() + 0x08, sizeof(u8), "Attack Rate");
     rgn->addADSRValue(offset() + 0x09, sizeof(u8), "Decay Rate");

--- a/src/main/formats/FFT/FFTInstr.cpp
+++ b/src/main/formats/FFT/FFTInstr.cpp
@@ -60,7 +60,7 @@ bool WdsInstrSet::parseHeader() {
   wdsHeader->addUnknownChild(offset() + 0x2C, sizeof(long));
 
   //波形objectの生成
-  sampColl = new PSXSampColl(FFTFormat::name, this, offset() + hdr.szHeader1, hdr.szSampColl);
+  adoptSampColl(new PSXSampColl(FFTFormat::name, this, offset() + hdr.szHeader1, hdr.szSampColl));
 //	sampColl->Load();				//VGMInstrSet::Load()関数内でやっている。
 //	sampColl->UseInstrSet(this);	//"WD.cpp"では、同様の事をやっている。
 

--- a/src/main/formats/FFT/FFTInstr.cpp
+++ b/src/main/formats/FFT/FFTInstr.cpp
@@ -60,7 +60,7 @@ bool WdsInstrSet::parseHeader() {
   wdsHeader->addUnknownChild(offset() + 0x2C, sizeof(long));
 
   //波形objectの生成
-  emplaceSampColl<PSXSampColl>(FFTFormat::name, this, offset() + hdr.szHeader1, hdr.szSampColl);
+  addSampColl<PSXSampColl>(FFTFormat::name, this, offset() + hdr.szHeader1, hdr.szSampColl);
 //	sampColl->Load();				//VGMInstrSet::Load()関数内でやっている。
 //	sampColl->UseInstrSet(this);	//"WD.cpp"では、同様の事をやっている。
 
@@ -81,7 +81,7 @@ bool    WdsInstrSet::parseInstrPointers() {
   //音色数だけ繰り返す。
   for (unsigned int i = 0; i <= hdr.iNumInstrs; i++) {
     //WdsInstr* newInstr = new WdsInstr(this,iOffset,sizeof(WdsRgnData),hdr.iBank,i);		//0 … hdr.iBank
-    emplaceInstr<WdsInstr>(this, iOffset, sizeof(WdsRgnData), i / 128, i % 128);        //0 … hdr.iBank
+    addInstr<WdsInstr>(this, iOffset, sizeof(WdsRgnData), i / 128, i % 128);        //0 … hdr.iBank
     //	newInstr->LoadInstr();		//VGMInstrSet::Load()関数内（LoadInstrs()）でやっている。
     iOffset += sizeof(WdsRgnData);    // size = 0x0010
   }
@@ -114,7 +114,7 @@ bool WdsInstr::loadInstr() {
   WdsInstrSet *parInstrSet = static_cast<WdsInstrSet*>(this->parInstrSet);
 
   readBytes(offset(), sizeof(WdsRgnData), &rgndata);
-  VGMRgn *rgn = emplaceRgn<VGMRgn>(this, offset(), length());
+  VGMRgn *rgn = addRgn<VGMRgn>(this, offset(), length());
   rgn->sampOffset = rgndata.ptBody;
   if (parInstrSet->version == WdsInstrSet::VERSION_WDS) {
     rgn->sampOffset *= 8;

--- a/src/main/formats/FFT/FFTInstr.h
+++ b/src/main/formats/FFT/FFTInstr.h
@@ -84,7 +84,7 @@ class WdsInstrSet:
   //ここで、Object"VabSampColl"を生成するべき？
   //（スキャナーでVBを検索すると、複数有るから解らなくなる。）
   bool parseInstrPointers() override;    //音色Object"WdsInstr"を生成する。
-  //"aInstrs"に、登録する。
+  //VGMInstrSet::instrs()に、登録する。
   //各音色毎の処理
 
   enum Version { VERSION_DWDS, VERSION_WDS };
@@ -94,7 +94,7 @@ class WdsInstrSet:
   Version version{};
 
 /*	member of "VGMInstrSet"
-	VGMInstrSet::aInstrs		//音色情報のvector
+	VGMInstrSet::instrs()		//音色情報のvector
 	VGMInstrSet::dls			//class DLSを作る用
 	VGMInstrSet::menu			//
 	VGMInstrSet::sampColl		//波形実体のオブジェクト

--- a/src/main/formats/FFT/FFTScanner.cpp
+++ b/src/main/formats/FFT/FFTScanner.cpp
@@ -36,7 +36,7 @@ void FFTScanner::searchForFFTSeq(RawFile *file) {
     if (file->readShort(i + 10) != 0 && file->readShort(i + 16) != 0)
       continue;
 
-    pRoot->emplaceVGMFile<FFTSeq>(file, i);
+    pRoot->loadVGMFile<FFTSeq>(file, i);
   }
 }
 
@@ -66,6 +66,6 @@ void FFTScanner::searchForFFTwds(RawFile *file) {
     //if (size <= file->GetWord(i+0x10) || size <= file->GetWord(i+0x18))
     //	continue;
 
-    pRoot->emplaceVGMFile<WdsInstrSet>(file, i);
+    pRoot->loadVGMFile<WdsInstrSet>(file, i);
   }
 }

--- a/src/main/formats/FFT/FFTScanner.cpp
+++ b/src/main/formats/FFT/FFTScanner.cpp
@@ -36,9 +36,7 @@ void FFTScanner::searchForFFTSeq(RawFile *file) {
     if (file->readShort(i + 10) != 0 && file->readShort(i + 16) != 0)
       continue;
 
-    FFTSeq *NewFFTSeq = new FFTSeq(file, i);
-    if (!NewFFTSeq->loadVGMFile())
-      delete NewFFTSeq;
+    pRoot->emplaceVGMFile<FFTSeq>(file, i);
   }
 }
 
@@ -68,8 +66,6 @@ void FFTScanner::searchForFFTwds(RawFile *file) {
     //if (size <= file->GetWord(i+0x10) || size <= file->GetWord(i+0x18))
     //	continue;
 
-    WdsInstrSet *newWds = new WdsInstrSet(file, i);
-    if (!newWds->loadVGMFile())
-      delete newWds;
+    pRoot->emplaceVGMFile<WdsInstrSet>(file, i);
   }
 }

--- a/src/main/formats/FFT/FFTSeq.cpp
+++ b/src/main/formats/FFT/FFTSeq.cpp
@@ -85,7 +85,7 @@ bool FFTSeq::parseHeader(void) {
 
 bool FFTSeq::parseTrackPointers(void) {
   for (unsigned int i = 0; i < nNumTracks; i++)
-    aTracks.push_back(new FFTTrack(this, readShort(offset() + 0x22 + (i * 2)) + offset()));
+    addTrack<FFTTrack>(this, readShort(offset() + 0x22 + (i * 2)) + offset());
   return true;
 }
 

--- a/src/main/formats/FalcomSnes/FalcomSnesInstr.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesInstr.cpp
@@ -82,7 +82,7 @@ bool FalcomSnesInstrSet::parseInstrPointers() {
     }
 
     auto instrName = fmt::format("Instrument {}", instr);
-    emplaceInstr<FalcomSnesInstr>(
+    addInstr<FalcomSnesInstr>(
       this, version, addrInstrHeader, instr >> 7, instr & 0x7f, srcn,
       spcDirAddr, instrName);
   }
@@ -124,7 +124,7 @@ bool FalcomSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  FalcomSnesRgn *rgn = emplaceRgn<FalcomSnesRgn>(this, version, offset(), srcn);
+  FalcomSnesRgn *rgn = addRgn<FalcomSnesRgn>(this, version, offset(), srcn);
   rgn->sampOffset = addrSampStart - spcDirAddr;
 
   return true;

--- a/src/main/formats/FalcomSnes/FalcomSnesInstr.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesInstr.cpp
@@ -82,19 +82,16 @@ bool FalcomSnesInstrSet::parseInstrPointers() {
     }
 
     auto instrName = fmt::format("Instrument {}", instr);
-    FalcomSnesInstr *newInstr = new FalcomSnesInstr(
+    emplaceInstr<FalcomSnesInstr>(
       this, version, addrInstrHeader, instr >> 7, instr & 0x7f, srcn,
       spcDirAddr, instrName);
-    aInstrs.push_back(newInstr);
   }
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(FalcomSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(FalcomSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -127,9 +124,8 @@ bool FalcomSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  FalcomSnesRgn *rgn = new FalcomSnesRgn(this, version, offset(), srcn);
+  FalcomSnesRgn *rgn = emplaceRgn<FalcomSnesRgn>(this, version, offset(), srcn);
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   return true;
 }

--- a/src/main/formats/FalcomSnes/FalcomSnesScanner.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesScanner.cpp
@@ -103,9 +103,8 @@ void FalcomSnesScanner::searchForFalcomSnesFromARAM(RawFile *file) {
     return;
   }
 
-  FalcomSnesSeq *newSeq = new FalcomSnesSeq(file, version, addrSeqHeader, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<FalcomSnesSeq>(file, version, addrSeqHeader, name);
+  if (!newSeq) {
     return;
   }
 
@@ -129,10 +128,9 @@ void FalcomSnesScanner::searchForFalcomSnesFromARAM(RawFile *file) {
     return;
   }
 
-  FalcomSnesInstrSet *newInstrSet = new FalcomSnesInstrSet(
+  auto* newInstrSet = pRoot->emplaceVGMFile<FalcomSnesInstrSet>(
     file, version, addrInstrTable, addrSampToInstrTable, spcDirAddr, newSeq->instrADSRHints);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/FalcomSnes/FalcomSnesScanner.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesScanner.cpp
@@ -103,7 +103,7 @@ void FalcomSnesScanner::searchForFalcomSnesFromARAM(RawFile *file) {
     return;
   }
 
-  auto* newSeq = pRoot->emplaceVGMFile<FalcomSnesSeq>(file, version, addrSeqHeader, name);
+  auto* newSeq = pRoot->loadVGMFile<FalcomSnesSeq>(file, version, addrSeqHeader, name);
   if (!newSeq) {
     return;
   }
@@ -128,7 +128,7 @@ void FalcomSnesScanner::searchForFalcomSnesFromARAM(RawFile *file) {
     return;
   }
 
-  auto* newInstrSet = pRoot->emplaceVGMFile<FalcomSnesInstrSet>(
+  auto* newInstrSet = pRoot->loadVGMFile<FalcomSnesInstrSet>(
     file, version, addrInstrTable, addrSampToInstrTable, spcDirAddr, newSeq->instrADSRHints);
   if (!newInstrSet) {
     return;

--- a/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
+++ b/src/main/formats/FalcomSnes/FalcomSnesSeq.cpp
@@ -96,8 +96,7 @@ bool FalcomSnesSeq::parseTrackPointers() {
     curOffset += 2;
     if (ofsTrackStart != 0) {
       u16 addrTrackStart = offset() + ofsTrackStart;
-      FalcomSnesTrack *track = new FalcomSnesTrack(this, addrTrackStart);
-      aTracks.push_back(track);
+      addTrack<FalcomSnesTrack>(this, addrTrackStart);
     }
   }
   return true;

--- a/src/main/formats/Format.cpp
+++ b/src/main/formats/Format.cpp
@@ -15,14 +15,11 @@ FormatMap &Format::registry() {
   return registry;
 }
 
-Format::Format(const std::string &formatName) : matcher(nullptr), scanner(nullptr) {
+Format::Format(const std::string &formatName) {
   registry().insert(make_pair(formatName, this));
 }
 
-Format::~Format() {
-  delete scanner;
-  delete matcher;
-}
+Format::~Format() = default;
 
 Format *Format::formatFromName(const std::string &name) {
   auto findIt = registry().find(name);
@@ -50,7 +47,7 @@ bool Format::onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VG
 }
 
 bool Format::init() {
-  scanner = newScanner();
-  matcher = newMatcher();
+  scanner.reset(newScanner());
+  matcher.reset(newMatcher());
   return true;
 }

--- a/src/main/formats/Format.cpp
+++ b/src/main/formats/Format.cpp
@@ -35,8 +35,8 @@ bool Format::onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMM
   return matcher->onNewFile(file);
 }
 
-VGMColl *Format::newCollection() {
-  return new VGMColl();
+std::unique_ptr<VGMColl> Format::newCollection() {
+  return std::make_unique<VGMColl>();
 }
 
 bool Format::onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file) {
@@ -47,7 +47,7 @@ bool Format::onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VG
 }
 
 bool Format::init() {
-  scanner.reset(newScanner());
-  matcher.reset(newMatcher());
+  scanner = newScanner();
+  matcher = newMatcher();
   return true;
 }

--- a/src/main/formats/Format.cpp
+++ b/src/main/formats/Format.cpp
@@ -39,6 +39,10 @@ std::unique_ptr<VGMColl> Format::newCollection() {
   return std::make_unique<VGMColl>();
 }
 
+std::unique_ptr<Matcher> Format::newMatcher() {
+  return nullptr;
+}
+
 bool Format::onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file) {
   if (!matcher) {
     return false;

--- a/src/main/formats/Format.h
+++ b/src/main/formats/Format.h
@@ -34,16 +34,16 @@ class VGMScanner;
   ;
 
 #define USING_SCANNER(scanner) \
-  VGMScanner* newScanner() override { return new scanner(this); }
+  std::unique_ptr<VGMScanner> newScanner() override { return std::make_unique<scanner>(this); }
 
 #define USING_MATCHER(matcher) \
-  Matcher* newMatcher() override { return new matcher(this); }
+  std::unique_ptr<Matcher> newMatcher() override { return std::make_unique<matcher>(this); }
 
 #define USING_MATCHER_WITH_ARG(matcher, arg) \
-  Matcher* newMatcher() override { return new matcher(this, arg); }
+  std::unique_ptr<Matcher> newMatcher() override { return std::make_unique<matcher>(this, arg); }
 
 #define USING_COLL(coll) \
-  VGMColl* newCollection() override { return new coll(); }
+  std::unique_ptr<VGMColl> newCollection() override { return std::make_unique<coll>(); }
 
 #define USES_COLLECTION_FOR_SEQ_CONVERSION() \
   bool usesCollectionDataForSeqConversion() override { return true; }
@@ -67,10 +67,10 @@ public:
 
   virtual bool init();
   virtual const std::string &getName() = 0;
-  virtual VGMScanner *newScanner() { return nullptr; }
+  virtual std::unique_ptr<VGMScanner> newScanner() { return nullptr; }
   VGMScanner &getScanner() const { return *scanner; }
-  virtual Matcher *newMatcher() { return nullptr; }
-  virtual VGMColl *newCollection();
+  virtual std::unique_ptr<Matcher> newMatcher() { return nullptr; }
+  virtual std::unique_ptr<VGMColl> newCollection();
   virtual bool onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file);
   virtual bool onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file);
   virtual bool onMatch(std::vector<VGMFile *> &) { return true; }

--- a/src/main/formats/Format.h
+++ b/src/main/formats/Format.h
@@ -69,7 +69,7 @@ public:
   virtual const std::string &getName() = 0;
   virtual std::unique_ptr<VGMScanner> newScanner() { return nullptr; }
   VGMScanner &getScanner() const { return *scanner; }
-  virtual std::unique_ptr<Matcher> newMatcher() { return nullptr; }
+  virtual std::unique_ptr<Matcher> newMatcher();
   virtual std::unique_ptr<VGMColl> newCollection();
   virtual bool onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file);
   virtual bool onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file);

--- a/src/main/formats/Format.h
+++ b/src/main/formats/Format.h
@@ -8,6 +8,7 @@
 #include "Scanner.h"
 
 #include <map>
+#include <memory>
 #include <string>
 #include <variant>
 #include <vector>
@@ -75,8 +76,8 @@ public:
   virtual bool onMatch(std::vector<VGMFile *> &) { return true; }
   virtual bool usesCollectionDataForSeqConversion() { return false; }
 
-  Matcher *matcher;
-  VGMScanner *scanner;
+  std::unique_ptr<Matcher> matcher;
+  std::unique_ptr<VGMScanner> scanner;
 
 protected:
     static FormatMap &registry();

--- a/src/main/formats/GraphResSnes/GraphResSnesInstr.cpp
+++ b/src/main/formats/GraphResSnes/GraphResSnesInstr.cpp
@@ -65,7 +65,7 @@ bool GraphResSnesInstrSet::parseInstrPointers() {
       adsr = instrADSRHints[srcn];
     }
 
-    emplaceInstr<GraphResSnesInstr>(
+    addInstr<GraphResSnesInstr>(
       this, version, srcn, spcDirAddr, adsr, fmt::format("Instrument {}", srcn));
   }
 
@@ -107,7 +107,7 @@ bool GraphResSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  GraphResSnesRgn *rgn = emplaceRgn<GraphResSnesRgn>(this, version, instrNum, spcDirAddr, adsr);
+  GraphResSnesRgn *rgn = addRgn<GraphResSnesRgn>(this, version, instrNum, spcDirAddr, adsr);
   rgn->sampOffset = addrSampStart - spcDirAddr;
 
   setGuessedLength();

--- a/src/main/formats/GraphResSnes/GraphResSnesInstr.cpp
+++ b/src/main/formats/GraphResSnes/GraphResSnesInstr.cpp
@@ -65,19 +65,16 @@ bool GraphResSnesInstrSet::parseInstrPointers() {
       adsr = instrADSRHints[srcn];
     }
 
-    GraphResSnesInstr *newInstr = new GraphResSnesInstr(
+    emplaceInstr<GraphResSnesInstr>(
       this, version, srcn, spcDirAddr, adsr, fmt::format("Instrument {}", srcn));
-    aInstrs.push_back(newInstr);
   }
 
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(GraphResSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(GraphResSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -110,9 +107,8 @@ bool GraphResSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  GraphResSnesRgn *rgn = new GraphResSnesRgn(this, version, instrNum, spcDirAddr, adsr);
+  GraphResSnesRgn *rgn = emplaceRgn<GraphResSnesRgn>(this, version, instrNum, spcDirAddr, adsr);
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   setGuessedLength();
   return true;

--- a/src/main/formats/GraphResSnes/GraphResSnesScanner.cpp
+++ b/src/main/formats/GraphResSnes/GraphResSnesScanner.cpp
@@ -83,9 +83,8 @@ void GraphResSnesScanner::searchForGraphResSnesFromARAM(RawFile *file) {
 
   GraphResSnesVersion version = GRAPHRESSNES_STANDARD;
 
-  GraphResSnesSeq *newSeq = new GraphResSnesSeq(file, version, addrSeqHeader, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<GraphResSnesSeq>(file, version, addrSeqHeader, name);
+  if (!newSeq) {
     return;
   }
 
@@ -98,9 +97,8 @@ void GraphResSnesScanner::searchForGraphResSnesFromARAM(RawFile *file) {
   u16 spcDirAddr = itSpcDIR->second << 8;
 
   // scan SRCN table
-  GraphResSnesInstrSet *newInstrSet = new GraphResSnesInstrSet(file, version, spcDirAddr, newSeq->instrADSRHints);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  auto* newInstrSet = pRoot->emplaceVGMFile<GraphResSnesInstrSet>(file, version, spcDirAddr, newSeq->instrADSRHints);
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/GraphResSnes/GraphResSnesScanner.cpp
+++ b/src/main/formats/GraphResSnes/GraphResSnesScanner.cpp
@@ -83,7 +83,7 @@ void GraphResSnesScanner::searchForGraphResSnesFromARAM(RawFile *file) {
 
   GraphResSnesVersion version = GRAPHRESSNES_STANDARD;
 
-  auto* newSeq = pRoot->emplaceVGMFile<GraphResSnesSeq>(file, version, addrSeqHeader, name);
+  auto* newSeq = pRoot->loadVGMFile<GraphResSnesSeq>(file, version, addrSeqHeader, name);
   if (!newSeq) {
     return;
   }
@@ -97,7 +97,7 @@ void GraphResSnesScanner::searchForGraphResSnesFromARAM(RawFile *file) {
   u16 spcDirAddr = itSpcDIR->second << 8;
 
   // scan SRCN table
-  auto* newInstrSet = pRoot->emplaceVGMFile<GraphResSnesInstrSet>(file, version, spcDirAddr, newSeq->instrADSRHints);
+  auto* newInstrSet = pRoot->loadVGMFile<GraphResSnesInstrSet>(file, version, spcDirAddr, newSeq->instrADSRHints);
   if (!newInstrSet) {
     return;
   }

--- a/src/main/formats/GraphResSnes/GraphResSnesSeq.cpp
+++ b/src/main/formats/GraphResSnes/GraphResSnesSeq.cpp
@@ -80,8 +80,7 @@ bool GraphResSnesSeq::parseTrackPointers(void) {
     u16 addrTrackStart = 24 + addrTrackStartVirt - addrTrackBase + offset();
 
     if (trackUsed) {
-      GraphResSnesTrack *track = new GraphResSnesTrack(this, addrTrackStart);
-      aTracks.push_back(track);
+      addTrack<GraphResSnesTrack>(this, addrTrackStart);
     }
   }
 

--- a/src/main/formats/HOSA/HOSAInstr.cpp
+++ b/src/main/formats/HOSA/HOSAInstr.cpp
@@ -65,8 +65,7 @@ bool HOSAInstrSet::parseInstrPointers() {
 
   //音色数だけ繰り返す。
   for (unsigned int i = 0; i < instrheader.numInstr; i++) {
-    HOSAInstr *newInstr = new HOSAInstr(this, offset() + readWord(iOffset), 0, i / 0x80, i % 0x80);
-    aInstrs.push_back(newInstr);
+    emplaceInstr<HOSAInstr>(this, offset() + readWord(iOffset), 0, i / 0x80, i % 0x80);
     iOffset += 4;
   }
 
@@ -110,7 +109,7 @@ bool HOSAInstr::loadInstr() {
   u8 cKeyLow = 0x00;
   for (unsigned int i = 0; i < instrinfo.numRgns; i++) {
     RgnInfo *rgninfo = &rgns[i];
-    VGMRgn *rgn = new VGMRgn(this, offset() + sizeof(InstrInfo) + sizeof(RgnInfo) * i, sizeof(RgnInfo));
+    VGMRgn *rgn = emplaceRgn<VGMRgn>(this, offset() + sizeof(InstrInfo) + sizeof(RgnInfo) * i, sizeof(RgnInfo));
 
     rgn->addChild(rgn->offset(), 4, "Sample Offset");
     rgn->sampOffset = rgninfo->sampOffset; //+ ((VGMInstrSet*)this->vgmfile)->sampColl->offset();
@@ -146,7 +145,6 @@ bool HOSAInstr::loadInstr() {
     // Unsure if volume is using a linear scale, but it sounds like it.
     double vol = rgninfo->volume / 255.0;
     rgn->setVolume(vol);
-    addRgn(rgn);
   }
   return true;
 }

--- a/src/main/formats/HOSA/HOSAInstr.cpp
+++ b/src/main/formats/HOSA/HOSAInstr.cpp
@@ -65,7 +65,7 @@ bool HOSAInstrSet::parseInstrPointers() {
 
   //音色数だけ繰り返す。
   for (unsigned int i = 0; i < instrheader.numInstr; i++) {
-    emplaceInstr<HOSAInstr>(this, offset() + readWord(iOffset), 0, i / 0x80, i % 0x80);
+    addInstr<HOSAInstr>(this, offset() + readWord(iOffset), 0, i / 0x80, i % 0x80);
     iOffset += 4;
   }
 
@@ -109,7 +109,7 @@ bool HOSAInstr::loadInstr() {
   u8 cKeyLow = 0x00;
   for (unsigned int i = 0; i < instrinfo.numRgns; i++) {
     RgnInfo *rgninfo = &rgns[i];
-    VGMRgn *rgn = emplaceRgn<VGMRgn>(this, offset() + sizeof(InstrInfo) + sizeof(RgnInfo) * i, sizeof(RgnInfo));
+    VGMRgn *rgn = addRgn<VGMRgn>(this, offset() + sizeof(InstrInfo) + sizeof(RgnInfo) * i, sizeof(RgnInfo));
 
     rgn->addChild(rgn->offset(), 4, "Sample Offset");
     rgn->sampOffset = rgninfo->sampOffset; //+ ((VGMInstrSet*)this->vgmfile)->sampColl->offset();

--- a/src/main/formats/HOSA/HOSAScanner.cpp
+++ b/src/main/formats/HOSA/HOSAScanner.cpp
@@ -12,6 +12,8 @@
 #include "VGMColl.h"
 #include "VGMMiscFile.h"
 
+#include <memory>
+
 namespace vgmtrans::scanners {
 ScannerRegistration<HOSAScanner> s_hosa("HOSA");
 }
@@ -50,13 +52,11 @@ void HOSAScanner::scan(RawFile *file, void *info) {
     return;
   }
 
-  VGMColl *coll = new VGMColl(seq->name());
+  auto coll = std::make_unique<VGMColl>(seq->name());
   coll->useSeq(seq);
   coll->addInstrSet(instrset);
   coll->addSampColl(sampcoll);
-  if (!coll->load()) {
-    delete coll;
-  }
+  pRoot->loadVGMColl(std::move(coll));
 
   return;
 }
@@ -80,9 +80,8 @@ HOSASeq *HOSAScanner::searchForHOSASeq(RawFile *file) {
     if (firstTrkPtr >= file->readShort(i + 0x54) && firstTrkPtr != 0x54)
       continue;
 
-    HOSASeq *seq = new HOSASeq(file, i, name);
-    if (!seq->loadVGMFile()) {
-      delete seq;
+    auto* seq = pRoot->emplaceVGMFile<HOSASeq>(file, i, name);
+    if (!seq) {
       return nullptr;
     }
     return seq;
@@ -95,14 +94,14 @@ HOSASeq *HOSAScanner::searchForHOSASeq(RawFile *file) {
 #define MIN_NUM_SAMPLES_COMPARE 5
 #define MIN_SAMPLES_MATCH 4
 HOSAInstrSet *HOSAScanner::searchForHOSAInstrSet(RawFile *file, const PSXSampColl *sampcoll) {
-  int numSamples = static_cast<int>(sampcoll->samples.size());
+  int numSamples = static_cast<int>(sampcoll->sampleCount());
   if (numSamples < MIN_NUM_SAMPLES_COMPARE) {
     return nullptr;
   }
 
   u32 *sampOffsets = new u32[numSamples];
   for (int i = 0; i < numSamples; i++)
-    sampOffsets[i] = sampcoll->samples[i]->offset() - sampcoll->offset();
+    sampOffsets[i] = sampcoll->sample(i)->offset() - sampcoll->offset();
 
   size_t nFileLength = file->size();
   for (u32 i = 0x20; i + 0x14 < nFileLength; i++) {
@@ -111,9 +110,8 @@ HOSAInstrSet *HOSAScanner::searchForHOSAInstrSet(RawFile *file, const PSXSampCol
         if ((file->readWord(i + 4) != 0) || (file->readWord(i) != 0))
           continue;
 
-        HOSAInstrSet *instrset = new HOSAInstrSet(file, i);
-        if (!instrset->loadVGMFile()) {
-          delete instrset;
+        auto* instrset = pRoot->emplaceVGMFile<HOSAInstrSet>(file, i);
+        if (!instrset) {
           delete[] sampOffsets;
           return nullptr;
         }

--- a/src/main/formats/HOSA/HOSAScanner.cpp
+++ b/src/main/formats/HOSA/HOSAScanner.cpp
@@ -53,9 +53,9 @@ void HOSAScanner::scan(RawFile *file, void *info) {
   }
 
   auto coll = std::make_unique<VGMColl>(seq->name());
-  coll->useSeq(seq);
-  coll->addInstrSet(instrset);
-  coll->addSampColl(sampcoll);
+  coll->attachSeq(seq);
+  coll->attachInstrSet(instrset);
+  coll->attachSampColl(sampcoll);
   pRoot->loadVGMColl(std::move(coll));
 
   return;
@@ -80,7 +80,7 @@ HOSASeq *HOSAScanner::searchForHOSASeq(RawFile *file) {
     if (firstTrkPtr >= file->readShort(i + 0x54) && firstTrkPtr != 0x54)
       continue;
 
-    auto* seq = pRoot->emplaceVGMFile<HOSASeq>(file, i, name);
+    auto* seq = pRoot->loadVGMFile<HOSASeq>(file, i, name);
     if (!seq) {
       return nullptr;
     }
@@ -110,7 +110,7 @@ HOSAInstrSet *HOSAScanner::searchForHOSAInstrSet(RawFile *file, const PSXSampCol
         if ((file->readWord(i + 4) != 0) || (file->readWord(i) != 0))
           continue;
 
-        auto* instrset = pRoot->emplaceVGMFile<HOSAInstrSet>(file, i);
+        auto* instrset = pRoot->loadVGMFile<HOSAInstrSet>(file, i);
         if (!instrset) {
           delete[] sampOffsets;
           return nullptr;

--- a/src/main/formats/HOSA/HOSASeq.cpp
+++ b/src/main/formats/HOSA/HOSASeq.cpp
@@ -64,8 +64,7 @@ bool HOSASeq::parseHeader(void) {
 //==============================================================
 bool HOSASeq::parseTrackPointers(void) {
   for (unsigned int i = 0; i < nNumTracks; i++)
-    aTracks.push_back(new HOSATrack(this, readShort(offset() + 0x50 + (i * 2)) + offset()));
-  //delect object is in "VGMSeq::~VGMSeq()"
+    addTrack<HOSATrack>(this, readShort(offset() + 0x50 + (i * 2)) + offset());
   return true;
 }
 

--- a/src/main/formats/HeartBeatPS1/HeartBeatPS1Scanner.cpp
+++ b/src/main/formats/HeartBeatPS1/HeartBeatPS1Scanner.cpp
@@ -147,11 +147,9 @@ std::vector<VGMFile *> HeartBeatPS1Scanner::searchForHeartBeatPS1VGMFile(RawFile
     }
 
     if (seq_size != 0) {
-      HeartBeatPS1Seq *newHeartBeatPS1Seq = new HeartBeatPS1Seq(file, static_cast<u32>(offset), total_size);
-      if (newHeartBeatPS1Seq->loadVGMFile()) {
+      auto* newHeartBeatPS1Seq = pRoot->emplaceVGMFile<HeartBeatPS1Seq>(file, static_cast<u32>(offset), total_size);
+      if (newHeartBeatPS1Seq) {
         loadedFiles.push_back(newHeartBeatPS1Seq);
-      } else {
-        delete newHeartBeatPS1Seq;
       }
     }
 

--- a/src/main/formats/HeartBeatPS1/HeartBeatPS1Scanner.cpp
+++ b/src/main/formats/HeartBeatPS1/HeartBeatPS1Scanner.cpp
@@ -147,7 +147,7 @@ std::vector<VGMFile *> HeartBeatPS1Scanner::searchForHeartBeatPS1VGMFile(RawFile
     }
 
     if (seq_size != 0) {
-      auto* newHeartBeatPS1Seq = pRoot->emplaceVGMFile<HeartBeatPS1Seq>(file, static_cast<u32>(offset), total_size);
+      auto* newHeartBeatPS1Seq = pRoot->loadVGMFile<HeartBeatPS1Seq>(file, static_cast<u32>(offset), total_size);
       if (newHeartBeatPS1Seq) {
         loadedFiles.push_back(newHeartBeatPS1Seq);
       }

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesInstr.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesInstr.cpp
@@ -74,20 +74,17 @@ bool HeartBeatSnesInstrSet::parseInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    HeartBeatSnesInstr *newInstr = new HeartBeatSnesInstr(
+    emplaceInstr<HeartBeatSnesInstr>(
       this, version, addrInstrHeader, instrNum >> 7, instrNum & 0x7f, addrSRCNTable,
       songIndex, spcDirAddr, fmt::format("Instrument {}", instrNum));
-    aInstrs.push_back(newInstr);
   }
 
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::ranges::sort(usedSRCNs);
-  SNESSampColl *newSampColl = new SNESSampColl(HeartBeatSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(HeartBeatSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -131,9 +128,8 @@ bool HeartBeatSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  HeartBeatSnesRgn *rgn = new HeartBeatSnesRgn(this, version, offset());
+  HeartBeatSnesRgn *rgn = emplaceRgn<HeartBeatSnesRgn>(this, version, offset());
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   return true;
 }

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesInstr.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesInstr.cpp
@@ -74,7 +74,7 @@ bool HeartBeatSnesInstrSet::parseInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    emplaceInstr<HeartBeatSnesInstr>(
+    addInstr<HeartBeatSnesInstr>(
       this, version, addrInstrHeader, instrNum >> 7, instrNum & 0x7f, addrSRCNTable,
       songIndex, spcDirAddr, fmt::format("Instrument {}", instrNum));
   }
@@ -128,7 +128,7 @@ bool HeartBeatSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  HeartBeatSnesRgn *rgn = emplaceRgn<HeartBeatSnesRgn>(this, version, offset());
+  HeartBeatSnesRgn *rgn = addRgn<HeartBeatSnesRgn>(this, version, offset());
   rgn->sampOffset = addrSampStart - spcDirAddr;
 
   return true;

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesScanner.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesScanner.cpp
@@ -184,9 +184,8 @@ void HeartBeatSnesScanner::searchForHeartBeatSnesFromARAM(RawFile *file) {
   }
 
   u16 addrSeqHeader = file->readByte(addrSongListLo + songIndex) | (file->readByte(addrSongListHi + songIndex) << 8);
-  HeartBeatSnesSeq *newSeq = new HeartBeatSnesSeq(file, version, addrSeqHeader, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<HeartBeatSnesSeq>(file, version, addrSeqHeader, name);
+  if (!newSeq) {
     return;
   }
 
@@ -212,10 +211,9 @@ void HeartBeatSnesScanner::searchForHeartBeatSnesFromARAM(RawFile *file) {
     }
   }
 
-  HeartBeatSnesInstrSet *newInstrSet =
-      new HeartBeatSnesInstrSet(file, version, addrInstrTable, instrTableSize, addrSRCNTable, songIndex, spcDirAddr);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  auto* newInstrSet =
+      pRoot->emplaceVGMFile<HeartBeatSnesInstrSet>(file, version, addrInstrTable, instrTableSize, addrSRCNTable, songIndex, spcDirAddr);
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesScanner.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesScanner.cpp
@@ -184,7 +184,7 @@ void HeartBeatSnesScanner::searchForHeartBeatSnesFromARAM(RawFile *file) {
   }
 
   u16 addrSeqHeader = file->readByte(addrSongListLo + songIndex) | (file->readByte(addrSongListHi + songIndex) << 8);
-  auto* newSeq = pRoot->emplaceVGMFile<HeartBeatSnesSeq>(file, version, addrSeqHeader, name);
+  auto* newSeq = pRoot->loadVGMFile<HeartBeatSnesSeq>(file, version, addrSeqHeader, name);
   if (!newSeq) {
     return;
   }
@@ -212,7 +212,7 @@ void HeartBeatSnesScanner::searchForHeartBeatSnesFromARAM(RawFile *file) {
   }
 
   auto* newInstrSet =
-      pRoot->emplaceVGMFile<HeartBeatSnesInstrSet>(file, version, addrInstrTable, instrTableSize, addrSRCNTable, songIndex, spcDirAddr);
+      pRoot->loadVGMFile<HeartBeatSnesInstrSet>(file, version, addrInstrTable, instrTableSize, addrSRCNTable, songIndex, spcDirAddr);
   if (!newInstrSet) {
     return;
   }

--- a/src/main/formats/HeartBeatSnes/HeartBeatSnesSeq.cpp
+++ b/src/main/formats/HeartBeatSnes/HeartBeatSnesSeq.cpp
@@ -104,8 +104,7 @@ bool HeartBeatSnesSeq::parseTrackPointers(void) {
       return false;
     }
 
-    HeartBeatSnesTrack *track = new HeartBeatSnesTrack(this, addrTrackStart);
-    aTracks.push_back(track);
+    addTrack<HeartBeatSnesTrack>(this, addrTrackStart);
   }
 
   return true;

--- a/src/main/formats/HudsonSnes/HudsonSnesInstr.cpp
+++ b/src/main/formats/HudsonSnes/HudsonSnesInstr.cpp
@@ -55,19 +55,16 @@ bool HudsonSnesInstrSet::parseInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    HudsonSnesInstr *newInstr = new HudsonSnesInstr(
+    emplaceInstr<HudsonSnesInstr>(
       this, version, ofsInstrEntry, instrNum, spcDirAddr, addrSampTuningTable,
       fmt::format("Instrument {}", instrNum));
-    aInstrs.push_back(newInstr);
   }
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(HudsonSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(HudsonSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -108,9 +105,8 @@ bool HudsonSnesInstr::loadInstr() {
     return false;
   }
 
-  HudsonSnesRgn *rgn = new HudsonSnesRgn(this, version, offset(), ofsTuningEnt);
+  HudsonSnesRgn *rgn = emplaceRgn<HudsonSnesRgn>(this, version, offset(), ofsTuningEnt);
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   return true;
 }

--- a/src/main/formats/HudsonSnes/HudsonSnesInstr.cpp
+++ b/src/main/formats/HudsonSnes/HudsonSnesInstr.cpp
@@ -55,7 +55,7 @@ bool HudsonSnesInstrSet::parseInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    emplaceInstr<HudsonSnesInstr>(
+    addInstr<HudsonSnesInstr>(
       this, version, ofsInstrEntry, instrNum, spcDirAddr, addrSampTuningTable,
       fmt::format("Instrument {}", instrNum));
   }
@@ -105,7 +105,7 @@ bool HudsonSnesInstr::loadInstr() {
     return false;
   }
 
-  HudsonSnesRgn *rgn = emplaceRgn<HudsonSnesRgn>(this, version, offset(), ofsTuningEnt);
+  HudsonSnesRgn *rgn = addRgn<HudsonSnesRgn>(this, version, offset(), ofsTuningEnt);
   rgn->sampOffset = addrSampStart - spcDirAddr;
 
   return true;

--- a/src/main/formats/HudsonSnes/HudsonSnesScanner.cpp
+++ b/src/main/formats/HudsonSnes/HudsonSnesScanner.cpp
@@ -245,9 +245,8 @@ void HudsonSnesScanner::searchForHudsonSnesFromARAM(RawFile *file) {
   // load song
   u16 addrSeqHeaderPtr = addrSongList + guessedSongIndex * 2;
   u16 addrSeqHeader = file->readShort(addrSeqHeaderPtr);
-  HudsonSnesSeq *newSeq = new HudsonSnesSeq(file, version, addrSeqHeader, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<HudsonSnesSeq>(file, version, addrSeqHeader, name);
+  if (!newSeq) {
     return;
   }
 
@@ -273,15 +272,14 @@ void HudsonSnesScanner::searchForHudsonSnesFromARAM(RawFile *file) {
       addrSampTuningTable = file->readShort(addrEngineHeader + 4);
     }
 
-    HudsonSnesInstrSet *newInstrSet = new HudsonSnesInstrSet(file,
-                                                             version,
-                                                             newSeq->InstrumentTableAddress,
-                                                             newSeq->InstrumentTableSize,
-                                                             spcDirAddr,
-                                                             addrSampTuningTable,
-                                                             name);
-    if (!newInstrSet->loadVGMFile()) {
-      delete newInstrSet;
+    auto* newInstrSet = pRoot->emplaceVGMFile<HudsonSnesInstrSet>(file,
+                                                           version,
+                                                           newSeq->InstrumentTableAddress,
+                                                           newSeq->InstrumentTableSize,
+                                                           spcDirAddr,
+                                                           addrSampTuningTable,
+                                                           name);
+    if (!newInstrSet) {
       return;
     }
   }

--- a/src/main/formats/HudsonSnes/HudsonSnesScanner.cpp
+++ b/src/main/formats/HudsonSnes/HudsonSnesScanner.cpp
@@ -245,7 +245,7 @@ void HudsonSnesScanner::searchForHudsonSnesFromARAM(RawFile *file) {
   // load song
   u16 addrSeqHeaderPtr = addrSongList + guessedSongIndex * 2;
   u16 addrSeqHeader = file->readShort(addrSeqHeaderPtr);
-  auto* newSeq = pRoot->emplaceVGMFile<HudsonSnesSeq>(file, version, addrSeqHeader, name);
+  auto* newSeq = pRoot->loadVGMFile<HudsonSnesSeq>(file, version, addrSeqHeader, name);
   if (!newSeq) {
     return;
   }
@@ -272,7 +272,7 @@ void HudsonSnesScanner::searchForHudsonSnesFromARAM(RawFile *file) {
       addrSampTuningTable = file->readShort(addrEngineHeader + 4);
     }
 
-    auto* newInstrSet = pRoot->emplaceVGMFile<HudsonSnesInstrSet>(file,
+    auto* newInstrSet = pRoot->loadVGMFile<HudsonSnesInstrSet>(file,
                                                            version,
                                                            newSeq->InstrumentTableAddress,
                                                            newSeq->InstrumentTableSize,

--- a/src/main/formats/HudsonSnes/HudsonSnesSeq.cpp
+++ b/src/main/formats/HudsonSnes/HudsonSnesSeq.cpp
@@ -361,8 +361,7 @@ bool HudsonSnesSeq::parseTrackPointersInHeader(VGMHeader *header, u32 &offset) {
 bool HudsonSnesSeq::parseTrackPointers() {
   for (int trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     if ((TrackAvailableBits & (1 << trackIndex)) != 0) {
-      HudsonSnesTrack *track = new HudsonSnesTrack(this, TrackAddresses[trackIndex]);
-      aTracks.push_back(track);
+      addTrack<HudsonSnesTrack>(this, TrackAddresses[trackIndex]);
     }
   }
 

--- a/src/main/formats/ItikitiSnes/ItikitiSnesInstr.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesInstr.cpp
@@ -37,19 +37,16 @@ bool ItikitiSnesInstrSet::parseInstrPointers() {
 
     srcns.push_back(srcn);
 
-    auto instrument = std::make_unique<ItikitiSnesInstr>(
+    emplaceInstr<ItikitiSnesInstr>(
       this, ins_tuning_offset, ins_adsr_offset, 0, srcn, srcn, spc_dir_offset(),
       fmt::format("Instrument {}", index));
-    aInstrs.push_back(instrument.release());
   }
 
-  if (aInstrs.empty())
+  if (!hasInstrs())
     return false;
 
-  auto sampleColl = std::make_unique<SNESSampColl>(ItikitiSnesFormat::name, this->rawFile(), spc_dir_offset(), srcns);
-  if (!sampleColl->loadVGMFile())
+  if (!addDiscoveredFile<SNESSampColl>(ItikitiSnesFormat::name, rawFile(), spc_dir_offset(), srcns))
     return false;
-  (void)sampleColl.release();
 
   return true;
 }
@@ -71,7 +68,7 @@ bool ItikitiSnesInstr::loadInstr() {
 
   auto region = std::make_unique<ItikitiSnesRgn>(this, m_tuning_offset, m_adsr_offset, srcn);
   region->sampOffset = sample_offset - spc_dir_offset();
-  addRgn(region.release());
+  addRgn(std::move(region));
 
   return true;
 }

--- a/src/main/formats/ItikitiSnes/ItikitiSnesInstr.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesInstr.cpp
@@ -68,7 +68,7 @@ bool ItikitiSnesInstr::loadInstr() {
 
   auto region = std::make_unique<ItikitiSnesRgn>(this, m_tuning_offset, m_adsr_offset, srcn);
   region->sampOffset = sample_offset - spc_dir_offset();
-  adoptRgn(std::move(region));
+  sinkRgn(std::move(region));
 
   return true;
 }

--- a/src/main/formats/ItikitiSnes/ItikitiSnesInstr.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesInstr.cpp
@@ -37,7 +37,7 @@ bool ItikitiSnesInstrSet::parseInstrPointers() {
 
     srcns.push_back(srcn);
 
-    emplaceInstr<ItikitiSnesInstr>(
+    addInstr<ItikitiSnesInstr>(
       this, ins_tuning_offset, ins_adsr_offset, 0, srcn, srcn, spc_dir_offset(),
       fmt::format("Instrument {}", index));
   }
@@ -68,7 +68,7 @@ bool ItikitiSnesInstr::loadInstr() {
 
   auto region = std::make_unique<ItikitiSnesRgn>(this, m_tuning_offset, m_adsr_offset, srcn);
   region->sampOffset = sample_offset - spc_dir_offset();
-  addRgn(std::move(region));
+  adoptRgn(std::move(region));
 
   return true;
 }

--- a/src/main/formats/ItikitiSnes/ItikitiSnesScanner.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesScanner.cpp
@@ -30,10 +30,10 @@ void ItikitiSnesScanner::scanFromApuRam(RawFile *file) {
   if (!scanSongHeader(file, song_header_offset))
     return;
 
-  if (!pRoot->emplaceVGMFile<ItikitiSnesSeq>(file, song_header_offset, name))
+  if (!pRoot->loadVGMFile<ItikitiSnesSeq>(file, song_header_offset, name))
     return;
 
-  if (!pRoot->emplaceVGMFile<ItikitiSnesInstrSet>(file, 0x1d40, 0x1e60, 0x1b00))
+  if (!pRoot->loadVGMFile<ItikitiSnesInstrSet>(file, 0x1d40, 0x1e60, 0x1b00))
     return;
 }
 

--- a/src/main/formats/ItikitiSnes/ItikitiSnesScanner.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesScanner.cpp
@@ -30,15 +30,11 @@ void ItikitiSnesScanner::scanFromApuRam(RawFile *file) {
   if (!scanSongHeader(file, song_header_offset))
     return;
 
-  auto seq = std::make_unique<ItikitiSnesSeq>(file, song_header_offset, name);
-  if (!seq->loadVGMFile())
+  if (!pRoot->emplaceVGMFile<ItikitiSnesSeq>(file, song_header_offset, name))
     return;
-  (void)seq.release();
 
-  auto insrument_set = std::make_unique<ItikitiSnesInstrSet>(file, 0x1d40, 0x1e60, 0x1b00);
-  if (!insrument_set->loadVGMFile())
+  if (!pRoot->emplaceVGMFile<ItikitiSnesInstrSet>(file, 0x1d40, 0x1e60, 0x1b00))
     return;
-  (void)insrument_set.release();
 }
 
 void ItikitiSnesScanner::scanFromRom(RawFile *file) {

--- a/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
+++ b/src/main/formats/ItikitiSnes/ItikitiSnesSeq.cpp
@@ -65,8 +65,7 @@ bool ItikitiSnesSeq::parseTrackPointers() {
   for (unsigned int track_index = 0; track_index < nNumTracks; track_index++) {
     const u32 offset_to_pointer = offset() + 2 + (2 * track_index);
     const u32 offset = readDecodedOffset(offset_to_pointer);
-    auto track = std::make_unique<ItikitiSnesTrack>(this, offset);
-    aTracks.push_back(track.release());
+    addTrack<ItikitiSnesTrack>(this, offset);
   }
   return true;
 }

--- a/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
@@ -75,8 +75,8 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
     int bank = sampNum > 127 ? 1 : 0;
     int instrNum = sampNum > 127 ? sampNum - 128 : sampNum;
     std::string name = fmt::format("Instrument {} Bank {}", instrNum, bank);
-    VGMInstr* instr = emplaceInstr<VGMInstr>(this, off, sizeof(konami_mw_sample_info), bank, instrNum, name);
-    VGMRgn* rgn = instr->emplaceRgn<VGMRgn>(instr, off, sizeof(konami_mw_sample_info));
+    VGMInstr* instr = addInstr<VGMInstr>(this, off, sizeof(konami_mw_sample_info), bank, instrNum, name);
+    VGMRgn* rgn = instr->addRgn<VGMRgn>(instr, off, sizeof(konami_mw_sample_info));
     rgn->sampNum = sampNum;
     rgn->release_time = instrReleaseTime;
 
@@ -121,7 +121,7 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
       break;
     }
 
-    VGMRgn* rgn = drumInstrRaw->emplaceRgn<VGMRgn>(drumInstrRaw, off, sizeof(drum), fmt::format("Region {:d}", i));
+    VGMRgn* rgn = drumInstrRaw->addRgn<VGMRgn>(drumInstrRaw, off, sizeof(drum), fmt::format("Region {:d}", i));
     // The driver offsets notes up 2 octaves relative to midi note values.
     rgn->keyLow = i + 24;
     rgn->keyHigh = i + 24;
@@ -224,7 +224,7 @@ bool KonamiArcadeSampColl::parseSampleInfo() {
     auto name = fmt::format("Sample {:d}", sampNum++);
     VGMSamp* sample;
     if (sampInfo.type() == konami_mw_sample_info::sample_type::ADPCM) {
-      sample = addSamp(std::make_unique<KonamiAdpcmSamp>(
+      sample = adoptSamp(std::make_unique<KonamiAdpcmSamp>(
         this,
         sampleOffset,
         sampleSize,

--- a/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
@@ -12,6 +12,8 @@
 #include "LogManager.h"
 #include "VGMRgn.h"
 
+#include <memory>
+
 #include <spdlog/fmt/fmt.h>
 
 // The driver doesn't define an envelope at the instrument level. Instead, it sets release time
@@ -73,18 +75,16 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
     int bank = sampNum > 127 ? 1 : 0;
     int instrNum = sampNum > 127 ? sampNum - 128 : sampNum;
     std::string name = fmt::format("Instrument {} Bank {}", instrNum, bank);
-    VGMInstr* instr = new VGMInstr(this, off, sizeof(konami_mw_sample_info), bank, instrNum, name);
-    VGMRgn* rgn = new VGMRgn(instr, off, sizeof(konami_mw_sample_info));
+    VGMInstr* instr = emplaceInstr<VGMInstr>(this, off, sizeof(konami_mw_sample_info), bank, instrNum, name);
+    VGMRgn* rgn = instr->emplaceRgn<VGMRgn>(instr, off, sizeof(konami_mw_sample_info));
     rgn->sampNum = sampNum;
     rgn->release_time = instrReleaseTime;
-    instr->addRgn(rgn);
 
     auto instrSampInfoItem = instrSampInfos->addChild(off, sizeof(konami_mw_sample_info),
                                       fmt::format("Instrument Sample Info {}", sampNum));
     addSampleInfoChildren(instrSampInfoItem, off);
     sampNum++;
 
-    aInstrs.push_back(instr);
   }
 
   if (m_drumTableOffset == 0 || m_drumSampleTableOffset == 0) {
@@ -101,9 +101,9 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
   }
 
   // Load drum table
-  int numMelodicInstrs = aInstrs.size();
+  int numMelodicInstrs = static_cast<int>(instrCount());
   readBytes(m_drumTableOffset, sizeof(m_drums), &m_drums);
-  VGMInstr* drumInstr = new VGMInstr(
+  auto drumInstr = std::make_unique<VGMInstr>(
     this,
     m_drumTableOffset,
     sizeof(m_drums),
@@ -111,7 +111,7 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
     0,
     "Drum Kit"
   );
-  std::vector<VGMInstr *> aDrumKit;
+  auto* drumInstrRaw = drumInstr.get();
   for (size_t i = 0; i < sizeof(m_drums) / sizeof(m_drums[0]); ++i) {
     drum& d = m_drums[i];
     u32 off = m_drumTableOffset + static_cast<u32>(i * sizeof(drum));
@@ -121,7 +121,7 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
       break;
     }
 
-    VGMRgn* rgn = new VGMRgn(drumInstr, off, sizeof(drum), fmt::format("Region {:d}", i));
+    VGMRgn* rgn = drumInstrRaw->emplaceRgn<VGMRgn>(drumInstrRaw, off, sizeof(drum), fmt::format("Region {:d}", i));
     // The driver offsets notes up 2 octaves relative to midi note values.
     rgn->keyLow = i + 24;
     rgn->keyHigh = i + 24;
@@ -138,11 +138,8 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
     rgn->addChild(off + 4, 2, "Unknown");
     rgn->addChild(off + 6, 1, "Default Duration");
     rgn->addChild(off + 7, 1, "Attenuation");
-    drumInstr->addRgn(rgn);
   }
-  aInstrs.push_back(drumInstr);
-  aDrumKit.push_back(drumInstr);
-  addChildren(aDrumKit);
+  adoptInstrAsChild(std::move(drumInstr));
 
   return true;
 }
@@ -227,16 +224,15 @@ bool KonamiArcadeSampColl::parseSampleInfo() {
     auto name = fmt::format("Sample {:d}", sampNum++);
     VGMSamp* sample;
     if (sampInfo.type() == konami_mw_sample_info::sample_type::ADPCM) {
-      sample = new KonamiAdpcmSamp(
+      sample = addSamp(std::make_unique<KonamiAdpcmSamp>(
         this,
         sampleOffset,
         sampleSize,
         KonamiAdpcmChip::K054539,
         24000,
         name
-      );
+      ));
       sample->setBPS(BPS::PCM16);
-      samples.push_back(sample);
     } else {
       BPS bps = sampInfo.type() == konami_mw_sample_info::sample_type::PCM_8 ? BPS::PCM8 : BPS::PCM16;
       sample = addSamp(sampleOffset,

--- a/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeInstr.cpp
@@ -139,7 +139,7 @@ bool KonamiArcadeInstrSet::parseInstrPointers() {
     rgn->addChild(off + 6, 1, "Default Duration");
     rgn->addChild(off + 7, 1, "Attenuation");
   }
-  adoptInstrAsChild(std::move(drumInstr));
+  sinkInstrAsChild(std::move(drumInstr));
 
   return true;
 }
@@ -224,7 +224,7 @@ bool KonamiArcadeSampColl::parseSampleInfo() {
     auto name = fmt::format("Sample {:d}", sampNum++);
     VGMSamp* sample;
     if (sampInfo.type() == konami_mw_sample_info::sample_type::ADPCM) {
-      sample = adoptSamp(std::make_unique<KonamiAdpcmSamp>(
+      sample = sinkSamp(std::make_unique<KonamiAdpcmSamp>(
         this,
         sampleOffset,
         sampleSize,

--- a/src/main/formats/KonamiArcade/KonamiArcadeScanner.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeScanner.cpp
@@ -153,7 +153,7 @@ void KonamiArcadeScanner::scan(RawFile *file, void *info) {
 
   std::string instrSetName = fmt::format("{} instrument set", gameentry->name);
 
-  auto* instrSet = pRoot->emplaceVGMFile<KonamiArcadeInstrSet>(
+  auto* instrSet = pRoot->loadVGMFile<KonamiArcadeInstrSet>(
     codeFile,
     samp_tables_offset,
     instrSetName,
@@ -167,7 +167,7 @@ void KonamiArcadeScanner::scan(RawFile *file, void *info) {
 
   std::string sampCollName = fmt::format("{} sample collection", gameentry->name);
 
-  auto* sampcoll = pRoot->emplaceVGMFile<KonamiArcadeSampColl>(samplesFile, instrSet, sampInfos, 0,
+  auto* sampcoll = pRoot->loadVGMFile<KonamiArcadeSampColl>(samplesFile, instrSet, sampInfos, 0,
                                                         static_cast<u32>(samplesFile->size()), sampCollName);
 
   std::vector<KonamiArcadeSeq*> seqs = loadSeqTable(
@@ -182,9 +182,9 @@ void KonamiArcadeScanner::scan(RawFile *file, void *info) {
   for (auto seq : seqs) {
     auto coll = std::make_unique<VGMColl>(seq->name());
 
-    coll->useSeq(seq);
-    coll->addInstrSet(instrSet);
-    coll->addSampColl(sampcoll);
+    coll->attachSeq(seq);
+    coll->attachInstrSet(instrSet);
+    coll->attachSampColl(sampcoll);
     pRoot->loadVGMColl(std::move(coll));
   }
 }
@@ -211,7 +211,7 @@ const std::vector<KonamiArcadeSeq*> KonamiArcadeScanner::loadSeqTable(
   KonamiArcadeFormatVer fmtVer
 ) {
   auto seqTableName = fmt::format("{} sequence pointer table", gameName);
-  auto* seqTable = pRoot->emplaceVGMFile<VGMMiscFile>(KonamiArcadeFormat::name, file, offset, 1, seqTableName);
+  auto* seqTable = pRoot->loadVGMFile<VGMMiscFile>(KonamiArcadeFormat::name, file, offset, 1, seqTableName);
   // Add SeqTable as Miscfile
   if (!seqTable) {
     return {};
@@ -234,7 +234,7 @@ const std::vector<KonamiArcadeSeq*> KonamiArcadeScanner::loadSeqTable(
       if (seqPointer == 0 || seqPointer >= nFileLength)
         break;
       auto name = fmt::format("{} {:d}", gameName, seqCounter++);
-      auto* newSeq = pRoot->emplaceVGMFile<KonamiArcadeSeq>(file, GX, seqPointer, 0, drums, nmiRate, name);
+      auto* newSeq = pRoot->loadVGMFile<KonamiArcadeSeq>(file, GX, seqPointer, 0, drums, nmiRate, name);
       if (newSeq)
         seqs.push_back(newSeq);
 
@@ -258,7 +258,7 @@ const std::vector<KonamiArcadeSeq*> KonamiArcadeScanner::loadSeqTable(
       if (seqOffset == 0 || seqOffset >= nFileLength)
         break;
       auto name = fmt::format("{} {:d}", gameName, seqCounter++);
-      auto* newSeq = pRoot->emplaceVGMFile<KonamiArcadeSeq>(file, MysticWarrior, seqOffset, dest, drums, nmiRate, name);
+      auto* newSeq = pRoot->loadVGMFile<KonamiArcadeSeq>(file, MysticWarrior, seqOffset, dest, drums, nmiRate, name);
       if (newSeq)
         seqs.push_back(newSeq);
 

--- a/src/main/formats/KonamiArcade/KonamiArcadeScanner.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeScanner.cpp
@@ -8,6 +8,8 @@
 #include "VGMColl.h"
 #include "VGMMiscFile.h"
 
+#include <memory>
+
 KonamiArcadeFormatVer konamiArcadeVersionEnum(const std::string &versionStr) {
   static const std::unordered_map<std::string, KonamiArcadeFormatVer> versionMap = {
     {"MysticWarrior", MysticWarrior},
@@ -151,7 +153,7 @@ void KonamiArcadeScanner::scan(RawFile *file, void *info) {
 
   std::string instrSetName = fmt::format("{} instrument set", gameentry->name);
 
-  auto instrSet = new KonamiArcadeInstrSet(
+  auto* instrSet = pRoot->emplaceVGMFile<KonamiArcadeInstrSet>(
     codeFile,
     samp_tables_offset,
     instrSetName,
@@ -159,19 +161,14 @@ void KonamiArcadeScanner::scan(RawFile *file, void *info) {
     drum_samp_table_offset,
     fmt_ver
   );
-  if (!instrSet->loadVGMFile()) {
-    delete instrSet;
-    instrSet = nullptr;
+  if (!instrSet) {
+    return;
   }
 
   std::string sampCollName = fmt::format("{} sample collection", gameentry->name);
 
-  auto sampcoll = new KonamiArcadeSampColl(samplesFile, instrSet, sampInfos, 0,
-    static_cast<u32>(samplesFile->size()), sampCollName);
-  if (!sampcoll->loadVGMFile()) {
-    delete sampcoll;
-    sampcoll = nullptr;
-  }
+  auto* sampcoll = pRoot->emplaceVGMFile<KonamiArcadeSampColl>(samplesFile, instrSet, sampInfos, 0,
+                                                        static_cast<u32>(samplesFile->size()), sampCollName);
 
   std::vector<KonamiArcadeSeq*> seqs = loadSeqTable(
     seqRomGroupEntry->file,
@@ -183,14 +180,12 @@ void KonamiArcadeScanner::scan(RawFile *file, void *info) {
   );
 
   for (auto seq : seqs) {
-    VGMColl* coll = new VGMColl(seq->name());
+    auto coll = std::make_unique<VGMColl>(seq->name());
 
     coll->useSeq(seq);
     coll->addInstrSet(instrSet);
     coll->addSampColl(sampcoll);
-    if (!coll->load()) {
-      delete coll;
-    }
+    pRoot->loadVGMColl(std::move(coll));
   }
 }
 
@@ -216,10 +211,9 @@ const std::vector<KonamiArcadeSeq*> KonamiArcadeScanner::loadSeqTable(
   KonamiArcadeFormatVer fmtVer
 ) {
   auto seqTableName = fmt::format("{} sequence pointer table", gameName);
-  VGMMiscFile *seqTable = new VGMMiscFile(KonamiArcadeFormat::name, file, offset, 1, seqTableName);
+  auto* seqTable = pRoot->emplaceVGMFile<VGMMiscFile>(KonamiArcadeFormat::name, file, offset, 1, seqTableName);
   // Add SeqTable as Miscfile
-  if (!seqTable->loadVGMFile()) {
-    delete seqTable;
+  if (!seqTable) {
     return {};
   }
   std::vector<KonamiArcadeSeq*> seqs;
@@ -240,10 +234,8 @@ const std::vector<KonamiArcadeSeq*> KonamiArcadeScanner::loadSeqTable(
       if (seqPointer == 0 || seqPointer >= nFileLength)
         break;
       auto name = fmt::format("{} {:d}", gameName, seqCounter++);
-      KonamiArcadeSeq *newSeq = new KonamiArcadeSeq(file, GX, seqPointer, 0, drums, nmiRate, name);
-      if (!newSeq->loadVGMFile())
-        delete newSeq;
-      else
+      auto* newSeq = pRoot->emplaceVGMFile<KonamiArcadeSeq>(file, GX, seqPointer, 0, drums, nmiRate, name);
+      if (newSeq)
         seqs.push_back(newSeq);
 
       auto child = seqTable->addChild(offset, sizeof(sequence_table_entry_gx), "Sequence Info Block");
@@ -266,10 +258,8 @@ const std::vector<KonamiArcadeSeq*> KonamiArcadeScanner::loadSeqTable(
       if (seqOffset == 0 || seqOffset >= nFileLength)
         break;
       auto name = fmt::format("{} {:d}", gameName, seqCounter++);
-      KonamiArcadeSeq *newSeq = new KonamiArcadeSeq(file, MysticWarrior, seqOffset, dest, drums, nmiRate, name);
-      if (!newSeq->loadVGMFile())
-        delete newSeq;
-      else
+      auto* newSeq = pRoot->emplaceVGMFile<KonamiArcadeSeq>(file, MysticWarrior, seqOffset, dest, drums, nmiRate, name);
+      if (newSeq)
         seqs.push_back(newSeq);
 
       auto child = seqTable->addChild(offset, sizeof(sequence_table_entry), "Sequence Pointer");

--- a/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
+++ b/src/main/formats/KonamiArcade/KonamiArcadeSeq.cpp
@@ -68,7 +68,7 @@ bool KonamiArcadeSeq::parseTrackPointers() {
 
       trackPtrTableItem->addChild(pos, 2, fmt::format("Track {} Pointer", i));
 
-      aTracks.push_back(new KonamiArcadeTrack(this, romTrackOffset, 0));
+      addTrack<KonamiArcadeTrack>(this, romTrackOffset, 0);
       pos += 2;
     }
   } else {
@@ -83,7 +83,7 @@ bool KonamiArcadeSeq::parseTrackPointers() {
 
       trackPtrTableItem->addChild(pos, 4, fmt::format("Track {} Pointer", i));
 
-      aTracks.push_back(new KonamiArcadeTrack(this, trackOffset, 0));
+      addTrack<KonamiArcadeTrack>(this, trackOffset, 0);
       pos += 4;
     }
   }
@@ -207,8 +207,9 @@ void KonamiArcadeTrack::applyTranspose() {
 
 void KonamiArcadeTrack::makeTrulyPrevDurNoteEnd(u32 absTime) const {
   if (readMode == READMODE_CONVERT_TO_MIDI) {
-    if (pMidiTrack->prevDurNoteOffs.size() > 0) {
-      auto prevDurNoteOff = pMidiTrack->prevDurNoteOffs.back();
+    const auto& previousDurNoteOffs = pMidiTrack->previousDurNoteOffs();
+    if (!previousDurNoteOffs.empty()) {
+      auto* prevDurNoteOff = previousDurNoteOffs.back();
       prevDurNoteOff->absTime = absTime;
     }
   }

--- a/src/main/formats/KonamiPS1/KonamiPS1Scanner.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Scanner.cpp
@@ -24,7 +24,7 @@ void KonamiPS1Scanner::scan(RawFile *file, void *info) {
         name += fmt::format("({})", numSeqFiles + 1);
       }
 
-      auto* newSeq = pRoot->emplaceVGMFile<KonamiPS1Seq>(file, offset, name);
+      auto* newSeq = pRoot->loadVGMFile<KonamiPS1Seq>(file, offset, name);
       if (newSeq) {
         offset += newSeq->length();
         numSeqFiles++;

--- a/src/main/formats/KonamiPS1/KonamiPS1Scanner.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Scanner.cpp
@@ -24,13 +24,11 @@ void KonamiPS1Scanner::scan(RawFile *file, void *info) {
         name += fmt::format("({})", numSeqFiles + 1);
       }
 
-      KonamiPS1Seq *newSeq = new KonamiPS1Seq(file, offset, name);
-      if (newSeq->loadVGMFile()) {
+      auto* newSeq = pRoot->emplaceVGMFile<KonamiPS1Seq>(file, offset, name);
+      if (newSeq) {
         offset += newSeq->length();
         numSeqFiles++;
         continue;
-      } else {
-        delete newSeq;
       }
     }
     offset++;

--- a/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
+++ b/src/main/formats/KonamiPS1/KonamiPS1Seq.cpp
@@ -54,8 +54,7 @@ bool KonamiPS1Seq::parseTrackPointers() {
   u32 trackStart = offset() + kHeaderSize + (numTracks * 2);
   for (u32 trackIndex = 0; trackIndex < numTracks; trackIndex++) {
     u16 trackSize = readShort(offset() + kHeaderSize + (trackIndex * 2));
-    KonamiPS1Track *track = new KonamiPS1Track(this, trackStart, trackSize);
-    aTracks.push_back(track);
+    addTrack<KonamiPS1Track>(this, trackStart, trackSize);
     trackStart += trackSize;
   }
 

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -265,7 +265,7 @@ bool KonamiSnesInstr::loadInstr() {
         return false;
       }
 
-      adoptRgn(std::move(rgn));
+      sinkRgn(std::move(rgn));
     }
     setGuessedLength();
     return !percussionHeaders.empty() && !regions().empty();

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -13,6 +13,7 @@
 #include "VGMColl.h"
 
 #include <algorithm>
+#include <memory>
 
 #include <spdlog/fmt/fmt.h>
 
@@ -173,10 +174,9 @@ bool KonamiSnesInstrSet::parseInstrPointers() {
 
     addUsedSRCN(srcn);
 
-    KonamiSnesInstr *newInstr = new KonamiSnesInstr(
+    emplaceInstr<KonamiSnesInstr>(
       this, version, addrInstrHeader, instr >> 7, instr & 0x7f,
       spcDirAddr, false, fmt::format("Instrument {}", instr));
-    aInstrs.push_back(newInstr);
   }
 
   const auto percussionHeaders = collectPercussionHeaders(this->rawFile(), version, percInstrOffset, spcDirAddr);
@@ -185,25 +185,22 @@ bool KonamiSnesInstrSet::parseInstrPointers() {
     addUsedSRCN(readByte(header.offset));
   }
   if (!percussionHeaders.empty()) {
-    auto *newInstr = new KonamiSnesInstr(this,
-                                         version,
-                                         percInstrOffset,
-                                         DRUMKIT_PROGRAM >> 7,
-                                         DRUMKIT_PROGRAM & 0x7f,
-                                         spcDirAddr,
-                                         true,
-                                         "Percussion");
-    aInstrs.push_back(newInstr);
+    emplaceInstr<KonamiSnesInstr>(this,
+                                  version,
+                                  percInstrOffset,
+                                  DRUMKIT_PROGRAM >> 7,
+                                  DRUMKIT_PROGRAM & 0x7f,
+                                  spcDirAddr,
+                                  true,
+                                  "Percussion");
   }
 
-  if (aInstrs.empty()) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(KonamiSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(KonamiSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -262,14 +259,13 @@ bool KonamiSnesInstr::loadInstr() {
       const u32 offDirEnt = spcDirAddr + (srcn * 4);
       const u16 addrSampStart = readShort(offDirEnt);
 
-      auto *rgn = new KonamiSnesRgn(this, version, header.offset, true, header.note);
+      auto rgn = std::make_unique<KonamiSnesRgn>(this, version, header.offset, true, header.note);
       rgn->sampOffset = addrSampStart - spcDirAddr;
       if (!rgn->loadRgn()) {
-        delete rgn;
         return false;
       }
 
-      addRgn(rgn);
+      addRgn(std::move(rgn));
     }
     setGuessedLength();
     return !percussionHeaders.empty() && !regions().empty();
@@ -283,9 +279,8 @@ bool KonamiSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  KonamiSnesRgn *rgn = new KonamiSnesRgn(this, version, offset(), percussion);
+  KonamiSnesRgn *rgn = emplaceRgn<KonamiSnesRgn>(this, version, offset(), percussion);
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   setGuessedLength();
   return true;

--- a/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesInstr.cpp
@@ -174,7 +174,7 @@ bool KonamiSnesInstrSet::parseInstrPointers() {
 
     addUsedSRCN(srcn);
 
-    emplaceInstr<KonamiSnesInstr>(
+    addInstr<KonamiSnesInstr>(
       this, version, addrInstrHeader, instr >> 7, instr & 0x7f,
       spcDirAddr, false, fmt::format("Instrument {}", instr));
   }
@@ -185,7 +185,7 @@ bool KonamiSnesInstrSet::parseInstrPointers() {
     addUsedSRCN(readByte(header.offset));
   }
   if (!percussionHeaders.empty()) {
-    emplaceInstr<KonamiSnesInstr>(this,
+    addInstr<KonamiSnesInstr>(this,
                                   version,
                                   percInstrOffset,
                                   DRUMKIT_PROGRAM >> 7,
@@ -265,7 +265,7 @@ bool KonamiSnesInstr::loadInstr() {
         return false;
       }
 
-      addRgn(std::move(rgn));
+      adoptRgn(std::move(rgn));
     }
     setGuessedLength();
     return !percussionHeaders.empty() && !regions().empty();
@@ -279,7 +279,7 @@ bool KonamiSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  KonamiSnesRgn *rgn = emplaceRgn<KonamiSnesRgn>(this, version, offset(), percussion);
+  KonamiSnesRgn *rgn = addRgn<KonamiSnesRgn>(this, version, offset(), percussion);
   rgn->sampOffset = addrSampStart - spcDirAddr;
 
   setGuessedLength();

--- a/src/main/formats/KonamiSnes/KonamiSnesScanner.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesScanner.cpp
@@ -633,7 +633,7 @@ void KonamiSnesScanner::searchForKonamiSnesFromARAM(RawFile *file) {
     }
   }
 
-  auto* newSeq = pRoot->emplaceVGMFile<KonamiSnesSeq>(file, version, addrSongHeader, name);
+  auto* newSeq = pRoot->loadVGMFile<KonamiSnesSeq>(file, version, addrSongHeader, name);
   if (!newSeq) {
     return;
   }
@@ -737,7 +737,7 @@ void KonamiSnesScanner::searchForKonamiSnesFromARAM(RawFile *file) {
     return;
   }
 
-  auto* newInstrSet = pRoot->emplaceVGMFile<KonamiSnesInstrSet>(file,
+  auto* newInstrSet = pRoot->loadVGMFile<KonamiSnesInstrSet>(file,
                                                          version,
                                                          addrCommonInstrTable,
                                                          addrBankedInstrTable,

--- a/src/main/formats/KonamiSnes/KonamiSnesScanner.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesScanner.cpp
@@ -633,9 +633,8 @@ void KonamiSnesScanner::searchForKonamiSnesFromARAM(RawFile *file) {
     }
   }
 
-  KonamiSnesSeq *newSeq = new KonamiSnesSeq(file, version, addrSongHeader, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<KonamiSnesSeq>(file, version, addrSongHeader, name);
+  if (!newSeq) {
     return;
   }
 
@@ -738,15 +737,14 @@ void KonamiSnesScanner::searchForKonamiSnesFromARAM(RawFile *file) {
     return;
   }
 
-  KonamiSnesInstrSet *newInstrSet = new KonamiSnesInstrSet(file,
-                                                           version,
-                                                           addrCommonInstrTable,
-                                                           addrBankedInstrTable,
-                                                           firstBankedInstr,
-                                                           addrPercInstrTable,
-                                                           spcDirAddr);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  auto* newInstrSet = pRoot->emplaceVGMFile<KonamiSnesInstrSet>(file,
+                                                         version,
+                                                         addrCommonInstrTable,
+                                                         addrBankedInstrTable,
+                                                         firstBankedInstr,
+                                                         addrPercInstrTable,
+                                                         spcDirAddr);
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
+++ b/src/main/formats/KonamiSnes/KonamiSnesSeq.cpp
@@ -203,7 +203,7 @@ bool KonamiSnesSeq::parseHeader(void) {
 bool KonamiSnesSeq::parseTrackPointers(void) {
   for (u32 trackNumber = 0; trackNumber < nNumTracks; trackNumber++) {
     u16 trkOff = readShort(offset() + trackNumber * 2);
-    aTracks.push_back(new KonamiSnesTrack(this, trkOff));
+    addTrack<KonamiSnesTrack>(this, trkOff);
   }
   return true;
 }
@@ -709,7 +709,7 @@ void KonamiSnesTrack::applyCurrentTempo() {
     parentSeq.tempo = newTempo;
     addTempoBPMNoItem(parentSeq.getTempoInBPM(newTempo));
     if (konami_snes::usesLegacyVibrato(parentSeq.version)) {
-      for (SeqTrack *track : parentSeq.aTracks) {
+      for (SeqTrack *track : parentSeq.tracks()) {
         static_cast<KonamiSnesTrack*>(track)->syncVibratoRateAndDelay();
       }
     }
@@ -1159,7 +1159,7 @@ bool KonamiSnesTrack::readEvent() {
       parentSeq.tempo = newTempo;
       addTempoBPM(beginOffset, curOffset - beginOffset, parentSeq.getTempoInBPM(newTempo));
       if (konami_snes::usesLegacyVibrato(parentSeq.version)) {
-        for (SeqTrack *track : parentSeq.aTracks) {
+        for (SeqTrack *track : parentSeq.tracks()) {
           static_cast<KonamiSnesTrack*>(track)->syncVibratoRateAndDelay();
         }
       }

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2Instr.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2Instr.cpp
@@ -109,7 +109,7 @@ bool KonamiTMNT2SampleInstrSet::parseMelodicInstrs() {
     rgn->sampOffset = instrInfo.start();
     rgn->sampDataLength = (instrInfo.length_hi << 8) | instrInfo.length_lo;
 
-    adoptInstr(std::move(instr));
+    sinkInstr(std::move(instr));
     instrNum += 1;
   }
   return true;
@@ -196,7 +196,7 @@ bool KonamiTMNT2SampleInstrSet::parseDrums() {
       drumNum += 1;
     }
   }
-  adoptInstr(std::move(drumKit));
+  sinkInstr(std::move(drumKit));
   drumsItem->setOffset(minDrumOffset);
   drumsItem->setLength((maxDrumOffset + sizeof(konami_tmnt2_drum_info)) - minDrumOffset);
   return true;
@@ -237,10 +237,10 @@ bool KonamiTMNT2SampColl::parseSampleInfo() {
     auto name = fmt::format("Sample {:d}", sampNum++);
     VGMSamp* sample;
     if (sampleOffset + sampleSize > length()) {
-      sample = adoptSamp(std::make_unique<EmptySamp>(this));
+      sample = sinkSamp(std::make_unique<EmptySamp>(this));
     }
     else if (sampInfo.isAdpcm) {
-      sample = adoptSamp(std::make_unique<KonamiAdpcmSamp>(
+      sample = sinkSamp(std::make_unique<KonamiAdpcmSamp>(
         this,
         sampleOffset,
         sampleSize,

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2Instr.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2Instr.cpp
@@ -105,7 +105,7 @@ bool KonamiTMNT2SampleInstrSet::parseMelodicInstrs() {
       name
     );
     auto* rawInstr = instr.get();
-    VGMRgn* rgn = rawInstr->emplaceRgn<VGMRgn>(rawInstr, offset, sizeof(konami_tmnt2_instr_info));
+    VGMRgn* rgn = rawInstr->addRgn<VGMRgn>(rawInstr, offset, sizeof(konami_tmnt2_instr_info));
     rgn->sampOffset = instrInfo.start();
     rgn->sampDataLength = (instrInfo.length_hi << 8) | instrInfo.length_lo;
 
@@ -181,7 +181,7 @@ bool KonamiTMNT2SampleInstrSet::parseDrums() {
 
       const konami_tmnt2_drum_info& drumInfo = m_drumTables[i][j];
 
-      VGMRgn* rgn = rawDrumKit->emplaceRgn<VGMRgn>(rawDrumKit, ptr, sizeof(konami_tmnt2_drum_info));
+      VGMRgn* rgn = rawDrumKit->addRgn<VGMRgn>(rawDrumKit, ptr, sizeof(konami_tmnt2_drum_info));
       rgn->sampOffset = drumInfo.start();
       rgn->sampDataLength = (drumInfo.length_hi << 8) | drumInfo.length_lo;
       u8 key = (i * 16) + j;
@@ -237,10 +237,10 @@ bool KonamiTMNT2SampColl::parseSampleInfo() {
     auto name = fmt::format("Sample {:d}", sampNum++);
     VGMSamp* sample;
     if (sampleOffset + sampleSize > length()) {
-      sample = addSamp(std::make_unique<EmptySamp>(this));
+      sample = adoptSamp(std::make_unique<EmptySamp>(this));
     }
     else if (sampInfo.isAdpcm) {
-      sample = addSamp(std::make_unique<KonamiAdpcmSamp>(
+      sample = adoptSamp(std::make_unique<KonamiAdpcmSamp>(
         this,
         sampleOffset,
         sampleSize,

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2Instr.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2Instr.cpp
@@ -12,6 +12,7 @@
 #include "KonamiTMNT2Format.h"
 #include "VGMRgn.h"
 
+#include <memory>
 #include <set>
 #include <tuple>
 
@@ -95,7 +96,7 @@ bool KonamiTMNT2SampleInstrSet::parseMelodicInstrs() {
     }
 
     std::string name = fmt::format("Instrument {}", instrNum);
-    VGMInstr* instr = new VGMInstr(
+    auto instr = std::make_unique<VGMInstr>(
       this,
       offset,
       sizeof(konami_tmnt2_instr_info),
@@ -103,12 +104,12 @@ bool KonamiTMNT2SampleInstrSet::parseMelodicInstrs() {
       instrNum % 128,
       name
     );
-    VGMRgn* rgn = new VGMRgn(instr, offset, sizeof(konami_tmnt2_instr_info));
+    auto* rawInstr = instr.get();
+    VGMRgn* rgn = rawInstr->emplaceRgn<VGMRgn>(rawInstr, offset, sizeof(konami_tmnt2_instr_info));
     rgn->sampOffset = instrInfo.start();
     rgn->sampDataLength = (instrInfo.length_hi << 8) | instrInfo.length_lo;
 
-    instr->addRgn(rgn);
-    aInstrs.push_back(instr);
+    adoptInstr(std::move(instr));
     instrNum += 1;
   }
   return true;
@@ -143,7 +144,8 @@ bool KonamiTMNT2SampleInstrSet::parseDrums() {
     "Drums"
   );
 
-  VGMInstr* drumKit = new VGMInstr(this, offset(), length(), 1, 0, "Drum Kit");
+  auto drumKit = std::make_unique<VGMInstr>(this, offset(), length(), 1, 0, "Drum Kit");
+  auto* rawDrumKit = drumKit.get();
 
   minDrumOffset = -1;
   maxDrumOffset = 0;
@@ -179,7 +181,7 @@ bool KonamiTMNT2SampleInstrSet::parseDrums() {
 
       const konami_tmnt2_drum_info& drumInfo = m_drumTables[i][j];
 
-      VGMRgn* rgn = new VGMRgn(drumKit, ptr, sizeof(konami_tmnt2_drum_info));
+      VGMRgn* rgn = rawDrumKit->emplaceRgn<VGMRgn>(rawDrumKit, ptr, sizeof(konami_tmnt2_drum_info));
       rgn->sampOffset = drumInfo.start();
       rgn->sampDataLength = (drumInfo.length_hi << 8) | drumInfo.length_lo;
       u8 key = (i * 16) + j;
@@ -191,11 +193,10 @@ bool KonamiTMNT2SampleInstrSet::parseDrums() {
       rgn->coarseTune = relativePitchCents / 100;
       rgn->fineTune = static_cast<int>(relativePitchCents) % 100;
 
-      drumKit->addRgn(rgn);
       drumNum += 1;
     }
   }
-  aInstrs.emplace_back(drumKit);
+  adoptInstr(std::move(drumKit));
   drumsItem->setOffset(minDrumOffset);
   drumsItem->setLength((maxDrumOffset + sizeof(konami_tmnt2_drum_info)) - minDrumOffset);
   return true;
@@ -236,19 +237,18 @@ bool KonamiTMNT2SampColl::parseSampleInfo() {
     auto name = fmt::format("Sample {:d}", sampNum++);
     VGMSamp* sample;
     if (sampleOffset + sampleSize > length()) {
-      sample = new EmptySamp(this);
+      sample = addSamp(std::make_unique<EmptySamp>(this));
     }
     else if (sampInfo.isAdpcm) {
-      sample = new KonamiAdpcmSamp(
+      sample = addSamp(std::make_unique<KonamiAdpcmSamp>(
         this,
         sampleOffset,
         sampleSize,
         KonamiAdpcmChip::K053260,
         K053260_BASE_PCM_RATE,
         name
-      );
+      ));
       sample->setBPS(BPS::PCM16);
-      samples.push_back(sample);
     } else {
       sample = addSamp(sampleOffset,
                            sampleSize,

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2OPMInstr.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2OPMInstr.cpp
@@ -33,7 +33,7 @@ bool KonamiTMNT2OPMInstrSet::parseInstrPointers() {
     konami_tmnt2_ym2151_instr instrData{};
     readBytes(instrPtr, sizeof(konami_tmnt2_ym2151_instr), &instrData);
 
-    VGMInstr* instr = emplaceInstr<VGMInstr>(this, instrPtr, sizeof(konami_tmnt2_ym2151_instr), 0, i, name, 0);
+    VGMInstr* instr = addInstr<VGMInstr>(this, instrPtr, sizeof(konami_tmnt2_ym2151_instr), 0, i, name, 0);
     instr->addChild(instrPtr, 1, "RL_FB_CONECT");
     for (int op = 0; op < 4; ++op) {
       int offset = instrPtr + 1 + (op * 6);

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2OPMInstr.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2OPMInstr.cpp
@@ -33,7 +33,7 @@ bool KonamiTMNT2OPMInstrSet::parseInstrPointers() {
     konami_tmnt2_ym2151_instr instrData{};
     readBytes(instrPtr, sizeof(konami_tmnt2_ym2151_instr), &instrData);
 
-    VGMInstr* instr = new VGMInstr(this, instrPtr, sizeof(konami_tmnt2_ym2151_instr), 0, i, name, 0);
+    VGMInstr* instr = emplaceInstr<VGMInstr>(this, instrPtr, sizeof(konami_tmnt2_ym2151_instr), 0, i, name, 0);
     instr->addChild(instrPtr, 1, "RL_FB_CONECT");
     for (int op = 0; op < 4; ++op) {
       int offset = instrPtr + 1 + (op * 6);
@@ -45,7 +45,6 @@ bool KonamiTMNT2OPMInstrSet::parseInstrPointers() {
       opItem->addChild(offset+4, 1, "DT2_D2R");
       opItem->addChild(offset+5, 1, "D1L_RR");
     }
-    aInstrs.push_back(instr);
     addOPMInstrument(convertToOPMData(instrData, name));
   }
   return true;

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2Scanner.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2Scanner.cpp
@@ -15,6 +15,7 @@
 #include "VGMColl.h"
 #include "VGMMiscFile.h"
 
+#include <memory>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -134,7 +135,7 @@ std::vector<KonamiTMNT2Seq*> KonamiTMNT2Scanner::loadSeqTable(
   u8 clkb,
   const std::string& gameName
 ) {
-  VGMMiscFile *seqTable = new VGMMiscFile(
+  auto seqTable = std::make_unique<VGMMiscFile>(
     KonamiTMNT2Format::name,
     programRom,
     seqTableAddr,
@@ -198,7 +199,7 @@ std::vector<KonamiTMNT2Seq*> KonamiTMNT2Scanner::loadSeqTable(
       std::ranges::min(k053260TrkPtrs)
     );
 
-    auto *sequence = new KonamiTMNT2Seq(
+    auto* sequence = pRoot->emplaceVGMFile<KonamiTMNT2Seq>(
       programRom,
       fmtVer,
       start,
@@ -208,17 +209,13 @@ std::vector<KonamiTMNT2Seq*> KonamiTMNT2Scanner::loadSeqTable(
       clkb,
       sequenceName
     );
-    if (!sequence->loadVGMFile()) {
-      delete sequence;
-    } else {
+    if (sequence) {
       seqs.push_back(sequence);
     }
   }
   auto lastSeq = seqTable->children().back();
   seqTable->setLength((lastSeq->offset() + lastSeq->length()) - seqTable->offset());
-  if (!seqTable->loadVGMFile()) {
-    delete seqTable;
-  }
+  pRoot->loadVGMFile(std::move(seqTable));
   return seqs;
 }
 
@@ -341,7 +338,7 @@ void KonamiTMNT2Scanner::scanTMNT2(
     minDrumPtr
   );
 
-  auto instrSet = new KonamiTMNT2SampleInstrSet(
+  auto* instrSet = pRoot->emplaceVGMFile<KonamiTMNT2SampleInstrSet>(
     programRom,
     instrTableAddrK053260,
     instrTableAddrK053260,
@@ -351,10 +348,6 @@ void KonamiTMNT2Scanner::scanTMNT2(
     fmt::format("{} K053260 Instrument Set", name),
     fmtVer
   );
-  if (!instrSet->loadVGMFile()) {
-    delete instrSet;
-    instrSet = nullptr;
-  }
 
 
   // Consolidate the melodic and drum instruments into a single sample_info vector
@@ -371,39 +364,35 @@ void KonamiTMNT2Scanner::scanTMNT2(
 
   std::string sampCollName = fmt::format("{} sample collection", name);
 
-  auto sampcoll = new KonamiTMNT2SampColl(
+  auto* sampcoll = pRoot->emplaceVGMFile<KonamiTMNT2SampColl>(
     samplesRom,
     sampInfos,
     0,
     static_cast<u32>(samplesRom->size()),
     sampCollName
   );
-  if (!sampcoll->loadVGMFile()) {
-    delete sampcoll;
-    sampcoll = nullptr;
-  }
 
-  auto opmInstrSet = new KonamiTMNT2OPMInstrSet(
+  auto* opmInstrSet = pRoot->emplaceVGMFile<KonamiTMNT2OPMInstrSet>(
     programRom,
     fmtVer,
     instrTableAddrYM2151,
     fmt::format("{} YM2151 Instrument Set", name)
   );
-  if (!opmInstrSet->loadVGMFile()) {
-    delete opmInstrSet;
-    opmInstrSet = nullptr;
-  }
 
   for (auto seq : seqs) {
-    VGMColl* coll = new VGMColl(seq->name());
+    auto coll = std::make_unique<VGMColl>(seq->name());
 
     coll->useSeq(seq);
-    coll->addInstrSet(opmInstrSet);
-    coll->addInstrSet(instrSet);
-    coll->addSampColl(sampcoll);
-    if (!coll->load()) {
-      delete coll;
+    if (opmInstrSet) {
+      coll->addInstrSet(opmInstrSet);
     }
+    if (instrSet) {
+      coll->addInstrSet(instrSet);
+    }
+    if (sampcoll) {
+      coll->addSampColl(sampcoll);
+    }
+    pRoot->loadVGMColl(std::move(coll));
   }
 }
 
@@ -496,7 +485,8 @@ void KonamiTMNT2Scanner::scanVendetta(
     sampInfos.emplace_back(sampInfo);
   }
 
-  auto instrSet = new KonamiVendettaSampleInstrSet(
+  vendetta_sub_offsets subOffsets{loadInstrSub, setPanSub, setPitchSub, noteOnSub};
+  auto* instrSet = pRoot->emplaceVGMFile<KonamiVendettaSampleInstrSet>(
     programRom,
     sampInfoTableOffset,
     instrTableOffsetYM2151,
@@ -504,16 +494,12 @@ void KonamiTMNT2Scanner::scanVendetta(
     sampInfoTableOffset,
     drumBanksOffset,
     drumsOffset,
-    { loadInstrSub, setPanSub, setPitchSub, noteOnSub },
+    subOffsets,
     instrs,
     sampInfos,
     fmt::format("{} K053260 Instrument Set", name),
     fmtVer
   );
-  if (!instrSet->loadVGMFile()) {
-    delete instrSet;
-    instrSet = nullptr;
-  }
 
   std::vector<KonamiTMNT2SampColl::sample_info> commonSampInfos;
   for (auto const& sampInfo : sampInfos) {
@@ -521,38 +507,34 @@ void KonamiTMNT2Scanner::scanVendetta(
   }
   std::string sampCollName = fmt::format("{} Sample Collection", name);
 
-  auto sampcoll = new KonamiTMNT2SampColl(
+  auto* sampcoll = pRoot->emplaceVGMFile<KonamiTMNT2SampColl>(
     samplesRom,
     commonSampInfos,
     0,
     static_cast<u32>(samplesRom->size()),
     sampCollName
   );
-  if (!sampcoll->loadVGMFile()) {
-    delete sampcoll;
-    sampcoll = nullptr;
-  }
 
-  auto opmInstrSet = new KonamiTMNT2OPMInstrSet(
+  auto* opmInstrSet = pRoot->emplaceVGMFile<KonamiTMNT2OPMInstrSet>(
     programRom,
     fmtVer,
     instrTableOffsetYM2151,
     fmt::format("{} YM2151 Instrument Set", name)
   );
-  if (!opmInstrSet->loadVGMFile()) {
-    delete opmInstrSet;
-    opmInstrSet = nullptr;
-  }
 
   for (auto seq : seqs) {
-    VGMColl* coll = new VGMColl(seq->name());
+    auto coll = std::make_unique<VGMColl>(seq->name());
 
     coll->useSeq(seq);
-    coll->addInstrSet(opmInstrSet);
-    coll->addInstrSet(instrSet);
-    coll->addSampColl(sampcoll);
-    if (!coll->load()) {
-      delete coll;
+    if (opmInstrSet) {
+      coll->addInstrSet(opmInstrSet);
     }
+    if (instrSet) {
+      coll->addInstrSet(instrSet);
+    }
+    if (sampcoll) {
+      coll->addSampColl(sampcoll);
+    }
+    pRoot->loadVGMColl(std::move(coll));
   }
 }

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2Scanner.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2Scanner.cpp
@@ -199,7 +199,7 @@ std::vector<KonamiTMNT2Seq*> KonamiTMNT2Scanner::loadSeqTable(
       std::ranges::min(k053260TrkPtrs)
     );
 
-    auto* sequence = pRoot->emplaceVGMFile<KonamiTMNT2Seq>(
+    auto* sequence = pRoot->loadVGMFile<KonamiTMNT2Seq>(
       programRom,
       fmtVer,
       start,
@@ -338,7 +338,7 @@ void KonamiTMNT2Scanner::scanTMNT2(
     minDrumPtr
   );
 
-  auto* instrSet = pRoot->emplaceVGMFile<KonamiTMNT2SampleInstrSet>(
+  auto* instrSet = pRoot->loadVGMFile<KonamiTMNT2SampleInstrSet>(
     programRom,
     instrTableAddrK053260,
     instrTableAddrK053260,
@@ -364,7 +364,7 @@ void KonamiTMNT2Scanner::scanTMNT2(
 
   std::string sampCollName = fmt::format("{} sample collection", name);
 
-  auto* sampcoll = pRoot->emplaceVGMFile<KonamiTMNT2SampColl>(
+  auto* sampcoll = pRoot->loadVGMFile<KonamiTMNT2SampColl>(
     samplesRom,
     sampInfos,
     0,
@@ -372,7 +372,7 @@ void KonamiTMNT2Scanner::scanTMNT2(
     sampCollName
   );
 
-  auto* opmInstrSet = pRoot->emplaceVGMFile<KonamiTMNT2OPMInstrSet>(
+  auto* opmInstrSet = pRoot->loadVGMFile<KonamiTMNT2OPMInstrSet>(
     programRom,
     fmtVer,
     instrTableAddrYM2151,
@@ -382,15 +382,15 @@ void KonamiTMNT2Scanner::scanTMNT2(
   for (auto seq : seqs) {
     auto coll = std::make_unique<VGMColl>(seq->name());
 
-    coll->useSeq(seq);
+    coll->attachSeq(seq);
     if (opmInstrSet) {
-      coll->addInstrSet(opmInstrSet);
+      coll->attachInstrSet(opmInstrSet);
     }
     if (instrSet) {
-      coll->addInstrSet(instrSet);
+      coll->attachInstrSet(instrSet);
     }
     if (sampcoll) {
-      coll->addSampColl(sampcoll);
+      coll->attachSampColl(sampcoll);
     }
     pRoot->loadVGMColl(std::move(coll));
   }
@@ -486,7 +486,7 @@ void KonamiTMNT2Scanner::scanVendetta(
   }
 
   vendetta_sub_offsets subOffsets{loadInstrSub, setPanSub, setPitchSub, noteOnSub};
-  auto* instrSet = pRoot->emplaceVGMFile<KonamiVendettaSampleInstrSet>(
+  auto* instrSet = pRoot->loadVGMFile<KonamiVendettaSampleInstrSet>(
     programRom,
     sampInfoTableOffset,
     instrTableOffsetYM2151,
@@ -507,7 +507,7 @@ void KonamiTMNT2Scanner::scanVendetta(
   }
   std::string sampCollName = fmt::format("{} Sample Collection", name);
 
-  auto* sampcoll = pRoot->emplaceVGMFile<KonamiTMNT2SampColl>(
+  auto* sampcoll = pRoot->loadVGMFile<KonamiTMNT2SampColl>(
     samplesRom,
     commonSampInfos,
     0,
@@ -515,7 +515,7 @@ void KonamiTMNT2Scanner::scanVendetta(
     sampCollName
   );
 
-  auto* opmInstrSet = pRoot->emplaceVGMFile<KonamiTMNT2OPMInstrSet>(
+  auto* opmInstrSet = pRoot->loadVGMFile<KonamiTMNT2OPMInstrSet>(
     programRom,
     fmtVer,
     instrTableOffsetYM2151,
@@ -525,15 +525,15 @@ void KonamiTMNT2Scanner::scanVendetta(
   for (auto seq : seqs) {
     auto coll = std::make_unique<VGMColl>(seq->name());
 
-    coll->useSeq(seq);
+    coll->attachSeq(seq);
     if (opmInstrSet) {
-      coll->addInstrSet(opmInstrSet);
+      coll->attachInstrSet(opmInstrSet);
     }
     if (instrSet) {
-      coll->addInstrSet(instrSet);
+      coll->attachInstrSet(instrSet);
     }
     if (sampcoll) {
-      coll->addSampColl(sampcoll);
+      coll->attachSampColl(sampcoll);
     }
     pRoot->loadVGMColl(std::move(coll));
   }

--- a/src/main/formats/KonamiTMNT2/KonamiTMNT2Seq.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiTMNT2Seq.cpp
@@ -98,17 +98,15 @@ bool KonamiTMNT2Seq::parseTrackPointers() {
   for (size_t i = 0; i < m_ym2151TrackOffsets.size(); ++i) {
     auto offset = m_ym2151TrackOffsets[i];
     auto name = fmt::format("FM Track {}", i);
-    auto *track = new KonamiTMNT2Track(true, this, offset, 0, name);
-    aTracks.push_back(track);
+    addTrack<KonamiTMNT2Track>(true, this, offset, 0, name);
   }
   for (size_t i = 0; i < m_k053260TrackOffsets.size(); ++i) {
     auto offset = m_k053260TrackOffsets[i];
     auto name = fmt::format("Sampled Track {}", i);
-    auto *track = new KonamiTMNT2Track(false, this, offset, 0, name);
-    aTracks.push_back(track);
+    addTrack<KonamiTMNT2Track>(false, this, offset, 0, name);
   }
 
-  nNumTracks = static_cast<u32>(aTracks.size());
+  nNumTracks = static_cast<u32>(trackCount());
   return nNumTracks > 0;
 }
 

--- a/src/main/formats/KonamiTMNT2/KonamiVendettaInstr.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiVendettaInstr.cpp
@@ -13,6 +13,8 @@
 #include "LogManager.h"
 #include "VGMRgn.h"
 
+#include <memory>
+
 KonamiVendettaSampleInstrSet::KonamiVendettaSampleInstrSet(
   RawFile *file,
   u32 offset,
@@ -125,7 +127,7 @@ bool KonamiVendettaSampleInstrSet::parseMelodicInstrs() {
     auto sampInfo = m_sampInfos[instrInfo.samp_info_idx];
 
     std::string name = fmt::format("Instrument {}", instrNum);
-    VGMInstr* instr = new VGMInstr(
+    auto instr = std::make_unique<VGMInstr>(
       this,
       offset,
       sizeof(konami_vendetta_instr_k053260),
@@ -134,11 +136,11 @@ bool KonamiVendettaSampleInstrSet::parseMelodicInstrs() {
       name
     );
 
-    VGMRgn* rgn = new VGMRgn(instr, offset, sizeof(konami_vendetta_instr_k053260));
+    auto* rawInstr = instr.get();
+    VGMRgn* rgn = rawInstr->emplaceRgn<VGMRgn>(rawInstr, offset, sizeof(konami_vendetta_instr_k053260));
     rgn->sampOffset = sampInfo.start();
     rgn->sampDataLength = sampInfo.length();
-    instr->addRgn(rgn);
-    aInstrs.push_back(instr);
+    adoptInstr(std::move(instr));
     instrNum += 1;
   }
   return true;
@@ -149,7 +151,7 @@ bool KonamiVendettaSampleInstrSet::parseDrums() {
   std::vector<konami_vendetta_drum_info> drumInfos;
 
   // Load Drums. Drums end at YM2151 Instr Table
-  VGMItem* drumsItem = new VGMItem(nullptr, m_drumsOffset, 0, "Drums");
+  auto* drumsItem = emplaceChild<VGMItem>(this, m_drumsOffset, 0, "Drums");
 
   std::map<u16, int> drumOffsetToIdx;
   int drumIdx = 0;
@@ -174,7 +176,8 @@ bool KonamiVendettaSampleInstrSet::parseDrums() {
 
   auto drumBanksItem = addChild(m_drumBanksOffset, numDrumTables * 0x20, "Drum Banks");
 
-  VGMInstr* drumKit = new VGMInstr(this, offset(), length(), 1, 0, "Drum Kit");
+  auto drumKit = std::make_unique<VGMInstr>(this, offset(), length(), 1, 0, "Drum Kit");
+  auto* rawDrumKit = drumKit.get();
 
   for (u32 i = 0; i < numDrumTables; ++i) {
     u16 drumBankPtr = m_drumBanksOffset + (i * 0x20);
@@ -192,7 +195,7 @@ bool KonamiVendettaSampleInstrSet::parseDrums() {
       const konami_vendetta_drum_info& drumInfo = drumInfos[drumNum];
       m_drumKeyMap[(i * 16) + j] = drumInfo;
 
-      VGMRgn* rgn = new VGMRgn(drumKit, ptr - 3, 3);
+      VGMRgn* rgn = rawDrumKit->emplaceRgn<VGMRgn>(rawDrumKit, ptr - 3, 3);
       auto sampInfoIdx = drumInfo.instr.samp_info_idx;
       auto sampInfo = m_sampInfos[sampInfoIdx];
       rgn->sampOffset = sampInfo.start();
@@ -207,10 +210,9 @@ bool KonamiVendettaSampleInstrSet::parseDrums() {
       rgn->coarseTune = relativePitchCents / 100;
       rgn->fineTune = static_cast<int>(relativePitchCents) % 100;
 
-      drumKit->addRgn(rgn);
     }
   }
-  aInstrs.emplace_back(drumKit);
+  adoptInstr(std::move(drumKit));
   return true;
 }
 

--- a/src/main/formats/KonamiTMNT2/KonamiVendettaInstr.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiVendettaInstr.cpp
@@ -140,7 +140,7 @@ bool KonamiVendettaSampleInstrSet::parseMelodicInstrs() {
     VGMRgn* rgn = rawInstr->addRgn<VGMRgn>(rawInstr, offset, sizeof(konami_vendetta_instr_k053260));
     rgn->sampOffset = sampInfo.start();
     rgn->sampDataLength = sampInfo.length();
-    adoptInstr(std::move(instr));
+    sinkInstr(std::move(instr));
     instrNum += 1;
   }
   return true;
@@ -212,7 +212,7 @@ bool KonamiVendettaSampleInstrSet::parseDrums() {
 
     }
   }
-  adoptInstr(std::move(drumKit));
+  sinkInstr(std::move(drumKit));
   return true;
 }
 

--- a/src/main/formats/KonamiTMNT2/KonamiVendettaInstr.cpp
+++ b/src/main/formats/KonamiTMNT2/KonamiVendettaInstr.cpp
@@ -137,7 +137,7 @@ bool KonamiVendettaSampleInstrSet::parseMelodicInstrs() {
     );
 
     auto* rawInstr = instr.get();
-    VGMRgn* rgn = rawInstr->emplaceRgn<VGMRgn>(rawInstr, offset, sizeof(konami_vendetta_instr_k053260));
+    VGMRgn* rgn = rawInstr->addRgn<VGMRgn>(rawInstr, offset, sizeof(konami_vendetta_instr_k053260));
     rgn->sampOffset = sampInfo.start();
     rgn->sampDataLength = sampInfo.length();
     adoptInstr(std::move(instr));
@@ -151,7 +151,7 @@ bool KonamiVendettaSampleInstrSet::parseDrums() {
   std::vector<konami_vendetta_drum_info> drumInfos;
 
   // Load Drums. Drums end at YM2151 Instr Table
-  auto* drumsItem = emplaceChild<VGMItem>(this, m_drumsOffset, 0, "Drums");
+  auto* drumsItem = addChild<VGMItem>(this, m_drumsOffset, 0, "Drums");
 
   std::map<u16, int> drumOffsetToIdx;
   int drumIdx = 0;
@@ -195,7 +195,7 @@ bool KonamiVendettaSampleInstrSet::parseDrums() {
       const konami_vendetta_drum_info& drumInfo = drumInfos[drumNum];
       m_drumKeyMap[(i * 16) + j] = drumInfo;
 
-      VGMRgn* rgn = rawDrumKit->emplaceRgn<VGMRgn>(rawDrumKit, ptr - 3, 3);
+      VGMRgn* rgn = rawDrumKit->addRgn<VGMRgn>(rawDrumKit, ptr - 3, 3);
       auto sampInfoIdx = drumInfo.instr.samp_info_idx;
       auto sampInfo = m_sampInfos[sampInfoIdx];
       rgn->sampOffset = sampInfo.start();

--- a/src/main/formats/MP2k/MP2kInstrSet.cpp
+++ b/src/main/formats/MP2k/MP2kInstrSet.cpp
@@ -115,7 +115,7 @@ bool MP2kInstrSet::loadInstrs() {
     }
   }
 
-  if (sampColl != nullptr && !sampColl->hasSamples()) {
+  if (sampColl() != nullptr && !sampColl()->hasSamples()) {
     clearSampColl();
   }
 
@@ -160,7 +160,8 @@ int MP2kInstrSet::makeOrGetSample(size_t sample_pointer) {
     loop = 0;
   }
 
-  auto samp = std::make_unique<MP2kSamp>(sampColl, MP2kSampParams{
+  auto* sampleColl = sampColl();
+  auto samp = std::make_unique<MP2kSamp>(sampleColl, MP2kSampParams{
       .type = loop == 0x01 ? MP2kWaveType::BDPCM : MP2kWaveType::PCM8,
       .offset = static_cast<u32>(sample_pointer),
       .length = 16 + len,
@@ -199,8 +200,8 @@ int MP2kInstrSet::makeOrGetSample(size_t sample_pointer) {
     return -1;
   }
 
-  const auto sample_id = sampColl->sampleCount();
-  sampColl->sinkSamp(std::move(samp));
+  const auto sample_id = sampleColl->sampleCount();
+  sampleColl->sinkSamp(std::move(samp));
   m_samples.emplace(sample_pointer, sample_id);
 
   return static_cast<int>(sample_id);
@@ -362,7 +363,7 @@ bool MP2kInstr::loadInstr() {
               sample_id != -1) {
             VGMRgn *rgn = addRgn(off, 12, sample_id, split_list[i], split_list[i + 1] - 1);
 
-            // rgn->sampCollPtr = static_cast<MP2kInstrSet *>(parInstrSet)->sampColl;
+            // rgn->sampCollPtr = static_cast<MP2kInstrSet *>(parInstrSet)->sampColl();
             setADSR(rgn, rawFile()->get<u32>(off + 8));
           }
         } else if (cgb_type == 1 || cgb_type == 2) {
@@ -410,7 +411,7 @@ bool MP2kInstr::loadInstr() {
                   static_cast<MP2kInstrSet *>(parInstrSet)->makeOrGetSample(sample_pointer);
               sample_id != -1) {
             VGMRgn *rgn = addRgn(offset(), length(), sample_id, key, key);
-            // rgn->sampCollPtr = static_cast<MP2kInstrSet *>(parInstrSet)->sampColl;
+            // rgn->sampCollPtr = static_cast<MP2kInstrSet *>(parInstrSet)->sampColl();
             rgn->setPan(pan);
 
             u32 pitch = rawFile()->get<u32>(sample_pointer + 4);

--- a/src/main/formats/MP2k/MP2kInstrSet.cpp
+++ b/src/main/formats/MP2k/MP2kInstrSet.cpp
@@ -88,7 +88,7 @@ MP2kInstrSet::MP2kInstrSet(RawFile *file, int rate, size_t offset, int count,
     : VGMInstrSet(MP2kFormat::name, file, offset, count * 12, name), m_count(count),
       m_operating_rate(rate), m_psg_samples(psg_samples) {
   assert(m_psg_samples != nullptr);
-  emplaceSampColl<VGMSampColl>(MP2kFormat::name, file, this, offset);
+  addSampColl<VGMSampColl>(MP2kFormat::name, file, this, offset);
 }
 
 MP2kPSGColl& MP2kInstrSet::psgSampColl() const noexcept {
@@ -127,7 +127,7 @@ bool MP2kInstrSet::parseInstrPointers() {
     size_t cur_ofs = offset() + i * 12;
     MP2kInstrData data{rawFile()->get<u32>(cur_ofs), rawFile()->get<u32>(cur_ofs + 4),
                        rawFile()->get<u32>(cur_ofs + 8)};
-    emplaceInstr<MP2kInstr>(this, cur_ofs, 0, 0, i, data);
+    addInstr<MP2kInstr>(this, cur_ofs, 0, 0, i, data);
   }
 
   return true;
@@ -200,7 +200,7 @@ int MP2kInstrSet::makeOrGetSample(size_t sample_pointer) {
   }
 
   const auto sample_id = sampColl->sampleCount();
-  sampColl->addSamp(std::move(samp));
+  sampColl->adoptSamp(std::move(samp));
   m_samples.emplace(sample_pointer, sample_id);
 
   return static_cast<int>(sample_id);
@@ -567,10 +567,10 @@ bool MP2kPSGColl::parseSampleInfo() {
   constexpr const char* kDutyLabels[4] = {"12.5%", "25%", "50%", "75%"};
   for (u8 duty = 0; duty < kPsgSquareCount; duty++) {
     auto name = fmt::format("PSG square {}", kDutyLabels[duty]);
-    emplaceSamp<MP2kPSGSamp>(this, duty, false, m_sample_rate, m_loop_samples, name);
+    addSamp<MP2kPSGSamp>(this, duty, false, m_sample_rate, m_loop_samples, name);
   }
 
-  emplaceSamp<MP2kPSGSamp>(this, 0, true, m_sample_rate, m_loop_samples, "PSG noise");
+  addSamp<MP2kPSGSamp>(this, 0, true, m_sample_rate, m_loop_samples, "PSG noise");
   return true;
 }
 
@@ -593,7 +593,7 @@ int MP2kPSGColl::makeOrGetProgrammableWave(size_t wavePointer) {
   int sample_id = static_cast<int>(sampleCount());
   auto name = fmt::format("PSG programmable wave {:#x}", wave_offset);
   constexpr u32 kCgbWaveSampleRate = kCgbWaveRamSamples * 440;
-  emplaceSamp<MP2kPSGWaveSamp>(this, wave_offset, kCgbWaveSampleRate, name);
+  addSamp<MP2kPSGWaveSamp>(this, wave_offset, kCgbWaveSampleRate, name);
   m_programmable_waves.emplace(wave_offset, sample_id);
   return sample_id;
 }

--- a/src/main/formats/MP2k/MP2kInstrSet.cpp
+++ b/src/main/formats/MP2k/MP2kInstrSet.cpp
@@ -88,7 +88,7 @@ MP2kInstrSet::MP2kInstrSet(RawFile *file, int rate, size_t offset, int count,
     : VGMInstrSet(MP2kFormat::name, file, offset, count * 12, name), m_count(count),
       m_operating_rate(rate), m_psg_samples(psg_samples) {
   assert(m_psg_samples != nullptr);
-  adoptSampColl(new VGMSampColl(MP2kFormat::name, file, this, offset));
+  emplaceSampColl<VGMSampColl>(MP2kFormat::name, file, this, offset);
 }
 
 MP2kPSGColl& MP2kInstrSet::psgSampColl() const noexcept {
@@ -97,33 +97,25 @@ MP2kPSGColl& MP2kInstrSet::psgSampColl() const noexcept {
 }
 
 bool MP2kInstrSet::loadInstrs() {
-  auto instrs = std::move(aInstrs);
-  aInstrs.clear();
-  aInstrs.reserve(instrs.size());
+  auto instrs = releaseInstrs();
+  reserveInstrs(instrs.size());
 
   for (size_t i = 0; i < instrs.size(); i++) {
-    VGMInstr *instr = instrs[i];
+    auto instr = std::move(instrs[i]);
     if (!instr->loadInstr()) {
       L_ERROR("Failed to load instrument #{} ({}), cannot load bank {} at offset {:#x}", i, instr->name(), name(), offset());
-      delete instr;
-      for (size_t j = i + 1; j < instrs.size(); j++) {
-        delete instrs[j];
-      }
-      for (auto *loadedInstr : aInstrs) {
-        delete loadedInstr;
-      }
-      aInstrs.clear();
+      clearInstrs();
       return false;
     }
 
     if (instr->regions().empty()) {
-      delete instr;
+      continue;
     } else {
-      aInstrs.push_back(instr);
+      adoptInstr(std::move(instr));
     }
   }
 
-  if (sampColl != nullptr && sampColl->samples.empty()) {
+  if (sampColl != nullptr && !sampColl->hasSamples()) {
     clearSampColl();
   }
 
@@ -135,7 +127,7 @@ bool MP2kInstrSet::parseInstrPointers() {
     size_t cur_ofs = offset() + i * 12;
     MP2kInstrData data{rawFile()->get<u32>(cur_ofs), rawFile()->get<u32>(cur_ofs + 4),
                        rawFile()->get<u32>(cur_ofs + 8)};
-    aInstrs.push_back(new MP2kInstr(this, cur_ofs, 0, 0, i, data));
+    emplaceInstr<MP2kInstr>(this, cur_ofs, 0, 0, i, data);
   }
 
   return true;
@@ -168,7 +160,7 @@ int MP2kInstrSet::makeOrGetSample(size_t sample_pointer) {
     loop = 0;
   }
 
-  MP2kSamp *samp = new MP2kSamp(sampColl, {
+  auto samp = std::make_unique<MP2kSamp>(sampColl, MP2kSampParams{
       .type = loop == 0x01 ? MP2kWaveType::BDPCM : MP2kWaveType::PCM8,
       .offset = static_cast<u32>(sample_pointer),
       .length = 16 + len,
@@ -204,14 +196,14 @@ int MP2kInstrSet::makeOrGetSample(size_t sample_pointer) {
   } else {
     /* Invalid loop, assume the whole thing is garbage */
     L_ERROR("Garbage loop data {}", loop);
-    delete samp;
     return -1;
   }
 
-  sampColl->samples.emplace_back(samp);
-  m_samples.insert(std::pair(sample_pointer, sampColl->samples.size() - 1));
+  const auto sample_id = sampColl->sampleCount();
+  sampColl->addSamp(std::move(samp));
+  m_samples.emplace(sample_pointer, sample_id);
 
-  return sampColl->samples.size() - 1;
+  return static_cast<int>(sample_id);
 }
 
 MP2kInstr::MP2kInstr(MP2kInstrSet *set, size_t offset, size_t length, u32 bank, u32 number,
@@ -575,11 +567,10 @@ bool MP2kPSGColl::parseSampleInfo() {
   constexpr const char* kDutyLabels[4] = {"12.5%", "25%", "50%", "75%"};
   for (u8 duty = 0; duty < kPsgSquareCount; duty++) {
     auto name = fmt::format("PSG square {}", kDutyLabels[duty]);
-    auto *sample = new MP2kPSGSamp(this, duty, false, m_sample_rate, m_loop_samples, name);
-    samples.push_back(sample);
+    emplaceSamp<MP2kPSGSamp>(this, duty, false, m_sample_rate, m_loop_samples, name);
   }
 
-  samples.push_back(new MP2kPSGSamp(this, 0, true, m_sample_rate, m_loop_samples, "PSG noise"));
+  emplaceSamp<MP2kPSGSamp>(this, 0, true, m_sample_rate, m_loop_samples, "PSG noise");
   return true;
 }
 
@@ -599,10 +590,10 @@ int MP2kPSGColl::makeOrGetProgrammableWave(size_t wavePointer) {
     return elem->second;
   }
 
-  int sample_id = static_cast<int>(samples.size());
+  int sample_id = static_cast<int>(sampleCount());
   auto name = fmt::format("PSG programmable wave {:#x}", wave_offset);
   constexpr u32 kCgbWaveSampleRate = kCgbWaveRamSamples * 440;
-  samples.push_back(new MP2kPSGWaveSamp(this, wave_offset, kCgbWaveSampleRate, name));
+  emplaceSamp<MP2kPSGWaveSamp>(this, wave_offset, kCgbWaveSampleRate, name);
   m_programmable_waves.emplace(wave_offset, sample_id);
   return sample_id;
 }

--- a/src/main/formats/MP2k/MP2kInstrSet.cpp
+++ b/src/main/formats/MP2k/MP2kInstrSet.cpp
@@ -111,7 +111,7 @@ bool MP2kInstrSet::loadInstrs() {
     if (instr->regions().empty()) {
       continue;
     } else {
-      adoptInstr(std::move(instr));
+      sinkInstr(std::move(instr));
     }
   }
 
@@ -200,7 +200,7 @@ int MP2kInstrSet::makeOrGetSample(size_t sample_pointer) {
   }
 
   const auto sample_id = sampColl->sampleCount();
-  sampColl->adoptSamp(std::move(samp));
+  sampColl->sinkSamp(std::move(samp));
   m_samples.emplace(sample_pointer, sample_id);
 
   return static_cast<int>(sample_id);

--- a/src/main/formats/MP2k/MP2kInstrSet.cpp
+++ b/src/main/formats/MP2k/MP2kInstrSet.cpp
@@ -88,7 +88,7 @@ MP2kInstrSet::MP2kInstrSet(RawFile *file, int rate, size_t offset, int count,
     : VGMInstrSet(MP2kFormat::name, file, offset, count * 12, name), m_count(count),
       m_operating_rate(rate), m_psg_samples(psg_samples) {
   assert(m_psg_samples != nullptr);
-  sampColl = new VGMSampColl(MP2kFormat::name, file, this, offset);
+  adoptSampColl(new VGMSampColl(MP2kFormat::name, file, this, offset));
 }
 
 MP2kPSGColl& MP2kInstrSet::psgSampColl() const noexcept {
@@ -124,8 +124,7 @@ bool MP2kInstrSet::loadInstrs() {
   }
 
   if (sampColl != nullptr && sampColl->samples.empty()) {
-    delete sampColl;
-    sampColl = nullptr;
+    clearSampColl();
   }
 
   return true;

--- a/src/main/formats/MP2k/MP2kScanner.cpp
+++ b/src/main/formats/MP2k/MP2kScanner.cpp
@@ -100,7 +100,7 @@ void MP2kScanner::scan(RawFile *file, void *) {
     return;
   }
 
-  auto* psg_sampcoll = pRoot->emplaceVGMFile<MP2kPSGColl>(file, psg_sample_rate, psg_sample_rate);
+  auto* psg_sampcoll = pRoot->loadVGMFile<MP2kPSGColl>(file, psg_sample_rate, psg_sample_rate);
   if (!psg_sampcoll) {
     return;
   }
@@ -121,7 +121,7 @@ void MP2kScanner::scan(RawFile *file, void *) {
       break;
     }
 
-    auto* nseq = pRoot->emplaceVGMFile<MP2kSeq>(file, song_pointer);
+    auto* nseq = pRoot->loadVGMFile<MP2kSeq>(file, song_pointer);
     if (!nseq) {
       continue;
     }
@@ -152,12 +152,12 @@ void MP2kScanner::scan(RawFile *file, void *) {
       if (seq != seqs.end()) {
         for (auto seqval : seq->second) {
           auto coll = std::make_unique<VGMColl>(fmt::format("MP2k Collection #{}", seqval.song_index));
-          coll->useSeq(seqval.seq);
-          coll->addInstrSet(rawInstrSet);
+          coll->attachSeq(seqval.seq);
+          coll->attachInstrSet(rawInstrSet);
           if (rawInstrSet->sampColl != nullptr && rawInstrSet->sampColl->hasSamples()) {
-            coll->addSampColl(rawInstrSet->sampColl);
+            coll->attachSampColl(rawInstrSet->sampColl);
           }
-          coll->addSampColl(psg_sampcoll);
+          coll->attachSampColl(psg_sampcoll);
 
           pRoot->loadVGMColl(std::move(coll));
         }

--- a/src/main/formats/MP2k/MP2kScanner.cpp
+++ b/src/main/formats/MP2k/MP2kScanner.cpp
@@ -154,8 +154,8 @@ void MP2kScanner::scan(RawFile *file, void *) {
           auto coll = std::make_unique<VGMColl>(fmt::format("MP2k Collection #{}", seqval.song_index));
           coll->attachSeq(seqval.seq);
           coll->attachInstrSet(rawInstrSet);
-          if (rawInstrSet->sampColl != nullptr && rawInstrSet->sampColl->hasSamples()) {
-            coll->attachSampColl(rawInstrSet->sampColl);
+          if (rawInstrSet->sampColl() != nullptr && rawInstrSet->sampColl()->hasSamples()) {
+            coll->attachSampColl(rawInstrSet->sampColl());
           }
           coll->attachSampColl(psg_sampcoll);
 

--- a/src/main/formats/MP2k/MP2kScanner.cpp
+++ b/src/main/formats/MP2k/MP2kScanner.cpp
@@ -24,6 +24,7 @@
 
 #include <array>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <set>
 #include <span>
@@ -99,8 +100,10 @@ void MP2kScanner::scan(RawFile *file, void *) {
     return;
   }
 
-  auto* psg_sampcoll = new MP2kPSGColl(file, psg_sample_rate, psg_sample_rate);
-  psg_sampcoll->loadVGMFile();
+  auto* psg_sampcoll = pRoot->emplaceVGMFile<MP2kPSGColl>(file, psg_sample_rate, psg_sample_rate);
+  if (!psg_sampcoll) {
+    return;
+  }
 
   /* First 32 bytes are the pointer, the rest is song info */
   std::set<size_t> soundbanks;
@@ -118,9 +121,8 @@ void MP2kScanner::scan(RawFile *file, void *) {
       break;
     }
 
-    auto nseq = new MP2kSeq(file, song_pointer);
-    if (!nseq->loadVGMFile()) {
-      delete nseq;
+    auto* nseq = pRoot->emplaceVGMFile<MP2kSeq>(file, song_pointer);
+    if (!nseq) {
       continue;
     }
 
@@ -142,26 +144,22 @@ void MP2kScanner::scan(RawFile *file, void *) {
       count = (*next_addr - *it) / 12;
     }
 
-    if (auto iset =
-            new MP2kInstrSet(file, samplerate_LUT[engine_settings.sampling_rate_index], *it, count,
-                              psg_sampcoll);
-        !iset->loadVGMFile()) {
-      delete iset;
-    } else {
+    auto iset = std::make_unique<MP2kInstrSet>(file, samplerate_LUT[engine_settings.sampling_rate_index], *it, count,
+                                               psg_sampcoll);
+    auto* rawInstrSet = iset.get();
+    if (pRoot->loadVGMFile(std::move(iset))) {
       auto seq = seqs.find(*it);
       if (seq != seqs.end()) {
         for (auto seqval : seq->second) {
-          auto coll = new VGMColl(fmt::format("MP2k Collection #{}", seqval.song_index));
+          auto coll = std::make_unique<VGMColl>(fmt::format("MP2k Collection #{}", seqval.song_index));
           coll->useSeq(seqval.seq);
-          coll->addInstrSet(iset);
-          if (iset->sampColl != nullptr && !iset->sampColl->samples.empty()) {
-            coll->addSampColl(iset->sampColl);
+          coll->addInstrSet(rawInstrSet);
+          if (rawInstrSet->sampColl != nullptr && rawInstrSet->sampColl->hasSamples()) {
+            coll->addSampColl(rawInstrSet->sampColl);
           }
           coll->addSampColl(psg_sampcoll);
 
-          if (!coll->load()) {
-            delete coll;
-          }
+          pRoot->loadVGMColl(std::move(coll));
         }
         seqs.erase(seq);
       }

--- a/src/main/formats/MP2k/MP2kSeq.cpp
+++ b/src/main/formats/MP2k/MP2kSeq.cpp
@@ -86,12 +86,11 @@ bool MP2kSeq::parseTrackPointers(void) {
   for (unsigned int i = 0; i < nNumTracks; i++) {
     u32 dwTrackPtrOffset = offset() + 8 + i * 4;
     u32 dwTrackPtr = readWord(dwTrackPtrOffset);
-    aTracks.push_back(new MP2kTrack(this, dwTrackPtr - 0x8000000));
+    addTrack<MP2kTrack>(this, dwTrackPtr - 0x8000000);
   }
 
   // Make seq offset the first track offset
-  for (auto itr = aTracks.begin(); itr != aTracks.end(); ++itr) {
-    SeqTrack *track = (*itr);
+  for (SeqTrack *track : tracks()) {
     if (track->offset() < offset()) {
       if (length() != 0) {
         setLength(length() + ((offset() - track->offset())));

--- a/src/main/formats/MoriSnes/MoriSnesInstr.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesInstr.cpp
@@ -115,20 +115,17 @@ bool MoriSnesInstrSet::parseInstrPointers() {
       }
     }
 
-    MoriSnesInstr *newInstr = new MoriSnesInstr(
+    emplaceInstr<MoriSnesInstr>(
       this, version, instrNum, spcDirAddr, instrumentHints[instrAddress],
       fmt::format("Instrument {}", instrNum));
-    aInstrs.push_back(newInstr);
   }
 
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(MoriSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(MoriSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -168,9 +165,8 @@ bool MoriSnesInstr::loadInstr() {
     addChild(instrHint->seqAddress, instrHint->seqSize, "Envelope Sequence");
 
     u16 addrSampStart = readShort(offDirEnt);
-    MoriSnesRgn *rgn = new MoriSnesRgn(this, version, spcDirAddr, *instrHint);
+    MoriSnesRgn *rgn = emplaceRgn<MoriSnesRgn>(this, version, spcDirAddr, *instrHint);
     rgn->sampOffset = addrSampStart - spcDirAddr;
-    addRgn(rgn);
   }
   else {
     for (u8 percNoteKey = 0; percNoteKey < instrHintDir.percHints.size(); percNoteKey++) {
@@ -189,9 +185,8 @@ bool MoriSnesInstr::loadInstr() {
       addChild(instrHint->seqAddress, instrHint->seqSize, seqName);
 
       u16 addrSampStart = readShort(offDirEnt);
-      MoriSnesRgn *rgn = new MoriSnesRgn(this, version, spcDirAddr, *instrHint, percNoteKey);
+      MoriSnesRgn *rgn = emplaceRgn<MoriSnesRgn>(this, version, spcDirAddr, *instrHint, percNoteKey);
       rgn->sampOffset = addrSampStart - spcDirAddr;
-      addRgn(rgn);
     }
   }
 

--- a/src/main/formats/MoriSnes/MoriSnesInstr.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesInstr.cpp
@@ -115,7 +115,7 @@ bool MoriSnesInstrSet::parseInstrPointers() {
       }
     }
 
-    emplaceInstr<MoriSnesInstr>(
+    addInstr<MoriSnesInstr>(
       this, version, instrNum, spcDirAddr, instrumentHints[instrAddress],
       fmt::format("Instrument {}", instrNum));
   }
@@ -165,7 +165,7 @@ bool MoriSnesInstr::loadInstr() {
     addChild(instrHint->seqAddress, instrHint->seqSize, "Envelope Sequence");
 
     u16 addrSampStart = readShort(offDirEnt);
-    MoriSnesRgn *rgn = emplaceRgn<MoriSnesRgn>(this, version, spcDirAddr, *instrHint);
+    MoriSnesRgn *rgn = addRgn<MoriSnesRgn>(this, version, spcDirAddr, *instrHint);
     rgn->sampOffset = addrSampStart - spcDirAddr;
   }
   else {
@@ -185,7 +185,7 @@ bool MoriSnesInstr::loadInstr() {
       addChild(instrHint->seqAddress, instrHint->seqSize, seqName);
 
       u16 addrSampStart = readShort(offDirEnt);
-      MoriSnesRgn *rgn = emplaceRgn<MoriSnesRgn>(this, version, spcDirAddr, *instrHint, percNoteKey);
+      MoriSnesRgn *rgn = addRgn<MoriSnesRgn>(this, version, spcDirAddr, *instrHint, percNoteKey);
       rgn->sampOffset = addrSampStart - spcDirAddr;
     }
   }

--- a/src/main/formats/MoriSnes/MoriSnesScanner.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesScanner.cpp
@@ -90,14 +90,14 @@ void MoriSnesScanner::searchForMoriSnesFromARAM(RawFile *file) {
   if (addrSongHeaderPtr + 2 <= 0x10000) {
     u16 addrSongHeader = file->readShort(addrSongHeaderPtr);
 
-    auto* newSeq = pRoot->emplaceVGMFile<MoriSnesSeq>(file, version, addrSongHeader, name);
+    auto* newSeq = pRoot->loadVGMFile<MoriSnesSeq>(file, version, addrSongHeader, name);
     if (!newSeq) {
       return;
     }
 
     if (spcDirAddr != 0) {
       auto* newInstrSet =
-          pRoot->emplaceVGMFile<MoriSnesInstrSet>(file, version, spcDirAddr, newSeq->InstrumentAddresses, newSeq->InstrumentHints);
+          pRoot->loadVGMFile<MoriSnesInstrSet>(file, version, spcDirAddr, newSeq->InstrumentAddresses, newSeq->InstrumentHints);
       if (!newInstrSet) {
         return;
       }

--- a/src/main/formats/MoriSnes/MoriSnesScanner.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesScanner.cpp
@@ -90,17 +90,15 @@ void MoriSnesScanner::searchForMoriSnesFromARAM(RawFile *file) {
   if (addrSongHeaderPtr + 2 <= 0x10000) {
     u16 addrSongHeader = file->readShort(addrSongHeaderPtr);
 
-    MoriSnesSeq *newSeq = new MoriSnesSeq(file, version, addrSongHeader, name);
-    if (!newSeq->loadVGMFile()) {
-      delete newSeq;
+    auto* newSeq = pRoot->emplaceVGMFile<MoriSnesSeq>(file, version, addrSongHeader, name);
+    if (!newSeq) {
       return;
     }
 
     if (spcDirAddr != 0) {
-      MoriSnesInstrSet *newInstrSet =
-          new MoriSnesInstrSet(file, version, spcDirAddr, newSeq->InstrumentAddresses, newSeq->InstrumentHints);
-      if (!newInstrSet->loadVGMFile()) {
-        delete newInstrSet;
+      auto* newInstrSet =
+          pRoot->emplaceVGMFile<MoriSnesInstrSet>(file, version, spcDirAddr, newSeq->InstrumentAddresses, newSeq->InstrumentHints);
+      if (!newInstrSet) {
         return;
       }
     }

--- a/src/main/formats/MoriSnes/MoriSnesSeq.cpp
+++ b/src/main/formats/MoriSnes/MoriSnesSeq.cpp
@@ -98,8 +98,7 @@ bool MoriSnesSeq::parseHeader() {
 bool MoriSnesSeq::parseTrackPointers() {
   for (u8 trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     if (TrackStartAddress[trackIndex] != 0) {
-      MoriSnesTrack *track = new MoriSnesTrack(this, TrackStartAddress[trackIndex]);
-      aTracks.push_back(track);
+      addTrack<MoriSnesTrack>(this, TrackStartAddress[trackIndex]);
     }
   }
   return true;

--- a/src/main/formats/NDS/NDSInstrSet.cpp
+++ b/src/main/formats/NDS/NDSInstrSet.cpp
@@ -64,7 +64,7 @@ bool NDSInstrSet::parseInstrPointers() {
 
     u8 instrType = temp & 0xFF;
     u32 pInstr = temp >> 8;
-    emplaceInstr<NDSInstr>(this, pInstr + offset(), 0, 0, i, instrType);
+    addInstr<NDSInstr>(this, pInstr + offset(), 0, 0, i, instrType);
 
     VGMHeader* hdr = instrptrHdr->addHeader(instrPtrOff, 4, "Pointer");
     hdr->addChild(instrPtrOff, 1, "Type");
@@ -332,7 +332,7 @@ bool NDSWaveArch::parseSampleInfo() {
     }
 
     auto name = fmt::format("Sample {}", sampleCount());
-    auto* samp = emplaceSamp<NDSSamp>(this, pSample, dataStart + dataLength - pSample, dataStart,
+    auto* samp = addSamp<NDSSamp>(this, pSample, dataStart + dataLength - pSample, dataStart,
                                       dataLength, nChannels, bps, rate, waveType, name);
 
     if (waveType == NDSSamp::IMA_ADPCM) {
@@ -357,7 +357,7 @@ NDSPSG::NDSPSG(RawFile* file) : VGMSampColl(NDSFormat::name, file, 0, 0, "NDS PS
 bool NDSPSG::parseSampleInfo() {
   /* 8 waves + noise */
   for (u8 i = 0; i <= 8; i++) {
-    emplaceSamp<NDSPSGSamp>(this, i);
+    addSamp<NDSPSGSamp>(this, i);
   }
 
   return true;

--- a/src/main/formats/NDS/NDSInstrSet.cpp
+++ b/src/main/formats/NDS/NDSInstrSet.cpp
@@ -64,7 +64,7 @@ bool NDSInstrSet::parseInstrPointers() {
 
     u8 instrType = temp & 0xFF;
     u32 pInstr = temp >> 8;
-    aInstrs.push_back(new NDSInstr(this, pInstr + offset(), 0, 0, i, instrType));
+    emplaceInstr<NDSInstr>(this, pInstr + offset(), 0, 0, i, instrType);
 
     VGMHeader* hdr = instrptrHdr->addHeader(instrPtrOff, 4, "Pointer");
     hdr->addChild(instrPtrOff, 1, "Type");
@@ -180,7 +180,7 @@ bool NDSInstr::loadInstr() {
 }
 
 void NDSInstr::getSampCollPtr(VGMRgn* rgn, int waNum) const {
-  rgn->sampCollPtr = static_cast<NDSInstrSet*>(parInstrSet)->sampCollWAList[waNum];
+  rgn->sampCollPtr = static_cast<NDSInstrSet*>(parInstrSet)->waveArchSampColl(waNum);
 }
 
 void NDSInstr::getArticData(VGMRgn* rgn, u32 offset) const {
@@ -331,9 +331,9 @@ bool NDSWaveArch::parseSampleInfo() {
       dataLength = loopOff + nonLoopLength;
     }
 
-    auto name = fmt::format("Sample {}", samples.size());
-    NDSSamp* samp = new NDSSamp(this, pSample, dataStart + dataLength - pSample, dataStart,
-                                dataLength, nChannels, bps, rate, waveType, name);
+    auto name = fmt::format("Sample {}", sampleCount());
+    auto* samp = emplaceSamp<NDSSamp>(this, pSample, dataStart + dataLength - pSample, dataStart,
+                                      dataLength, nChannels, bps, rate, waveType, name);
 
     if (waveType == NDSSamp::IMA_ADPCM) {
       samp->setLoopStartMeasure(LM_SAMPLES);
@@ -347,7 +347,6 @@ bool NDSWaveArch::parseSampleInfo() {
     samp->setLoopStatus(bLoops);
     samp->setLoopOffset(loopOff);
     samp->setLoopLength(nonLoopLength);
-    samples.push_back(samp);
   }
   return true;
 }
@@ -358,7 +357,7 @@ NDSPSG::NDSPSG(RawFile* file) : VGMSampColl(NDSFormat::name, file, 0, 0, "NDS PS
 bool NDSPSG::parseSampleInfo() {
   /* 8 waves + noise */
   for (u8 i = 0; i <= 8; i++) {
-    samples.push_back(new NDSPSGSamp(this, i));
+    emplaceSamp<NDSPSGSamp>(this, i);
   }
 
   return true;

--- a/src/main/formats/NDS/NDSInstrSet.h
+++ b/src/main/formats/NDS/NDSInstrSet.h
@@ -27,9 +27,11 @@ public:
               std::string name = "NDS Instrument Bank");
   bool parseInstrPointers() override;
 
-  std::vector<VGMSampColl *> sampCollWAList;
+  void addWaveArchSampColl(VGMSampColl* sampColl) { m_sampCollWAList.push_back(sampColl); }
+  [[nodiscard]] VGMSampColl* waveArchSampColl(size_t index) const { return m_sampCollWAList.at(index); }
 
 private:
+  std::vector<VGMSampColl *> m_sampCollWAList;
   VGMSampColl* m_psg_samples{};
   friend NDSInstr;
 };

--- a/src/main/formats/NDS/NDSScanner.cpp
+++ b/src/main/formats/NDS/NDSScanner.cpp
@@ -12,6 +12,7 @@
 #include "ScannerManager.h"
 
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -158,8 +159,10 @@ u32 NDSScanner::loadFromSDAT(RawFile *file, u32 baseOff) {
       waFileIDs.push_back(file->readShort(pWAInfo));
   }
 
-  NDSPSG* psg_sampcoll = new NDSPSG(file);
-  psg_sampcoll->loadVGMFile();
+  auto* psg_sampcoll = pRoot->emplaceVGMFile<NDSPSG>(file);
+  if (!psg_sampcoll) {
+    return SDATLength;
+  }
 
   {
     std::vector<u16> vUniqueWAs;// = vector<u16>(bnkWAs);
@@ -186,11 +189,10 @@ u32 NDSScanner::loadFromSDAT(RawFile *file, u32 baseOff) {
       u32 pWAFatData = file->readWord(offset) + baseOff;
       offset += 4;
       u32 fileSize = file->readWord(offset);
-      NDSWaveArch *NewNDSwa = new NDSWaveArch(file, pWAFatData, fileSize, waNames[i]);
-      if (!NewNDSwa->loadVGMFile()) {
+      auto* NewNDSwa = pRoot->emplaceVGMFile<NDSWaveArch>(file, pWAFatData, fileSize, waNames[i]);
+      if (!NewNDSwa) {
         L_ERROR("Failed to load NDSWaveArch at 0x{:08X}", pWAFatData);
         WAs.push_back(NULL);
-        delete NewNDSwa;
         continue;
       }
       WAs.push_back(NewNDSwa);
@@ -214,20 +216,22 @@ u32 NDSScanner::loadFromSDAT(RawFile *file, u32 baseOff) {
       u32 fileSize = file->readWord(offset);
       //if (bnkWAs[*iter][0] == (u16)-1 || numWAs != 1)
       //	continue;
-      NDSInstrSet *NewNDSInstrSet = new NDSInstrSet(file, pBnkFatData, fileSize, psg_sampcoll,
-                                                    bnkNames[*iter]);
+      auto NewNDSInstrSet = std::make_unique<NDSInstrSet>(file, pBnkFatData, fileSize, psg_sampcoll,
+                                                          bnkNames[*iter]);
       for (int i = 0; i < 4; i++)        //use first WA found.  Ideally, should load all WAs
       {
         short WAnum = bnkWAs[*iter][i];
         if (WAnum != -1)
-          NewNDSInstrSet->sampCollWAList.push_back(WAs[WAnum]);
+          NewNDSInstrSet->addWaveArchSampColl(WAs[WAnum]);
         else
-          NewNDSInstrSet->sampCollWAList.push_back(NULL);
+          NewNDSInstrSet->addWaveArchSampColl(nullptr);
       }
-      if (!NewNDSInstrSet->loadVGMFile()) {
+      auto* rawInstrSet = NewNDSInstrSet.get();
+      if (!pRoot->loadVGMFile(std::move(NewNDSInstrSet))) {
         L_ERROR("Failed to load NDSInstrSet at 0x{:08X}", pBnkFatData);
+        continue;
       }
-      std::pair<u16, NDSInstrSet *> theBank(*iter, NewNDSInstrSet);
+      std::pair<u16, NDSInstrSet *> theBank(*iter, rawInstrSet);
       BNKs.push_back(theBank);
     }
   }
@@ -244,12 +248,13 @@ u32 NDSScanner::loadFromSDAT(RawFile *file, u32 baseOff) {
       u32 pSeqFatData = file->readWord(offset) + baseOff;
       offset += 4;
       u32 fileSize = file->readWord(offset);
-      NDSSeq *NewNDSSeq = new NDSSeq(file, pSeqFatData, fileSize, seqNames[i]);
-      if (!NewNDSSeq->loadVGMFile()) {
+      auto* NewNDSSeq = pRoot->emplaceVGMFile<NDSSeq>(file, pSeqFatData, fileSize, seqNames[i]);
+      if (!NewNDSSeq) {
         L_ERROR("Failed to load NDSSeq at 0x{:08X}", pSeqFatData);
+        continue;
       }
 
-      VGMColl *coll = new VGMColl(seqNames[i]);
+      auto coll = std::make_unique<VGMColl>(seqNames[i]);
       coll->useSeq(NewNDSSeq);
       u32 bnkIndex = 0;
       for (u32 j = 0; j < BNKs.size(); j++) {
@@ -266,9 +271,7 @@ u32 NDSScanner::loadFromSDAT(RawFile *file, u32 baseOff) {
         if (WAnum != -1)
           coll->addSampColl(WAs[WAnum]);
       }
-      if (!coll->load()) {
-        delete coll;
-      }
+      pRoot->loadVGMColl(std::move(coll));
     }
   }
   return SDATLength;

--- a/src/main/formats/NDS/NDSScanner.cpp
+++ b/src/main/formats/NDS/NDSScanner.cpp
@@ -159,7 +159,7 @@ u32 NDSScanner::loadFromSDAT(RawFile *file, u32 baseOff) {
       waFileIDs.push_back(file->readShort(pWAInfo));
   }
 
-  auto* psg_sampcoll = pRoot->emplaceVGMFile<NDSPSG>(file);
+  auto* psg_sampcoll = pRoot->loadVGMFile<NDSPSG>(file);
   if (!psg_sampcoll) {
     return SDATLength;
   }
@@ -189,7 +189,7 @@ u32 NDSScanner::loadFromSDAT(RawFile *file, u32 baseOff) {
       u32 pWAFatData = file->readWord(offset) + baseOff;
       offset += 4;
       u32 fileSize = file->readWord(offset);
-      auto* NewNDSwa = pRoot->emplaceVGMFile<NDSWaveArch>(file, pWAFatData, fileSize, waNames[i]);
+      auto* NewNDSwa = pRoot->loadVGMFile<NDSWaveArch>(file, pWAFatData, fileSize, waNames[i]);
       if (!NewNDSwa) {
         L_ERROR("Failed to load NDSWaveArch at 0x{:08X}", pWAFatData);
         WAs.push_back(NULL);
@@ -248,14 +248,14 @@ u32 NDSScanner::loadFromSDAT(RawFile *file, u32 baseOff) {
       u32 pSeqFatData = file->readWord(offset) + baseOff;
       offset += 4;
       u32 fileSize = file->readWord(offset);
-      auto* NewNDSSeq = pRoot->emplaceVGMFile<NDSSeq>(file, pSeqFatData, fileSize, seqNames[i]);
+      auto* NewNDSSeq = pRoot->loadVGMFile<NDSSeq>(file, pSeqFatData, fileSize, seqNames[i]);
       if (!NewNDSSeq) {
         L_ERROR("Failed to load NDSSeq at 0x{:08X}", pSeqFatData);
         continue;
       }
 
       auto coll = std::make_unique<VGMColl>(seqNames[i]);
-      coll->useSeq(NewNDSSeq);
+      coll->attachSeq(NewNDSSeq);
       u32 bnkIndex = 0;
       for (u32 j = 0; j < BNKs.size(); j++) {
         if (seqFileBnks[i] == BNKs[j].first) {
@@ -264,12 +264,12 @@ u32 NDSScanner::loadFromSDAT(RawFile *file, u32 baseOff) {
         }
       }
       
-      coll->addSampColl(psg_sampcoll);
-      coll->addInstrSet(BNKs[bnkIndex].second);
+      coll->attachSampColl(psg_sampcoll);
+      coll->attachInstrSet(BNKs[bnkIndex].second);
       for (int j = 0; j < 4; j++) {
         short WAnum = bnkWAs[seqFileBnks[i]][j];
         if (WAnum != -1)
-          coll->addSampColl(WAs[WAnum]);
+          coll->attachSampColl(WAs[WAnum]);
       }
       pRoot->loadVGMColl(std::move(coll));
     }

--- a/src/main/formats/NDS/NDSSeq.cpp
+++ b/src/main/formats/NDS/NDSSeq.cpp
@@ -30,7 +30,7 @@ bool NDSSeq::parseTrackPointers(void) {
   DATAHdr->addChild(offset() + 0x10 + 8, 4, "Data Pointer");
   u32 off = offset() + 0x1C;
   u8 b = readByte(off);
-  aTracks.push_back(new NDSTrack(this));
+  auto *firstTrack = addTrack<NDSTrack>(this);
 
   //FE XX XX signifies multiple tracks, each true bit in the XX values signifies there is a track for that channel
   if (b == 0xFE)
@@ -60,16 +60,15 @@ bool NDSSeq::parseTrackPointers(void) {
       TrkPtrs->addChild(off, 5, "Track Pointer");
       u32 trkOffset = readByte(off + 2) + (readByte(off + 3) << 8) +
           (readByte(off + 4) << 16) + offset() + 0x1C;
-      NDSTrack *newTrack = new NDSTrack(this, trkOffset);
-      aTracks.push_back(newTrack);
+      addTrack<NDSTrack>(this, trkOffset);
       //newTrack->
       off += 5;
       b = readByte(off);
     }
     TrkPtrs->setLength(off - TrkPtrs->offset());
   }
-  aTracks[0]->setOffset(off);
-  aTracks[0]->dwStartOffset = off;
+  firstTrack->setOffset(off);
+  firstTrack->dwStartOffset = off;
   return true;
 }
 

--- a/src/main/formats/NamcoSnes/NamcoSnesInstr.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesInstr.cpp
@@ -66,7 +66,7 @@ bool NamcoSnesInstrSet::parseInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    emplaceInstr<NamcoSnesInstr>(this, version, srcn, spcDirAddr, ofsTuningEntry,
+    addInstr<NamcoSnesInstr>(this, version, srcn, spcDirAddr, ofsTuningEntry,
                                  fmt::format("Instrument {}", srcn));
   }
 
@@ -108,7 +108,7 @@ bool NamcoSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  NamcoSnesRgn *rgn = emplaceRgn<NamcoSnesRgn>(this, version, instrNum, spcDirAddr, addrTuningEntry);
+  NamcoSnesRgn *rgn = addRgn<NamcoSnesRgn>(this, version, instrNum, spcDirAddr, addrTuningEntry);
   rgn->sampOffset = addrSampStart - spcDirAddr;
 
   setGuessedLength();

--- a/src/main/formats/NamcoSnes/NamcoSnesInstr.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesInstr.cpp
@@ -66,19 +66,16 @@ bool NamcoSnesInstrSet::parseInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    NamcoSnesInstr *newInstr = new NamcoSnesInstr(this, version, srcn, spcDirAddr, ofsTuningEntry,
-fmt::format("Instrument {}", srcn));
-    aInstrs.push_back(newInstr);
+    emplaceInstr<NamcoSnesInstr>(this, version, srcn, spcDirAddr, ofsTuningEntry,
+                                 fmt::format("Instrument {}", srcn));
   }
 
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(NamcoSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(NamcoSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -111,9 +108,8 @@ bool NamcoSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  NamcoSnesRgn *rgn = new NamcoSnesRgn(this, version, instrNum, spcDirAddr, addrTuningEntry);
+  NamcoSnesRgn *rgn = emplaceRgn<NamcoSnesRgn>(this, version, instrNum, spcDirAddr, addrTuningEntry);
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   setGuessedLength();
   return true;

--- a/src/main/formats/NamcoSnes/NamcoSnesScanner.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesScanner.cpp
@@ -171,9 +171,8 @@ void NamcoSnesScanner::searchForNamcoSnesFromARAM(RawFile *file) {
     return;
   }
 
-  NamcoSnesSeq *newSeq = new NamcoSnesSeq(file, version, addrEventStart, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<NamcoSnesSeq>(file, version, addrEventStart, name);
+  if (!newSeq) {
     return;
   }
 
@@ -192,9 +191,8 @@ void NamcoSnesScanner::searchForNamcoSnesFromARAM(RawFile *file) {
   }
   u16 spcDirAddr = dspRegMap[0x5d] << 8;
 
-  NamcoSnesInstrSet *newInstrSet = new NamcoSnesInstrSet(file, version, spcDirAddr, addrTuningTable);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  auto* newInstrSet = pRoot->emplaceVGMFile<NamcoSnesInstrSet>(file, version, spcDirAddr, addrTuningTable);
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/NamcoSnes/NamcoSnesScanner.cpp
+++ b/src/main/formats/NamcoSnes/NamcoSnesScanner.cpp
@@ -171,7 +171,7 @@ void NamcoSnesScanner::searchForNamcoSnesFromARAM(RawFile *file) {
     return;
   }
 
-  auto* newSeq = pRoot->emplaceVGMFile<NamcoSnesSeq>(file, version, addrEventStart, name);
+  auto* newSeq = pRoot->loadVGMFile<NamcoSnesSeq>(file, version, addrEventStart, name);
   if (!newSeq) {
     return;
   }
@@ -191,7 +191,7 @@ void NamcoSnesScanner::searchForNamcoSnesFromARAM(RawFile *file) {
   }
   u16 spcDirAddr = dspRegMap[0x5d] << 8;
 
-  auto* newInstrSet = pRoot->emplaceVGMFile<NamcoSnesInstrSet>(file, version, spcDirAddr, addrTuningTable);
+  auto* newInstrSet = pRoot->loadVGMFile<NamcoSnesInstrSet>(file, version, spcDirAddr, addrTuningTable);
   if (!newInstrSet) {
     return;
   }

--- a/src/main/formats/NeverlandSnes/NeverlandSnesScanner.cpp
+++ b/src/main/formats/NeverlandSnes/NeverlandSnesScanner.cpp
@@ -90,9 +90,8 @@ void NeverlandSnesScanner::searchForNeverlandSnesFromARAM(RawFile *file) {
     return;
   }
 
-  NeverlandSnesSeq *newSeq = new NeverlandSnesSeq(file, version, addrSeqHeader);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<NeverlandSnesSeq>(file, version, addrSeqHeader);
+  if (!newSeq) {
     return;
   }
 }

--- a/src/main/formats/NeverlandSnes/NeverlandSnesScanner.cpp
+++ b/src/main/formats/NeverlandSnes/NeverlandSnesScanner.cpp
@@ -90,7 +90,7 @@ void NeverlandSnesScanner::searchForNeverlandSnesFromARAM(RawFile *file) {
     return;
   }
 
-  auto* newSeq = pRoot->emplaceVGMFile<NeverlandSnesSeq>(file, version, addrSeqHeader);
+  auto* newSeq = pRoot->loadVGMFile<NeverlandSnesSeq>(file, version, addrSeqHeader);
   if (!newSeq) {
     return;
   }

--- a/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
+++ b/src/main/formats/NeverlandSnes/NeverlandSnesSeq.cpp
@@ -84,8 +84,7 @@ bool NeverlandSnesSeq::parseHeader(void) {
       auto playlistName = fmt::format("Track {:d} Playlist Pointer", trackIndex + 1);
       header->addChild(sectionListOffsetPtr, 2, playlistName);
 
-      NeverlandSnesTrack *track = new NeverlandSnesTrack(this, sectionListAddress);
-      aTracks.push_back(track);
+      addTrack<NeverlandSnesTrack>(this, sectionListAddress);
     }
     else {
       header->addChild(sectionListOffsetPtr, 2, "NULL");

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -259,7 +259,7 @@ bool NinSnesInstrSet::parseInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    auto *newInstr = emplaceInstr<NinSnesInstr>(
+    auto *newInstr = addInstr<NinSnesInstr>(
       this, profileId, addrInstrHeader, instr >> 7, instr & 0x7f,
       spcDirAddr, fmt::format("Instrument {}", instr));
     newInstr->konamiTuningTableAddress = konamiTuningTableAddress;
@@ -306,8 +306,8 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
       if (rgn == nullptr) {
         continue;
       }
-      overrideInstrOwner->addRgn(std::move(rgn));
-      addTempInstr(std::move(overrideInstrOwner));
+      overrideInstrOwner->adoptRgn(std::move(rgn));
+      adoptTempInstr(std::move(overrideInstrOwner));
     }
 
     for (const auto& drumKitDef : seq->intelliTADrumKitDefs()) {
@@ -328,7 +328,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
 
         const u8 drumKey = static_cast<u8>(0x24 + slot);
         for (auto* sourceRgn : sourceInstr->regions()) {
-          drumKit->addRgn(
+          drumKit->adoptRgn(
               cloneIntelliTARgnForDrumKit(drumKit.get(), sourceRgn, drumKey, slotDef.playedNoteByte));
         }
       }
@@ -337,7 +337,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
         continue;
       }
 
-      addTempInstr(std::move(drumKit));
+      adoptTempInstr(std::move(drumKit));
     }
   } else {
     const auto& percussionInstrNoteMap = seq->percussionInstrNoteMap();
@@ -358,15 +358,15 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
         }
 
         for (auto* sourceRgn : sourceInstr->regions()) {
-          drumKit->addRgn(cloneLegacyRgnForDrumKit(drumKit.get(),
-                                                   sourceRgn,
-                                                   percussionDef.noteIndex,
-                                                   percussionDef.globalTranspose));
+          drumKit->adoptRgn(cloneLegacyRgnForDrumKit(drumKit.get(),
+                                                     sourceRgn,
+                                                     percussionDef.noteIndex,
+                                                     percussionDef.globalTranspose));
         }
       }
 
       if (!drumKit->regions().empty()) {
-        addTempInstr(std::move(drumKit));
+        adoptTempInstr(std::move(drumKit));
       }
     }
   }
@@ -411,7 +411,7 @@ bool NinSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  NinSnesRgn *rgn = emplaceRgn<NinSnesRgn>(this, profileId, offset(), konamiTuningTableAddress, konamiTuningTableSize);
+  NinSnesRgn *rgn = addRgn<NinSnesRgn>(this, profileId, offset(), konamiTuningTableAddress, konamiTuningTableSize);
   rgn->sampOffset = addrSampStart - spcDirAddr;
 
   return true;

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -306,8 +306,8 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
       if (rgn == nullptr) {
         continue;
       }
-      overrideInstrOwner->adoptRgn(std::move(rgn));
-      adoptTempInstr(std::move(overrideInstrOwner));
+      overrideInstrOwner->sinkRgn(std::move(rgn));
+      sinkTempInstr(std::move(overrideInstrOwner));
     }
 
     for (const auto& drumKitDef : seq->intelliTADrumKitDefs()) {
@@ -328,7 +328,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
 
         const u8 drumKey = static_cast<u8>(0x24 + slot);
         for (auto* sourceRgn : sourceInstr->regions()) {
-          drumKit->adoptRgn(
+          drumKit->sinkRgn(
               cloneIntelliTARgnForDrumKit(drumKit.get(), sourceRgn, drumKey, slotDef.playedNoteByte));
         }
       }
@@ -337,7 +337,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
         continue;
       }
 
-      adoptTempInstr(std::move(drumKit));
+      sinkTempInstr(std::move(drumKit));
     }
   } else {
     const auto& percussionInstrNoteMap = seq->percussionInstrNoteMap();
@@ -358,7 +358,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
         }
 
         for (auto* sourceRgn : sourceInstr->regions()) {
-          drumKit->adoptRgn(cloneLegacyRgnForDrumKit(drumKit.get(),
+          drumKit->sinkRgn(cloneLegacyRgnForDrumKit(drumKit.get(),
                                                      sourceRgn,
                                                      percussionDef.noteIndex,
                                                      percussionDef.globalTranspose));
@@ -366,7 +366,7 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
       }
 
       if (!drumKit->regions().empty()) {
-        adoptTempInstr(std::move(drumKit));
+        sinkTempInstr(std::move(drumKit));
       }
     }
   }

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -11,6 +11,8 @@
 #include "SNESDSP.h"
 #include "VGMColl.h"
 
+#include <memory>
+
 #include <spdlog/fmt/fmt.h>
 
 namespace {
@@ -82,18 +84,18 @@ NinSnesPitchTuning calculatePitchTuning(u16 pitchScale) {
   };
 }
 
-VGMRgn* cloneLegacyRgnForDrumKit(VGMInstr* instr,
-                                 VGMRgn* sourceRgn,
-                                 u8 noteIndex,
-                                 s8 globalTranspose) {
-  auto* newRgn = new VGMRgn(instr,
-                            sourceRgn->offset(),
-                            sourceRgn->length(),
-                            noteIndex,
-                            noteIndex,
-                            sourceRgn->velLow,
-                            sourceRgn->velHigh,
-                            sourceRgn->sampNum);
+std::unique_ptr<VGMRgn> cloneLegacyRgnForDrumKit(VGMInstr* instr,
+                                                 VGMRgn* sourceRgn,
+                                                 u8 noteIndex,
+                                                 s8 globalTranspose) {
+  auto newRgn = std::make_unique<VGMRgn>(instr,
+                                         sourceRgn->offset(),
+                                         sourceRgn->length(),
+                                         noteIndex,
+                                         noteIndex,
+                                         sourceRgn->velLow,
+                                         sourceRgn->velHigh,
+                                         sourceRgn->sampNum);
 
   newRgn->sampOffset = sourceRgn->sampOffset;
   newRgn->unityKey = sourceRgn->unityKey + (noteIndex - 0x3C) - globalTranspose;
@@ -106,18 +108,18 @@ VGMRgn* cloneLegacyRgnForDrumKit(VGMInstr* instr,
   return newRgn;
 }
 
-VGMRgn* cloneIntelliTARgnForDrumKit(VGMInstr* instr,
-                                    VGMRgn* sourceRgn,
-                                    u8 drumKey,
-                                    u8 playedNoteByte) {
-  auto* newRgn = new VGMRgn(instr,
-                            sourceRgn->offset(),
-                            sourceRgn->length(),
-                            drumKey,
-                            drumKey,
-                            sourceRgn->velLow,
-                            sourceRgn->velHigh,
-                            sourceRgn->sampNum);
+std::unique_ptr<VGMRgn> cloneIntelliTARgnForDrumKit(VGMInstr* instr,
+                                                    VGMRgn* sourceRgn,
+                                                    u8 drumKey,
+                                                    u8 playedNoteByte) {
+  auto newRgn = std::make_unique<VGMRgn>(instr,
+                                         sourceRgn->offset(),
+                                         sourceRgn->length(),
+                                         drumKey,
+                                         drumKey,
+                                         sourceRgn->velLow,
+                                         sourceRgn->velHigh,
+                                         sourceRgn->sampNum);
 
   newRgn->sampOffset = sourceRgn->sampOffset;
   newRgn->sampDataLength = sourceRgn->sampDataLength;
@@ -139,11 +141,11 @@ VGMRgn* cloneIntelliTARgnForDrumKit(VGMInstr* instr,
   return newRgn;
 }
 
-VGMRgn* createRgnFromHeaderData(VGMInstr* instr,
-                                RawFile* rawFile,
-                                NinSnesProfileId profileId,
-                                u32 spcDirAddr,
-                                const std::array<u8, 6>& regionData) {
+std::unique_ptr<VGMRgn> createRgnFromHeaderData(VGMInstr* instr,
+                                                RawFile* rawFile,
+                                                NinSnesProfileId profileId,
+                                                u32 spcDirAddr,
+                                                const std::array<u8, 6>& regionData) {
   const auto& profile = getNinSnesProfile(profileId);
   const u8 srcn = regionData[0];
   const u8 adsr1 = regionData[1];
@@ -157,12 +159,12 @@ VGMRgn* createRgnFromHeaderData(VGMInstr* instr,
 
   const auto tuning = calculatePitchTuning(readPitchScale(profile, regionData[4], regionData[5]));
 
-  auto* rgn = new VGMRgn(instr, 0, NinSnesInstr::expectedSize(profileId));
+  auto rgn = std::make_unique<VGMRgn>(instr, 0, NinSnesInstr::expectedSize(profileId));
   rgn->sampOffset = rawFile->readShort(offDirEnt) - spcDirAddr;
   rgn->sampNum = srcn;
   rgn->unityKey = tuning.unityKey;
   rgn->fineTune = tuning.fineTune;
-  snesConvADSR<VGMRgn>(rgn, adsr1, adsr2, gain);
+  snesConvADSR<VGMRgn>(rgn.get(), adsr1, adsr2, gain);
   return rgn;
 }
 
@@ -257,28 +259,26 @@ bool NinSnesInstrSet::parseInstrPointers() {
       usedSRCNs.push_back(srcn);
     }
 
-    NinSnesInstr *newInstr = new NinSnesInstr(
+    auto *newInstr = emplaceInstr<NinSnesInstr>(
       this, profileId, addrInstrHeader, instr >> 7, instr & 0x7f,
       spcDirAddr, fmt::format("Instrument {}", instr));
     newInstr->konamiTuningTableAddress = konamiTuningTableAddress;
     newInstr->konamiTuningTableSize = konamiTuningTableSize;
-    aInstrs.push_back(newInstr);
   }
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = nullptr;
   if (loadsFullNinSnesSampleDirectory(profile)) {
-    newSampColl = new SNESSampColl(NinSnesFormat::name, this->rawFile(), spcDirAddr, 0x80);
+    if (!addDiscoveredFile<SNESSampColl>(NinSnesFormat::name, rawFile(), spcDirAddr, 0x80)) {
+      return false;
+    }
   }
   else {
-    newSampColl = new SNESSampColl(NinSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  }
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
-    return false;
+    if (!addDiscoveredFile<SNESSampColl>(NinSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
+      return false;
+    }
   }
 
   return true;
@@ -293,26 +293,25 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
 
   if (usesIntelliTempDrumKitExport(seq->profileId)) {
     for (const auto& overrideDef : seq->intelliTAInstrumentOverrides()) {
-      auto* overrideInstr = new VGMInstr(
+      auto overrideInstrOwner = std::make_unique<VGMInstr>(
           this,
           0,
           NinSnesInstr::expectedSize(profileId),
           overrideDef.progNum >> 7,
           overrideDef.progNum & 0x7f,
           fmt::format("Instrument {:d} (Overwrite)", overrideDef.logicalInstrIndex));
-      overrideInstr->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
-      auto* rgn =
-          createRgnFromHeaderData(overrideInstr, rawFile(), profileId, spcDirAddr, overrideDef.regionData);
+      overrideInstrOwner->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
+      auto rgn =
+          createRgnFromHeaderData(overrideInstrOwner.get(), rawFile(), profileId, spcDirAddr, overrideDef.regionData);
       if (rgn == nullptr) {
-        delete overrideInstr;
         continue;
       }
-      overrideInstr->addRgn(rgn);
-      addTempInstr(overrideInstr);
+      overrideInstrOwner->addRgn(std::move(rgn));
+      addTempInstr(std::move(overrideInstrOwner));
     }
 
     for (const auto& drumKitDef : seq->intelliTADrumKitDefs()) {
-      auto* drumKit = new VGMInstr(
+      auto drumKit = std::make_unique<VGMInstr>(
           this, 0, 0, 127, drumKitDef.program, fmt::format("Drum Kit {:d}", drumKitDef.program));
       drumKit->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
 
@@ -330,26 +329,25 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
         const u8 drumKey = static_cast<u8>(0x24 + slot);
         for (auto* sourceRgn : sourceInstr->regions()) {
           drumKit->addRgn(
-              cloneIntelliTARgnForDrumKit(drumKit, sourceRgn, drumKey, slotDef.playedNoteByte));
+              cloneIntelliTARgnForDrumKit(drumKit.get(), sourceRgn, drumKey, slotDef.playedNoteByte));
         }
       }
 
       if (drumKit->regions().empty()) {
-        delete drumKit;
         continue;
       }
 
-      addTempInstr(drumKit);
+      addTempInstr(std::move(drumKit));
     }
   } else {
     const auto& percussionInstrNoteMap = seq->percussionInstrNoteMap();
     if (!percussionInstrNoteMap.empty()) {
       // Create the drumkit instrument for percussion note events.
-      auto* drumKit = new VGMInstr(this, 0, 0, 127, 0, "Drum Kit");
+      auto drumKit = std::make_unique<VGMInstr>(this, 0, 0, 127, 0, "Drum Kit");
       drumKit->addStandardVibratoHandling(nin_snes::vibrato::modulationSpec());
       for (const auto& [instrIndex, percussionDef] : percussionInstrNoteMap) {
         VGMInstr* sourceInstr = nullptr;
-        for (auto* instr : aInstrs) {
+        for (auto* instr : instrs()) {
           if (instr->instrNum == instrIndex) {
             sourceInstr = instr;
             break;
@@ -360,17 +358,15 @@ void NinSnesInstrSet::useColl(const VGMColl* coll) {
         }
 
         for (auto* sourceRgn : sourceInstr->regions()) {
-          drumKit->addRgn(cloneLegacyRgnForDrumKit(drumKit,
+          drumKit->addRgn(cloneLegacyRgnForDrumKit(drumKit.get(),
                                                    sourceRgn,
                                                    percussionDef.noteIndex,
                                                    percussionDef.globalTranspose));
         }
       }
 
-      if (drumKit->regions().empty()) {
-        delete drumKit;
-      } else {
-        addTempInstr(drumKit);
+      if (!drumKit->regions().empty()) {
+        addTempInstr(std::move(drumKit));
       }
     }
   }
@@ -415,9 +411,8 @@ bool NinSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  NinSnesRgn *rgn = new NinSnesRgn(this, profileId, offset(), konamiTuningTableAddress, konamiTuningTableSize);
+  NinSnesRgn *rgn = emplaceRgn<NinSnesRgn>(this, profileId, offset(), konamiTuningTableAddress, konamiTuningTableSize);
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   return true;
 }

--- a/src/main/formats/NinSnes/NinSnesScanner.cpp
+++ b/src/main/formats/NinSnes/NinSnesScanner.cpp
@@ -97,9 +97,8 @@ void NinSnesScanner::scan(RawFile* file, void* info) {
 }
 
 void NinSnesScanner::loadFromScanResult(RawFile* file, const NinSnesScanResult& scanResult) {
-  auto* newSeq = new NinSnesSeq(file, scanResult);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<NinSnesSeq>(file, scanResult);
+  if (!newSeq) {
     return;
   }
 
@@ -108,9 +107,8 @@ void NinSnesScanner::loadFromScanResult(RawFile* file, const NinSnesScanResult& 
     return;
   }
 
-  auto* newInstrSet = new NinSnesInstrSet(file, scanResult);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  auto* newInstrSet = pRoot->emplaceVGMFile<NinSnesInstrSet>(file, scanResult);
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/NinSnes/NinSnesScanner.cpp
+++ b/src/main/formats/NinSnes/NinSnesScanner.cpp
@@ -97,7 +97,7 @@ void NinSnesScanner::scan(RawFile* file, void* info) {
 }
 
 void NinSnesScanner::loadFromScanResult(RawFile* file, const NinSnesScanResult& scanResult) {
-  auto* newSeq = pRoot->emplaceVGMFile<NinSnesSeq>(file, scanResult);
+  auto* newSeq = pRoot->loadVGMFile<NinSnesSeq>(file, scanResult);
   if (!newSeq) {
     return;
   }
@@ -107,7 +107,7 @@ void NinSnesScanner::loadFromScanResult(RawFile* file, const NinSnesScanResult& 
     return;
   }
 
-  auto* newInstrSet = pRoot->emplaceVGMFile<NinSnesInstrSet>(file, scanResult);
+  auto* newInstrSet = pRoot->loadVGMFile<NinSnesInstrSet>(file, scanResult);
   if (!newInstrSet) {
     return;
   }

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -153,7 +153,7 @@ bool NinSnesSeq::postLoad() {
     }
 
     for (auto& section : m_ownedSections) {
-      addChild(std::move(section));
+      adoptChild(std::move(section));
     }
     m_ownedSections.clear();
     setGuessedLength();
@@ -185,7 +185,7 @@ bool NinSnesSeq::loadSection(NinSnesSection *section, u32 stopTime) {
   return section->postLoad();
 }
 
-NinSnesSection* NinSnesSeq::addSection(std::unique_ptr<NinSnesSection> section) {
+NinSnesSection* NinSnesSeq::adoptSection(std::unique_ptr<NinSnesSection> section) {
   auto* rawSection = section.get();
   if (offset() > section->offset()) {
     const u32 distance = offset() - section->offset();
@@ -383,7 +383,7 @@ bool NinSnesSeq::readPlaylistEvent(long stopTime) {
         L_ERROR("Failed to load section");
         return false;
       }
-      addSection(std::move(newSection));
+      adoptSection(std::move(newSection));
     }
 
     if (!loadSection(section, stopTime)) {
@@ -560,7 +560,7 @@ bool NinSnesSection::postLoad() {
     if (!m_tracksAddedToChildren) {
       for (auto& track : m_ownedTracks) {
         if (track != nullptr) {
-          addChild(std::move(track));
+          adoptChild(std::move(track));
         }
       }
       m_tracksAddedToChildren = true;

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -153,7 +153,7 @@ bool NinSnesSeq::postLoad() {
     }
 
     for (auto& section : m_ownedSections) {
-      adoptChild(std::move(section));
+      sinkChild(std::move(section));
     }
     m_ownedSections.clear();
     setGuessedLength();
@@ -185,7 +185,7 @@ bool NinSnesSeq::loadSection(NinSnesSection *section, u32 stopTime) {
   return section->postLoad();
 }
 
-NinSnesSection* NinSnesSeq::adoptSection(std::unique_ptr<NinSnesSection> section) {
+NinSnesSection* NinSnesSeq::sinkSection(std::unique_ptr<NinSnesSection>&& section) {
   auto* rawSection = section.get();
   if (offset() > section->offset()) {
     const u32 distance = offset() - section->offset();
@@ -383,7 +383,7 @@ bool NinSnesSeq::readPlaylistEvent(long stopTime) {
         L_ERROR("Failed to load section");
         return false;
       }
-      adoptSection(std::move(newSection));
+      sinkSection(std::move(newSection));
     }
 
     if (!loadSection(section, stopTime)) {
@@ -560,7 +560,7 @@ bool NinSnesSection::postLoad() {
     if (!m_tracksAddedToChildren) {
       for (auto& track : m_ownedTracks) {
         if (track != nullptr) {
-          adoptChild(std::move(track));
+          sinkChild(std::move(track));
         }
       }
       m_tracksAddedToChildren = true;

--- a/src/main/formats/NinSnes/NinSnesSeq.cpp
+++ b/src/main/formats/NinSnes/NinSnesSeq.cpp
@@ -56,13 +56,6 @@ NinSnesSeq::NinSnesSeq(RawFile* file, const NinSnesScanResult& scanResult)
   falcomBaseOffset = scanResult.falcomBaseOffset;
 }
 
-NinSnesSeq::~NinSnesSeq() {
-  for (auto* track : aTracks) {
-    delete track;
-  }
-  aTracks.clear();
-}
-
 bool NinSnesSeq::load() {
   readMode = READMODE_ADD_TO_UI;
 
@@ -70,7 +63,7 @@ bool NinSnesSeq::load() {
     return false;
   }
 
-  nNumTracks = static_cast<u32>(aTracks.size());
+  nNumTracks = static_cast<u32>(trackCount());
   if (nNumTracks == 0) {
     return false;
   }
@@ -111,20 +104,20 @@ void NinSnesSeq::resetVars() {
 }
 
 void NinSnesSeq::createTracks() {
-  if (!aTracks.empty()) {
+  if (hasTracks()) {
     return;
   }
 
-  aTracks.reserve(MAX_TRACKS);
+  reserveTracks(MAX_TRACKS);
   for (u32 trackIndex = 0; trackIndex < MAX_TRACKS; trackIndex++) {
     auto trackName = fmt::format("Track {}", trackIndex + 1);
-    aTracks.push_back(new NinSnesTrack(this, dwStartOffset, 0, trackName));
+    addTrack<NinSnesTrack>(this, dwStartOffset, 0, trackName);
   }
 }
 
 bool NinSnesSeq::loadTracks(ReadMode readMode, u32 stopTime) {
   this->readMode = readMode;
-  for (auto* track : aTracks) {
+  for (auto* track : tracks()) {
     track->readMode = readMode;
   }
 
@@ -136,7 +129,7 @@ bool NinSnesSeq::loadTracks(ReadMode readMode, u32 stopTime) {
 
   resetVars();
   for (u32 trackNum = 0; trackNum < nNumTracks; trackNum++) {
-    if (!aTracks[trackNum]->loadTrackInit(trackNum, nullptr)) {
+    if (!track(trackNum)->loadTrackInit(trackNum, nullptr)) {
       return false;
     }
   }
@@ -155,11 +148,14 @@ bool NinSnesSeq::postLoad() {
   if (readMode == READMODE_ADD_TO_UI) {
     std::ranges::sort(aInstrumentsUsed);
 
-    for (auto* section : aSections) {
+    for (auto* section : m_sections) {
       section->postLoad();
     }
 
-    addChildren(aSections);
+    for (auto& section : m_ownedSections) {
+      addChild(std::move(section));
+    }
+    m_ownedSections.clear();
     setGuessedLength();
     if (length() == 0) {
       return false;
@@ -173,9 +169,9 @@ bool NinSnesSeq::postLoad() {
 }
 
 bool NinSnesSeq::loadSection(NinSnesSection *section, u32 stopTime) {
-  assert(aTracks.size() == nNumTracks);
+  assert(trackCount() == nNumTracks);
   for (u32 trackNum = 0; trackNum < nNumTracks; trackNum++) {
-    auto* track = static_cast<NinSnesTrack*>(aTracks[trackNum]);
+    auto* track = static_cast<NinSnesTrack*>(this->track(trackNum));
     track->readMode = readMode;
     if (!track->prepareSectionTrack(*section, trackNum)) {
       return false;
@@ -189,7 +185,8 @@ bool NinSnesSeq::loadSection(NinSnesSection *section, u32 stopTime) {
   return section->postLoad();
 }
 
-void NinSnesSeq::addSection(NinSnesSection *section) {
+NinSnesSection* NinSnesSeq::addSection(std::unique_ptr<NinSnesSection> section) {
+  auto* rawSection = section.get();
   if (offset() > section->offset()) {
     const u32 distance = offset() - section->offset();
     setOffset(section->offset());
@@ -197,11 +194,13 @@ void NinSnesSeq::addSection(NinSnesSection *section) {
       setLength(length() + distance);
     }
   }
-  aSections.push_back(section);
+  m_sections.push_back(rawSection);
+  m_ownedSections.emplace_back(std::move(section));
+  return rawSection;
 }
 
 NinSnesSection *NinSnesSeq::getSectionAtOffset(u32 offset) {
-  for (auto* section : aSections) {
+  for (auto* section : m_sections) {
     if (section->offset() == offset) {
       return section;
     }
@@ -378,12 +377,13 @@ bool NinSnesSeq::readPlaylistEvent(long stopTime) {
 
     NinSnesSection* section = getSectionAtOffset(sectionAddress);
     if (section == nullptr) {
-      section = new NinSnesSection(this, sectionAddress);
+      auto newSection = std::make_unique<NinSnesSection>(this, sectionAddress);
+      section = newSection.get();
       if (!section->load()) {
         L_ERROR("Failed to load section");
         return false;
       }
-      addSection(section);
+      addSection(std::move(newSection));
     }
 
     if (!loadSection(section, stopTime)) {
@@ -436,7 +436,7 @@ void NinSnesSeq::startTempoFade(u8 fadeLength, u8 targetTempo) {
 }
 
 void NinSnesSeq::syncTempoDependentTracks() {
-  for (auto* track : aTracks) {
+  for (auto* track : tracks()) {
     static_cast<NinSnesTrack*>(track)->syncVibratoRateAndDelay();
   }
 }
@@ -445,8 +445,8 @@ void NinSnesSeq::onTickEnd() {
   // EVENT_TEMPO_FADE applies its first tempo step at the end of the tick that parsed the command.
   tempoFade.tickRaw([this](s32 tempoValue) {
     tempo = static_cast<u8>(std::clamp(tempoValue, 0, 0xff));
-    if (!aTracks.empty()) {
-      aTracks[0]->addTempoBPMNoItem(getTempoInBPM(tempo));
+    if (hasTracks()) {
+      track(0)->addTempoBPMNoItem(getTempoInBPM(tempo));
     }
     syncTempoDependentTracks();
   });
@@ -516,7 +516,9 @@ bool NinSnesSection::parseTrackPointers() {
       segment.startOffset = curOffset;
       segment.rangeOffset = curOffset;
       segment.rangeLength = 2;
-      m_tracks[trackIndex] = new NinSnesSectionTrackItem(parentSeq, curOffset, 2, "NULL");
+      auto track = std::make_unique<NinSnesSectionTrackItem>(parentSeq, curOffset, 2, "NULL");
+      m_tracks[trackIndex] = track.get();
+      m_ownedTracks[trackIndex] = std::move(track);
       m_tracks[trackIndex]->readMode = parentSeq->readMode;
       curOffset += 2;
       continue;
@@ -525,8 +527,10 @@ bool NinSnesSection::parseTrackPointers() {
     startAddress = convertToApuAddress(startAddress);
     segment.startOffset = startAddress;
     segment.rangeOffset = startAddress;
-    m_tracks[trackIndex] = new NinSnesSectionTrackItem(
+    auto track = std::make_unique<NinSnesSectionTrackItem>(
         parentSeq, startAddress, 0, fmt::format("Track {}", trackIndex + 1));
+    m_tracks[trackIndex] = track.get();
+    m_ownedTracks[trackIndex] = std::move(track);
     m_tracks[trackIndex]->readMode = parentSeq->readMode;
 
     // Correct section address. Probably not necessary for regular cases, but just in case.
@@ -554,9 +558,9 @@ bool NinSnesSection::postLoad() {
     }
 
     if (!m_tracksAddedToChildren) {
-      for (auto* track : m_tracks) {
+      for (auto& track : m_ownedTracks) {
         if (track != nullptr) {
-          addChild(track);
+          addChild(std::move(track));
         }
       }
       m_tracksAddedToChildren = true;

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -116,7 +116,7 @@ private:
   void loadEventMap();
   void createTracks();
   bool loadSection(NinSnesSection *section, u32 stopTime = 1000000);
-  NinSnesSection* adoptSection(std::unique_ptr<NinSnesSection> section);
+  NinSnesSection* sinkSection(std::unique_ptr<NinSnesSection>&& section);
   NinSnesSection *getSectionAtOffset(u32 offset);
   bool addLoopForeverNoItem();
   void setImmediateTempo(u8 newTempo);

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -116,7 +116,7 @@ private:
   void loadEventMap();
   void createTracks();
   bool loadSection(NinSnesSection *section, u32 stopTime = 1000000);
-  NinSnesSection* addSection(std::unique_ptr<NinSnesSection> section);
+  NinSnesSection* adoptSection(std::unique_ptr<NinSnesSection> section);
   NinSnesSection *getSectionAtOffset(u32 offset);
   bool addLoopForeverNoItem();
   void setImmediateTempo(u8 newTempo);

--- a/src/main/formats/NinSnes/NinSnesSeq.h
+++ b/src/main/formats/NinSnes/NinSnesSeq.h
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <array>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -28,7 +29,7 @@ public:
              const std::vector<u8>& durRateTable = std::vector<u8>(),
              std::string name = "NinSnes Seq");
   NinSnesSeq(RawFile* file, const NinSnesScanResult& scanResult);
-  virtual ~NinSnesSeq();
+  ~NinSnesSeq() override = default;
 
   bool load() override;
   bool parseHeader() override;
@@ -71,7 +72,6 @@ public:
   double maxVibratoRateHz;
   u32 dwStartOffset;
   u32 curOffset;
-  std::vector<NinSnesSection *> aSections;
 
   // Konami:
   u16 konamiBaseAddress;
@@ -116,7 +116,7 @@ private:
   void loadEventMap();
   void createTracks();
   bool loadSection(NinSnesSection *section, u32 stopTime = 1000000);
-  void addSection(NinSnesSection *section);
+  NinSnesSection* addSection(std::unique_ptr<NinSnesSection> section);
   NinSnesSection *getSectionAtOffset(u32 offset);
   bool addLoopForeverNoItem();
   void setImmediateTempo(u8 newTempo);
@@ -130,6 +130,8 @@ private:
   u32 m_nextIntelliTAOverrideProgram;
   std::vector<NinSnesIntelliTAInstrumentOverride> m_intelliTAInstrumentOverrides;
   std::vector<NinSnesIntelliTADrumKitDef> m_intelliTADrumKitDefs;
+  std::vector<std::unique_ptr<NinSnesSection>> m_ownedSections;
+  std::vector<NinSnesSection *> m_sections;
 };
 
 class NinSnesSection : public VGMItem {
@@ -187,6 +189,7 @@ public:
   bool m_loaded = false;
   bool m_tracksAddedToChildren = false;
   std::array<TrackSegment, kNinSnesTrackCount> m_trackSegments {};
+  std::array<std::unique_ptr<NinSnesSectionTrackItem>, kNinSnesTrackCount> m_ownedTracks {};
   std::array<NinSnesSectionTrackItem*, kNinSnesTrackCount> m_tracks {};
 };
 

--- a/src/main/formats/NinSnes/NinSnesTrack.cpp
+++ b/src/main/formats/NinSnes/NinSnesTrack.cpp
@@ -311,12 +311,12 @@ bool NinSnesTrack::handleCoreEvent(NinSnesSeqEventType eventType, u32 beginOffse
     case EVENT_END:
       if (state.loopCount == 0) {
         if (readMode == READMODE_FIND_DELTA_LENGTH) {
-          for (size_t trackIndex = 0; trackIndex < parentSeq.aTracks.size(); trackIndex++) {
-            parentSeq.aTracks[trackIndex]->totalTicks = getTime();
+          for (size_t trackIndex = 0; trackIndex < parentSeq.trackCount(); trackIndex++) {
+            parentSeq.track(trackIndex)->totalTicks = getTime();
           }
         } else if (readMode == READMODE_CONVERT_TO_MIDI) {
-          for (size_t trackIndex = 0; trackIndex < parentSeq.aTracks.size(); trackIndex++) {
-            parentSeq.aTracks[trackIndex]->limitPrevDurNoteEnd();
+          for (size_t trackIndex = 0; trackIndex < parentSeq.trackCount(); trackIndex++) {
+            parentSeq.track(trackIndex)->limitPrevDurNoteEnd();
           }
         }
 
@@ -611,10 +611,10 @@ bool NinSnesTrack::handleControllerEvent(NinSnesSeqEventType eventType, u32 begi
       for (int channelNo = MAX_TRACKS - 1; channelNo >= 0; channelNo--) {
         if ((spcEON & (1 << channelNo)) != 0) {
           fmt::format_to(std::back_inserter(desc), "{}", channelNo);
-          parentSeq.aTracks[channelNo]->addReverbNoItem(40);
+          parentSeq.track(channelNo)->addReverbNoItem(40);
         } else {
           desc.push_back('-');
-          parentSeq.aTracks[channelNo]->addReverbNoItem(0);
+          parentSeq.track(channelNo)->addReverbNoItem(0);
         }
       }
 

--- a/src/main/formats/Org/OrgScanner.cpp
+++ b/src/main/formats/Org/OrgScanner.cpp
@@ -25,9 +25,7 @@ void OrgScanner::searchForOrgSeq(RawFile *file) {
     if ((*file)[i] == 'O' && (*file)[i + 1] == 'r' && (*file)[i + 2] == 'g' && (*file)[i + 3] == '-' &&
         (*file)[i + 4] == '0' && (*file)[i + 5] == '2') {
       if (file->readShort(i + 6)) {
-        OrgSeq *NewOrgSeq = new OrgSeq(file, i);
-        if (!NewOrgSeq->loadVGMFile())
-          delete NewOrgSeq;
+        pRoot->emplaceVGMFile<OrgSeq>(file, i);
       }
     }
   }

--- a/src/main/formats/Org/OrgScanner.cpp
+++ b/src/main/formats/Org/OrgScanner.cpp
@@ -25,7 +25,7 @@ void OrgScanner::searchForOrgSeq(RawFile *file) {
     if ((*file)[i] == 'O' && (*file)[i + 1] == 'r' && (*file)[i + 2] == 'g' && (*file)[i + 3] == '-' &&
         (*file)[i + 4] == '0' && (*file)[i + 5] == '2') {
       if (file->readShort(i + 6)) {
-        pRoot->emplaceVGMFile<OrgSeq>(file, i);
+        pRoot->loadVGMFile<OrgSeq>(file, i);
       }
     }
   }

--- a/src/main/formats/Org/OrgSeq.cpp
+++ b/src/main/formats/Org/OrgSeq.cpp
@@ -22,13 +22,12 @@ bool OrgSeq::parseHeader(void) {
     if (readShort(offset() + 0x16 + i * 6))            //if there are notes in this track
     {
       nNumTracks++;                    //well then, we might as well say it exists
-      OrgTrack
-          *newOrgTrack = new OrgTrack(this, offset() + 0x12 + 16 * 6 + notesSoFar * 8, readShort(0x16 + i * 6) * 8, i);
+      auto *newOrgTrack = addTrack<OrgTrack>(
+          this, offset() + 0x12 + 16 * 6 + notesSoFar * 8, readShort(0x16 + i * 6) * 8, i);
       newOrgTrack->numNotes = readShort(offset() + 0x16 + i * 6);
       newOrgTrack->freq = readShort(offset() + 0x12 + i * 6);
       newOrgTrack->waveNum = readByte(offset() + 0x14 + i * 6);
       newOrgTrack->numNotes = readShort(offset() + 0x16 + i * 6);
-      aTracks.push_back(newOrgTrack);
 
       notesSoFar += newOrgTrack->numNotes;
     }

--- a/src/main/formats/PS1/PS1Seq.cpp
+++ b/src/main/formats/PS1/PS1Seq.cpp
@@ -44,10 +44,7 @@ bool PS1Seq::parseHeader() {
       return false;
 
     setEventsOffset(offset() + 0x0F + 4);
-    PS1Seq *newPS1Seq = new PS1Seq(rawFile(), newSeqOffset);
-    if (!newPS1Seq->loadVGMFile()) {
-      delete newPS1Seq;
-    }
+    addDiscoveredFile<PS1Seq>(rawFile(), newSeqOffset);
     //short relOffset = (short)GetShortBE(curOffset);
     //AddGenericEvent(beginOffset, 4, "Jump Relative", NULL, BG_CLR_PINK);
     //curOffset += relOffset;

--- a/src/main/formats/PS1/PS1SeqScanner.cpp
+++ b/src/main/formats/PS1/PS1SeqScanner.cpp
@@ -32,7 +32,7 @@ std::vector<PS1Seq *> PS1SeqScanner::searchForPS1Seq(RawFile *file) {
                         std::boyer_moore_searcher(signature.rbegin(), signature.rend()));
 
   while (it != file->end()) {
-    auto* newPS1Seq = pRoot->emplaceVGMFile<PS1Seq>(file, it - file->begin());
+    auto* newPS1Seq = pRoot->loadVGMFile<PS1Seq>(file, it - file->begin());
     if (newPS1Seq) {
       loadedFiles.push_back(newPS1Seq);
     }
@@ -53,7 +53,7 @@ std::vector<Vab *> PS1SeqScanner::searchForVab(RawFile *file) {
                         std::boyer_moore_searcher(signature.rbegin(), signature.rend()));
 
   while (it != file->end()) {
-    auto* newVab = pRoot->emplaceVGMFile<Vab>(file, it - file->begin());
+    auto* newVab = pRoot->loadVGMFile<Vab>(file, it - file->begin());
     if (newVab) {
       loadedFiles.push_back(newVab);
     }

--- a/src/main/formats/PS1/PS1SeqScanner.cpp
+++ b/src/main/formats/PS1/PS1SeqScanner.cpp
@@ -32,11 +32,9 @@ std::vector<PS1Seq *> PS1SeqScanner::searchForPS1Seq(RawFile *file) {
                         std::boyer_moore_searcher(signature.rbegin(), signature.rend()));
 
   while (it != file->end()) {
-    PS1Seq *newPS1Seq = new PS1Seq(file, it - file->begin());
-    if (newPS1Seq->loadVGMFile()) {
+    auto* newPS1Seq = pRoot->emplaceVGMFile<PS1Seq>(file, it - file->begin());
+    if (newPS1Seq) {
       loadedFiles.push_back(newPS1Seq);
-    } else {
-      delete newPS1Seq;
     }
 
     it = std::search(std::next(it), file->end(),
@@ -55,11 +53,9 @@ std::vector<Vab *> PS1SeqScanner::searchForVab(RawFile *file) {
                         std::boyer_moore_searcher(signature.rbegin(), signature.rend()));
 
   while (it != file->end()) {
-    Vab *newVab = new Vab(file, it - file->begin());
-    if (newVab->loadVGMFile()) {
+    auto* newVab = pRoot->emplaceVGMFile<Vab>(file, it - file->begin());
+    if (newVab) {
       loadedFiles.push_back(newVab);
-    } else {
-      delete newVab;
     }
 
     it = std::search(std::next(it), file->end(),

--- a/src/main/formats/PS1/Vab.cpp
+++ b/src/main/formats/PS1/Vab.cpp
@@ -93,7 +93,7 @@ bool Vab::parseInstrPointers() {
     }
     else if (numTonesPerInstr != 0) {
       auto instrName = fmt::format("Instrument {:d}", progIndex);
-      VabInstr *newInstr = emplaceInstr<VabInstr>(this, offCurrToneAttrs, 0x20 * 16, 0, progIndex, instrName);
+      VabInstr *newInstr = addInstr<VabInstr>(this, offCurrToneAttrs, 0x20 * 16, 0, progIndex, instrName);
       readBytes(offCurrProg, 0x10, &newInstr->attr);
 
       const auto progName = fmt::format("Program {:d}", progIndex);
@@ -190,7 +190,7 @@ bool VabInstr::loadInstr() {
     if (!rgn->loadRgn()) {
       continue;
     }
-    addRgn(std::move(rgn));
+    adoptRgn(std::move(rgn));
   }
   return true;
 }

--- a/src/main/formats/PS1/Vab.cpp
+++ b/src/main/formats/PS1/Vab.cpp
@@ -5,6 +5,8 @@
 #include "formats/PS1/PS1Format.h"
 #include "PSXSPU.h"
 
+#include <memory>
+
 using namespace std;
 
 Vab::Vab(RawFile *file, u32 offset)
@@ -79,7 +81,7 @@ bool Vab::parseInstrPointers() {
   u32 numProgramsLoaded = 0;
   for (u32 progIndex = 0; progIndex < 128 && numProgramsLoaded < numPrograms; progIndex++) {
     u32 offCurrProg = offProgs + (progIndex * 16);
-    u32 offCurrToneAttrs = offToneAttrs + (u32) (aInstrs.size() * 32 * 16);
+    u32 offCurrToneAttrs = offToneAttrs + (u32) (instrCount() * 32 * 16);
 
     if (offCurrToneAttrs + (32 * 16) > nEndOffset) {
       break;
@@ -91,8 +93,7 @@ bool Vab::parseInstrPointers() {
     }
     else if (numTonesPerInstr != 0) {
       auto instrName = fmt::format("Instrument {:d}", progIndex);
-      VabInstr *newInstr = new VabInstr(this, offCurrToneAttrs, 0x20 * 16, 0, progIndex, instrName);
-      aInstrs.push_back(newInstr);
+      VabInstr *newInstr = emplaceInstr<VabInstr>(this, offCurrToneAttrs, 0x20 * 16, 0, progIndex, instrName);
       readBytes(offCurrProg, 0x10, &newInstr->attr);
 
       const auto progName = fmt::format("Program {:d}", progIndex);
@@ -152,10 +153,10 @@ bool Vab::isViableSampCollMatch(VGMSampColl* sampColl) {
     if (vagLoc.offset == 0 && vagLoc.size == 0)
       continue;
 
-    if (sampleIndex >= sampColl->samples.size())
+    if (sampleIndex >= sampColl->sampleCount())
       return false;
 
-    auto sample = sampColl->samples[sampleIndex++];
+    auto sample = sampColl->sample(sampleIndex++);
     auto sampleRelOffset = sample->offset() - sampCollOffset;
     if (sampleRelOffset != vagLoc.offset ||
       (sample->length() > vagLoc.size + 32 || sample->length() < vagLoc.size))
@@ -185,12 +186,11 @@ VabInstr::~VabInstr() {
 bool VabInstr::loadInstr() {
   s8 numRgns = attr.tones;
   for (int i = 0; i < numRgns; i++) {
-    VabRgn *rgn = new VabRgn(this, offset() + i * 0x20);
+    auto rgn = std::make_unique<VabRgn>(this, offset() + i * 0x20);
     if (!rgn->loadRgn()) {
-      delete rgn;
       continue;
     }
-    addRgn(rgn);
+    addRgn(std::move(rgn));
   }
   return true;
 }

--- a/src/main/formats/PS1/Vab.cpp
+++ b/src/main/formats/PS1/Vab.cpp
@@ -190,7 +190,7 @@ bool VabInstr::loadInstr() {
     if (!rgn->loadRgn()) {
       continue;
     }
-    adoptRgn(std::move(rgn));
+    sinkRgn(std::move(rgn));
   }
   return true;
 }

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesInstr.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesInstr.cpp
@@ -86,20 +86,17 @@ bool PandoraBoxSnesInstrSet::parseInstrPointers() {
       adsr = instrADSRHints[srcn];
     }
 
-    PandoraBoxSnesInstr *newInstr = new PandoraBoxSnesInstr(
+    emplaceInstr<PandoraBoxSnesInstr>(
       this, version, addrLocalInstrItem, instrNum, srcn, spcDirAddr, adsr,
       fmt::format("Instrument {}", srcn));
-    aInstrs.push_back(newInstr);
   }
 
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(PandoraBoxSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(PandoraBoxSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -135,9 +132,8 @@ bool PandoraBoxSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  PandoraBoxSnesRgn *rgn = new PandoraBoxSnesRgn(this, version, offset(), srcn, spcDirAddr, adsr);
+  PandoraBoxSnesRgn *rgn = emplaceRgn<PandoraBoxSnesRgn>(this, version, offset(), srcn, spcDirAddr, adsr);
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   setGuessedLength();
   return true;

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesInstr.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesInstr.cpp
@@ -86,7 +86,7 @@ bool PandoraBoxSnesInstrSet::parseInstrPointers() {
       adsr = instrADSRHints[srcn];
     }
 
-    emplaceInstr<PandoraBoxSnesInstr>(
+    addInstr<PandoraBoxSnesInstr>(
       this, version, addrLocalInstrItem, instrNum, srcn, spcDirAddr, adsr,
       fmt::format("Instrument {}", srcn));
   }
@@ -132,7 +132,7 @@ bool PandoraBoxSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  PandoraBoxSnesRgn *rgn = emplaceRgn<PandoraBoxSnesRgn>(this, version, offset(), srcn, spcDirAddr, adsr);
+  PandoraBoxSnesRgn *rgn = addRgn<PandoraBoxSnesRgn>(this, version, offset(), srcn, spcDirAddr, adsr);
   rgn->sampOffset = addrSampStart - spcDirAddr;
 
   setGuessedLength();

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesScanner.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesScanner.cpp
@@ -119,9 +119,8 @@ void PandoraBoxSnesScanner::searchForPandoraBoxSnesFromARAM(RawFile *file) {
     return;
   }
 
-  PandoraBoxSnesSeq *newSeq = new PandoraBoxSnesSeq(file, version, addrSeqHeader, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<PandoraBoxSnesSeq>(file, version, addrSeqHeader, name);
+  if (!newSeq) {
     return;
   }
 
@@ -154,11 +153,10 @@ void PandoraBoxSnesScanner::searchForPandoraBoxSnesFromARAM(RawFile *file) {
     return;
   }
 
-    PandoraBoxSnesInstrSet *newInstrSet = new PandoraBoxSnesInstrSet(
+  auto* newInstrSet = pRoot->emplaceVGMFile<PandoraBoxSnesInstrSet>(
       file, version, spcDirAddr, addrLocalInstrTable, addrGlobalInstrTable, globalInstrumentCount,
       newSeq->instrADSRHints);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesScanner.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesScanner.cpp
@@ -119,7 +119,7 @@ void PandoraBoxSnesScanner::searchForPandoraBoxSnesFromARAM(RawFile *file) {
     return;
   }
 
-  auto* newSeq = pRoot->emplaceVGMFile<PandoraBoxSnesSeq>(file, version, addrSeqHeader, name);
+  auto* newSeq = pRoot->loadVGMFile<PandoraBoxSnesSeq>(file, version, addrSeqHeader, name);
   if (!newSeq) {
     return;
   }
@@ -153,7 +153,7 @@ void PandoraBoxSnesScanner::searchForPandoraBoxSnesFromARAM(RawFile *file) {
     return;
   }
 
-  auto* newInstrSet = pRoot->emplaceVGMFile<PandoraBoxSnesInstrSet>(
+  auto* newInstrSet = pRoot->loadVGMFile<PandoraBoxSnesInstrSet>(
       file, version, spcDirAddr, addrLocalInstrTable, addrGlobalInstrTable, globalInstrumentCount,
       newSeq->instrADSRHints);
   if (!newInstrSet) {

--- a/src/main/formats/PandoraBoxSnes/PandoraBoxSnesSeq.cpp
+++ b/src/main/formats/PandoraBoxSnes/PandoraBoxSnesSeq.cpp
@@ -81,8 +81,7 @@ bool PandoraBoxSnesSeq::parseTrackPointers() {
     curOffset += 2;
     if (ofsTrackStart != 0xffff) {
       u16 addrTrackStart = offset() + ofsTrackStart;
-      PandoraBoxSnesTrack *track = new PandoraBoxSnesTrack(this, addrTrackStart);
-      aTracks.push_back(track);
+      addTrack<PandoraBoxSnesTrack>(this, addrTrackStart);
     }
   }
   return true;

--- a/src/main/formats/PrismSnes/PrismSnesInstr.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesInstr.cpp
@@ -77,7 +77,7 @@ bool PrismSnesInstrSet::parseInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    emplaceInstr<PrismSnesInstr>(
+    addInstr<PrismSnesInstr>(
       this, version, srcn, spcDirAddr, ofsADSR1Entry, ofsADSR2Entry, ofsTuningEntryHigh,
       ofsTuningEntryLow, fmt::format("Instrument: {:#x}", srcn));
   }
@@ -127,7 +127,7 @@ bool PrismSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  PrismSnesRgn *rgn = emplaceRgn<PrismSnesRgn>(this,
+  PrismSnesRgn *rgn = addRgn<PrismSnesRgn>(this,
                                                version,
                                                srcn,
                                                spcDirAddr,

--- a/src/main/formats/PrismSnes/PrismSnesInstr.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesInstr.cpp
@@ -77,20 +77,17 @@ bool PrismSnesInstrSet::parseInstrPointers() {
 
     usedSRCNs.push_back(srcn);
 
-    PrismSnesInstr *newInstr = new PrismSnesInstr(
+    emplaceInstr<PrismSnesInstr>(
       this, version, srcn, spcDirAddr, ofsADSR1Entry, ofsADSR2Entry, ofsTuningEntryHigh,
       ofsTuningEntryLow, fmt::format("Instrument: {:#x}", srcn));
-    aInstrs.push_back(newInstr);
   }
 
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
-  SNESSampColl *newSampColl = new SNESSampColl(PrismSnesFormat::name, this->rawFile(), spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(PrismSnesFormat::name, rawFile(), spcDirAddr, usedSRCNs)) {
     return false;
   }
 
@@ -130,16 +127,15 @@ bool PrismSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  PrismSnesRgn *rgn = new PrismSnesRgn(this,
-                                       version,
-                                       srcn,
-                                       spcDirAddr,
-                                       addrADSR1Entry,
-                                       addrADSR2Entry,
-                                       addrTuningEntryHigh,
-                                       addrTuningEntryLow);
+  PrismSnesRgn *rgn = emplaceRgn<PrismSnesRgn>(this,
+                                               version,
+                                               srcn,
+                                               spcDirAddr,
+                                               addrADSR1Entry,
+                                               addrADSR2Entry,
+                                               addrTuningEntryHigh,
+                                               addrTuningEntryLow);
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
 
   setGuessedLength();
   return true;

--- a/src/main/formats/PrismSnes/PrismSnesScanner.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesScanner.cpp
@@ -172,9 +172,8 @@ void PrismSnesScanner::searchForPrismSnesFromARAM(RawFile *file) {
 
   u32 addrSeqHeaderPtr = addrSeqList + (songIndex * 2);
   u32 addrSeqHeader = file->readShort(addrSeqHeaderPtr);
-  PrismSnesSeq *newSeq = new PrismSnesSeq(file, version, addrSeqHeader, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<PrismSnesSeq>(file, version, addrSeqHeader, name);
+  if (!newSeq) {
     return;
   }
 
@@ -210,10 +209,9 @@ void PrismSnesScanner::searchForPrismSnesFromARAM(RawFile *file) {
     return;
   }
 
-  PrismSnesInstrSet *newInstrSet = new PrismSnesInstrSet(
+  auto* newInstrSet = pRoot->emplaceVGMFile<PrismSnesInstrSet>(
     file, version, spcDirAddr, addrADSR1Table, addrADSR2Table, adsrTuningTableHigh, adsrTuningTableLow);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/PrismSnes/PrismSnesScanner.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesScanner.cpp
@@ -172,7 +172,7 @@ void PrismSnesScanner::searchForPrismSnesFromARAM(RawFile *file) {
 
   u32 addrSeqHeaderPtr = addrSeqList + (songIndex * 2);
   u32 addrSeqHeader = file->readShort(addrSeqHeaderPtr);
-  auto* newSeq = pRoot->emplaceVGMFile<PrismSnesSeq>(file, version, addrSeqHeader, name);
+  auto* newSeq = pRoot->loadVGMFile<PrismSnesSeq>(file, version, addrSeqHeader, name);
   if (!newSeq) {
     return;
   }
@@ -209,7 +209,7 @@ void PrismSnesScanner::searchForPrismSnesFromARAM(RawFile *file) {
     return;
   }
 
-  auto* newInstrSet = pRoot->emplaceVGMFile<PrismSnesInstrSet>(
+  auto* newInstrSet = pRoot->loadVGMFile<PrismSnesInstrSet>(
     file, version, spcDirAddr, addrADSR1Table, addrADSR2Table, adsrTuningTableHigh, adsrTuningTableLow);
   if (!newInstrSet) {
     return;

--- a/src/main/formats/PrismSnes/PrismSnesSeq.cpp
+++ b/src/main/formats/PrismSnes/PrismSnesSeq.cpp
@@ -98,8 +98,7 @@ bool PrismSnesSeq::parseHeader() {
     trackHeader->addChild(curOffset, 2, "Track Pointer");
     curOffset += 2;
 
-    PrismSnesTrack *track = new PrismSnesTrack(this, addrTrackStart);
-    aTracks.push_back(track);
+    addTrack<PrismSnesTrack>(this, addrTrackStart);
   }
 
   return true;

--- a/src/main/formats/RareSnes/RareSnesInstr.cpp
+++ b/src/main/formats/RareSnes/RareSnesInstr.cpp
@@ -159,7 +159,7 @@ bool RareSnesInstrSet::parseInstrPointers() {
       adsr = itrADSR->second;
     }
 
-    emplaceInstr<RareSnesInstr>(
+    addInstr<RareSnesInstr>(
       this, offset() + inst, inst >> 7, inst & 0x7f, spcDirAddr, transpose,
       pitch, adsr, fmt::format("Instrument: {:#x}", inst));
   }
@@ -202,7 +202,7 @@ bool RareSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  RareSnesRgn *rgn = emplaceRgn<RareSnesRgn>(this, offset(), transpose, pitch, adsr);
+  RareSnesRgn *rgn = addRgn<RareSnesRgn>(this, offset(), transpose, pitch, adsr);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   return true;
 }

--- a/src/main/formats/RareSnes/RareSnesInstr.cpp
+++ b/src/main/formats/RareSnes/RareSnesInstr.cpp
@@ -159,12 +159,11 @@ bool RareSnesInstrSet::parseInstrPointers() {
       adsr = itrADSR->second;
     }
 
-    RareSnesInstr *newInstr = new RareSnesInstr(
+    emplaceInstr<RareSnesInstr>(
       this, offset() + inst, inst >> 7, inst & 0x7f, spcDirAddr, transpose,
       pitch, adsr, fmt::format("Instrument: {:#x}", inst));
-    aInstrs.push_back(newInstr);
   }
-  return aInstrs.size() != 0;
+  return hasInstrs();
 }
 
 const std::vector<u8> &RareSnesInstrSet::getAvailableInstruments() {
@@ -203,9 +202,8 @@ bool RareSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  RareSnesRgn *rgn = new RareSnesRgn(this, offset(), transpose, pitch, adsr);
+  RareSnesRgn *rgn = emplaceRgn<RareSnesRgn>(this, offset(), transpose, pitch, adsr);
   rgn->sampOffset = addrSampStart - spcDirAddr;
-  addRgn(rgn);
   return true;
 }
 

--- a/src/main/formats/RareSnes/RareSnesScanner.cpp
+++ b/src/main/formats/RareSnes/RareSnesScanner.cpp
@@ -156,9 +156,8 @@ void RareSnesScanner::searchForRareSnesFromARAM(RawFile *file) {
   }
 
   // load sequence
-  RareSnesSeq *newSeq = new RareSnesSeq(file, version, addrSeqHeader, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<RareSnesSeq>(file, version, addrSeqHeader, name);
+  if (!newSeq) {
     return;
   }
 
@@ -180,11 +179,10 @@ void RareSnesScanner::searchForRareSnesFromARAM(RawFile *file) {
   u32 spcDirAddr = file->readByte(ofsSetDIRASM + 4) << 8;
 
   // scan SRCN table
-    RareSnesInstrSet *newInstrSet = new RareSnesInstrSet(
+  auto* newInstrSet = pRoot->emplaceVGMFile<RareSnesInstrSet>(
       file, addrSRCNTable, spcDirAddr, newSeq->instrUnityKeyHints,
       newSeq->instrPitchHints, newSeq->instrADSRHints);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  if (!newInstrSet) {
     return;
   }
 
@@ -208,9 +206,7 @@ void RareSnesScanner::searchForRareSnesFromARAM(RawFile *file) {
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
 
   // load BRR samples
-  SNESSampColl *newSampColl = new SNESSampColl(RareSnesFormat::name, file, spcDirAddr, usedSRCNs);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!pRoot->emplaceVGMFile<SNESSampColl>(RareSnesFormat::name, file, spcDirAddr, usedSRCNs)) {
     return;
   }
 }

--- a/src/main/formats/RareSnes/RareSnesScanner.cpp
+++ b/src/main/formats/RareSnes/RareSnesScanner.cpp
@@ -156,7 +156,7 @@ void RareSnesScanner::searchForRareSnesFromARAM(RawFile *file) {
   }
 
   // load sequence
-  auto* newSeq = pRoot->emplaceVGMFile<RareSnesSeq>(file, version, addrSeqHeader, name);
+  auto* newSeq = pRoot->loadVGMFile<RareSnesSeq>(file, version, addrSeqHeader, name);
   if (!newSeq) {
     return;
   }
@@ -179,7 +179,7 @@ void RareSnesScanner::searchForRareSnesFromARAM(RawFile *file) {
   u32 spcDirAddr = file->readByte(ofsSetDIRASM + 4) << 8;
 
   // scan SRCN table
-  auto* newInstrSet = pRoot->emplaceVGMFile<RareSnesInstrSet>(
+  auto* newInstrSet = pRoot->loadVGMFile<RareSnesInstrSet>(
       file, addrSRCNTable, spcDirAddr, newSeq->instrUnityKeyHints,
       newSeq->instrPitchHints, newSeq->instrADSRHints);
   if (!newInstrSet) {
@@ -206,7 +206,7 @@ void RareSnesScanner::searchForRareSnesFromARAM(RawFile *file) {
   std::sort(usedSRCNs.begin(), usedSRCNs.end());
 
   // load BRR samples
-  if (!pRoot->emplaceVGMFile<SNESSampColl>(RareSnesFormat::name, file, spcDirAddr, usedSRCNs)) {
+  if (!pRoot->loadVGMFile<SNESSampColl>(RareSnesFormat::name, file, spcDirAddr, usedSRCNs)) {
     return;
   }
 }

--- a/src/main/formats/RareSnes/RareSnesSeq.cpp
+++ b/src/main/formats/RareSnes/RareSnesSeq.cpp
@@ -88,7 +88,7 @@ bool RareSnesSeq::parseTrackPointers(void) {
   for (int i = 0; i < MAX_TRACKS; i++) {
     u16 trkOff = readShort(offset() + i * 2);
     if (trkOff != 0)
-      aTracks.push_back(new RareSnesTrack(this, trkOff));
+      addTrack<RareSnesTrack>(this, trkOff);
   }
   return true;
 }

--- a/src/main/formats/SegSat/SegSatInstrSet.cpp
+++ b/src/main/formats/SegSat/SegSatInstrSet.cpp
@@ -53,7 +53,7 @@ constexpr PanLinAmp panToAmp(u8 pan) {
 
 SegSatInstrSet::SegSatInstrSet(RawFile* file, u32 offset, int numInstrs, SegSatDriverVer ver, const std::string& name) :
     VGMInstrSet(SegSatFormat::name, file, offset, 0, name), m_numInstrs(numInstrs), m_driverVer(ver) {
-  emplaceSampColl<VGMSampColl>(SegSatFormat::name, file, this, offset);
+  addSampColl<VGMSampColl>(SegSatFormat::name, file, this, offset);
 }
 
 bool SegSatInstrSet::parseHeader() {
@@ -137,7 +137,7 @@ bool SegSatInstrSet::parseInstrPointers() {
     u8 numRgns = rawFile()->readByte(instrOff + 2) + 1;
     size_t instrSize = 4 + numRgns * 0x20;
     auto name = fmt::format("Instrument {:d}", i);
-    emplaceInstr<SegSatInstr>(this, instrOff, instrSize, 0, i, name);
+    addInstr<SegSatInstr>(this, instrOff, instrSize, 0, i, name);
     instrList->addChild(off + (i * 2), 2, fmt::format("Instrument {:d} Pointer", i));
   }
 
@@ -177,7 +177,7 @@ bool SegSatInstr::loadInstr() {
     if (!rgn->isRegionValid()) {
       continue;
     }
-    auto* rawRgn = static_cast<SegSatRgn*>(addRgn(std::move(rgn)));
+    auto* rawRgn = static_cast<SegSatRgn*>(adoptRgn(std::move(rgn)));
 
     // Add sample
     u32 sampLength = rawRgn->sampleLoopEnd();

--- a/src/main/formats/SegSat/SegSatInstrSet.cpp
+++ b/src/main/formats/SegSat/SegSatInstrSet.cpp
@@ -52,7 +52,7 @@ constexpr PanLinAmp panToAmp(u8 pan) {
 
 SegSatInstrSet::SegSatInstrSet(RawFile* file, u32 offset, int numInstrs, SegSatDriverVer ver, const std::string& name) :
     VGMInstrSet(SegSatFormat::name, file, offset, 0, name), m_numInstrs(numInstrs), m_driverVer(ver) {
-  sampColl = new VGMSampColl(SegSatFormat::name, file, this, offset);
+  adoptSampColl(new VGMSampColl(SegSatFormat::name, file, this, offset));
 }
 
 bool SegSatInstrSet::parseHeader() {

--- a/src/main/formats/SegSat/SegSatInstrSet.cpp
+++ b/src/main/formats/SegSat/SegSatInstrSet.cpp
@@ -169,7 +169,7 @@ bool SegSatInstr::loadInstr() {
   u8 numRgns = rawFile()->readByte(offset() + 2) + 1;
   m_volBias = rawFile()->readByte(offset() + 3);
 
-  auto sampColl = parInstrSet->sampColl;
+  auto sampColl = parInstrSet->sampColl();
   for (int i = 0; i < numRgns; ++i) {
     u32 rgnOff = offset() + 4 + (i * 0x20);
     auto name = fmt::format("Region {:d}", i);

--- a/src/main/formats/SegSat/SegSatInstrSet.cpp
+++ b/src/main/formats/SegSat/SegSatInstrSet.cpp
@@ -10,6 +10,7 @@
 #include "ScaleConversion.h"
 #include "VGMSamp.h"
 
+#include <memory>
 #include <utility>
 
 #include <spdlog/fmt/fmt.h>
@@ -52,7 +53,7 @@ constexpr PanLinAmp panToAmp(u8 pan) {
 
 SegSatInstrSet::SegSatInstrSet(RawFile* file, u32 offset, int numInstrs, SegSatDriverVer ver, const std::string& name) :
     VGMInstrSet(SegSatFormat::name, file, offset, 0, name), m_numInstrs(numInstrs), m_driverVer(ver) {
-  adoptSampColl(new VGMSampColl(SegSatFormat::name, file, this, offset));
+  emplaceSampColl<VGMSampColl>(SegSatFormat::name, file, this, offset);
 }
 
 bool SegSatInstrSet::parseHeader() {
@@ -136,7 +137,7 @@ bool SegSatInstrSet::parseInstrPointers() {
     u8 numRgns = rawFile()->readByte(instrOff + 2) + 1;
     size_t instrSize = 4 + numRgns * 0x20;
     auto name = fmt::format("Instrument {:d}", i);
-    aInstrs.push_back(new SegSatInstr(this, instrOff, instrSize, 0, i, name));
+    emplaceInstr<SegSatInstr>(this, instrOff, instrSize, 0, i, name);
     instrList->addChild(off + (i * 2), 2, fmt::format("Instrument {:d} Pointer", i));
   }
 
@@ -144,7 +145,7 @@ bool SegSatInstrSet::parseInstrPointers() {
 }
 
 void SegSatInstrSet::assignBankNumber(u8 bankNum) {
-  for (auto instr : aInstrs) {
+  for (auto instr : instrs()) {
     instr->bank = bankNum;
   }
 }
@@ -172,21 +173,20 @@ bool SegSatInstr::loadInstr() {
   for (int i = 0; i < numRgns; ++i) {
     u32 rgnOff = offset() + 4 + (i * 0x20);
     auto name = fmt::format("Region {:d}", i);
-    auto rgn = new SegSatRgn(this, rgnOff, name);
+    auto rgn = std::make_unique<SegSatRgn>(this, rgnOff, name);
     if (!rgn->isRegionValid()) {
-      delete rgn;
       continue;
     }
-    addRgn(rgn);
+    auto* rawRgn = static_cast<SegSatRgn*>(addRgn(std::move(rgn)));
 
     // Add sample
-    u32 sampLength = rgn->sampleLoopEnd();
-    BPS bps = rgn->sampleType() == SegSatRgn::SampleType::PCM16 ? BPS::PCM16 : BPS::PCM8;
+    u32 sampLength = rawRgn->sampleLoopEnd();
+    BPS bps = rawRgn->sampleType() == SegSatRgn::SampleType::PCM16 ? BPS::PCM16 : BPS::PCM8;
     auto instrSet = static_cast<SegSatInstrSet*>(parInstrSet);
     // check if a sample at the offset was already added
-    bool inserted = instrSet->sampleOffsets.insert(rgn->sampOffset).second;
+    bool inserted = instrSet->sampleOffsets.insert(rawRgn->sampOffset).second;
 
-    u32 sampOffset = rgn->sampOffset;
+    u32 sampOffset = rawRgn->sampOffset;
     if (inserted) {
       auto sample = sampColl->addSamp(
        sampOffset,
@@ -196,13 +196,13 @@ bool SegSatInstr::loadInstr() {
        1,
        bps,
        44100,
-       fmt::format("Sample: 0x{:X}",  rgn->sampOffset)
+       fmt::format("Sample: 0x{:X}",  rawRgn->sampOffset)
       );
       sample->setSignedness(Signedness::Signed);
-      sample->loop = rgn->loop;
+      sample->loop = rawRgn->loop;
       sample->setEndianness(Endianness::Big);
       // TODO: We should only reverse the looped portion of the sample
-      if (rgn->loopType() == SegSatRgn::LoopType::Reverse)
+      if (rawRgn->loopType() == SegSatRgn::LoopType::Reverse)
         sample->setReverse(true);
 
       size_t newLength = sampOffset + sampLength - instrSet->offset();

--- a/src/main/formats/SegSat/SegSatInstrSet.cpp
+++ b/src/main/formats/SegSat/SegSatInstrSet.cpp
@@ -177,7 +177,7 @@ bool SegSatInstr::loadInstr() {
     if (!rgn->isRegionValid()) {
       continue;
     }
-    auto* rawRgn = static_cast<SegSatRgn*>(adoptRgn(std::move(rgn)));
+    auto* rawRgn = static_cast<SegSatRgn*>(sinkRgn(std::move(rgn)));
 
     // Add sample
     u32 sampLength = rawRgn->sampleLoopEnd();

--- a/src/main/formats/SegSat/SegSatScanner.cpp
+++ b/src/main/formats/SegSat/SegSatScanner.cpp
@@ -120,10 +120,10 @@ void SegSatScanner::handleSsfFile(RawFile* file) {
 
   for (const auto seq : seqs) {
     auto coll = std::make_unique<VGMColl>(seq->name());
-    coll->useSeq(seq);
+    coll->attachSeq(seq);
     if (instrSets.size() == 1) {
       instrSets[0]->assignBankNumber(0);
-      coll->addInstrSet(instrSets[0]);
+      coll->attachInstrSet(instrSets[0]);
     } else {
       auto referencedBanks = seq->referencedBanks();
       auto numRefBanks = referencedBanks.size();
@@ -135,7 +135,7 @@ void SegSatScanner::handleSsfFile(RawFile* file) {
         else
           bank = it->second;
         bank->assignBankNumber(numRefBanks == 1 ? 0 : bankNum);
-        coll->addInstrSet(bank);
+        coll->attachInstrSet(bank);
       }
     }
     pRoot->loadVGMColl(std::move(coll));
@@ -206,7 +206,7 @@ std::vector<SegSatSeq*> SegSatScanner::searchForSeqs(RawFile *file, bool useMatc
       }
 
       auto name = fmt::format("{} {:d}_{:d}", file->name(), seqTableCounter, n);
-      auto* seq = pRoot->emplaceVGMFileWithMatcher<SegSatSeq>(useMatcher, file, i + seqPtr, name);
+      auto* seq = pRoot->loadVGMFileWithMatcher<SegSatSeq>(useMatcher, file, i + seqPtr, name);
       if (seq) {
         bParsedSeq = true;
         seqs.push_back(seq);
@@ -339,7 +339,7 @@ std::vector<SegSatInstrSet*> SegSatScanner::searchForInstrSets(RawFile* file, Se
       if (ver == SegSatDriverVer::Unknown)
         ver = determineVersion(file);
       u32 numInstrs = ((ptrMixes - 8) / 2);
-      auto* instrSet = pRoot->emplaceVGMFileWithMatcher<SegSatInstrSet>(useMatcher, file, base, numInstrs, ver);
+      auto* instrSet = pRoot->loadVGMFileWithMatcher<SegSatInstrSet>(useMatcher, file, base, numInstrs, ver);
       if (instrSet)
         instrSets.push_back(instrSet);
 

--- a/src/main/formats/SegSat/SegSatScanner.cpp
+++ b/src/main/formats/SegSat/SegSatScanner.cpp
@@ -14,6 +14,7 @@
 #include "VGMMiscFile.h"
 
 #include <array>
+#include <memory>
 
 namespace vgmtrans::scanners {
 ScannerRegistration<SegSatScanner> s_segsat("SegSat");
@@ -118,7 +119,7 @@ void SegSatScanner::handleSsfFile(RawFile* file) {
     return;
 
   for (const auto seq : seqs) {
-    VGMColl* coll = new VGMColl(seq->name());
+    auto coll = std::make_unique<VGMColl>(seq->name());
     coll->useSeq(seq);
     if (instrSets.size() == 1) {
       instrSets[0]->assignBankNumber(0);
@@ -137,9 +138,7 @@ void SegSatScanner::handleSsfFile(RawFile* file) {
         coll->addInstrSet(bank);
       }
     }
-    if (!coll->load()) {
-      delete coll;
-    }
+    pRoot->loadVGMColl(std::move(coll));
   }
 }
 
@@ -207,22 +206,20 @@ std::vector<SegSatSeq*> SegSatScanner::searchForSeqs(RawFile *file, bool useMatc
       }
 
       auto name = fmt::format("{} {:d}_{:d}", file->name(), seqTableCounter, n);
-      SegSatSeq* seq = new SegSatSeq(file, i + seqPtr, name);
-      if (!seq->loadVGMFile(useMatcher))
-        delete seq;
-      else {
+      auto* seq = pRoot->emplaceVGMFileWithMatcher<SegSatSeq>(useMatcher, file, i + seqPtr, name);
+      if (seq) {
         bParsedSeq = true;
         seqs.push_back(seq);
       }
     }
     if (bParsedSeq) {
-      auto seqTable = new VGMMiscFile(SegSatFormat::name, file, i,
-        2 + (numSeqs * 4), "Sega Saturn Seq Table");
+      auto seqTable = std::make_unique<VGMMiscFile>(SegSatFormat::name, file, i,
+                                                    2 + (numSeqs * 4), "Sega Saturn Seq Table");
       seqTable->addChild(i, 2, "Sequence Count");
       for (int j = 0; j < numSeqs; j++) {
         seqTable->addChild(i + 2 + (j * 4), 4, fmt::format("Sequence {:d} Pointer", j));
       }
-      seqTable->loadVGMFile();
+      pRoot->loadVGMFile(std::move(seqTable), useMatcher);
       seqTableCounter += 1;
     }
 
@@ -342,15 +339,13 @@ std::vector<SegSatInstrSet*> SegSatScanner::searchForInstrSets(RawFile* file, Se
       if (ver == SegSatDriverVer::Unknown)
         ver = determineVersion(file);
       u32 numInstrs = ((ptrMixes - 8) / 2);
-      auto instrSet = new SegSatInstrSet(file, base, numInstrs, ver);
-      if (useMatcher ? !instrSet->loadVGMFile() : !instrSet->load())
-        delete instrSet;
-      else
+      auto* instrSet = pRoot->emplaceVGMFileWithMatcher<SegSatInstrSet>(useMatcher, file, base, numInstrs, ver);
+      if (instrSet)
         instrSets.push_back(instrSet);
 
       // We can safely skip ahead: the instrument table runs until base + ptrMixes
       // Jumping avoids re-scanning in the middle of a confirmed bank.
-      base = std::min(base + instrSet->length(), fileLength - 8);
+      base = std::min(base + (instrSet ? instrSet->length() : 1), fileLength - 8);
     } else {
       ++base;
     }

--- a/src/main/formats/SegSat/SegSatSeq.cpp
+++ b/src/main/formats/SegSat/SegSatSeq.cpp
@@ -44,16 +44,16 @@ void SegSatSeq::useColl(const VGMColl* coll) {
     return;
 
   auto* instrSet = dynamic_cast<SegSatInstrSet*>(instrSets.front());
-  if (!instrSet || instrSet->aInstrs.empty())
+  if (!instrSet || !instrSet->hasInstrs())
     return;
 
   m_collContext.m_vlTables = instrSet->vlTables();
   if (m_collContext.m_vlTables.empty())
     return;
 
-  m_collContext.instrs.reserve(instrSet->aInstrs.size());
+  m_collContext.instrs.reserve(instrSet->instrCount());
 
-  for (VGMInstr* instr : instrSet->aInstrs) {
+  for (VGMInstr* instr : instrSet->instrs()) {
     m_collContext.instrs.push_back(dynamic_cast<const SegSatInstr*>(instr));
   }
 }

--- a/src/main/formats/SoftCreatSnes/SoftCreatSnesScanner.cpp
+++ b/src/main/formats/SoftCreatSnes/SoftCreatSnesScanner.cpp
@@ -138,9 +138,8 @@ void SoftCreatSnesScanner::searchForSoftCreatSnesFromARAM(RawFile *file) {
   s8 songIndex = 1;
 
   u32 addrSeqHeader = addrSeqList + songIndex;
-  SoftCreatSnesSeq *newSeq = new SoftCreatSnesSeq(file, version, addrSeqHeader, headerAlignSize, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<SoftCreatSnesSeq>(file, version, addrSeqHeader, headerAlignSize, name);
+  if (!newSeq) {
     return;
   }
 }

--- a/src/main/formats/SoftCreatSnes/SoftCreatSnesScanner.cpp
+++ b/src/main/formats/SoftCreatSnes/SoftCreatSnesScanner.cpp
@@ -138,7 +138,7 @@ void SoftCreatSnesScanner::searchForSoftCreatSnesFromARAM(RawFile *file) {
   s8 songIndex = 1;
 
   u32 addrSeqHeader = addrSeqList + songIndex;
-  auto* newSeq = pRoot->emplaceVGMFile<SoftCreatSnesSeq>(file, version, addrSeqHeader, headerAlignSize, name);
+  auto* newSeq = pRoot->loadVGMFile<SoftCreatSnesSeq>(file, version, addrSeqHeader, headerAlignSize, name);
   if (!newSeq) {
     return;
   }

--- a/src/main/formats/SoftCreatSnes/SoftCreatSnesSeq.cpp
+++ b/src/main/formats/SoftCreatSnes/SoftCreatSnesSeq.cpp
@@ -57,8 +57,7 @@ bool SoftCreatSnesSeq::parseHeader(void) {
 
     u16 addrTrackStart = readByte(addrTrackLowPtr) | (readByte(addrTrackHighPtr) << 8);
     if (addrTrackStart != 0xffff) {
-      SoftCreatSnesTrack *track = new SoftCreatSnesTrack(this, addrTrackStart);
-      aTracks.push_back(track);
+      addTrack<SoftCreatSnesTrack>(this, addrTrackStart);
     }
   }
 

--- a/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
@@ -415,7 +415,7 @@ bool SonyPS2SampColl::parseSampleInfo() {
     u16 sampleRate = vagInfoParam.vagSampleRate;
 
     auto name = fmt::format("Sample {}", sampleCount());
-    auto* samp = emplaceSamp<PSXSamp>(this, offset, length, offset, length, 1,
+    auto* samp = addSamp<PSXSamp>(this, offset, length, offset, length, 1,
                                       BPS::PCM16, sampleRate, name, true);
 
     // Determine loop information from VAGInfo Param

--- a/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
@@ -3,6 +3,8 @@
 #include "base/Types.h"
 #include "PSXSPU.h"
 
+#include <memory>
+
 using namespace std;
 
 // ***************
@@ -215,9 +217,9 @@ bool SonyPS2InstrSet::parseInstrPointers() {
     //VGMHeader* progParamHdr = progParamsHdr->addHeader(curOffset+progCk.programOffsetAddr[i],
     //	sizeof(SonyPS2Instr::ProgParam), "Program Param");
 
-    SonyPS2Instr *instr = new SonyPS2Instr(this, curOffset + progCk.programOffsetAddr[i],
-                                           sizeof(SonyPS2Instr::ProgParam), i / 128, i % 128);
-    aInstrs.push_back(instr);
+    auto newInstr = std::make_unique<SonyPS2Instr>(this, curOffset + progCk.programOffsetAddr[i],
+                                                   sizeof(SonyPS2Instr::ProgParam), i / 128, i % 128);
+    SonyPS2Instr *instr = newInstr.get();
 
     instr->addChild(curOffset + progCk.programOffsetAddr[i], 4, "SplitBlock Addr");
     instr->addChild(curOffset + progCk.programOffsetAddr[i] + 4, 1, "Number of SplitBlocks");
@@ -277,9 +279,8 @@ bool SonyPS2InstrSet::parseInstrPointers() {
       splitBlockHdr->addChild(splitOff + 18, 1, "Split Transpose");
       splitBlockHdr->addChild(splitOff + 19, 1, "Split Detune");
     }
+    adoptInstrAsChild(*progParamsHdr, std::move(newInstr));
   }
-
-  progParamsHdr->addChildren(aInstrs);
 
   u32 maxProgNum = progCk.maxProgramNumber;
   progParamsHdr->setLength((curOffset + progCk.programOffsetAddr[maxProgNum]) + sizeof(SonyPS2Instr::ProgParam) +
@@ -387,7 +388,6 @@ s8 SonyPS2Instr::convertPanValue(u8 panVal) {
 SonyPS2SampColl::SonyPS2SampColl(RawFile *rawfile, u32 offset, u32 length)
     : VGMSampColl(SonyPS2Format::name, rawfile, offset, length) {
   this->setShouldLoadOnInstrSetMatch(true);
-  pRoot->addVGMFile(this);
 }
 
 bool SonyPS2SampColl::parseSampleInfo() {
@@ -414,10 +414,9 @@ bool SonyPS2SampColl::parseSampleInfo() {
 
     u16 sampleRate = vagInfoParam.vagSampleRate;
 
-    auto name = fmt::format("Sample {}", samples.size());
-    PSXSamp *samp = new PSXSamp(this, offset, length, offset, length, 1,
-      BPS::PCM16, sampleRate, name, true);
-    samples.push_back(samp);
+    auto name = fmt::format("Sample {}", sampleCount());
+    auto* samp = emplaceSamp<PSXSamp>(this, offset, length, offset, length, 1,
+                                      BPS::PCM16, sampleRate, name, true);
 
     // Determine loop information from VAGInfo Param
     if (vagInfoParam.vagAttribute == SCEHD_VAG_1SHOT) {

--- a/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2InstrSet.cpp
@@ -279,7 +279,7 @@ bool SonyPS2InstrSet::parseInstrPointers() {
       splitBlockHdr->addChild(splitOff + 18, 1, "Split Transpose");
       splitBlockHdr->addChild(splitOff + 19, 1, "Split Detune");
     }
-    adoptInstrAsChild(*progParamsHdr, std::move(newInstr));
+    sinkInstrAsChild(*progParamsHdr, std::move(newInstr));
   }
 
   u32 maxProgNum = progCk.maxProgramNumber;

--- a/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
@@ -92,8 +92,7 @@ void SonyPS2Scanner::searchForSampColl(RawFile *file) {
     Format *fmt = sampColl->format();
     if (fmt) {
       fmt->onNewFile(sampColl);
-      file->addContainedVGMFile(
-        std::make_shared<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>(sampColl));
+      file->addContainedVGMFile(sampColl);
     }
   }
 }

--- a/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
@@ -39,9 +39,7 @@ void SonyPS2Scanner::searchForSeq(RawFile *file) {
     if (sig1 != 0x53434549 || sig2 != 0x4D696469)  // "SCEIMidi" in ASCII
       continue;
 
-    SonyPS2Seq *newSeq = new SonyPS2Seq(file, i, "Sony PS2 Seq");
-    if (!newSeq->loadVGMFile())
-      delete newSeq;
+    pRoot->emplaceVGMFile<SonyPS2Seq>(file, i, "Sony PS2 Seq");
   }
 }
 
@@ -63,9 +61,7 @@ void SonyPS2Scanner::searchForInstrSet(RawFile *file) {
     if (sig1 != 0x53434549 || sig2 != 0x56616769)  // "SCEIVagi" in ASCII
       continue;
 
-    SonyPS2InstrSet *newInstrSet = new SonyPS2InstrSet(file, i);
-    if (!newInstrSet->loadVGMFile())
-      delete newInstrSet;
+    pRoot->emplaceVGMFile<SonyPS2InstrSet>(file, i);
   }
 }
 
@@ -88,11 +84,6 @@ void SonyPS2Scanner::searchForSampColl(RawFile *file) {
       return;
     }
 
-    SonyPS2SampColl *sampColl = new SonyPS2SampColl(file, 0);
-    Format *fmt = sampColl->format();
-    if (fmt) {
-      fmt->onNewFile(sampColl);
-      file->addContainedVGMFile(sampColl);
-    }
+    pRoot->emplacePendingVGMFile<SonyPS2SampColl>(file, 0);
   }
 }

--- a/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
@@ -9,6 +9,8 @@
 #include "SonyPS2InstrSet.h"
 #include "SonyPS2Seq.h"
 
+#include <vector>
+
 namespace vgmtrans::scanners {
 ScannerRegistration<SonyPS2Scanner> s_sonyps2("SonyPS2", {"sq", "hd", "bd"});
 }
@@ -77,10 +79,9 @@ void SonyPS2Scanner::searchForSampColl(RawFile *file) {
     int num = std::count(file->begin(), file->begin() + 16, 0);
     if (num != 16) {
       u32 newFileSize = file->size() + 16;
-      u8 *newdataBuf = new u8[newFileSize];
-      file->readBytes(0, file->size(), newdataBuf + 16);
-      memset(newdataBuf, 0, 16);
-      pRoot->createVirtFile(newdataBuf, newFileSize, file->name(), file->path());
+      std::vector<u8> newdataBuf(newFileSize);
+      file->readBytes(0, file->size(), newdataBuf.data() + 16);
+      pRoot->createVirtFile(newdataBuf.data(), newFileSize, file->name(), file->path());
       return;
     }
 

--- a/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
+++ b/src/main/formats/SonyPS2/SonyPS2Scanner.cpp
@@ -39,7 +39,7 @@ void SonyPS2Scanner::searchForSeq(RawFile *file) {
     if (sig1 != 0x53434549 || sig2 != 0x4D696469)  // "SCEIMidi" in ASCII
       continue;
 
-    pRoot->emplaceVGMFile<SonyPS2Seq>(file, i, "Sony PS2 Seq");
+    pRoot->loadVGMFile<SonyPS2Seq>(file, i, "Sony PS2 Seq");
   }
 }
 
@@ -61,7 +61,7 @@ void SonyPS2Scanner::searchForInstrSet(RawFile *file) {
     if (sig1 != 0x53434549 || sig2 != 0x56616769)  // "SCEIVagi" in ASCII
       continue;
 
-    pRoot->emplaceVGMFile<SonyPS2InstrSet>(file, i);
+    pRoot->loadVGMFile<SonyPS2InstrSet>(file, i);
   }
 }
 
@@ -84,6 +84,6 @@ void SonyPS2Scanner::searchForSampColl(RawFile *file) {
       return;
     }
 
-    pRoot->emplacePendingVGMFile<SonyPS2SampColl>(file, 0);
+    pRoot->loadPendingVGMFile<SonyPS2SampColl>(file, 0);
   }
 }

--- a/src/main/formats/SquarePS2/SquarePS2Scanner.cpp
+++ b/src/main/formats/SquarePS2/SquarePS2Scanner.cpp
@@ -43,7 +43,7 @@ void SquarePS2Scanner::searchForBGMSeq(RawFile *file) {
         if (!bValid)
           continue;
 
-        pRoot->emplaceVGMFile<BGMSeq>(file, i);
+        pRoot->loadVGMFile<BGMSeq>(file, i);
       }
     }
   }
@@ -105,7 +105,7 @@ void SquarePS2Scanner::searchForWDSet(RawFile *file) {
 
           // then there was a row of 16 00 bytes.  yay
           if (bValid) {
-            pRoot->emplaceVGMFile<WDInstrSet>(file, i);
+            pRoot->loadVGMFile<WDInstrSet>(file, i);
           }
         }
       }

--- a/src/main/formats/SquarePS2/SquarePS2Scanner.cpp
+++ b/src/main/formats/SquarePS2/SquarePS2Scanner.cpp
@@ -43,9 +43,7 @@ void SquarePS2Scanner::searchForBGMSeq(RawFile *file) {
         if (!bValid)
           continue;
 
-        BGMSeq *NewBGMSeq = new BGMSeq(file, i);
-        if (!NewBGMSeq->loadVGMFile())
-          delete NewBGMSeq;
+        pRoot->emplaceVGMFile<BGMSeq>(file, i);
       }
     }
   }
@@ -107,9 +105,7 @@ void SquarePS2Scanner::searchForWDSet(RawFile *file) {
 
           // then there was a row of 16 00 bytes.  yay
           if (bValid) {
-            WDInstrSet *instrset = new WDInstrSet(file, i);
-            if (!instrset->loadVGMFile())
-              delete instrset;
+            pRoot->emplaceVGMFile<WDInstrSet>(file, i);
           }
         }
       }

--- a/src/main/formats/SquarePS2/SquarePS2Seq.cpp
+++ b/src/main/formats/SquarePS2/SquarePS2Seq.cpp
@@ -48,7 +48,7 @@ bool BGMSeq::parseTrackPointers() {
       return true;
     //END HACK
     u32 trackSize = readWord(pos);        //get the track size (first word before track data)
-    aTracks.push_back(new BGMTrack(this, pos + 4, trackSize));
+    addTrack<BGMTrack>(this, pos + 4, trackSize);
     pos += trackSize + 4;                //jump to the next track
   }
   return true;

--- a/src/main/formats/SquarePS2/WD.cpp
+++ b/src/main/formats/SquarePS2/WD.cpp
@@ -70,7 +70,7 @@ bool WDInstrSet::parseHeader() {
 
   u32 sampCollOff = offset() + readWord(offset() + 0x20) + (dwTotalRegions * 0x20);
 
-  sampColl = new PSXSampColl(SquarePS2Format::name, this, sampCollOff, dwSampSectSize);
+  adoptSampColl(new PSXSampColl(SquarePS2Format::name, this, sampCollOff, dwSampSectSize));
   setLength(sampCollOff + dwSampSectSize - offset());
 
   return true;

--- a/src/main/formats/SquarePS2/WD.cpp
+++ b/src/main/formats/SquarePS2/WD.cpp
@@ -70,7 +70,7 @@ bool WDInstrSet::parseHeader() {
 
   u32 sampCollOff = offset() + readWord(offset() + 0x20) + (dwTotalRegions * 0x20);
 
-  emplaceSampColl<PSXSampColl>(SquarePS2Format::name, this, sampCollOff, dwSampSectSize);
+  addSampColl<PSXSampColl>(SquarePS2Format::name, this, sampCollOff, dwSampSectSize);
   setLength(sampCollOff + dwSampSectSize - offset());
 
   return true;
@@ -92,7 +92,7 @@ bool WDInstrSet::parseInstrPointers() {
     else
       instrLength = sampColl->offset() - (readWord(j + (i * 4)) + offset());
 
-    emplaceInstr<WDInstr>(this, offset() + readWord(j + (i * 4)), instrLength,
+    addInstr<WDInstr>(this, offset() + readWord(j + (i * 4)), instrLength,
                           0, i, fmt::format("Instrument {}", i));
   }
   return true;
@@ -110,7 +110,7 @@ WDInstr::WDInstr(VGMInstrSet *instrSet, u32 offset, u32 length, u32 bank,
 bool WDInstr::loadInstr() {
   unsigned int k = 0;
   while (k * 0x20 < length()) {
-    auto *rgn = emplaceRgn<WDRgn>(this, k * 0x20 + offset());
+    auto *rgn = addRgn<WDRgn>(this, k * 0x20 + offset());
 
     rgn->addChild(k * 0x20 + offset(), 1, "Stereo Region Flag");
     rgn->addChild(k * 0x20 + 1 + offset(), 1, "First/Last Region Flags");

--- a/src/main/formats/SquarePS2/WD.cpp
+++ b/src/main/formats/SquarePS2/WD.cpp
@@ -70,7 +70,7 @@ bool WDInstrSet::parseHeader() {
 
   u32 sampCollOff = offset() + readWord(offset() + 0x20) + (dwTotalRegions * 0x20);
 
-  adoptSampColl(new PSXSampColl(SquarePS2Format::name, this, sampCollOff, dwSampSectSize));
+  emplaceSampColl<PSXSampColl>(SquarePS2Format::name, this, sampCollOff, dwSampSectSize);
   setLength(sampCollOff + dwSampSectSize - offset());
 
   return true;
@@ -92,9 +92,8 @@ bool WDInstrSet::parseInstrPointers() {
     else
       instrLength = sampColl->offset() - (readWord(j + (i * 4)) + offset());
 
-    auto *newWDInstr = new WDInstr(this, offset() + readWord(j + (i * 4)), instrLength,
-      0, i, fmt::format("Instrument {}", i));
-    aInstrs.push_back(newWDInstr);
+    emplaceInstr<WDInstr>(this, offset() + readWord(j + (i * 4)), instrLength,
+                          0, i, fmt::format("Instrument {}", i));
   }
   return true;
 }
@@ -111,8 +110,7 @@ WDInstr::WDInstr(VGMInstrSet *instrSet, u32 offset, u32 length, u32 bank,
 bool WDInstr::loadInstr() {
   unsigned int k = 0;
   while (k * 0x20 < length()) {
-    auto *rgn = new WDRgn(this, k * 0x20 + offset());
-    addRgn(rgn);
+    auto *rgn = emplaceRgn<WDRgn>(this, k * 0x20 + offset());
 
     rgn->addChild(k * 0x20 + offset(), 1, "Stereo Region Flag");
     rgn->addChild(k * 0x20 + 1 + offset(), 1, "First/Last Region Flags");

--- a/src/main/formats/SquarePS2/WD.cpp
+++ b/src/main/formats/SquarePS2/WD.cpp
@@ -90,7 +90,7 @@ bool WDInstrSet::parseInstrPointers() {
     if (i != dwNumInstrs - 1)  // while not the last instr
       instrLength = readWord(j + ((i + 1) * 4)) - readWord(j + (i * 4));
     else
-      instrLength = sampColl->offset() - (readWord(j + (i * 4)) + offset());
+      instrLength = sampColl()->offset() - (readWord(j + (i * 4)) + offset());
 
     addInstr<WDInstr>(this, offset() + readWord(j + (i * 4)), instrLength,
                           0, i, fmt::format("Instrument {}", i));

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -11,6 +11,8 @@
 #include "SuzukiSnesSeq.h"
 #include "VGMColl.h"
 
+#include <memory>
+
 #include <spdlog/fmt/fmt.h>
 
 namespace {
@@ -86,20 +88,17 @@ bool SuzukiSnesInstrSet::parseInstrPointers() {
       continue;
     }
 
-    SuzukiSnesInstr *newInstr = new SuzukiSnesInstr(
+    emplaceInstr<SuzukiSnesInstr>(
       this, version, instrNum, spcDirAddr, addrSRCNTable, addrVolumeTable, addrADSRTable,
       addrTuningTable, fmt::format("Instrument: {:#x}", srcn));
-    aInstrs.push_back(newInstr);
   }
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
   // Load all valid Suzuki sample slots so conversion-time drumkits can reuse the base sample collection.
-  SNESSampColl *newSampColl = new SNESSampColl(
-      SuzukiSnesFormat::name, this->rawFile(), spcDirAddr, kSuzukiSnesSrcnCount);
-  if (!newSampColl->loadVGMFile()) {
-    delete newSampColl;
+  if (!addDiscoveredFile<SNESSampColl>(
+      SuzukiSnesFormat::name, rawFile(), spcDirAddr, kSuzukiSnesSrcnCount)) {
     return false;
   }
 
@@ -124,14 +123,14 @@ void SuzukiSnesInstrSet::useColl(const VGMColl* coll) {
     return;
   }
 
-  auto* drumKit = new SuzukiSnesDrumKit(this, version, DRUMKIT_PROGRAM, spcDirAddr, addrSRCNTable,
-                                        addrTuningTable, addrADSRTable, addrDrumKitTable, "Drum Kit");
+  auto drumKit = std::make_unique<SuzukiSnesDrumKit>(
+      this, version, DRUMKIT_PROGRAM, spcDirAddr, addrSRCNTable,
+      addrTuningTable, addrADSRTable, addrDrumKitTable, "Drum Kit");
   if (!drumKit->loadInstr() || drumKit->regions().empty()) {
-    delete drumKit;
     return;
   }
 
-  addTempInstr(drumKit);
+  addTempInstr(std::move(drumKit));
 }
 
 // ***************
@@ -172,12 +171,11 @@ bool SuzukiSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  SuzukiSnesRgn *rgn = new SuzukiSnesRgn(this, version, addrSRCNTable);
+  SuzukiSnesRgn *rgn = emplaceRgn<SuzukiSnesRgn>(this, version, addrSRCNTable);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   rgn->initializeNonPercussionRegion(instrNum, addrVolumeTable);
   rgn->initializeCommonRegion(srcn, spcDirAddr, addrADSRTable, addrTuningTable);
   rgn->loadRgn();
-  addRgn(rgn);
 
   setGuessedLength();
   return true;
@@ -208,20 +206,17 @@ bool SuzukiSnesDrumKit::loadInstr() {
   u16 addr = addrDrumKitTable;
 
   for (u16 i = addr; readByte(i) < 0x80; i += 5) {
-    SuzukiSnesDrumKitRgn *rgn = new SuzukiSnesDrumKitRgn(this, version, addrDrumKitTable);
+    auto rgn = std::make_unique<SuzukiSnesDrumKitRgn>(this, version, addrDrumKitTable);
 
     if (!rgn->initializePercussionRegion(i, spcDirAddr, addrSRCNTable, addrADSRTable, addrTuningTable)) {
-      delete rgn;
       continue;
     }
     if (!rgn->loadRgn()) {
-      delete rgn;
       return false;
     }
 
     u32 rgnOffDirEnt = spcDirAddr + (rgn->sampNum * 4);
     if (rgnOffDirEnt + 4 > 0x10000) {
-      delete rgn;
       return false;
     }
 
@@ -229,7 +224,7 @@ bool SuzukiSnesDrumKit::loadInstr() {
 
     rgn->sampOffset = addrSampStart - spcDirAddr;
 
-    addRgn(rgn);
+    addRgn(std::move(rgn));
   }
 
   setGuessedLength();

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -130,7 +130,7 @@ void SuzukiSnesInstrSet::useColl(const VGMColl* coll) {
     return;
   }
 
-  adoptTempInstr(std::move(drumKit));
+  sinkTempInstr(std::move(drumKit));
 }
 
 // ***************
@@ -224,7 +224,7 @@ bool SuzukiSnesDrumKit::loadInstr() {
 
     rgn->sampOffset = addrSampStart - spcDirAddr;
 
-    adoptRgn(std::move(rgn));
+    sinkRgn(std::move(rgn));
   }
 
   setGuessedLength();

--- a/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesInstr.cpp
@@ -88,7 +88,7 @@ bool SuzukiSnesInstrSet::parseInstrPointers() {
       continue;
     }
 
-    emplaceInstr<SuzukiSnesInstr>(
+    addInstr<SuzukiSnesInstr>(
       this, version, instrNum, spcDirAddr, addrSRCNTable, addrVolumeTable, addrADSRTable,
       addrTuningTable, fmt::format("Instrument: {:#x}", srcn));
   }
@@ -130,7 +130,7 @@ void SuzukiSnesInstrSet::useColl(const VGMColl* coll) {
     return;
   }
 
-  addTempInstr(std::move(drumKit));
+  adoptTempInstr(std::move(drumKit));
 }
 
 // ***************
@@ -171,7 +171,7 @@ bool SuzukiSnesInstr::loadInstr() {
 
   u16 addrSampStart = readShort(offDirEnt);
 
-  SuzukiSnesRgn *rgn = emplaceRgn<SuzukiSnesRgn>(this, version, addrSRCNTable);
+  SuzukiSnesRgn *rgn = addRgn<SuzukiSnesRgn>(this, version, addrSRCNTable);
   rgn->sampOffset = addrSampStart - spcDirAddr;
   rgn->initializeNonPercussionRegion(instrNum, addrVolumeTable);
   rgn->initializeCommonRegion(srcn, spcDirAddr, addrADSRTable, addrTuningTable);
@@ -224,7 +224,7 @@ bool SuzukiSnesDrumKit::loadInstr() {
 
     rgn->sampOffset = addrSampStart - spcDirAddr;
 
-    addRgn(std::move(rgn));
+    adoptRgn(std::move(rgn));
   }
 
   setGuessedLength();

--- a/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
@@ -192,7 +192,7 @@ void SuzukiSnesScanner::searchForSuzukiSnesFromARAM(RawFile *file) {
   }
 
   // load sequence
-  auto* newSeq = pRoot->emplaceVGMFile<SuzukiSnesSeq>(file, version, addrSeqHeader, name);
+  auto* newSeq = pRoot->loadVGMFile<SuzukiSnesSeq>(file, version, addrSeqHeader, name);
   if (!newSeq) {
     return;
   }
@@ -219,7 +219,7 @@ void SuzukiSnesScanner::searchForSuzukiSnesFromARAM(RawFile *file) {
     return;
   }
 
-  auto* newInstrSet = pRoot->emplaceVGMFile<SuzukiSnesInstrSet>(
+  auto* newInstrSet = pRoot->loadVGMFile<SuzukiSnesInstrSet>(
       file, version, spcDirAddr, addrSRCNTable, addrVolumeTable, addrADSRTable, addrTuningTable);
   if (!newInstrSet) {
     return;

--- a/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesScanner.cpp
@@ -192,9 +192,8 @@ void SuzukiSnesScanner::searchForSuzukiSnesFromARAM(RawFile *file) {
   }
 
   // load sequence
-  SuzukiSnesSeq *newSeq = new SuzukiSnesSeq(file, version, addrSeqHeader, name);
-  if (!newSeq->loadVGMFile()) {
-    delete newSeq;
+  auto* newSeq = pRoot->emplaceVGMFile<SuzukiSnesSeq>(file, version, addrSeqHeader, name);
+  if (!newSeq) {
     return;
   }
 
@@ -220,11 +219,9 @@ void SuzukiSnesScanner::searchForSuzukiSnesFromARAM(RawFile *file) {
     return;
   }
 
-  SuzukiSnesInstrSet *newInstrSet =
-      new SuzukiSnesInstrSet(file, version, spcDirAddr, addrSRCNTable, addrVolumeTable,
-                             addrADSRTable, addrTuningTable);
-  if (!newInstrSet->loadVGMFile()) {
-    delete newInstrSet;
+  auto* newInstrSet = pRoot->emplaceVGMFile<SuzukiSnesInstrSet>(
+      file, version, spcDirAddr, addrSRCNTable, addrVolumeTable, addrADSRTable, addrTuningTable);
+  if (!newInstrSet) {
     return;
   }
 }

--- a/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
+++ b/src/main/formats/SuzukiSnes/SuzukiSnesSeq.cpp
@@ -77,7 +77,7 @@ bool SuzukiSnesSeq::parseHeader() {
         auto trackName = fmt::format("Track Pointer {:d}", trackIndex + 1);
         header->addChild(curOffset, 2, trackName);
 
-        aTracks.push_back(new SuzukiSnesTrack(this, addrTrackStart));
+        addTrack<SuzukiSnesTrack>(this, addrTrackStart);
       }
       else {
         // example: Super Mario RPG - Where Am I Going?

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
@@ -38,7 +38,7 @@ bool TamSoftPS1InstrSet::parseInstrPointers() {
       SizeOffsetPair vagLocation(vagOffset - 0x800, PSXSamp::getSampleLength(rawFile(), vagOffset, offset() + length(), vagLoop));
       vagLocations.push_back(vagLocation);
 
-      emplaceInstr<TamSoftPS1Instr>(this, instrNum, fmt::format("Instrument {}", instrNum));
+      addInstr<TamSoftPS1Instr>(this, instrNum, fmt::format("Instrument {}", instrNum));
     }
   }
 
@@ -46,7 +46,7 @@ bool TamSoftPS1InstrSet::parseInstrPointers() {
     return false;
   }
 
-  emplaceSampColl<PSXSampColl>(TamSoftPS1Format::name, this, offset() + 0x800, length() - 0x800, vagLocations);
+  addSampColl<PSXSampColl>(TamSoftPS1Format::name, this, offset() + 0x800, length() - 0x800, vagLocations);
   return true;
 }
 
@@ -66,7 +66,7 @@ bool TamSoftPS1Instr::loadInstr() {
 
   addChild(offset(), 4, "Sample Offset");
 
-  TamSoftPS1Rgn *rgn = emplaceRgn<TamSoftPS1Rgn>(this, offset() + 0x400, parInstrSet->ps2);
+  TamSoftPS1Rgn *rgn = addRgn<TamSoftPS1Rgn>(this, offset() + 0x400, parInstrSet->ps2);
   rgn->sampNum = instrNum;
   return true;
 }

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
@@ -38,17 +38,15 @@ bool TamSoftPS1InstrSet::parseInstrPointers() {
       SizeOffsetPair vagLocation(vagOffset - 0x800, PSXSamp::getSampleLength(rawFile(), vagOffset, offset() + length(), vagLoop));
       vagLocations.push_back(vagLocation);
 
-      TamSoftPS1Instr *newInstr = new TamSoftPS1Instr(this, instrNum,
-        fmt::format("Instrument {}", instrNum));
-      aInstrs.push_back(newInstr);
+      emplaceInstr<TamSoftPS1Instr>(this, instrNum, fmt::format("Instrument {}", instrNum));
     }
   }
 
-  if (aInstrs.size() == 0) {
+  if (!hasInstrs()) {
     return false;
   }
 
-  adoptSampColl(new PSXSampColl(TamSoftPS1Format::name, this, offset() + 0x800, length() - 0x800, vagLocations));
+  emplaceSampColl<PSXSampColl>(TamSoftPS1Format::name, this, offset() + 0x800, length() - 0x800, vagLocations);
   return true;
 }
 
@@ -68,9 +66,8 @@ bool TamSoftPS1Instr::loadInstr() {
 
   addChild(offset(), 4, "Sample Offset");
 
-  TamSoftPS1Rgn *rgn = new TamSoftPS1Rgn(this, offset() + 0x400, parInstrSet->ps2);
+  TamSoftPS1Rgn *rgn = emplaceRgn<TamSoftPS1Rgn>(this, offset() + 0x400, parInstrSet->ps2);
   rgn->sampNum = instrNum;
-  addRgn(rgn);
   return true;
 }
 

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Instr.cpp
@@ -48,7 +48,7 @@ bool TamSoftPS1InstrSet::parseInstrPointers() {
     return false;
   }
 
-  sampColl = new PSXSampColl(TamSoftPS1Format::name, this, offset() + 0x800, length() - 0x800, vagLocations);
+  adoptSampColl(new PSXSampColl(TamSoftPS1Format::name, this, offset() + 0x800, length() - 0x800, vagLocations));
   return true;
 }
 

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Scanner.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Scanner.cpp
@@ -44,7 +44,7 @@ void TamSoftPS1Scanner::scan(RawFile *file, void *info) {
 
     for (u8 songIndex = 0; songIndex < numSongs; songIndex++) {
       std::string seqname = fmt::format("{} ({})", basename, songIndex);
-      auto* newSeq = pRoot->emplaceVGMFile<TamSoftPS1Seq>(file, 0, songIndex, seqname);
+      auto* newSeq = pRoot->loadVGMFile<TamSoftPS1Seq>(file, 0, songIndex, seqname);
       if (newSeq) {
         newSeq->setLength(file->size());
       }
@@ -56,7 +56,7 @@ void TamSoftPS1Scanner::scan(RawFile *file, void *info) {
       ps2 = true;
     }
 
-    auto* newInstrSet = pRoot->emplaceVGMFile<TamSoftPS1InstrSet>(file, 0, ps2, basename);
+    auto* newInstrSet = pRoot->loadVGMFile<TamSoftPS1InstrSet>(file, 0, ps2, basename);
     if (newInstrSet) {
       newInstrSet->setLength(file->size());
     }

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Scanner.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Scanner.cpp
@@ -44,11 +44,9 @@ void TamSoftPS1Scanner::scan(RawFile *file, void *info) {
 
     for (u8 songIndex = 0; songIndex < numSongs; songIndex++) {
       std::string seqname = fmt::format("{} ({})", basename, songIndex);
-      TamSoftPS1Seq *newSeq = new TamSoftPS1Seq(file, 0, songIndex, seqname);
-      if (newSeq->loadVGMFile()) {
+      auto* newSeq = pRoot->emplaceVGMFile<TamSoftPS1Seq>(file, 0, songIndex, seqname);
+      if (newSeq) {
         newSeq->setLength(file->size());
-      } else {
-        delete newSeq;
       }
     }
   } else if (extension == "tvb" || extension == "tvb2") {
@@ -58,11 +56,9 @@ void TamSoftPS1Scanner::scan(RawFile *file, void *info) {
       ps2 = true;
     }
 
-    TamSoftPS1InstrSet *newInstrSet = new TamSoftPS1InstrSet(file, 0, ps2, basename);
-    if (newInstrSet->loadVGMFile()) {
+    auto* newInstrSet = pRoot->emplaceVGMFile<TamSoftPS1InstrSet>(file, 0, ps2, basename);
+    if (newInstrSet) {
       newInstrSet->setLength(file->size());
-    } else {
-      delete newInstrSet;
     }
   }
 

--- a/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
+++ b/src/main/formats/TamSoftPS1/TamSoftPS1Seq.cpp
@@ -135,8 +135,7 @@ bool TamSoftPS1Seq::parseHeader() {
 
         if (live != 0) {
           if (dwHeaderOffset + dwRelTrackOffset < vgmFile()->endOffset()) {
-            TamSoftPS1Track *track = new TamSoftPS1Track(this, dwHeaderOffset + dwRelTrackOffset);
-            aTracks.push_back(track);
+            addTrack<TamSoftPS1Track>(this, dwHeaderOffset + dwRelTrackOffset);
           }
           else {
             return false;
@@ -151,8 +150,7 @@ bool TamSoftPS1Seq::parseHeader() {
 
     // ignore silence sequence
     if (readShort(dwTrackOffset) != 0xfff0) {
-      TamSoftPS1Track *track = new TamSoftPS1Track(this, dwTrackOffset);
-      aTracks.push_back(track);
+      addTrack<TamSoftPS1Track>(this, dwTrackOffset);
     }
   }
 

--- a/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
@@ -122,7 +122,7 @@ bool TriAcePS1Instr::loadInstr() {
     rgn->addVelLow(rgninfo->vel_range_high == 0 ? 0 : rgninfo->vel_range_low, rgn->offset() + 2);
     rgn->addVelHigh(rgninfo->vel_range_high == 0 ? 0x7F : rgninfo->vel_range_high, rgn->offset() + 3);
     rgn->addChild(rgn->offset() + 4, 4, "Sample Offset");
-    rgn->sampOffset = rgninfo->sampOffset; //+ ((VGMInstrSet*)this->vgmfile)->sampColl->offset();
+    rgn->sampOffset = rgninfo->sampOffset; //+ ((VGMInstrSet*)this->vgmfile)->sampColl()->offset();
     rgn->addChild(rgn->offset() + 8, 4, "Sample Loop Point");
     //rgn->loop.loopStatus = (rgninfo->loopOffset != rgninfo->sampOffset) && (rgninfo->loopOffset != 0);
     rgn->loop.loopStart = rgninfo->loopOffset;
@@ -132,7 +132,7 @@ bool TriAcePS1Instr::loadInstr() {
     rgn->addChild(rgn->offset() + 14, 1, "Pitch Fine Tune");
     const int kTuningOffset = 22; // approx. 21.500638 from pitch table (0x10be vs 0x1000)
     rgn->fineTune = (short)((double)rgninfo->pitchTuneFine / 64.0 * 100) - kTuningOffset;
-    rgn->sampCollPtr = ((VGMInstrSet *) this->vgmFile())->sampColl;
+    rgn->sampCollPtr = ((VGMInstrSet *) this->vgmFile())->sampColl();
     rgn->addChild(rgn->offset() + 15, 5, "Unknown values");
 
 

--- a/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
@@ -39,7 +39,7 @@ bool TriAcePS1InstrSet::parseHeader() {
 
 
   //sampColl = new TriAcePS1SampColl(this, offset()+instrSectionSize, length()-instrSectionSize);
-  emplaceSampColl<PSXSampColl>(TriAcePS1Format::name, this, offset() + instrSectionSize, length() - instrSectionSize);
+  addSampColl<PSXSampColl>(TriAcePS1Format::name, this, offset() + instrSectionSize, length() - instrSectionSize);
 
 
   return true;
@@ -59,7 +59,7 @@ bool TriAcePS1InstrSet::parseInstrPointers() {
   for (u32 i = offset() + sizeof(TriAcePS1InstrSet::_InstrHeader);                    //1,Sep.2009 revise
        ((firstWord != 0xFFFFFFFF) && (i < offset() + length()));
        i += sizeof(TriAcePS1Instr::InstrInfo), firstWord = readWord(i)) {
-    TriAcePS1Instr *newInstr = emplaceInstr<TriAcePS1Instr>(this, i, 0, 0, 0);
+    TriAcePS1Instr *newInstr = addInstr<TriAcePS1Instr>(this, i, 0, 0, 0);
     readBytes(i, sizeof(TriAcePS1Instr::InstrInfo), &newInstr->instrinfo);
     newInstr->addChild(i + 0, sizeof(short), "Instrument Number");            //1,Sep.2009 revise
     newInstr->addChild(i + 2, sizeof(short), "ADSR1");                        //1,Sep.2009 revise
@@ -114,7 +114,7 @@ bool TriAcePS1Instr::loadInstr() {
 
   for (int i = 0; i < instrinfo.numRgns; i++) {
     RgnInfo *rgninfo = &rgns[i];
-    VGMRgn *rgn = emplaceRgn<VGMRgn>(this,
+    VGMRgn *rgn = addRgn<VGMRgn>(this,
                                      offset() + sizeof(InstrInfo) + sizeof(RgnInfo) * i,
                                      sizeof(RgnInfo));        //1,Sep.2009 revise
     rgn->addKeyLow(rgninfo->note_range_low, rgn->offset());

--- a/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
@@ -39,7 +39,7 @@ bool TriAcePS1InstrSet::parseHeader() {
 
 
   //sampColl = new TriAcePS1SampColl(this, offset()+instrSectionSize, length()-instrSectionSize);
-  sampColl = new PSXSampColl(TriAcePS1Format::name, this, offset() + instrSectionSize, length() - instrSectionSize);
+  adoptSampColl(new PSXSampColl(TriAcePS1Format::name, this, offset() + instrSectionSize, length() - instrSectionSize));
 
 
   return true;

--- a/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1InstrSet.cpp
@@ -39,7 +39,7 @@ bool TriAcePS1InstrSet::parseHeader() {
 
 
   //sampColl = new TriAcePS1SampColl(this, offset()+instrSectionSize, length()-instrSectionSize);
-  adoptSampColl(new PSXSampColl(TriAcePS1Format::name, this, offset() + instrSectionSize, length() - instrSectionSize));
+  emplaceSampColl<PSXSampColl>(TriAcePS1Format::name, this, offset() + instrSectionSize, length() - instrSectionSize);
 
 
   return true;
@@ -59,8 +59,7 @@ bool TriAcePS1InstrSet::parseInstrPointers() {
   for (u32 i = offset() + sizeof(TriAcePS1InstrSet::_InstrHeader);                    //1,Sep.2009 revise
        ((firstWord != 0xFFFFFFFF) && (i < offset() + length()));
        i += sizeof(TriAcePS1Instr::InstrInfo), firstWord = readWord(i)) {
-    TriAcePS1Instr *newInstr = new TriAcePS1Instr(this, i, 0, 0, 0);
-    aInstrs.push_back(newInstr);
+    TriAcePS1Instr *newInstr = emplaceInstr<TriAcePS1Instr>(this, i, 0, 0, 0);
     readBytes(i, sizeof(TriAcePS1Instr::InstrInfo), &newInstr->instrinfo);
     newInstr->addChild(i + 0, sizeof(short), "Instrument Number");            //1,Sep.2009 revise
     newInstr->addChild(i + 2, sizeof(short), "ADSR1");                        //1,Sep.2009 revise
@@ -115,9 +114,9 @@ bool TriAcePS1Instr::loadInstr() {
 
   for (int i = 0; i < instrinfo.numRgns; i++) {
     RgnInfo *rgninfo = &rgns[i];
-    VGMRgn *rgn = new VGMRgn(this,
-                             offset() + sizeof(InstrInfo) + sizeof(RgnInfo) * i,
-                             sizeof(RgnInfo));        //1,Sep.2009 revise
+    VGMRgn *rgn = emplaceRgn<VGMRgn>(this,
+                                     offset() + sizeof(InstrInfo) + sizeof(RgnInfo) * i,
+                                     sizeof(RgnInfo));        //1,Sep.2009 revise
     rgn->addKeyLow(rgninfo->note_range_low, rgn->offset());
     rgn->addKeyHigh(rgninfo->note_range_high, rgn->offset() + 1);
     rgn->addVelLow(rgninfo->vel_range_high == 0 ? 0 : rgninfo->vel_range_low, rgn->offset() + 2);
@@ -142,7 +141,6 @@ bool TriAcePS1Instr::loadInstr() {
     //  also, be aware the same scale may be employed for vol and expression events (haven't investigated).
     //long dlsAtten = -(ConvertPercentVolToAttenDB(rgninfo->attenuation/((double)255)) * DLS_DECIBEL_UNIT);
     //rgn->SetAttenuation(dlsAtten);
-    addRgn(rgn);
   }
   return true;
 }

--- a/src/main/formats/TriAcePS1/TriAcePS1Scanner.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1Scanner.cpp
@@ -67,9 +67,9 @@ void TriAcePS1Scanner::searchForSLZSeq(RawFile *file) {
 
     std::string name = file->tag.hasTitle() ? file->tag.title : file->stem();
     auto coll = std::make_unique<VGMColl>(name);
-    coll->useSeq(seq);
+    coll->attachSeq(seq);
     for (u32 setIdx = 0; setIdx < instrsets.size(); setIdx++)
-      coll->addInstrSet(instrsets[setIdx]);
+      coll->attachInstrSet(instrsets[setIdx]);
     pRoot->loadVGMColl(std::move(coll));
   }
 }
@@ -108,7 +108,7 @@ void TriAcePS1Scanner::searchForInstrSet(RawFile *file, std::vector<TriAcePS1Ins
     if (file->readWord(i + instrSectSize - 4) != 0xFFFFFFFF)
       continue;
 
-    auto* instrset = pRoot->emplaceVGMFile<TriAcePS1InstrSet>(file, i);
+    auto* instrset = pRoot->loadVGMFile<TriAcePS1InstrSet>(file, i);
     if (!instrset) {
       continue;
     }

--- a/src/main/formats/TriAcePS1/TriAcePS1Scanner.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1Scanner.cpp
@@ -62,24 +62,15 @@ void TriAcePS1Scanner::searchForSLZSeq(RawFile *file) {
     std::vector<TriAcePS1InstrSet *> instrsets;
     searchForInstrSet(file, instrsets);
 
-    //u32 cfSize = file->GetWord(i-4);
-    //TriAcePS1InstrSet* instrset = new TriAcePS1InstrSet(file, i-4 + cfSize);
-    //if (!instrset->LoadVGMFile())
-    //{
-    //	delete instrset;
-    //	return;
-    //}
     if (!instrsets.size())
       return;
 
     std::string name = file->tag.hasTitle() ? file->tag.title : file->stem();
-    VGMColl *coll = new VGMColl(name);
+    auto coll = std::make_unique<VGMColl>(name);
     coll->useSeq(seq);
     for (u32 setIdx = 0; setIdx < instrsets.size(); setIdx++)
       coll->addInstrSet(instrsets[setIdx]);
-    if (!coll->load()) {
-      delete coll;
-    }
+    pRoot->loadVGMColl(std::move(coll));
   }
 }
 
@@ -117,9 +108,8 @@ void TriAcePS1Scanner::searchForInstrSet(RawFile *file, std::vector<TriAcePS1Ins
     if (file->readWord(i + instrSectSize - 4) != 0xFFFFFFFF)
       continue;
 
-    TriAcePS1InstrSet *instrset = new TriAcePS1InstrSet(file, i);
-    if (!instrset->loadVGMFile()) {
-      delete instrset;
+    auto* instrset = pRoot->emplaceVGMFile<TriAcePS1InstrSet>(file, i);
+    if (!instrset) {
       continue;
     }
     instrsets.push_back(instrset);
@@ -211,19 +201,17 @@ TriAcePS1Seq *TriAcePS1Scanner::decompressTriAceSLZFile(RawFile *file, u32 cfOff
 
   // Create the new virtual file, and analyze the sequence
   std::string name = file->tag.hasTitle() ? file->tag.title : file->stem();
-  auto newVirtFile = new VirtFile(uf, ufOff, fmt::format("{} Sequence", name), file->path());
+  auto newVirtFile = std::make_unique<VirtFile>(uf, ufOff, fmt::format("{} Sequence", name), file->path());
+  delete[] uf;
 
-  TriAcePS1Seq *newSeq = new TriAcePS1Seq(newVirtFile, 0, name);
-  bool bLoadSucceed = newSeq->loadVGMFile();
+  auto* rawVirtFile = newVirtFile.get();
+  rawVirtFile->setUseLoaders(false);
+  rawVirtFile->setUseScanners(false);
 
-  newVirtFile->setUseLoaders(false);
-  newVirtFile->setUseScanners(false);
-  pRoot->loadRawFile(newVirtFile);
+  auto seq = std::make_unique<TriAcePS1Seq>(rawVirtFile, 0, name);
+  auto* rawSeq = seq.get();
+  const bool loadSucceeded = pRoot->loadVGMFile(std::move(seq));
+  pRoot->loadRawFile(std::move(newVirtFile));
 
-  if (bLoadSucceed)
-    return newSeq;
-  else {
-    delete newSeq;
-    return NULL;
-  }
+  return loadSucceeded ? rawSeq : nullptr;
 }

--- a/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
@@ -57,14 +57,14 @@ bool TriAcePS1Seq::postLoad() {
   bool success = VGMSeq::postLoad();
   if (readMode == READMODE_ADD_TO_UI) {
     for (auto& pattern : m_ownedScorePatterns) {
-      adoptChild(std::move(pattern));
+      sinkChild(std::move(pattern));
     }
     m_ownedScorePatterns.clear();
   }
   return success;
 }
 
-TriAcePS1ScorePattern* TriAcePS1Seq::adoptScorePattern(std::unique_ptr<TriAcePS1ScorePattern> pattern) {
+TriAcePS1ScorePattern* TriAcePS1Seq::sinkScorePattern(std::unique_ptr<TriAcePS1ScorePattern>&& pattern) {
   auto* rawPattern = pattern.get();
   m_scorePatterns.push_back(rawPattern);
   m_ownedScorePatterns.emplace_back(std::move(pattern));
@@ -87,7 +87,7 @@ void TriAcePS1Track::loadTrackMainLoop(u32 stopOffset, s32 stopTime) {
     if (seq->patternMap[scorePatternOffset])
       seq->curScorePattern = NULL;
     else {
-      auto* pattern = seq->adoptScorePattern(std::make_unique<TriAcePS1ScorePattern>(seq, scorePatternOffset));
+      auto* pattern = seq->sinkScorePattern(std::make_unique<TriAcePS1ScorePattern>(seq, scorePatternOffset));
       seq->patternMap[scorePatternOffset] = pattern;
       seq->curScorePattern = pattern;
     }
@@ -330,7 +330,7 @@ bool TriAcePS1Track::isOffsetUsed(u32 offset) {
   return false;
 }
 
-SeqEvent* TriAcePS1Track::adoptEvent(std::unique_ptr<SeqEvent> seqEvent) {
+SeqEvent* TriAcePS1Track::sinkEvent(std::unique_ptr<SeqEvent>&& seqEvent) {
   TriAcePS1ScorePattern *pattern = ((TriAcePS1Seq *) parentSeq)->curScorePattern;
   if (pattern == NULL) {
     // it must be already added, reject it
@@ -341,6 +341,6 @@ SeqEvent* TriAcePS1Track::adoptEvent(std::unique_ptr<SeqEvent> seqEvent) {
     return nullptr;
 
   auto* rawEvent = seqEvent.get();
-  pattern->adoptChild(std::move(seqEvent));
+  pattern->sinkChild(std::move(seqEvent));
   return rawEvent;
 }

--- a/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
@@ -57,14 +57,14 @@ bool TriAcePS1Seq::postLoad() {
   bool success = VGMSeq::postLoad();
   if (readMode == READMODE_ADD_TO_UI) {
     for (auto& pattern : m_ownedScorePatterns) {
-      addChild(std::move(pattern));
+      adoptChild(std::move(pattern));
     }
     m_ownedScorePatterns.clear();
   }
   return success;
 }
 
-TriAcePS1ScorePattern* TriAcePS1Seq::addScorePattern(std::unique_ptr<TriAcePS1ScorePattern> pattern) {
+TriAcePS1ScorePattern* TriAcePS1Seq::adoptScorePattern(std::unique_ptr<TriAcePS1ScorePattern> pattern) {
   auto* rawPattern = pattern.get();
   m_scorePatterns.push_back(rawPattern);
   m_ownedScorePatterns.emplace_back(std::move(pattern));
@@ -87,7 +87,7 @@ void TriAcePS1Track::loadTrackMainLoop(u32 stopOffset, s32 stopTime) {
     if (seq->patternMap[scorePatternOffset])
       seq->curScorePattern = NULL;
     else {
-      auto* pattern = seq->addScorePattern(std::make_unique<TriAcePS1ScorePattern>(seq, scorePatternOffset));
+      auto* pattern = seq->adoptScorePattern(std::make_unique<TriAcePS1ScorePattern>(seq, scorePatternOffset));
       seq->patternMap[scorePatternOffset] = pattern;
       seq->curScorePattern = pattern;
     }
@@ -330,7 +330,7 @@ bool TriAcePS1Track::isOffsetUsed(u32 offset) {
   return false;
 }
 
-SeqEvent* TriAcePS1Track::addEvent(std::unique_ptr<SeqEvent> seqEvent) {
+SeqEvent* TriAcePS1Track::adoptEvent(std::unique_ptr<SeqEvent> seqEvent) {
   TriAcePS1ScorePattern *pattern = ((TriAcePS1Seq *) parentSeq)->curScorePattern;
   if (pattern == NULL) {
     // it must be already added, reject it
@@ -341,6 +341,6 @@ SeqEvent* TriAcePS1Track::addEvent(std::unique_ptr<SeqEvent> seqEvent) {
     return nullptr;
 
   auto* rawEvent = seqEvent.get();
-  pattern->addChild(std::move(seqEvent));
+  pattern->adoptChild(std::move(seqEvent));
   return rawEvent;
 }

--- a/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
+++ b/src/main/formats/TriAcePS1/TriAcePS1Seq.cpp
@@ -6,6 +6,8 @@
 #include "base/Types.h"
 #include "SeqEvent.h"
 
+#include <memory>
+
 DECLARE_FORMAT(TriAcePS1);
 
 // ************
@@ -40,7 +42,7 @@ bool TriAcePS1Seq::parseTrackPointers() {
   readBytes(offset() + 0x16, 6 * 32, &TrkInfos);
   for (int i = 0; i < 32; i++)
     if (TrkInfos[i].trkOffset != 0) {
-      aTracks.push_back(new TriAcePS1Track(this, TrkInfos[i].trkOffset, 0));
+      addTrack<TriAcePS1Track>(this, TrkInfos[i].trkOffset, 0);
 
       TrkInfoHeader->addHeader(offset() + 0x16 + 6 * i, 6, "Track Info");
     }
@@ -54,9 +56,19 @@ void TriAcePS1Seq::resetVars() {
 bool TriAcePS1Seq::postLoad() {
   bool success = VGMSeq::postLoad();
   if (readMode == READMODE_ADD_TO_UI) {
-    addChildren(aScorePatterns);
+    for (auto& pattern : m_ownedScorePatterns) {
+      addChild(std::move(pattern));
+    }
+    m_ownedScorePatterns.clear();
   }
   return success;
+}
+
+TriAcePS1ScorePattern* TriAcePS1Seq::addScorePattern(std::unique_ptr<TriAcePS1ScorePattern> pattern) {
+  auto* rawPattern = pattern.get();
+  m_scorePatterns.push_back(rawPattern);
+  m_ownedScorePatterns.emplace_back(std::move(pattern));
+  return rawPattern;
 }
 
 // **************
@@ -75,10 +87,9 @@ void TriAcePS1Track::loadTrackMainLoop(u32 stopOffset, s32 stopTime) {
     if (seq->patternMap[scorePatternOffset])
       seq->curScorePattern = NULL;
     else {
-      TriAcePS1ScorePattern *pattern = new TriAcePS1ScorePattern(seq, scorePatternOffset);
+      auto* pattern = seq->addScorePattern(std::make_unique<TriAcePS1ScorePattern>(seq, scorePatternOffset));
       seq->patternMap[scorePatternOffset] = pattern;
       seq->curScorePattern = pattern;
-      seq->aScorePatterns.push_back(pattern);
     }
     u32 endOffset = readScorePattern(scorePatternOffset);
     if (seq->curScorePattern)
@@ -319,17 +330,17 @@ bool TriAcePS1Track::isOffsetUsed(u32 offset) {
   return false;
 }
 
-SeqEvent* TriAcePS1Track::addEvent(SeqEvent *pSeqEvent) {
+SeqEvent* TriAcePS1Track::addEvent(std::unique_ptr<SeqEvent> seqEvent) {
   TriAcePS1ScorePattern *pattern = ((TriAcePS1Seq *) parentSeq)->curScorePattern;
   if (pattern == NULL) {
     // it must be already added, reject it
-    delete pSeqEvent;
     return nullptr;
   }
 
   if (readMode != READMODE_ADD_TO_UI)
     return nullptr;
 
-  pattern->addChild(pSeqEvent);
-  return pSeqEvent;
+  auto* rawEvent = seqEvent.get();
+  pattern->addChild(std::move(seqEvent));
+  return rawEvent;
 }

--- a/src/main/formats/TriAcePS1/TriAcePS1Seq.h
+++ b/src/main/formats/TriAcePS1/TriAcePS1Seq.h
@@ -39,7 +39,7 @@ class TriAcePS1Seq:
 
  private:
   friend class TriAcePS1Track;
-  TriAcePS1ScorePattern* addScorePattern(std::unique_ptr<TriAcePS1ScorePattern> pattern);
+  TriAcePS1ScorePattern* adoptScorePattern(std::unique_ptr<TriAcePS1ScorePattern> pattern);
 
   TriAcePS1ScorePattern *curScorePattern = nullptr;
   std::map<u32, TriAcePS1ScorePattern *> patternMap;
@@ -63,7 +63,7 @@ class TriAcePS1Track
   void loadTrackMainLoop(u32 stopOffset, s32 stopTime) override;
   u32 readScorePattern(u32 offset);
   bool isOffsetUsed(u32 offset) override;
-  SeqEvent* addEvent(std::unique_ptr<SeqEvent> seqEvent) override;
+  SeqEvent* adoptEvent(std::unique_ptr<SeqEvent> seqEvent) override;
   bool readEvent() override;
 
   u8 impliedNoteDur;

--- a/src/main/formats/TriAcePS1/TriAcePS1Seq.h
+++ b/src/main/formats/TriAcePS1/TriAcePS1Seq.h
@@ -39,7 +39,7 @@ class TriAcePS1Seq:
 
  private:
   friend class TriAcePS1Track;
-  TriAcePS1ScorePattern* adoptScorePattern(std::unique_ptr<TriAcePS1ScorePattern> pattern);
+  TriAcePS1ScorePattern* sinkScorePattern(std::unique_ptr<TriAcePS1ScorePattern>&& pattern);
 
   TriAcePS1ScorePattern *curScorePattern = nullptr;
   std::map<u32, TriAcePS1ScorePattern *> patternMap;
@@ -63,7 +63,7 @@ class TriAcePS1Track
   void loadTrackMainLoop(u32 stopOffset, s32 stopTime) override;
   u32 readScorePattern(u32 offset);
   bool isOffsetUsed(u32 offset) override;
-  SeqEvent* adoptEvent(std::unique_ptr<SeqEvent> seqEvent) override;
+  SeqEvent* sinkEvent(std::unique_ptr<SeqEvent>&& seqEvent) override;
   bool readEvent() override;
 
   u8 impliedNoteDur;

--- a/src/main/formats/TriAcePS1/TriAcePS1Seq.h
+++ b/src/main/formats/TriAcePS1/TriAcePS1Seq.h
@@ -6,6 +6,7 @@
 #include "VGMSeq.h"
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -28,13 +29,22 @@ class TriAcePS1Seq:
   void resetVars() override;
 
   bool postLoad() override;
+  [[nodiscard]] const std::vector<TriAcePS1ScorePattern*>& scorePatterns() const {
+    return m_scorePatterns;
+  }
 
   VGMHeader *header;
   TrkInfo TrkInfos[32];
-  std::vector<TriAcePS1ScorePattern *> aScorePatterns;
-  TriAcePS1ScorePattern *curScorePattern;
-  std::map<u32, TriAcePS1ScorePattern *> patternMap;
   u8 initialTempoBPM;
+
+ private:
+  friend class TriAcePS1Track;
+  TriAcePS1ScorePattern* addScorePattern(std::unique_ptr<TriAcePS1ScorePattern> pattern);
+
+  TriAcePS1ScorePattern *curScorePattern = nullptr;
+  std::map<u32, TriAcePS1ScorePattern *> patternMap;
+  std::vector<std::unique_ptr<TriAcePS1ScorePattern>> m_ownedScorePatterns;
+  std::vector<TriAcePS1ScorePattern *> m_scorePatterns;
 };
 
 class TriAcePS1ScorePattern
@@ -50,11 +60,11 @@ class TriAcePS1Track
  public:
   TriAcePS1Track(TriAcePS1Seq *parentSeq, u32 offset = 0, u32 length = 0);
 
-  virtual void loadTrackMainLoop(u32 stopOffset, s32 stopTime);
+  void loadTrackMainLoop(u32 stopOffset, s32 stopTime) override;
   u32 readScorePattern(u32 offset);
-  virtual bool isOffsetUsed(u32 offset);
-  virtual SeqEvent* addEvent(SeqEvent *pSeqEvent);
-  virtual bool readEvent();
+  bool isOffsetUsed(u32 offset) override;
+  SeqEvent* addEvent(std::unique_ptr<SeqEvent> seqEvent) override;
+  bool readEvent() override;
 
   u8 impliedNoteDur;
   u8 impliedVelocity;

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -156,7 +156,7 @@ bool PSXSampColl::parseSampleInfo() {
       }
       // If endLoopOffset wasn't set, default it to the end of the sample
       endLoopOffset = endLoopOffset >= beginOffset ? endLoopOffset : i;
-      emplaceSamp<PSXSamp>(this,
+      addSamp<PSXSamp>(this,
                            beginOffset,
                            i - beginOffset,
                            beginOffset,
@@ -194,7 +194,7 @@ bool PSXSampColl::parseSampleInfo() {
         offSampEnd += 16;
       } while (!lastBlock);
 
-      emplaceSamp<PSXSamp>(this,
+      addSamp<PSXSamp>(this,
                            offset() + it->offset,
                            it->size,
                            offset() + it->offset,

--- a/src/main/formats/common/PSXSPU.cpp
+++ b/src/main/formats/common/PSXSPU.cpp
@@ -6,6 +6,9 @@
 
 #include "base/Types.h"
 #include "formats/PS1/PS1Format.h"
+#include "Root.h"
+
+#include <memory>
 
 using namespace std;
 
@@ -153,16 +156,15 @@ bool PSXSampColl::parseSampleInfo() {
       }
       // If endLoopOffset wasn't set, default it to the end of the sample
       endLoopOffset = endLoopOffset >= beginOffset ? endLoopOffset : i;
-      PSXSamp *samp = new PSXSamp(this,
-                                  beginOffset,
-                                  i - beginOffset,
-                                  beginOffset,
-                                  endLoopOffset - beginOffset - extraGunkLength,
-                                  1,
-                                  BPS::PCM16,
-                                  44100,
-                                  fmt::format("Sample {:d}", samples.size()));
-      samples.push_back(samp);
+      emplaceSamp<PSXSamp>(this,
+                           beginOffset,
+                           i - beginOffset,
+                           beginOffset,
+                           endLoopOffset - beginOffset - extraGunkLength,
+                           1,
+                           BPS::PCM16,
+                           44100,
+                           fmt::format("Sample {:d}", sampleCount()));
     }
     setLength(i - offset());
   }
@@ -192,17 +194,15 @@ bool PSXSampColl::parseSampleInfo() {
         offSampEnd += 16;
       } while (!lastBlock);
 
-      PSXSamp *samp = new PSXSamp(this,
-                                  offset() + it->offset,
-                                  it->size,
-                                  offset() + it->offset,
-                                  offSampEnd - offSampStart,
-                                  1,
-                                  BPS::PCM16,
-                                  44100,
-                                  fmt::format("Sample {:d}", sampleIndex));
-
-      samples.push_back(samp);
+      emplaceSamp<PSXSamp>(this,
+                           offset() + it->offset,
+                           it->size,
+                           offset() + it->offset,
+                           offSampEnd - offSampStart,
+                           1,
+                           BPS::PCM16,
+                           44100,
+                           fmt::format("Sample {:d}", sampleIndex));
       sampleIndex++;
     }
   }
@@ -334,7 +334,7 @@ static bool isValidSampleStart(const RawFile* file, u32 offset, bool allowShort)
   return true;
 }
 
-std::vector<PSXSampColl*> PSXSampColl::searchForPSXADPCMs(RawFile* file, const std::string&) {
+std::vector<PSXSampColl*> PSXSampColl::searchForPSXADPCMs(RawFile* file, const std::string& format) {
   std::vector<PSXSampColl*> sampColls;
   const size_t len = file->size();
 
@@ -379,16 +379,19 @@ std::vector<PSXSampColl*> PSXSampColl::searchForPSXADPCMs(RawFile* file, const s
       start = offset; // extend the start of the sample collection backward
     }
 
-    auto* coll = new PSXSampColl(PS1Format::name, file, start);
-    if (!coll->loadVGMFile()) { delete coll; continue; }
+    auto coll = std::make_unique<PSXSampColl>(format, file, start);
+    auto* rawColl = coll.get();
+    if (!pRoot->loadVGMFile(std::move(coll))) {
+      continue;
+    }
 
-    sampColls.push_back(coll);
+    sampColls.push_back(rawColl);
 
     // Sanity check that the detected sampcoll isn't smaller than the back scanned distance
-    if ((start + coll->length() - 1) < origOffset) {
+    if ((start + rawColl->length() - 1) < origOffset) {
       i = origOffset + 32;
     } else {
-      i = start + coll->length() - 1;                      // skip parsed area
+      i = start + rawColl->length() - 1;                      // skip parsed area
     }
   }
   return sampColls;

--- a/src/main/formats/common/SNESDSP.cpp
+++ b/src/main/formats/common/SNESDSP.cpp
@@ -357,12 +357,11 @@ bool SNESSampColl::parseSampleInfo() {
         spcDirHeader->addChild(offDirEnt, 2, fmt::format("SA: {:#x}", srcn));
         spcDirHeader->addChild(offDirEnt + 2, 2, fmt::format("LSA: {:#x}", srcn));
 
-        SNESSamp *samp = new SNESSamp(this, addrSampStart, length, addrSampStart, length,
-                                      addrSampLoop, fmt::format("Sample: {:#x}", srcn));
-    samples.push_back(samp);
+    emplaceSamp<SNESSamp>(this, addrSampStart, length, addrSampStart, length,
+                          addrSampLoop, fmt::format("Sample: {:#x}", srcn));
   }
   spcDirHeader->setGuessedLength();
-  return samples.size() != 0;
+  return hasSamples();
 }
 
 bool SNESSampColl::isValidSampleDir(const RawFile *file, u32 spcDirEntAddr, bool validateSample) {

--- a/src/main/formats/common/SNESDSP.cpp
+++ b/src/main/formats/common/SNESDSP.cpp
@@ -357,7 +357,7 @@ bool SNESSampColl::parseSampleInfo() {
         spcDirHeader->addChild(offDirEnt, 2, fmt::format("SA: {:#x}", srcn));
         spcDirHeader->addChild(offDirEnt + 2, 2, fmt::format("LSA: {:#x}", srcn));
 
-    emplaceSamp<SNESSamp>(this, addrSampStart, length, addrSampStart, length,
+    addSamp<SNESSamp>(this, addrSampStart, length, addrSampStart, length,
                           addrSampLoop, fmt::format("Sample: {:#x}", srcn));
   }
   spcDirHeader->setGuessedLength();

--- a/src/main/io/RawFile.cpp
+++ b/src/main/io/RawFile.cpp
@@ -13,13 +13,12 @@
 
 /* RawFile */
 
-/* FIXME: we own the VGMFile, should use unique_ptr instead */
-void RawFile::addContainedVGMFile(std::shared_ptr<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>> vgmfile) {
+void RawFile::addContainedVGMFile(VGMFileVariant vgmfile) {
     m_vgmfiles.emplace_back(vgmfile);
 }
 
-void RawFile::removeContainedVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> vgmfile) {
-    auto iter = std::ranges::find_if(m_vgmfiles, [vgmfile](auto file) { return *file == vgmfile; });
+void RawFile::removeContainedVGMFile(VGMFileVariant vgmfile) {
+    auto iter = std::ranges::find(m_vgmfiles, vgmfile);
     if (iter != m_vgmfiles.end())
         m_vgmfiles.erase(iter);
     else {

--- a/src/main/io/RawFile.h
+++ b/src/main/io/RawFile.h
@@ -15,7 +15,6 @@
 #include <cassert>
 #include <climits>
 #include <filesystem>
-#include <memory>
 #include <string>
 #include <variant>
 #include <vector>
@@ -116,19 +115,19 @@ class RawFile {
     [[nodiscard]] const std::vector<T*> containedVGMFilesOfType() const noexcept {
       std::vector<T*> files = {};
       for (const auto& vgmfile : m_vgmfiles) {
-        if (T* fileOfType = variantToType<T>(*vgmfile)) {
+        if (T* fileOfType = variantToType<T>(vgmfile)) {
           files.emplace_back(fileOfType);
         }
       }
       return files;
     }
-    void addContainedVGMFile(std::shared_ptr<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>);
-    void removeContainedVGMFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>);
+    void addContainedVGMFile(VGMFileVariant);
+    void removeContainedVGMFile(VGMFileVariant);
 
     VGMTag tag;
 
    private:
-    std::vector<std::shared_ptr<std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *>>> m_vgmfiles;
+    std::vector<VGMFileVariant> m_vgmfiles;
     enum ProcessFlags { UseLoaders = 1, UseScanners = 2 };
     unsigned m_flags = UseLoaders | UseScanners;
 };

--- a/src/main/loaders/CHDLoader.cpp
+++ b/src/main/loaders/CHDLoader.cpp
@@ -11,6 +11,8 @@
 #include "LoaderManager.h"
 #include "LogManager.h"
 
+#include <memory>
+
 extern "C" {
 #include <libchdr/chd.h>
 }
@@ -99,7 +101,6 @@ void CHDLoader::apply(const RawFile *file) {
   }
   chd_close(chd);
 
-  auto virtFile = new VirtFile(data.data(), static_cast<u32>(data.size()),
-                               file->name(), file->path(), file->tag);
-  enqueue(virtFile);
+  enqueue(std::make_unique<VirtFile>(data.data(), static_cast<u32>(data.size()),
+                                     file->name(), file->path(), file->tag));
 }

--- a/src/main/loaders/MAMELoader.cpp
+++ b/src/main/loaders/MAMELoader.cpp
@@ -8,7 +8,6 @@
 
 #include "CPS3Decrypt.h"
 #include "Format.h"
-#include "Helper.h"
 #include "KabukiDecrypt.h"
 #include "LoaderManager.h"
 #include "LogManager.h"
@@ -20,6 +19,7 @@
 #include <fstream>
 #include <ranges>
 #include <utility>
+#include <vector>
 
 #if defined(_WIN32) || defined(WIN32)
 #include <ioapi.h>
@@ -64,9 +64,7 @@ MAMELoader::MAMELoader() {
   bLoadedXml = loadJSON();
 }
 
-MAMELoader::~MAMELoader() {
-  deleteMap<std::string, MAMEGame>(gamemap);
-}
+MAMELoader::~MAMELoader() = default;
 
 namespace {
 
@@ -183,7 +181,7 @@ bool loadRomGroupEntry(const json& romgroupJson, MAMEGame* gameentry) {
   return true;
 }
 
-MAMEGame* loadGameEntry(const json& gameJson) {
+std::unique_ptr<MAMEGame> loadGameEntry(const json& gameJson) {
   if (!gameJson.is_object()) {
     return nullptr;
   }
@@ -195,7 +193,7 @@ MAMEGame* loadGameEntry(const json& gameJson) {
     return nullptr;
   }
 
-  auto* gameentry = new MAMEGame;
+  auto gameentry = std::make_unique<MAMEGame>();
   gameentry->name = nameIt->get<std::string>();
   gameentry->format = formatIt->get<std::string>();
   if (auto fmtVersionIt = gameJson.find("fmt_version");
@@ -206,20 +204,17 @@ MAMEGame* loadGameEntry(const json& gameJson) {
   const json* romGroupsArray = nullptr;
   if (auto romGroupsIt = gameJson.find("rom_groups"); romGroupsIt != gameJson.end()) {
     if (!romGroupsIt->is_array()) {
-      delete gameentry;
       return nullptr;
     }
     romGroupsArray = &(*romGroupsIt);
   }
 
   if (!romGroupsArray) {
-    delete gameentry;
     return nullptr;
   }
 
   for (const auto& romgroupJson : *romGroupsArray) {
-    if (!loadRomGroupEntry(romgroupJson, gameentry)) {
-      delete gameentry;
+    if (!loadRomGroupEntry(romgroupJson, gameentry.get())) {
       return nullptr;
     }
   }
@@ -267,11 +262,12 @@ bool MAMELoader::loadJSON() {
     }
 
     for (const auto& gameJson : *games) {
-      MAMEGame* gameentry = loadGameEntry(gameJson);
+      auto gameentry = loadGameEntry(gameJson);
       if (!gameentry) {
         return false;
       }
-      gamemap[gameentry->name] = gameentry;
+      auto gameName = gameentry->name;
+      gamemap[gameName] = std::move(gameentry);
     }
 
     return true;
@@ -293,7 +289,7 @@ void MAMELoader::apply(const RawFile* file) {
     return;
   }
 
-  MAMEGame* gameentry = it->second;
+  MAMEGame* gameentry = it->second.get();
 
   /* Check if we support this format */
   Format* fmt = Format::formatFromName(gameentry->format);
@@ -317,30 +313,35 @@ void MAMELoader::apply(const RawFile* file) {
   // file member
   // Note that this does not check for an error, so the romgroup entry's file member may receive
   // NULL. This must be checked for in Scan().
+  std::vector<std::unique_ptr<VirtFile>> loadedFiles;
   for (auto& entry : gameentry->romgroupentries) {
-    entry.file = loadRomGroup(entry, gameentry->format, cur_file);
+    auto loadedFile = loadRomGroup(entry, gameentry->format, cur_file);
+    entry.file = loadedFile.get();
+    if (loadedFile) {
+      loadedFiles.push_back(std::move(loadedFile));
+    }
   }
 
   fmt->getScanner().scan(nullptr, gameentry);
+  for (auto& loadedFile : loadedFiles) {
+    enqueue(std::move(loadedFile));
+  }
   for (auto& entry : gameentry->romgroupentries) {
-    if (entry.file) {
-      enqueue(entry.file);
-    }
+    entry.file = nullptr;
   }
 
   (void)unzClose(cur_file);
 }
 
-VirtFile* MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string& format,
-                                   const unzFile& cur_file) {
+std::unique_ptr<VirtFile> MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string& format,
+                                                   const unzFile& cur_file) {
   u32 destFileSize = 0;
-  std::list<std::pair<u8*, u32>> buffers;
+  std::list<std::vector<u8>> buffers;
   auto roms = entry.roms;
   for (auto& rom : roms) {
     int ret = unzLocateFile(cur_file, rom.c_str(), 0);
     if (ret == UNZ_END_OF_LIST_OF_FILE) {
       // file not found
-      deleteBuffers(buffers);
       return nullptr;
     }
 
@@ -348,7 +349,6 @@ VirtFile* MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string&
     ret = unzGetCurrentFileInfo(cur_file, &info, nullptr, 0, nullptr, 0, nullptr, 0);
     if (ret != UNZ_OK) {
       // could not get zipped file info
-      deleteBuffers(buffers);
       return nullptr;
     }
 
@@ -356,30 +356,26 @@ VirtFile* MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string&
     ret = unzOpenCurrentFile(cur_file);
     if (ret != UNZ_OK) {
       // could not open file in zip archive
-      deleteBuffers(buffers);
       return nullptr;
     }
 
-    u8* buf = new u8[info.uncompressed_size];
-    ret = unzReadCurrentFile(cur_file, buf, static_cast<u32>(info.uncompressed_size));
+    std::vector<u8> buf(info.uncompressed_size);
+    ret = unzReadCurrentFile(cur_file, buf.data(), static_cast<u32>(info.uncompressed_size));
     if (!std::cmp_equal(ret, info.uncompressed_size)) {
       // error reading file in zip archive
-      delete[] buf;
-      deleteBuffers(buffers);
       return nullptr;
     }
 
     ret = unzCloseCurrentFile(cur_file);
     if (ret != UNZ_OK) {
       // could not close file in zip archive
-      deleteBuffers(buffers);
       return nullptr;
     }
 
-    buffers.emplace_back(std::make_pair(buf, info.uncompressed_size));
+    buffers.emplace_back(std::move(buf));
   }
 
-  u8* destFile = new u8[destFileSize];
+  std::vector<u8> destFile(destFileSize);
   switch (entry.loadmethod) {
     // append the files
     case LoadMethod::APPEND: {
@@ -387,16 +383,15 @@ VirtFile* MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string&
 
       if (entry.load_order == LoadOrder::REVERSE) {
         for (auto it = buffers.rbegin(); it != buffers.rend(); ++it) {
-          u8* buf = it->first;
-          u32 romSize = it->second;
-          memcpy(destFile + curOffset, buf, romSize);
+          const auto& buf = *it;
+          const auto romSize = static_cast<u32>(buf.size());
+          memcpy(destFile.data() + curOffset, buf.data(), romSize);
           curOffset += romSize;
         }
       } else {
-        for (auto& bufInfo : buffers) {
-          u8* buf = bufInfo.first;
-          u32 romSize = bufInfo.second;
-          memcpy(destFile + curOffset, buf, romSize);
+        for (const auto& buf : buffers) {
+          const auto romSize = static_cast<u32>(buf.size());
+          memcpy(destFile.data() + curOffset, buf.data(), romSize);
           curOffset += romSize;
         }
       }
@@ -409,8 +404,8 @@ VirtFile* MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string&
 
       if (entry.load_order == LoadOrder::REVERSE) {
         for (auto it = buffers.rbegin(); it != buffers.rend(); ++it) {
-          u8* romBuf = it->first;
-          u32 romSize = it->second;
+          const auto& romBuf = *it;
+          const auto romSize = static_cast<u32>(romBuf.size());
           for (u32 i = 0; i < romSize; i += 2) {
             destFile[curDestOffset + i] = romBuf[i + 1];
             destFile[curDestOffset + i + 1] = romBuf[i];
@@ -418,9 +413,8 @@ VirtFile* MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string&
           curDestOffset += romSize;
         }
       } else {
-        for (auto& bufInfo : buffers) {
-          u8* buf = bufInfo.first;
-          u32 romSize = bufInfo.second;
+        for (const auto& buf : buffers) {
+          const auto romSize = static_cast<u32>(buf.size());
           for (u32 i = 0; i < romSize; i += 2) {
             destFile[curDestOffset + i] = buf[i + 1];
             destFile[curDestOffset + i + 1] = buf[i];
@@ -440,11 +434,11 @@ VirtFile* MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string&
       while (curDestOffset < destFileSize) {
         if (entry.load_order == LoadOrder::REVERSE) {
           for (auto & buffer : std::ranges::reverse_view(buffers))
-            destFile[curDestOffset++] = buffer.first[curRomOffset];
+            destFile[curDestOffset++] = buffer[curRomOffset];
         }
         else {
-          for (auto& bufInfo : buffers)
-            destFile[curDestOffset++] = bufInfo.first[curRomOffset];
+          for (const auto& buf : buffers)
+            destFile[curDestOffset++] = buf[curRomOffset];
         }
         curRomOffset++;
       }
@@ -455,8 +449,6 @@ VirtFile* MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string&
       if (buffers.size() % 2 > 0) {
         L_ERROR("MAMELoader was going to load a rom group by deinterlacing rom pairs, but there"
                 "an odd number of roms in the group. Aborting.");
-        deleteBuffers(buffers);
-        delete[] destFile;
         return nullptr;
       }
 
@@ -473,10 +465,10 @@ VirtFile* MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string&
           auto firstBuf = entry.load_order == LoadOrder::REVERSE ? &buf2 : &buf1;
           auto secondBuf = entry.load_order == LoadOrder::REVERSE ? &buf1 : &buf2;
 
-          while (curDestOffset < destFileSize && curRomOffset < firstBuf->second &&
-                 curRomOffset < secondBuf->second) {
-            destFile[curDestOffset++] = firstBuf->first[curRomOffset];
-            destFile[curDestOffset++] = secondBuf->first[curRomOffset];
+          while (curDestOffset < destFileSize && curRomOffset < firstBuf->size() &&
+                 curRomOffset < secondBuf->size()) {
+            destFile[curDestOffset++] = (*firstBuf)[curRomOffset];
+            destFile[curDestOffset++] = (*secondBuf)[curRomOffset];
             curRomOffset++;
           }
           curRomOffset = 0;  // Reset for the next pair
@@ -485,8 +477,6 @@ VirtFile* MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string&
       break;
     }
   }
-  deleteBuffers(buffers);
-
   // If an encryption type is defined, decrypt the data
   if (!entry.encryption.empty()) {
     if (entry.encryption == "kabuki") {
@@ -495,37 +485,28 @@ VirtFile* MAMELoader::loadRomGroup(const MAMERomGroup& entry, const std::string&
           !entry.getHexAttribute("kabuki_swap_key2", &swap_key2) ||
           !entry.getHexAttribute("kabuki_addr_key", &addr_key) ||
           !entry.getHexAttribute("kabuki_xor_key", &xor_key)) {
-        delete[] destFile;
         return nullptr;
       }
-      u8* decrypt = new u8[0x8000];
-      KabukiDecrypter::kabuki_decode(destFile, decrypt, destFile, 0x0000, 0x8000, swap_key1,
+      std::vector<u8> decrypt(0x8000);
+      KabukiDecrypter::kabuki_decode(destFile.data(), decrypt.data(), destFile.data(), 0x0000, 0x8000, swap_key1,
                                      swap_key2, addr_key, xor_key);
-      delete[] decrypt;
     } else if (entry.encryption == "cps3") {
       u32 key1, key2;
       if (!entry.getHexAttribute("key1", &key1) ||
           !entry.getHexAttribute("key2", &key2)) {
-        delete[] destFile;
         return nullptr;
       }
 
       if (key1 != 0 && key2 != 0) {
-        CPS3Decrypt::cps3_decode(reinterpret_cast<u32*>(destFile),
-                                 reinterpret_cast<u32*>(destFile), key1, key2, destFileSize);
+        CPS3Decrypt::cps3_decode(reinterpret_cast<u32*>(destFile.data()),
+                                 reinterpret_cast<u32*>(destFile.data()), key1, key2, destFileSize);
       }
     }
   }
 
-  VirtFile* newVirtFile = new VirtFile(destFile, destFileSize, fmt::format("romgroup - {}", entry.type.c_str()));
+  auto newVirtFile = std::make_unique<VirtFile>(destFile.data(), destFileSize,
+                                                fmt::format("romgroup - {}", entry.type.c_str()));
   newVirtFile->setUseLoaders(false);
   newVirtFile->setUseScanners(false);
-  delete[] destFile;
   return newVirtFile;
-}
-
-void MAMELoader::deleteBuffers(const std::list<std::pair<u8*, u32>>& buffers) {
-  for (auto& buf : buffers) {
-    delete[] buf.first;
-  }
 }

--- a/src/main/loaders/MAMELoader.h
+++ b/src/main/loaders/MAMELoader.h
@@ -11,9 +11,11 @@
 #include <cassert>
 #include <list>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <unzip.h>
 
@@ -65,7 +67,7 @@ struct MAMEGame {
     std::list<MAMERomGroup> romgroupentries;
 };
 
-typedef std::map<std::string, MAMEGame *> GameMap;
+typedef std::map<std::string, std::unique_ptr<MAMEGame>> GameMap;
 
 class MAMELoader : public FileLoader {
    public:
@@ -74,10 +76,8 @@ class MAMELoader : public FileLoader {
     void apply(const RawFile *theFile) override;
 
    private:
-    static VirtFile *loadRomGroup(const MAMERomGroup &romgroup, const std::string &format,
-                                  const unzFile &cur_file);
-    static void deleteBuffers(const std::list<std::pair<u8 *, u32>> &buffers);
-
+    static std::unique_ptr<VirtFile> loadRomGroup(const MAMERomGroup &romgroup, const std::string &format,
+                                                  const unzFile &cur_file);
     bool loadJSON();
 
     GameMap gamemap;

--- a/src/main/loaders/PSF2Loader.cpp
+++ b/src/main/loaders/PSF2Loader.cpp
@@ -10,6 +10,9 @@
 #include "components/PSFFile.h"
 #include "LogManager.h"
 
+#include <memory>
+#include <vector>
+
 #include <zlib.h>
 
 namespace vgmtrans::loaders {
@@ -38,27 +41,23 @@ int PSF2Loader::psf2_decompress_block(const RawFile *file, unsigned fileoffset,
                                       unsigned blocknumber, unsigned numblocks,
                                       unsigned char *decompressedblock, unsigned blocksize) {
   unsigned long destlen;
-  u8 *blocks = new u8[numblocks * 4];
+  std::vector<u8> blocks(numblocks * 4);
 
-  file->readBytes(fileoffset, numblocks * 4, blocks);
-  unsigned long current_block = get32lsb(blocks + (blocknumber * 4));
-  u8 *zblock = new u8[current_block];
+  file->readBytes(fileoffset, numblocks * 4, blocks.data());
+  unsigned long current_block = get32lsb(blocks.data() + (blocknumber * 4));
+  std::vector<u8> zblock(current_block);
 
   int tempOffset = fileoffset + numblocks * 4;
   for (u32 i = 0; i < blocknumber; i++)
-    tempOffset += get32lsb(blocks + (i * 4));
-  file->readBytes(tempOffset, current_block, zblock);
+    tempOffset += get32lsb(blocks.data() + (i * 4));
+  file->readBytes(tempOffset, current_block, zblock.data());
 
   destlen = blocksize;
-  if (uncompress(decompressedblock, &destlen, zblock, current_block) != Z_OK) {
+  if (uncompress(decompressedblock, &destlen, zblock.data(), current_block) != Z_OK) {
     L_ERROR("Decompression failed");
-    delete[] zblock;
-    delete[] blocks;
     return -1;
   }
 
-  delete[] zblock;
-  delete[] blocks;
   return 0;
 }
 
@@ -88,34 +87,30 @@ int PSF2Loader::psf2unpack(const RawFile *file, unsigned long fileoffset, unsign
     } else {
       u32 blockcount = ((filesize + buffersize) - 1) / buffersize;
 
-      u8 *newdataBuf = new u8[filesize];
       u32 actualFileSize = filesize;
+      std::vector<u8> newdataBuf(actualFileSize);
       u32 k = 0;
 
-      u8 *dblock = new u8[buffersize];
+      std::vector<u8> dblock(buffersize);
 
       for (u32 j = 0; j < blockcount; j++) {
-        r = psf2_decompress_block(file, offset + 0x10, j, blockcount, dblock, buffersize);
+        r = psf2_decompress_block(file, offset + 0x10, j, blockcount, dblock.data(), buffersize);
 
         if (r) {
           //string.Format("File %s failed to decompress",filename);
-          delete[] dblock;
-          delete[] newdataBuf;
           return -1;
         }
         if (filesize > buffersize) {
           filesize -= buffersize;
-          memcpy(newdataBuf + k, dblock, buffersize);
+          memcpy(newdataBuf.data() + k, dblock.data(), buffersize);
           k += buffersize;
         } else {
-          memcpy(newdataBuf + k, dblock, filesize);
+          memcpy(newdataBuf.data() + k, dblock.data(), filesize);
           k += filesize;
         }
       }
 
-      enqueue(new VirtFile(newdataBuf, actualFileSize, filename, file->path()));
-      delete[] dblock;
-      delete[] newdataBuf;
+      enqueue(std::make_unique<VirtFile>(newdataBuf.data(), actualFileSize, filename, file->path()));
     }
   }
 

--- a/src/main/loaders/PSFLoader.cpp
+++ b/src/main/loaders/PSFLoader.cpp
@@ -12,6 +12,7 @@
 #include "PSFFile.h"
 
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <unordered_map>
 #include <vector>
@@ -143,8 +144,7 @@ void PSFLoader::psf_read_exe(const RawFile *file) {
     load_with_libs(psf, file->path().parent_path(), img);
     if (!img.data.empty()) {
       auto tag = PSFFile::tagFromPSFFile(psf);
-      auto virt = new VirtFile(img.data.data(), img.data.size(), file->name(), file->path(), tag);
-      enqueue(virt);
+      enqueue(std::make_unique<VirtFile>(img.data.data(), img.data.size(), file->name(), file->path(), tag));
     }
   } catch (std::exception &e) {
     L_ERROR(e.what());

--- a/src/main/loaders/RSNLoader.cpp
+++ b/src/main/loaders/RSNLoader.cpp
@@ -11,6 +11,9 @@
 #include "LoaderManager.h"
 #include "LogManager.h"
 
+#include <memory>
+#include <vector>
+
 #include "unarr.h"
 
 namespace vgmtrans::loaders {
@@ -48,17 +51,14 @@ void RSNLoader::apply(const RawFile *file) {
     } else {
       continue;
     }
-    auto buffer = new u8[size];
-    if (!ar_entry_uncompress(ar, buffer, size)) {
+    std::vector<u8> buffer(size);
+    if (!ar_entry_uncompress(ar, buffer.data(), size)) {
       L_ERROR("Error decompressing file from rar archive: {}", raw_filename);
-      delete[] buffer;
       ar_close_archive(ar);
       ar_close(stream);
       return;
     }
-    auto virtFile = new VirtFile(buffer, static_cast<u32>(size), raw_filename, "", file->tag);
-    enqueue(virtFile);
-    delete[] buffer;
+    enqueue(std::make_unique<VirtFile>(buffer.data(), static_cast<u32>(size), raw_filename, "", file->tag));
   }
   ar_close_archive(ar);
   ar_close(stream);

--- a/src/main/loaders/SPC2Loader.cpp
+++ b/src/main/loaders/SPC2Loader.cpp
@@ -10,7 +10,9 @@
 #include "LoaderManager.h"
 #include "LogManager.h"
 
+#include <array>
 #include <cstring>
+#include <memory>
 #include <string>
 
 // SPC2 file specs available here: http://blog.kevtris.org/blogfiles/spc2_file_specification_v1.txt
@@ -58,8 +60,7 @@ void SPC2Loader::apply(const RawFile* file) {
     file->readBytes(spcBlockOffset, SPC_DATA_BLOCK_SIZE, spcDataBlock);
 
     // Reconstruct the SPC file's RAM
-    auto* spcFile = new u8[SPC_FILE_SIZE];
-    memset(spcFile, 0, SPC_FILE_SIZE);
+    std::array<u8, SPC_FILE_SIZE> spcFile{};
 
     // Extract spc file name
     // Find the length of the string up to the first null byte or 28 characters, whichever comes
@@ -71,13 +72,13 @@ void SPC2Loader::apply(const RawFile* file) {
 
     // Construct SPC file header
     const char* headerTitle = "SNES-SPC700 Sound File Data v0.30\x1A\x1A";
-    std::memcpy(spcFile, headerTitle, std::strlen(headerTitle));  // Copy header title
+    std::memcpy(spcFile.data(), headerTitle, std::strlen(headerTitle));  // Copy header title
 
     // Copy SPC700 registers from SPC2 file to SPC header
-    std::memcpy(spcFile + 0x25, spcDataBlock + 704, 9);  // Copy PC, A, X, Y, PSW, SP
+    std::memcpy(spcFile.data() + 0x25, spcDataBlock + 704, 9);  // Copy PC, A, X, Y, PSW, SP
 
     // Copy the id666 tags
-    std::memcpy(spcFile + 0x2E, spcDataBlock + 768, 224);
+    std::memcpy(spcFile.data() + 0x2E, spcDataBlock + 768, 224);
 
     // Reconstruct the SPC file's RAM
     for (int j = 0; j < 256; ++j) {
@@ -85,14 +86,13 @@ void SPC2Loader::apply(const RawFile* file) {
       u8 ramBlock[RAM_BLOCK_SIZE];
       size_t ramBlockOffset = 16 + (numSPCs * SPC_DATA_BLOCK_SIZE) + (blockIndex * RAM_BLOCK_SIZE);
       file->readBytes(ramBlockOffset, RAM_BLOCK_SIZE, ramBlock);
-      std::copy_n(ramBlock, RAM_BLOCK_SIZE, spcFile + SPC_HEADER_SIZE + (j * RAM_BLOCK_SIZE));
+      std::copy_n(ramBlock, RAM_BLOCK_SIZE, spcFile.data() + SPC_HEADER_SIZE + (j * RAM_BLOCK_SIZE));
     }
 
     // Add DSP Registers
-    std::copy(spcDataBlock + 512, spcDataBlock + 640, spcFile + SPC_HEADER_SIZE + SPC_RAM_SIZE);
+    std::copy(spcDataBlock + 512, spcDataBlock + 640, spcFile.data() + SPC_HEADER_SIZE + SPC_RAM_SIZE);
 
     // Save the reconstructed SPC file
-    auto virtFile = new VirtFile(spcFile, SPC_FILE_SIZE, originalSpcFilename, "", file->tag);
-    enqueue(virtFile);
+    enqueue(std::make_unique<VirtFile>(spcFile.data(), SPC_FILE_SIZE, originalSpcFilename, "", file->tag));
   }
 }

--- a/src/main/loaders/SPCLoader.cpp
+++ b/src/main/loaders/SPCLoader.cpp
@@ -10,6 +10,8 @@
 #include "LogManager.h"
 #include "SPCFile.h"
 
+#include <memory>
+
 namespace vgmtrans::loaders {
 LoaderRegistration<SPCLoader> _spc{"SPC"};
 }
@@ -29,8 +31,7 @@ void SPCLoader::apply(const RawFile *file) {
 
     auto tag = SPCFile::tagFromSPCFile(spc);
     std::string name = fmt::format("{} - ram", file->name());
-    auto newfile = new VirtFile(spc.ram().data(), spc.ram().size(), name, file->path(), tag);
-    enqueue(newfile);
+    enqueue(std::make_unique<VirtFile>(spc.ram().data(), spc.ram().size(), name, file->path(), tag));
   } catch (const std::exception& e) {
     L_ERROR(e.what());
   }

--- a/src/main/util/BytePattern.cpp
+++ b/src/main/util/BytePattern.cpp
@@ -14,65 +14,69 @@
 #include <memory>
 
 BytePattern::BytePattern() :
-    ptn_str(NULL),
-    ptn_mask(NULL),
     ptn_len(0) {
 }
 
 BytePattern::BytePattern(const char *pattern, size_t length) :
-    ptn_str(NULL),
-    ptn_mask(NULL),
     ptn_len(length) {
   if (length != 0) {
     if (pattern != NULL) {
-      ptn_str = new char[length];
-      memcpy(ptn_str, pattern, length);
+      ptn_str = std::make_unique<char[]>(length);
+      memcpy(ptn_str.get(), pattern, length);
     }
   }
 }
 
 BytePattern::BytePattern(const char *pattern, const char *mask, size_t length) :
-    ptn_str(NULL),
-    ptn_mask(NULL),
     ptn_len(length) {
   if (length != 0) {
     if (pattern != NULL) {
-      ptn_str = new char[length];
-      memcpy(ptn_str, pattern, length);
+      ptn_str = std::make_unique<char[]>(length);
+      memcpy(ptn_str.get(), pattern, length);
 
       if (mask != NULL) {
         assert(strlen(mask) == length);
 
-        ptn_mask = new char[length];
-        memcpy(ptn_mask, mask, length);
+        ptn_mask = std::make_unique<char[]>(length);
+        memcpy(ptn_mask.get(), mask, length);
       }
     }
   }
 }
 
 BytePattern::BytePattern(const BytePattern &obj) :
-    ptn_str(NULL),
-    ptn_mask(NULL),
     ptn_len(obj.ptn_len) {
   if (obj.ptn_str != NULL) {
-    ptn_str = new char[ptn_len];
-    memcpy(ptn_str, obj.ptn_str, ptn_len);
+    ptn_str = std::make_unique<char[]>(ptn_len);
+    memcpy(ptn_str.get(), obj.ptn_str.get(), ptn_len);
   }
 
   if (obj.ptn_mask != NULL) {
-    ptn_mask = new char[ptn_len];
-    memcpy(ptn_mask, obj.ptn_mask, ptn_len);
+    ptn_mask = std::make_unique<char[]>(ptn_len);
+    memcpy(ptn_mask.get(), obj.ptn_mask.get(), ptn_len);
   }
 }
 
-BytePattern::~BytePattern() {
-  if (ptn_str != NULL) {
-    delete[] ptn_str;
+BytePattern& BytePattern::operator=(const BytePattern& obj) {
+  if (this == &obj) {
+    return *this;
   }
 
-  if (ptn_mask != NULL) {
-    delete[] ptn_mask;
+  ptn_len = obj.ptn_len;
+  ptn_str.reset();
+  ptn_mask.reset();
+
+  if (obj.ptn_str != NULL) {
+    ptn_str = std::make_unique<char[]>(ptn_len);
+    memcpy(ptn_str.get(), obj.ptn_str.get(), ptn_len);
   }
+
+  if (obj.ptn_mask != NULL) {
+    ptn_mask = std::make_unique<char[]>(ptn_len);
+    memcpy(ptn_mask.get(), obj.ptn_mask.get(), ptn_len);
+  }
+
+  return *this;
 }
 
 bool BytePattern::match(const void *buf, size_t buf_len) const {

--- a/src/main/util/BytePattern.h
+++ b/src/main/util/BytePattern.h
@@ -4,10 +4,12 @@
 #pragma once
 #include "base/Types.h"
 
+#include <memory>
+
 class BytePattern {
  private:
   /** The pattern to scan for */
-  char *ptn_str;
+  std::unique_ptr<char[]> ptn_str;
 
   /**
    * A mask to ignore certain bytes in the pattern such as addresses.
@@ -16,7 +18,7 @@ class BytePattern {
    * Example: "xxx????xx" - The first 3 bytes are checked, then the next 4 are ignored,
    * then the last 2 are checked
    */
-  char *ptn_mask;
+  std::unique_ptr<char[]> ptn_mask;
 
   /** The length of ptn_str and ptn_mask (not including a terminating null for ptn_mask) */
   size_t ptn_len;
@@ -26,7 +28,10 @@ class BytePattern {
   BytePattern(const char *pattern, size_t length);
   BytePattern(const char *pattern, const char *mask, size_t length);
   BytePattern(const BytePattern &obj);
-  ~BytePattern();
+  BytePattern(BytePattern&& obj) noexcept = default;
+  BytePattern& operator=(const BytePattern& obj);
+  BytePattern& operator=(BytePattern&& obj) noexcept = default;
+  ~BytePattern() = default;
 
   bool match(const void *buf, size_t buf_len) const;
   bool search(const void *buf, size_t buf_len, size_t &match_offset, size_t search_offset = 0) const;

--- a/src/main/util/Helper.h
+++ b/src/main/util/Helper.h
@@ -8,34 +8,8 @@
 
 #include "base/Types.h"
 
-#include <list>
-#include <map>
 #include <string>
 #include <vector>
-
-template <class T>
-void deleteVect(std::vector<T *> &vect) {
-  for (auto p : vect) {
-    delete p;
-  }
-  vect.clear();
-}
-
-template <class T>
-void deleteList(std::list<T *> &list) {
-  for (auto p : list) {
-    delete p;
-  }
-  list.clear();
-}
-
-template <class T1, class T2>
-void deleteMap(std::map<T1, T2 *> &container) {
-  for (auto el : container) {
-    delete el.second;
-  }
-  container.clear();
-}
 
 template <class T>
 inline void pushTypeOnVect(std::vector<u8> &theVector, T unit) {

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -181,7 +181,7 @@ void ManualCollectionDialog::createCollection() {
     }
   }
 
-  if (coll->sampColls().empty() && coll->instrSets().front()->sampColl == nullptr) {
+  if (coll->sampColls().empty() && coll->instrSets().front()->sampColl() == nullptr) {
     pRoot->UI_toast("The created collection does not contain a sample collection. "
                     "The instrument bank will be silent.", ToastType::Warning);
   }

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -155,14 +155,14 @@ void ManualCollectionDialog::createCollection() {
   // Get the VGMColl class for the format of the chosen sequence
   auto coll = chosen_seq->format()->newCollection();
   coll->setName(m_name_field->text().toStdString());
-  coll->useSeq(chosen_seq);
+  coll->attachSeq(chosen_seq);
 
   for (int i = 0; i < m_instr_list->count(); i++) {
     auto item = m_instr_list->item(i);
     auto radio = qobject_cast<QCheckBox *>(m_instr_list->itemWidget(item));
     if (radio->checkState() == (Qt::Checked)) {
       auto chosen_set = static_cast<VGMInstrSet*>(item->data(Qt::UserRole).value<void*>());
-      coll->addInstrSet(chosen_set);
+      coll->attachInstrSet(chosen_set);
     }
   }
   if (coll->instrSets().empty()) {
@@ -177,7 +177,7 @@ void ManualCollectionDialog::createCollection() {
     auto radio = qobject_cast<QCheckBox *>(m_samp_list->itemWidget(item));
     if (radio->checkState() == (Qt::Checked)) {
       auto sampcoll = static_cast<VGMSampColl*>(item->data(Qt::UserRole).value<void*>());
-      coll->addSampColl(sampcoll);
+      coll->attachSampColl(sampcoll);
     }
   }
 

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -153,7 +153,7 @@ void ManualCollectionDialog::createCollection() {
   }
 
   // Get the VGMColl class for the format of the chosen sequence
-  auto coll = std::unique_ptr<VGMColl>(chosen_seq->format()->newCollection());
+  auto coll = chosen_seq->format()->newCollection();
   coll->setName(m_name_field->text().toStdString());
   coll->useSeq(chosen_seq);
 

--- a/src/ui/qt/SequencePlayer.cpp
+++ b/src/ui/qt/SequencePlayer.cpp
@@ -190,14 +190,13 @@ bool SequencePlayer::loadCollection(const VGMColl *coll, bool startPlaying) {
     return false;
   }
 
-  SF2File *sf2 = conversion::createSF2File(*coll);
+  auto sf2 = conversion::createSF2File(*coll);
   if (!sf2) {
     L_ERROR("Failed to play collection as a soundfont file could not be produced.");
     return false;
   }
 
   auto rawSF2 = sf2->saveToMem();
-  delete sf2;
   /* Deleted by MemFile::mem_close */
   auto sf2_data_blob = std::make_unique<MemFile::DataBlob>(MemFile::DataBlob{0, std::move(rawSF2)});
 
@@ -211,7 +210,7 @@ bool SequencePlayer::loadCollection(const VGMColl *coll, bool startPlaying) {
   }
   sf2_data_blob.release();
 
-  auto midi = std::unique_ptr<MidiFile>(seq->convertToMidi(coll));
+  auto midi = seq->convertToMidi(coll);
   if (!midi) {
     BASS_MIDI_FontFree(sf2_handle);
     L_ERROR("Failed to convert sequence to MIDI");

--- a/src/ui/qt/services/commands/SaveCommands.h
+++ b/src/ui/qt/services/commands/SaveCommands.h
@@ -174,7 +174,8 @@ public:
   SaveAsMidiCommand() : SaveCommand<VGMSeq, VGMFile>(false) {}
 
   void save(const std::filesystem::path& path, VGMSeq* seq) const override {
-    int numAssocColls = seq->assocColls.size();
+    const auto& assocColls = seq->assocColls();
+    int numAssocColls = static_cast<int>(assocColls.size());
     if (numAssocColls > 0) {
       if (numAssocColls > 1 && seq->format()->usesCollectionDataForSeqConversion()) {
         pRoot->UI_toast("This sequence format uses collection data as context for "
@@ -183,7 +184,7 @@ public:
           "on a collection directly.",
           ToastType::Info, 15000);
       }
-      seq->saveAsMidi(path, seq->assocColls[0]);
+      seq->saveAsMidi(path, assocColls[0]);
     } else {
       if (seq->format()->usesCollectionDataForSeqConversion()) {
         pRoot->UI_toast("This sequence format uses collection data as context for "

--- a/src/ui/qt/services/commands/StitchCommands.cpp
+++ b/src/ui/qt/services/commands/StitchCommands.cpp
@@ -25,7 +25,8 @@ void StitchSequencesCommand::executeItems(std::vector<VGMFile*> vgmfiles) const 
       continue;
     }
 
-    const VGMColl* coll = seq->assocColls.empty() ? nullptr : seq->assocColls.front();
+    const auto& assocColls = seq->assocColls();
+    const VGMColl* coll = assocColls.empty() ? nullptr : assocColls.front();
     if (!coll) {
       pRoot->UI_toast("Each selected sequence must be associated with a collection to stitch.",
                       ToastType::Error, 15000);

--- a/src/ui/qt/workarea/VGMCollListView.cpp
+++ b/src/ui/qt/workarea/VGMCollListView.cpp
@@ -544,11 +544,11 @@ void VGMCollListView::onVGMFileSelected(VGMFile* file, const QWidget* caller) {
   }
 
   auto *seq = dynamic_cast<VGMSeq *>(file);
-  if (!seq || seq->assocColls.empty()) {
+  if (!seq || !seq->hasAssocColls()) {
     return;
   }
 
-  VGMColl *coll = seq->assocColls.front();
+  VGMColl *coll = seq->assocColls().front();
   const auto& colls = qtVGMRoot.vgmColls();
   auto it = std::find(colls.begin(), colls.end(), coll);
   if (it == colls.end()) {

--- a/src/ui/qt/workarea/VGMFileView.cpp
+++ b/src/ui/qt/workarea/VGMFileView.cpp
@@ -181,8 +181,8 @@ void VGMFileView::seekToEvent(VGMItem* item) const {
   if (!event || !event->parentTrack || !event->parentTrack->parentSeq) {
     return;
   }
-  if (!m_vgmfile->assocColls.empty()) {
-    auto assocColl = m_vgmfile->assocColls.front();
+  if (m_vgmfile->hasAssocColls()) {
+    auto assocColl = m_vgmfile->assocColls().front();
     if (SequencePlayer::the().activeCollection() != assocColl) {
       auto& seqPlayer = SequencePlayer::the();
       seqPlayer.setActiveCollection(assocColl);
@@ -209,15 +209,15 @@ void VGMFileView::ensureTrackIndexMap(VGMSeq* seq) {
     return;
   }
 
-  if (m_trackIndexSeq == seq && m_trackIndexByPtr.size() == seq->aTracks.size()) {
+  if (m_trackIndexSeq == seq && m_trackIndexByPtr.size() == seq->trackCount()) {
     return;
   }
 
   m_trackIndexSeq = seq;
   m_trackIndexByPtr.clear();
   m_trackIndexByMidiPtr.clear();
-  for (size_t i = 0; i < seq->aTracks.size(); ++i) {
-    auto* track = seq->aTracks[i];
+  for (size_t i = 0; i < seq->trackCount(); ++i) {
+    auto* track = seq->track(i);
     if (!track) {
       continue;
     }

--- a/src/ui/shell/commands.cpp
+++ b/src/ui/shell/commands.cpp
@@ -381,8 +381,8 @@ void instrumentset_info(const std::vector<std::string>& args) {
   fmt::print("Name: {}\nFormat: {}\nOffset: 0x{:x}\nLength: 0x{:x}\n", instrSet->name(),
              instrSet->formatName(), instrSet->startOffset(), instrSet->size());
   fmt::println("Instruments:");
-  for (size_t i = 0; i < instrSet->aInstrs.size(); ++i) {
-    VGMInstr* instr = instrSet->aInstrs[i];
+  for (size_t i = 0; i < instrSet->instrCount(); ++i) {
+    VGMInstr* instr = instrSet->instr(i);
     fmt::print("  Instr #{}: Bank {} Num {} - {}\n", i, instr->bank, instr->instrNum,
                instr->name());
   }
@@ -401,8 +401,8 @@ void instrumentset_inspect(const std::vector<std::string>& args) {
 
   try {
     int instrIdx = std::stoi(args[3]);
-    if (instrIdx >= 0 && static_cast<size_t>(instrIdx) < instrSet->aInstrs.size()) {
-      VGMInstr* instr = instrSet->aInstrs[instrIdx];
+    if (instrIdx >= 0 && static_cast<size_t>(instrIdx) < instrSet->instrCount()) {
+      VGMInstr* instr = instrSet->instr(static_cast<size_t>(instrIdx));
       fmt::println("Regions for Instrument #{}:", instrIdx);
       const auto& regions = instr->regions();
       for (size_t i = 0; i < regions.size(); ++i) {
@@ -473,9 +473,9 @@ void samplecollection_info(const std::vector<std::string>& args) {
 
   fmt::print("Name: {}\nFormat: {}\nOffset: 0x{:x}\nLength: 0x{:x}\n", sampColl->name(),
              sampColl->formatName(), sampColl->startOffset(), sampColl->size());
-  fmt::println("Samples ({}):", sampColl->samples.size());
-  for (size_t i = 0; i < sampColl->samples.size(); ++i) {
-    VGMSamp* samp = sampColl->samples[i];
+  fmt::println("Samples ({}):", sampColl->sampleCount());
+  for (size_t i = 0; i < sampColl->sampleCount(); ++i) {
+    VGMSamp* samp = sampColl->sample(i);
     fmt::print("  [{}] Def [{}:{}] Data [{}:{}] {} ({} Hz)\n",
                fmt::styled(fmt::format("#{}", i), fmt::fg(fmt::color::cyan)),
                fmt::styled(fmt::format("0x{:x}", samp->offset()), fmt::fg(fmt::color::yellow)),
@@ -499,8 +499,8 @@ void samplecollection_inspect(const std::vector<std::string>& args) {
 
   try {
     int sampIdx = std::stoi(args[3]);
-    if (sampIdx >= 0 && static_cast<size_t>(sampIdx) < sampColl->samples.size()) {
-      VGMSamp* samp = sampColl->samples[sampIdx];
+    if (sampIdx >= 0 && static_cast<size_t>(sampIdx) < sampColl->sampleCount()) {
+      VGMSamp* samp = sampColl->sample(sampIdx);
       fmt::print("{}\n",
                  fmt::styled(fmt::format("Sample #{} Information:", sampIdx), fmt::emphasis::bold));
       fmt::print("  {:<12} {}\n", "Name:", samp->name());
@@ -555,7 +555,7 @@ void samplecollection_export(const std::vector<std::string>& args) {
     std::filesystem::create_directories(dir);
   }
 
-  fmt::println("Exporting {} samples to {}...", sampColl->samples.size(), dir.string());
+  fmt::println("Exporting {} samples to {}...", sampColl->sampleCount(), dir.string());
   conversion::saveAllAsWav(*sampColl, dir);
 }
 
@@ -572,11 +572,11 @@ void samplecollection_dump(const std::vector<std::string>& args) {
 
   try {
     int sampIdx = std::stoi(args[3]);
-    if (sampIdx < 0 || static_cast<size_t>(sampIdx) >= sampColl->samples.size()) {
+    if (sampIdx < 0 || static_cast<size_t>(sampIdx) >= sampColl->sampleCount()) {
       fmt::println("Sample index out of bounds");
       return;
     }
-    VGMSamp* samp = sampColl->samples[sampIdx];
+    VGMSamp* samp = sampColl->sample(sampIdx);
     const char* rawData = samp->rawFile()->data();
     writeToFile(args[4], rawData + samp->dataOff, samp->dataLength);
   } catch (...) {
@@ -601,8 +601,8 @@ void sequence_events(const std::vector<std::string>& args) {
 
   try {
     int trackIdx = std::stoi(args[3]);
-    if (trackIdx >= 0 && static_cast<size_t>(trackIdx) < seq->aTracks.size()) {
-      SeqTrack* track = seq->aTracks[trackIdx];
+    if (trackIdx >= 0 && static_cast<size_t>(trackIdx) < seq->trackCount()) {
+      SeqTrack* track = seq->track(static_cast<size_t>(trackIdx));
       fmt::println("Events for Track {}:", trackIdx);
       printChildren(track);
     } else {


### PR DESCRIPTION
## Summary

This PR attempts to migrate our pointer usage toward something resembling modern practices. Objects are now held with std::unique_ptr, while raw pointers are kept only as non-owning references.

The goal is to make lifetime rules easier to understand and safer to maintain. Most of the changes are mechanical updates across scanners, matchers, sequence/instrument/sample loaders, and export code to use the new ownership APIs.

@sykhro I'm curious to get your take on this approach. If you have a different vision for how to refactor the code, don't hesitate to share. We can scrap this PR and/or plan on another refactor down the road.

## What Changed

VGMRoot is now the central owner and registrar for loaded raw files, VGMFiles, and collections. Scanners and Matchers now hand newly created files and collections to Root through smart-pointer based APIs.

load() methods now focus on parsing and validation. They no longer register themselves globally as a side effect - that is instead handled by Root. This makes loading easier to reason about: construct, load, then let Root adopt/register the object.

Public raw-pointer containers are now private and exposed through read-only accessors.

New builder/adoption patterns were added:

- add*() creates and owns a child object in one step.
- adopt*() accepts an already-created unique_ptr.
- attach*() associates an existing object without taking ownership (like with VGMColl).
- raw pointers returned from these APIs are non-owning references for immediate use.

Synth, SoundFont, DLS, RIFF, and MIDI objects now use std::unique_ptr instead of manual deletion.

Format factories now return std::unique_ptr for scanners, matchers, and collections, removing another ownership handoff through raw pointers.

Several old raw-pointer helper patterns were removed, including obsolete vector/list/map deletion helpers.

## New Pattern

Code should no longer create owned objects with `new` and pass raw pointers around expecting another object to delete them later.

The preferred pattern is now:

```
auto* seq = pRoot->loadVGMFile<MySeq>(file, offset);
auto* region = instr->addRgn<MyRegion>(instr, offset, length);
auto* event = midiTrack->addEvent<NoteEvent>(...);
```

The caller can use the returned pointer, but it does not own it. Ownership lives in the parent object or in VGMRoot.

When ownership is transferred explicitly, the API takes a std::unique_ptr:

```
pRoot->loadVGMFile(std::move(file));
pRoot->loadVGMColl(std::move(coll));
parent.adoptChild(std::move(child));
```

Raw pointers still exist where they represent non-owning relationships, such as links between formats, UI selections, parent references, Qt-owned objects, and temporary views into owned containers.

## How Has This Been Tested?
- Tested loading and playback of each format
- Tested that SF2/MIDI export is working
- Tested the collection stitcher
- ~~I plan to test for memory leaks using Xcode Instruments~~
- ran ASan and loaded a files across (virtually) all formats. Also ran macOS leaks test, since LSan apparently doesn't work on macOS. Detected a leak in SonyPS2Scanner and fixed it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
