### PR TITLE
Use span over vector for public API, rename Format::new*() methods to create*()

### DIFF
--- a/src/main/Root.h
+++ b/src/main/Root.h
@@ -11,6 +11,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <span>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -130,9 +131,9 @@ public:
   virtual std::filesystem::path UI_openFolder(const std::filesystem::path& suggestedPath,
                                               std::string_view reason) { return {}; }
 
-  const std::vector<RawFile*>& rawFiles() { return m_rawfiles; }
+  std::span<RawFile* const> rawFiles() const { return m_rawfiles; }
   const std::vector<VGMFileVariant>& vgmFiles() { return m_vgmfiles; }
-  const std::vector<VGMColl*>& vgmColls() { return m_vgmcolls; }
+  std::span<VGMColl* const> vgmColls() const { return m_vgmcolls; }
 
 private:
   int rawFileLoadRecurseStack = 0;

--- a/src/main/components/VGMColl.h
+++ b/src/main/components/VGMColl.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <span>
 #include <string>
 #include <vector>
 
@@ -36,9 +37,9 @@ class VGMColl {
 
   bool containsVGMFile(const VGMFile*) const;
 
-  const std::vector<VGMInstrSet*>& instrSets() const { return m_instrsets; }
-  const std::vector<VGMSampColl*>& sampColls() const { return m_sampcolls; }
-  const std::vector<VGMMiscFile*>& miscFiles() const { return m_miscfiles; }
+  std::span<VGMInstrSet* const> instrSets() const { return m_instrsets; }
+  std::span<VGMSampColl* const> sampColls() const { return m_sampcolls; }
+  std::span<VGMMiscFile* const> miscFiles() const { return m_miscfiles; }
 
  private:
   std::vector<VGMInstrSet*> m_instrsets;

--- a/src/main/components/VGMFile.h
+++ b/src/main/components/VGMFile.h
@@ -10,6 +10,7 @@
 #include "VGMItem.h"
 
 #include <memory>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -50,7 +51,7 @@ public:
 
   void addCollAssoc(VGMColl *coll);
   void removeCollAssoc(VGMColl *coll);
-  [[nodiscard]] const std::vector<VGMColl*>& assocColls() const { return m_assocColls; }
+  [[nodiscard]] std::span<VGMColl* const> assocColls() const { return m_assocColls; }
   [[nodiscard]] bool hasAssocColls() const { return !m_assocColls.empty(); }
   [[nodiscard]] RawFile *rawFile() const;
 

--- a/src/main/components/VGMItem.h
+++ b/src/main/components/VGMItem.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -112,7 +113,7 @@ public:
   virtual std::string description() { return ""; }
   virtual void addToUI(VGMItem *parent, void *UI_specific);
 
-  [[nodiscard]] const std::vector<VGMItem*>& children() const { return m_children; }
+  [[nodiscard]] std::span<VGMItem* const> children() const { return m_children; }
   [[nodiscard]] u32 offset() const noexcept { return m_offset; }
   [[nodiscard]] u32 length() const noexcept { return m_length; }
   void setOffset(u32 offset);

--- a/src/main/components/VGMSampColl.h
+++ b/src/main/components/VGMSampColl.h
@@ -5,6 +5,7 @@
 #include "VGMSamp.h"
 
 #include <memory>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -41,7 +42,7 @@ class VGMSampColl : public VGMFile {
     return rawSamp;
   }
 
-  [[nodiscard]] const std::vector<VGMSamp*>& samples() const { return m_samples; }
+  [[nodiscard]] std::span<VGMSamp* const> samples() const { return m_samples; }
   [[nodiscard]] bool hasSamples() const { return !m_samples.empty(); }
   [[nodiscard]] size_t sampleCount() const { return m_samples.size(); }
   [[nodiscard]] VGMSamp* sample(size_t index) const { return m_samples.at(index); }

--- a/src/main/components/instr/VGMInstrSet.cpp
+++ b/src/main/components/instr/VGMInstrSet.cpp
@@ -134,7 +134,7 @@ void VGMInstrSet::cleanupAfterExport() {
   m_tempInstrs.clear();
 }
 
-const std::vector<VGMInstr*>& VGMInstrSet::exportInstrs() const {
+std::span<VGMInstr* const> VGMInstrSet::exportInstrs() const {
   return m_exportInstrs.empty() ? m_instrs : m_exportInstrs;
 }
 

--- a/src/main/components/instr/VGMInstrSet.h
+++ b/src/main/components/instr/VGMInstrSet.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -39,11 +40,11 @@ public:
   void prepareForExport(const VGMColl* coll);
   void cleanupAfterExport();
 
-  [[nodiscard]] const std::vector<VGMInstr*>& instrs() const { return m_instrs; }
+  [[nodiscard]] std::span<VGMInstr* const> instrs() const { return m_instrs; }
   [[nodiscard]] bool hasInstrs() const { return !m_instrs.empty(); }
   [[nodiscard]] size_t instrCount() const { return m_instrs.size(); }
   VGMInstr* instr(size_t index) const { return m_instrs.at(index); }
-  const std::vector<VGMInstr*>& exportInstrs() const;
+  std::span<VGMInstr* const> exportInstrs() const;
 
   VGMInstr *addInstr(u32 offset, u32 length, u32 bank, u32 instrNum,
                      const std::string &instrName = "");
@@ -99,8 +100,7 @@ public:
   VGMInstr& operator=(const VGMInstr& other) = delete;
   ~VGMInstr() override;
 
-  const std::vector<VGMRgn*>& regions() { return m_regions; }
-  const std::vector<VGMRgn*>& regions() const { return m_regions; }
+  std::span<VGMRgn* const> regions() const { return m_regions; }
 
   inline void setBank(u32 bankNum);
   inline void setInstrNum(u32 theInstrNum);

--- a/src/main/components/matcher/FilegroupMatcher.cpp
+++ b/src/main/components/matcher/FilegroupMatcher.cpp
@@ -135,7 +135,7 @@ void FilegroupMatcher::lookForMatch() {
   for (VGMSeq* seq : seqs) {
     const InstrAssoc& assoc = *assocIt;
 
-    auto coll = fmt->newCollection();
+    auto coll = fmt->createCollection();
     coll->setName(seq->name());
     coll->attachSeq(seq);
     coll->attachInstrSet(assoc.instrSet);

--- a/src/main/components/matcher/SimpleMatcher.h
+++ b/src/main/components/matcher/SimpleMatcher.h
@@ -48,7 +48,7 @@ protected:
     if (VGMInstrSet *matchingInstrSet = instrsets[id]) {
       if (bRequiresSampColl) {
         if (VGMSampColl *matchingSampColl = sampcolls[id]) {
-          auto coll = fmt->newCollection();
+          auto coll = fmt->createCollection();
           if (!coll)
             return false;
           coll->setName(seq->name());
@@ -60,7 +60,7 @@ protected:
           }
         }
       } else {
-        auto coll = fmt->newCollection();
+        auto coll = fmt->createCollection();
         if (!coll)
           return false;
         coll->setName(seq->name());
@@ -108,7 +108,7 @@ protected:
 
       if (bRequiresSampColl) {
         if (matchingSampColl) {
-          auto coll = fmt->newCollection();
+          auto coll = fmt->createCollection();
           if (!coll)
             return false;
           coll->setName(matchingSeq->name());
@@ -119,7 +119,7 @@ protected:
             return false;
         }
       } else {
-        auto coll = fmt->newCollection();
+        auto coll = fmt->createCollection();
         if (!coll)
           return false;
         coll->setName(matchingSeq->name());
@@ -166,7 +166,7 @@ protected:
         VGMSeq *matchingSeq = (*it2).second;
 
         if (matchingSeq && matchingInstrSet) {
-          auto coll = fmt->newCollection();
+          auto coll = fmt->createCollection();
           if (!coll)
             return false;
           coll->setName(matchingSeq->name());

--- a/src/main/components/seq/VGMSeq.h
+++ b/src/main/components/seq/VGMSeq.h
@@ -17,6 +17,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <span>
 #include <set>
 #include <string>
 #include <utility>
@@ -118,7 +119,7 @@ class VGMSeq : public VGMFile {
   void setInitialPitchBendRange(u16 cents) { m_initial_pitch_bend_range_cents = cents; }
 
   SeqEventTimeIndex& timedEventIndex() { return m_timedEvents; }
-  [[nodiscard]] const std::vector<SeqTrack*>& tracks() const { return m_tracks; }
+  [[nodiscard]] std::span<SeqTrack* const> tracks() const { return m_tracks; }
   [[nodiscard]] bool hasTracks() const { return !m_tracks.empty(); }
   [[nodiscard]] size_t trackCount() const { return m_tracks.size(); }
   SeqTrack* track(size_t index) const { return m_tracks.at(index); }

--- a/src/main/conversion/DLSConversion.cpp
+++ b/src/main/conversion/DLSConversion.cpp
@@ -56,8 +56,8 @@ bool createDLSFile(DLSFile& dls, const VGMColl& coll, const ConversionContext& c
 
 bool createDLSFile(
   DLSFile& dls,
-  const std::vector<VGMInstrSet*>& instrsets,
-  const std::vector<VGMSampColl*>& sampcolls,
+  std::span<VGMInstrSet* const> instrsets,
+  std::span<VGMSampColl* const> sampcolls,
   const VGMColl* coll,
   const ConversionContext& context
 ) {
@@ -76,8 +76,8 @@ bool createDLSFile(
 
 bool mainDLSCreation(
   DLSFile& dls,
-  const std::vector<VGMInstrSet*>& m_instrsets,
-  const std::vector<VGMSampColl*>& m_sampcolls,
+  std::span<VGMInstrSet* const> m_instrsets,
+  std::span<VGMSampColl* const> m_sampcolls,
   const ConversionContext& context
 ) {
   if (m_instrsets.empty()) {

--- a/src/main/conversion/DLSConversion.h
+++ b/src/main/conversion/DLSConversion.h
@@ -5,6 +5,7 @@
 */
 #pragma once
 
+#include <span>
 #include <vector>
 
 class DLSFile;
@@ -20,15 +21,15 @@ bool createDLSFile(DLSFile& dls, const VGMColl& coll);
 bool createDLSFile(DLSFile& dls, const VGMColl& coll, const ConversionContext& context);
 bool createDLSFile(
   DLSFile& dls,
-  const std::vector<VGMInstrSet*>& instrsets,
-  const std::vector<VGMSampColl*>& sampcolls,
+  std::span<VGMInstrSet* const> instrsets,
+  std::span<VGMSampColl* const> sampcolls,
   const VGMColl* coll,
   const ConversionContext& context
 );
 bool mainDLSCreation(
   DLSFile& dls,
-  const std::vector<VGMInstrSet*>& instrsets,
-  const std::vector<VGMSampColl*>& sampcolls,
+  std::span<VGMInstrSet* const> instrsets,
+  std::span<VGMSampColl* const> sampcolls,
   const ConversionContext& context
 );
 void unpackSampColl(DLSFile& dls, const VGMSampColl* sampColl, std::vector<VGMSamp*>& finalSamps);

--- a/src/main/conversion/MidiFile.h
+++ b/src/main/conversion/MidiFile.h
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <list>
 #include <memory>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -78,9 +79,9 @@ class MidiTrack {
   MidiEvent* sinkEvent(std::unique_ptr<MidiEvent>&& event);
   void prependEvents(std::vector<std::unique_ptr<MidiEvent>> events);
   std::vector<std::unique_ptr<MidiEvent>> releaseEvents();
-  [[nodiscard]] const std::vector<MidiEvent*>& events() const { return m_events; }
+  [[nodiscard]] std::span<MidiEvent* const> events() const { return m_events; }
   [[nodiscard]] bool hasEvents() const { return !m_events.empty(); }
-  [[nodiscard]] const std::vector<NoteEvent*>& previousDurNoteOffs() const { return m_prevDurNoteOffs; }
+  [[nodiscard]] std::span<NoteEvent* const> previousDurNoteOffs() const { return m_prevDurNoteOffs; }
 
   template <class EventType, class... Args>
   EventType* addEvent(Args&&... args) {
@@ -240,7 +241,7 @@ class MidiFile {
   MidiTrack* sinkTrack(std::unique_ptr<MidiTrack>&& track);
   std::vector<std::unique_ptr<MidiTrack>> releaseTracks();
   int getMidiTrackIndex(const MidiTrack *midiTrack);
-  [[nodiscard]] const std::vector<MidiTrack*>& tracks() const { return m_tracks; }
+  [[nodiscard]] std::span<MidiTrack* const> tracks() const { return m_tracks; }
   [[nodiscard]] size_t trackCount() const { return m_tracks.size(); }
   MidiTrack* track(size_t index) const { return m_tracks.at(index); }
   void setPPQN(u16 ppqn);

--- a/src/main/conversion/MidiMerge.cpp
+++ b/src/main/conversion/MidiMerge.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <numeric>
 #include <set>
+#include <span>
 #include <unordered_map>
 #include <utility>
 
@@ -186,8 +187,8 @@ bool applyBankOffsetToTrack(MidiTrack* track,
 
 class ExportPrepGuard {
 public:
-  ExportPrepGuard(std::vector<VGMInstrSet*> instrsets, const VGMColl* coll)
-      : m_instrsets(std::move(instrsets)) {
+  ExportPrepGuard(std::span<VGMInstrSet* const> instrsets, const VGMColl* coll)
+      : m_instrsets(instrsets.begin(), instrsets.end()) {
     for (VGMInstrSet* instrset : m_instrsets) {
       if (instrset) {
         instrset->prepareForExport(coll);
@@ -473,7 +474,7 @@ bool saveMergedSoundfont(const std::vector<MidiMergeEntry>& entries,
     processedColls.insert(coll);
 
     const auto instrsets = coll->instrSets();
-    const auto& sampcolls = coll->sampColls();
+    const auto sampcolls = coll->sampColls();
 
     if (instrsets.empty()) {
       L_ERROR("Collection has no instrument sets, so a merged SF2 cannot be produced.");

--- a/src/main/conversion/SF2Conversion.cpp
+++ b/src/main/conversion/SF2Conversion.cpp
@@ -32,8 +32,8 @@ std::unique_ptr<SF2File> createSF2File(const VGMColl& coll, const ConversionCont
 }
 
 std::unique_ptr<SF2File> createSF2File(
-  const std::vector<VGMInstrSet*>& instrsets,
-  const std::vector<VGMSampColl*>& sampcolls,
+  std::span<VGMInstrSet* const> instrsets,
+  std::span<VGMSampColl* const> sampcolls,
   const VGMColl* coll,
   const ConversionContext& context
 ) {
@@ -54,8 +54,8 @@ std::unique_ptr<SF2File> createSF2File(
 }
 
 std::unique_ptr<SynthFile> createSynthFile(
-  const std::vector<VGMInstrSet*>& m_instrsets,
-  const std::vector<VGMSampColl*>& m_sampcolls
+  std::span<VGMInstrSet* const> m_instrsets,
+  std::span<VGMSampColl* const> m_sampcolls
 ) {
   if (m_instrsets.empty()) {
     L_ERROR("No instrument sets available to create a SynthFile.");

--- a/src/main/conversion/SF2Conversion.h
+++ b/src/main/conversion/SF2Conversion.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <memory>
+#include <span>
 #include <vector>
 
 class SF2File;
@@ -21,14 +22,14 @@ namespace conversion {
 std::unique_ptr<SF2File> createSF2File(const VGMColl& coll);
 std::unique_ptr<SF2File> createSF2File(const VGMColl& coll, const ConversionContext& context);
 std::unique_ptr<SF2File> createSF2File(
-  const std::vector<VGMInstrSet*>& instrsets,
-  const std::vector<VGMSampColl*>& sampcolls,
+  std::span<VGMInstrSet* const> instrsets,
+  std::span<VGMSampColl* const> sampcolls,
   const VGMColl* coll,
   const ConversionContext& context
 );
 std::unique_ptr<SynthFile> createSynthFile(
-  const std::vector<VGMInstrSet*>& instrsets,
-  const std::vector<VGMSampColl*>& sampcolls
+  std::span<VGMInstrSet* const> instrsets,
+  std::span<VGMSampColl* const> sampcolls
 );
 void unpackSampColl(SynthFile &synthfile, const VGMSampColl *sampColl, std::vector<VGMSamp *> &finalSamps);
 

--- a/src/main/conversion/SynthFile.h
+++ b/src/main/conversion/SynthFile.h
@@ -5,6 +5,7 @@
 #include "RiffFile.h"
 
 #include <memory>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -39,8 +40,8 @@ class SynthFile {
   void sinkWave(std::unique_ptr<SynthWave>&& wave);
   std::vector<std::unique_ptr<SynthWave>> releaseWaves();
 
-  [[nodiscard]] const std::vector<SynthInstr*>& instrs() const { return m_instrObservers; }
-  [[nodiscard]] const std::vector<SynthWave*>& waves() const { return m_waveObservers; }
+  [[nodiscard]] std::span<SynthInstr* const> instrs() const { return m_instrObservers; }
+  [[nodiscard]] std::span<SynthWave* const> waves() const { return m_waveObservers; }
   [[nodiscard]] bool hasInstrs() const { return !m_instrObservers.empty(); }
   [[nodiscard]] bool hasWaves() const { return !m_waveObservers.empty(); }
   [[nodiscard]] size_t instrCount() const { return m_instrObservers.size(); }
@@ -64,7 +65,7 @@ class SynthInstr {
   SynthRgn *addRgn();
   SynthRgn *addRgn(const SynthRgn& rgn);
   void sinkRgn(std::unique_ptr<SynthRgn>&& rgn);
-  [[nodiscard]] const std::vector<SynthRgn*>& regions() const { return m_regionObservers; }
+  [[nodiscard]] std::span<SynthRgn* const> regions() const { return m_regionObservers; }
 
   void addModulator(const SynthModulator& modulator);
   void addModulator(ModSource source, ModDest destination, ModAmount amount);

--- a/src/main/conversion/VGMExport.cpp
+++ b/src/main/conversion/VGMExport.cpp
@@ -31,8 +31,10 @@ bool saveAsDLS(VGMInstrSet &set, const fs::path &filepath) {
   std::vector<VGMInstrSet*> instrsets;
   std::vector<VGMSampColl*> sampcolls;
   if (coll) {
-    instrsets = coll->instrSets();
-    sampcolls = coll->sampColls();
+    const auto collInstrSets = coll->instrSets();
+    const auto collSampColls = coll->sampColls();
+    instrsets.assign(collInstrSets.begin(), collInstrSets.end());
+    sampcolls.assign(collSampColls.begin(), collSampColls.end());
   } else {
     instrsets.emplace_back(&set);
   }
@@ -53,8 +55,10 @@ bool saveAsSF2(VGMInstrSet &set, const fs::path &filepath) {
   std::vector<VGMInstrSet*> instrsets;
   std::vector<VGMSampColl*> sampcolls;
   if (coll) {
-    instrsets = coll->instrSets();
-    sampcolls = coll->sampColls();
+    const auto collInstrSets = coll->instrSets();
+    const auto collSampColls = coll->sampColls();
+    instrsets.assign(collInstrSets.begin(), collInstrSets.end());
+    sampcolls.assign(collSampColls.begin(), collSampColls.end());
   } else {
     instrsets.emplace_back(&set);
   }

--- a/src/main/formats/Akao/AkaoMatcher.cpp
+++ b/src/main/formats/Akao/AkaoMatcher.cpp
@@ -156,7 +156,7 @@ bool AkaoMatcher::tryCreateCollection(int id) {
     }
 
     if (matchingSampColls.size() > 0) {
-      auto coll = fmt->newCollection();
+      auto coll = fmt->createCollection();
       if (!coll) return false;
 
       coll->setName(seq->name());

--- a/src/main/formats/Akao/AkaoScanner.cpp
+++ b/src/main/formats/Akao/AkaoScanner.cpp
@@ -39,7 +39,7 @@ void AkaoScanner::scan(RawFile* file, void* /*info*/) {
         continue;
       }
 
-      auto instrset = seq->newInstrSet();
+      auto instrset = seq->createInstrSet();
       if (!instrset)
         continue;
       pRoot->loadVGMFile(std::move(instrset));

--- a/src/main/formats/Akao/AkaoSeq.cpp
+++ b/src/main/formats/Akao/AkaoSeq.cpp
@@ -219,7 +219,7 @@ double AkaoSeq::getTempoInBPM(u16 tempo) const {
   }
 }
 
-std::unique_ptr<AkaoInstrSet> AkaoSeq::newInstrSet() const {
+std::unique_ptr<AkaoInstrSet> AkaoSeq::createInstrSet() const {
   if (version() >= AkaoPs1Version::VERSION_3_0) {
     u32 instrSetLen = 0;
     if (has_instrument_set_offset())

--- a/src/main/formats/Akao/AkaoSeq.h
+++ b/src/main/formats/Akao/AkaoSeq.h
@@ -161,7 +161,7 @@ class AkaoSeq final :
   [[nodiscard]] double getTempoInBPM(u16 tempo) const;
   [[nodiscard]] bool usesIndividualArts() const noexcept { return bUsesIndividualArts; }
 
-  [[nodiscard]] std::unique_ptr<AkaoInstrSet> newInstrSet() const;
+  [[nodiscard]] std::unique_ptr<AkaoInstrSet> createInstrSet() const;
 
   [[nodiscard]] static bool isPossibleAkaoSeq(const RawFile *file, u32 offset);
   [[nodiscard]] static AkaoPs1Version guessVersion(const RawFile *file, u32 offset);

--- a/src/main/formats/Format.cpp
+++ b/src/main/formats/Format.cpp
@@ -35,11 +35,11 @@ bool Format::onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMM
   return matcher->onNewFile(file);
 }
 
-std::unique_ptr<VGMColl> Format::newCollection() {
+std::unique_ptr<VGMColl> Format::createCollection() {
   return std::make_unique<VGMColl>();
 }
 
-std::unique_ptr<Matcher> Format::newMatcher() {
+std::unique_ptr<Matcher> Format::createMatcher() {
   return nullptr;
 }
 
@@ -51,7 +51,7 @@ bool Format::onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VG
 }
 
 bool Format::init() {
-  scanner = newScanner();
-  matcher = newMatcher();
+  scanner = createScanner();
+  matcher = createMatcher();
   return true;
 }

--- a/src/main/formats/Format.h
+++ b/src/main/formats/Format.h
@@ -34,16 +34,16 @@ class VGMScanner;
   ;
 
 #define USING_SCANNER(scanner) \
-  std::unique_ptr<VGMScanner> newScanner() override { return std::make_unique<scanner>(this); }
+  std::unique_ptr<VGMScanner> createScanner() override { return std::make_unique<scanner>(this); }
 
 #define USING_MATCHER(matcher) \
-  std::unique_ptr<Matcher> newMatcher() override { return std::make_unique<matcher>(this); }
+  std::unique_ptr<Matcher> createMatcher() override { return std::make_unique<matcher>(this); }
 
 #define USING_MATCHER_WITH_ARG(matcher, arg) \
-  std::unique_ptr<Matcher> newMatcher() override { return std::make_unique<matcher>(this, arg); }
+  std::unique_ptr<Matcher> createMatcher() override { return std::make_unique<matcher>(this, arg); }
 
 #define USING_COLL(coll) \
-  std::unique_ptr<VGMColl> newCollection() override { return std::make_unique<coll>(); }
+  std::unique_ptr<VGMColl> createCollection() override { return std::make_unique<coll>(); }
 
 #define USES_COLLECTION_FOR_SEQ_CONVERSION() \
   bool usesCollectionDataForSeqConversion() override { return true; }
@@ -67,10 +67,10 @@ public:
 
   virtual bool init();
   virtual const std::string &getName() = 0;
-  virtual std::unique_ptr<VGMScanner> newScanner() { return nullptr; }
+  virtual std::unique_ptr<VGMScanner> createScanner() { return nullptr; }
   VGMScanner &getScanner() const { return *scanner; }
-  virtual std::unique_ptr<Matcher> newMatcher();
-  virtual std::unique_ptr<VGMColl> newCollection();
+  virtual std::unique_ptr<Matcher> createMatcher();
+  virtual std::unique_ptr<VGMColl> createCollection();
   virtual bool onNewFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file);
   virtual bool onCloseFile(std::variant<VGMSeq *, VGMInstrSet *, VGMSampColl *, VGMMiscFile *> file);
   virtual bool onMatch(std::vector<VGMFile *> &) { return true; }

--- a/src/main/formats/NinSnes/NinSnesInstr.cpp
+++ b/src/main/formats/NinSnes/NinSnesInstr.cpp
@@ -12,6 +12,7 @@
 #include "VGMColl.h"
 
 #include <memory>
+#include <span>
 
 #include <spdlog/fmt/fmt.h>
 
@@ -40,7 +41,7 @@ void applyVibratoScaling(NinSnesInstrSet* instrSet, const VibratoModulationSpec&
   }
 }
 
-VGMInstr* findInstrByProgram(const std::vector<VGMInstr*>& instrs, u32 progNum) {
+VGMInstr* findInstrByProgram(std::span<VGMInstr* const> instrs, u32 progNum) {
   for (auto* instr : instrs) {
     if (getProgramNumber(instr) == progNum) {
       return instr;

--- a/src/main/formats/TriAcePS1/TriAcePS1Seq.h
+++ b/src/main/formats/TriAcePS1/TriAcePS1Seq.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -29,7 +30,7 @@ class TriAcePS1Seq:
   void resetVars() override;
 
   bool postLoad() override;
-  [[nodiscard]] const std::vector<TriAcePS1ScorePattern*>& scorePatterns() const {
+  [[nodiscard]] std::span<TriAcePS1ScorePattern* const> scorePatterns() const {
     return m_scorePatterns;
   }
 

--- a/src/ui/qt/ManualCollectionDialog.cpp
+++ b/src/ui/qt/ManualCollectionDialog.cpp
@@ -153,7 +153,7 @@ void ManualCollectionDialog::createCollection() {
   }
 
   // Get the VGMColl class for the format of the chosen sequence
-  auto coll = chosen_seq->format()->newCollection();
+  auto coll = chosen_seq->format()->createCollection();
   coll->setName(m_name_field->text().toStdString());
   coll->attachSeq(chosen_seq);
 

--- a/src/ui/qt/services/commands/GeneralCommands.h
+++ b/src/ui/qt/services/commands/GeneralCommands.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -29,7 +30,7 @@ public:
     m_items = f;
   }
 
-  [[nodiscard]] const std::vector<T*>& items() const { return *m_items; }
+  [[nodiscard]] std::span<T* const> items() const { return *m_items; }
 
 private:
   std::shared_ptr<std::vector<T*>> m_items{};
@@ -75,7 +76,7 @@ public:
 
   void execute(CommandContext& context) override {
     auto& vgmContext = dynamic_cast<ItemListCommandContext<T>&>(context);
-    const auto& items = vgmContext.items();
+    const auto items = vgmContext.items();
 
     executeItems(items);
   }
@@ -90,12 +91,12 @@ public:
       return false;
     }
 
-    const auto& items = dynamic_cast<ItemListCommandContext<T>&>(*context).items();
+    const auto items = dynamic_cast<ItemListCommandContext<T>&>(*context).items();
     return isEnabledForItems(items);
   }
 
-  virtual void executeItems(std::vector<T*> items) const = 0;
-  [[nodiscard]] virtual bool isEnabledForItems(const std::vector<T*>& items) const { return !items.empty(); }
+  virtual void executeItems(std::span<T* const> items) const = 0;
+  [[nodiscard]] virtual bool isEnabledForItems(std::span<T* const> items) const { return !items.empty(); }
 
 private:
   std::shared_ptr<ItemListContextFactory<T>> m_contextFactory;
@@ -108,7 +109,7 @@ private:
 template <typename T>
 class SingleItemCommand : public ItemListCommand<T> {
 public:
-  void executeItems(std::vector<T*> items) const override {
+  void executeItems(std::span<T* const> items) const override {
     T* item = items.front();
     this->executeItem(item);
   }
@@ -120,7 +121,7 @@ public:
  */
 class CloseVGMFileCommand : public ItemListCommand<VGMFile> {
 public:
-  void executeItems(std::vector<VGMFile*> vgmfiles) const override {
+  void executeItems(std::span<VGMFile* const> vgmfiles) const override {
     // If all files are selected, we can remove everything at once more efficiently
     if (vgmfiles.size() == pRoot->vgmFiles().size()) {
       pRoot->removeAllFilesAndCollections();
@@ -142,7 +143,7 @@ public:
  */
 class CloseRawFileCommand : public ItemListCommand<RawFile> {
 public:
-  void executeItems(std::vector<RawFile*> rawfiles) const override {
+  void executeItems(std::span<RawFile* const> rawfiles) const override {
     // If all files are selected, we can remove everything at once more efficiently
     if (rawfiles.size() == pRoot->rawFiles().size()) {
       pRoot->removeAllFilesAndCollections();
@@ -164,7 +165,7 @@ public:
  */
 class OpenCommand : public ItemListCommand<VGMFile> {
 public:
-  void executeItems(std::vector<VGMFile*> vgmfiles) const override {
+  void executeItems(std::span<VGMFile* const> vgmfiles) const override {
     for (auto vgmfile : vgmfiles) {
       MdiArea::the()->newView(vgmfile);
     }

--- a/src/ui/qt/services/commands/SaveCommands.h
+++ b/src/ui/qt/services/commands/SaveCommands.h
@@ -19,6 +19,7 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -41,7 +42,7 @@ public:
     m_path = p;
   }
 
-  [[nodiscard]] const std::vector<TSavable*>& items() const { return *m_items; }
+  [[nodiscard]] std::span<TSavable* const> items() const { return *m_items; }
   [[nodiscard]] const std::filesystem::path& path() const { return m_path; }
 
 private:
@@ -111,7 +112,7 @@ public:
 
   void execute(CommandContext& context) override {
     auto& vgmContext = dynamic_cast<SaveCommandContext<TInContext>&>(context);
-    const auto& files = vgmContext.items();
+    const auto files = vgmContext.items();
     const auto& path = vgmContext.path();
 
     if (alwaysSaveToDir) {
@@ -174,7 +175,7 @@ public:
   SaveAsMidiCommand() : SaveCommand<VGMSeq, VGMFile>(false) {}
 
   void save(const std::filesystem::path& path, VGMSeq* seq) const override {
-    const auto& assocColls = seq->assocColls();
+    const auto assocColls = seq->assocColls();
     int numAssocColls = static_cast<int>(assocColls.size());
     if (numAssocColls > 0) {
       if (numAssocColls > 1 && seq->format()->usesCollectionDataForSeqConversion()) {

--- a/src/ui/qt/services/commands/StitchCommands.cpp
+++ b/src/ui/qt/services/commands/StitchCommands.cpp
@@ -11,11 +11,12 @@
 #include "VGMSeq.h"
 #include "widgets/StitchUI.h"
 
+#include <span>
 #include <vector>
 
 #include <QApplication>
 
-void StitchSequencesCommand::executeItems(std::vector<VGMFile*> vgmfiles) const {
+void StitchSequencesCommand::executeItems(std::span<VGMFile* const> vgmfiles) const {
   std::vector<VGMColl*> collections;
   collections.reserve(vgmfiles.size());
 
@@ -25,7 +26,7 @@ void StitchSequencesCommand::executeItems(std::vector<VGMFile*> vgmfiles) const 
       continue;
     }
 
-    const auto& assocColls = seq->assocColls();
+    const auto assocColls = seq->assocColls();
     const VGMColl* coll = assocColls.empty() ? nullptr : assocColls.front();
     if (!coll) {
       pRoot->UI_toast("Each selected sequence must be associated with a collection to stitch.",
@@ -38,6 +39,6 @@ void StitchSequencesCommand::executeItems(std::vector<VGMFile*> vgmfiles) const 
   stitchui::openCollectionStitchBalloon(collections, QApplication::activeWindow());
 }
 
-void StitchCollectionsCommand::executeItems(std::vector<VGMColl*> vgmcolls) const {
+void StitchCollectionsCommand::executeItems(std::span<VGMColl* const> vgmcolls) const {
   stitchui::openCollectionStitchBalloon(vgmcolls, QApplication::activeWindow());
 }

--- a/src/ui/qt/services/commands/StitchCommands.h
+++ b/src/ui/qt/services/commands/StitchCommands.h
@@ -9,6 +9,7 @@
 #include "services/commands/GeneralCommands.h"
 
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -20,8 +21,8 @@ class QAbstractButton;
 
 class StitchSequencesCommand : public ItemListCommand<VGMFile> {
 public:
-  void executeItems(std::vector<VGMFile*> vgmfiles) const override;
-  [[nodiscard]] bool isEnabledForItems(const std::vector<VGMFile*>& vgmfiles) const override {
+  void executeItems(std::span<VGMFile* const> vgmfiles) const override;
+  [[nodiscard]] bool isEnabledForItems(std::span<VGMFile* const> vgmfiles) const override {
     return vgmfiles.size() >= 2;
   }
   [[nodiscard]] std::string name() const override { return "Stitch"; }
@@ -30,8 +31,8 @@ public:
 
 class StitchCollectionsCommand : public ItemListCommand<VGMColl> {
 public:
-  void executeItems(std::vector<VGMColl*> vgmcolls) const override;
-  [[nodiscard]] bool isEnabledForItems(const std::vector<VGMColl*>& vgmcolls) const override {
+  void executeItems(std::span<VGMColl* const> vgmcolls) const override;
+  [[nodiscard]] bool isEnabledForItems(std::span<VGMColl* const> vgmcolls) const override {
     return vgmcolls.size() >= 2;
   }
   [[nodiscard]] std::string name() const override { return "Stitch"; }

--- a/src/ui/qt/widgets/StitchUI.cpp
+++ b/src/ui/qt/widgets/StitchUI.cpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <functional>
+#include <span>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -60,7 +61,7 @@ constexpr int kBalloonMinWidth = 420;
 constexpr int kBalloonMinHeight = 320;
 constexpr int kAnchorVerticalGap = 6;
 
-std::vector<VGMColl*> dedupeCollections(const std::vector<VGMColl*>& collections) {
+std::vector<VGMColl*> dedupeCollections(std::span<VGMColl* const> collections) {
   std::vector<VGMColl*> deduped;
   deduped.reserve(collections.size());
   std::unordered_set<VGMColl*> seen;
@@ -82,7 +83,7 @@ bool collectionExists(VGMColl* coll) {
     return false;
   }
 
-  const auto& allCollections = qtVGMRoot.vgmColls();
+  const auto allCollections = qtVGMRoot.vgmColls();
   return std::find(allCollections.begin(), allCollections.end(), coll) != allCollections.end();
 }
 
@@ -699,7 +700,7 @@ StitchExportBalloon* ensureStitchExportBalloon(QWidget* owner) {
 
 namespace stitchui {
 
-void openCollectionStitchBalloon(const std::vector<VGMColl*>& initialCollections,
+void openCollectionStitchBalloon(std::span<VGMColl* const> initialCollections,
                                  QWidget* parent,
                                  QWidget* anchor,
                                  QAbstractButton* toggleButton) {
@@ -708,7 +709,7 @@ void openCollectionStitchBalloon(const std::vector<VGMColl*>& initialCollections
   balloon->openForCollections(dedupeCollections(initialCollections), anchor ? anchor : owner, toggleButton);
 }
 
-bool toggleCollectionStitchBalloon(const std::vector<VGMColl*>& initialCollections,
+bool toggleCollectionStitchBalloon(std::span<VGMColl* const> initialCollections,
                                    QWidget* parent,
                                    QWidget* anchor,
                                    QAbstractButton* toggleButton) {

--- a/src/ui/qt/widgets/StitchUI.h
+++ b/src/ui/qt/widgets/StitchUI.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <span>
 #include <vector>
 
 class QWidget;
@@ -13,11 +14,11 @@ class QAbstractButton;
 class VGMColl;
 
 namespace stitchui {
-void openCollectionStitchBalloon(const std::vector<VGMColl*>& initialCollections,
+void openCollectionStitchBalloon(std::span<VGMColl* const> initialCollections,
                                  QWidget* parent = nullptr,
                                  QWidget* anchor = nullptr,
                                  QAbstractButton* toggleButton = nullptr);
-[[nodiscard]] bool toggleCollectionStitchBalloon(const std::vector<VGMColl*>& initialCollections,
+[[nodiscard]] bool toggleCollectionStitchBalloon(std::span<VGMColl* const> initialCollections,
                                                  QWidget* parent = nullptr,
                                                  QWidget* anchor = nullptr,
                                                  QAbstractButton* toggleButton = nullptr);

--- a/src/ui/qt/workarea/hexview/HexView.cpp
+++ b/src/ui/qt/workarea/hexview/HexView.cpp
@@ -907,7 +907,7 @@ void HexView::rebuildStyleMap() {
   // Flatten the item tree to leaf items; leaf ranges represent final semantic regions.
   std::vector<VGMItem*> leaves;
   std::function<void(VGMItem*)> walk = [&](VGMItem* item) {
-    auto& children = item->children();
+    auto children = item->children();
     if (children.empty()) {
       leaves.push_back(item);
       return;


### PR DESCRIPTION
More cleanup:
- update public APIs to use span instead of vector where reasonable
- rename `Format::newScanner()`, `newMatcher()`, and `newCollection()` to `createScanner()`, `createMatcher()`, and `createCollection()`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
