### PR TITLE
Load track titles from GSF, 2SF, NCSF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,13 @@
 
 * **Sappy (mp2k):** Added support for missing commands (LFO, pitch bend range, transpose, etc.).
 * **Sappy (mp2k):** Added support for GBA PSG instruments and programmable wavetables.
+* **Sappy (mp2k):** When possible, track names from GSF files are used instead of the song table index.
 * **Sappy (mp2k):** Fixed sequences being exported 0.45% faster than they should be.
 * **Sappy (mp2k):** Fixed instruments potentially having very long release times.
 
 **Nintendo DS (SDAT)**
 
+* **2SF/NCSF:** When possible, track names from 2SF/NCSF is used instead of "NDS Seq" or internal track names.
 * **Instruments:** Improved accuracy of instrument ADSR.
 * **Instruments:** Fixed an issue where PSG instruments were exported too quiet (-4.6dB attenuated).
 * **Samples:** Fixed an issue where samples were being read with the wrong sample rate, resulting in instruments playing at the wrong pitch or seemingly being absent.

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -501,6 +501,7 @@ target_sources(vgmtranscore
       components/VGMColl.h
       components/VGMFile.h
       components/VGMItem.h
+      components/VGMMetadataHint.h
       components/VGMMiscFile.h
       components/VGMSampColl.h
       components/VGMTag.h

--- a/src/main/components/PSFFile.cpp
+++ b/src/main/components/PSFFile.cpp
@@ -10,17 +10,70 @@
 #include "io/RawFile.h"
 #include "util/Decompression.h"
 
+#include <cerrno>
+#include <optional>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
 constexpr auto PSF_TAG_SIG = "[TAG]";
 constexpr auto PSF_TAG_SIG_LEN = 5;
 
+namespace {
+
+std::optional<double> parsePsfLength(std::string_view value) {
+  double totalSeconds = 0.0;
+  size_t componentStart = 0;
+  size_t componentCount = 0;
+
+  while (componentStart <= value.size()) {
+    const size_t componentEnd = value.find(':', componentStart);
+    const auto component = value.substr(
+        componentStart,
+        componentEnd == std::string_view::npos ? std::string_view::npos
+                                               : componentEnd - componentStart);
+    if (component.empty()) {
+      return std::nullopt;
+    }
+
+    const std::string componentString(component);
+    char* parseEnd = nullptr;
+    errno = 0;
+    const double parsed = std::strtod(componentString.c_str(), &parseEnd);
+    if (errno == ERANGE || parseEnd != componentString.c_str() + componentString.size()) {
+      return std::nullopt;
+    }
+
+    totalSeconds = totalSeconds * 60.0 + parsed;
+    componentCount++;
+
+    if (componentEnd == std::string_view::npos) {
+      break;
+    }
+    componentStart = componentEnd + 1;
+  }
+
+  return componentCount > 0 ? std::optional<double>(totalSeconds) : std::nullopt;
+}
+
+}  // namespace
+
 VGMTag PSFFile::tagFromPSFFile(const PSFFile& psf) {
   auto& psfTags = psf.tags();
-  return VGMTag(
+  auto tag = VGMTag(
     psfTags.contains("title") ? psfTags.at("title") : "",
     psfTags.contains("artist") ? psfTags.at("artist") : "",
     psfTags.contains("game") ? psfTags.at("game") : "",
     psfTags.contains("comment") ? psfTags.at("comment") : ""
   );
+
+  if (auto it = psfTags.find("length"); it != psfTags.end()) {
+    if (auto length = parsePsfLength(it->second)) {
+      tag.length = *length;
+    }
+  }
+
+  return tag;
 }
 
 PSFFile::PSFFile(const RawFile &file) {

--- a/src/main/components/VGMMetadataHint.h
+++ b/src/main/components/VGMMetadataHint.h
@@ -15,24 +15,22 @@
 #include <utility>
 #include <vector>
 
-struct VGMMetadataHint {
+struct VGMMetadataHintTarget {
   std::string targetFormat;
-  std::string sourceFormat;
-  std::filesystem::path sourcePath;
-  VGMTag tag;
   std::optional<u32> songIndex;
   std::optional<u32> romAddress;
   std::optional<u32> fileOffset;
   std::optional<std::string> lookupKey;
 };
 
-struct VGMMetadataHintQuery {
-  std::string targetFormat;
-  std::optional<u32> songIndex;
-  std::optional<u32> romAddress;
-  std::optional<u32> fileOffset;
-  std::optional<std::string> lookupKey;
+struct VGMMetadataHint {
+  VGMMetadataHintTarget target;
+  std::string sourceFormat;
+  std::filesystem::path sourcePath;
+  VGMTag tag;
 };
+
+using VGMMetadataHintQuery = VGMMetadataHintTarget;
 
 class VGMMetadataHintProvider {
 public:
@@ -46,35 +44,33 @@ public:
 class IndexedMetadataHintProvider final : public VGMMetadataHintProvider {
 public:
   explicit IndexedMetadataHintProvider(std::vector<VGMMetadataHint> hints)
-      : m_hints(std::move(hints)) {
-    buildIndexes();
-  }
+      : m_hints(std::move(hints)), m_indexes(buildIndexes(m_hints)) {}
 
   [[nodiscard]] const VGMMetadataHint* findHint(
       const VGMMetadataHintQuery& query) const override {
     if (query.songIndex) {
-      if (const auto* hint = findIndexed(m_bySongIndex, query.targetFormat, *query.songIndex);
+      if (const auto* hint = findIndexed(m_indexes.bySongIndex, query.targetFormat, *query.songIndex);
           hint && matchesQuery(*hint, query)) {
         return hint;
       }
     }
 
     if (query.romAddress) {
-      if (const auto* hint = findIndexed(m_byRomAddress, query.targetFormat, *query.romAddress);
+      if (const auto* hint = findIndexed(m_indexes.byRomAddress, query.targetFormat, *query.romAddress);
           hint && matchesQuery(*hint, query)) {
         return hint;
       }
     }
 
     if (query.fileOffset) {
-      if (const auto* hint = findIndexed(m_byFileOffset, query.targetFormat, *query.fileOffset);
+      if (const auto* hint = findIndexed(m_indexes.byFileOffset, query.targetFormat, *query.fileOffset);
           hint && matchesQuery(*hint, query)) {
         return hint;
       }
     }
 
     if (query.lookupKey) {
-      if (const auto* hint = findIndexed(m_byLookupKey, query.targetFormat, *query.lookupKey);
+      if (const auto* hint = findIndexed(m_indexes.byLookupKey, query.targetFormat, *query.lookupKey);
           hint && matchesQuery(*hint, query)) {
         return hint;
       }
@@ -97,47 +93,53 @@ private:
   using Index = std::unordered_map<std::string, std::unordered_map<u32, size_t>>;
   using StringIndex = std::unordered_map<std::string, std::unordered_map<std::string, size_t>>;
 
-  std::vector<VGMMetadataHint> m_hints;
-  Index m_bySongIndex;
-  Index m_byRomAddress;
-  Index m_byFileOffset;
-  StringIndex m_byLookupKey;
+  struct Indexes {
+    Index bySongIndex;
+    Index byRomAddress;
+    Index byFileOffset;
+    StringIndex byLookupKey;
+  };
+
+  const std::vector<VGMMetadataHint> m_hints;
+  const Indexes m_indexes;
 
   static bool matchesQuery(const VGMMetadataHint& hint, const VGMMetadataHintQuery& query) {
-    if (!query.targetFormat.empty() && hint.targetFormat != query.targetFormat) {
+    if (!query.targetFormat.empty() && hint.target.targetFormat != query.targetFormat) {
       return false;
     }
-    if (query.songIndex && hint.songIndex != query.songIndex) {
+    if (query.songIndex && hint.target.songIndex != query.songIndex) {
       return false;
     }
-    if (query.romAddress && hint.romAddress != query.romAddress) {
+    if (query.romAddress && hint.target.romAddress != query.romAddress) {
       return false;
     }
-    if (query.fileOffset && hint.fileOffset != query.fileOffset) {
+    if (query.fileOffset && hint.target.fileOffset != query.fileOffset) {
       return false;
     }
-    if (query.lookupKey && hint.lookupKey != query.lookupKey) {
+    if (query.lookupKey && hint.target.lookupKey != query.lookupKey) {
       return false;
     }
     return true;
   }
 
-  void buildIndexes() {
-    for (size_t i = 0; i < m_hints.size(); i++) {
-      const auto& hint = m_hints[i];
-      if (hint.songIndex) {
-        m_bySongIndex[hint.targetFormat].try_emplace(*hint.songIndex, i);
+  static Indexes buildIndexes(const std::vector<VGMMetadataHint>& hints) {
+    Indexes indexes;
+    for (size_t i = 0; i < hints.size(); i++) {
+      const auto& hint = hints[i];
+      if (hint.target.songIndex) {
+        indexes.bySongIndex[hint.target.targetFormat].try_emplace(*hint.target.songIndex, i);
       }
-      if (hint.romAddress) {
-        m_byRomAddress[hint.targetFormat].try_emplace(*hint.romAddress, i);
+      if (hint.target.romAddress) {
+        indexes.byRomAddress[hint.target.targetFormat].try_emplace(*hint.target.romAddress, i);
       }
-      if (hint.fileOffset) {
-        m_byFileOffset[hint.targetFormat].try_emplace(*hint.fileOffset, i);
+      if (hint.target.fileOffset) {
+        indexes.byFileOffset[hint.target.targetFormat].try_emplace(*hint.target.fileOffset, i);
       }
-      if (hint.lookupKey) {
-        m_byLookupKey[hint.targetFormat].try_emplace(*hint.lookupKey, i);
+      if (hint.target.lookupKey) {
+        indexes.byLookupKey[hint.target.targetFormat].try_emplace(*hint.target.lookupKey, i);
       }
     }
+    return indexes;
   }
 
   [[nodiscard]] const VGMMetadataHint* findIndexed(

--- a/src/main/components/VGMMetadataHint.h
+++ b/src/main/components/VGMMetadataHint.h
@@ -16,18 +16,18 @@
 #include <vector>
 
 struct VGMMetadataHintTarget {
-  std::string targetFormat;
-  std::optional<u32> songIndex;
-  std::optional<u32> romAddress;
-  std::optional<u32> fileOffset;
-  std::optional<std::string> lookupKey;
+  std::string targetFormat{};
+  std::optional<u32> songIndex = std::nullopt;
+  std::optional<u32> romAddress = std::nullopt;
+  std::optional<u32> fileOffset = std::nullopt;
+  std::optional<std::string> lookupKey = std::nullopt;
 };
 
 struct VGMMetadataHint {
-  VGMMetadataHintTarget target;
-  std::string sourceFormat;
-  std::filesystem::path sourcePath;
-  VGMTag tag;
+  VGMMetadataHintTarget target{};
+  std::string sourceFormat{};
+  std::filesystem::path sourcePath{};
+  VGMTag tag{};
 };
 
 using VGMMetadataHintQuery = VGMMetadataHintTarget;

--- a/src/main/components/VGMMetadataHint.h
+++ b/src/main/components/VGMMetadataHint.h
@@ -1,0 +1,172 @@
+/*
+ * VGMTrans (c) 2002-2026
+ * Licensed under the zlib license,
+ * refer to the included LICENSE.txt file
+ */
+#pragma once
+
+#include "base/Types.h"
+#include "VGMTag.h"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+struct VGMMetadataHint {
+  std::string targetFormat;
+  std::string sourceFormat;
+  std::filesystem::path sourcePath;
+  VGMTag tag;
+  std::optional<u32> songIndex;
+  std::optional<u32> romAddress;
+  std::optional<u32> fileOffset;
+  std::optional<std::string> lookupKey;
+};
+
+struct VGMMetadataHintQuery {
+  std::string targetFormat;
+  std::optional<u32> songIndex;
+  std::optional<u32> romAddress;
+  std::optional<u32> fileOffset;
+  std::optional<std::string> lookupKey;
+};
+
+class VGMMetadataHintProvider {
+public:
+  virtual ~VGMMetadataHintProvider() = default;
+
+  [[nodiscard]] virtual const VGMMetadataHint* findHint(
+      const VGMMetadataHintQuery& query) const = 0;
+  [[nodiscard]] virtual const std::vector<VGMMetadataHint>& allHints() const = 0;
+};
+
+class IndexedMetadataHintProvider final : public VGMMetadataHintProvider {
+public:
+  explicit IndexedMetadataHintProvider(std::vector<VGMMetadataHint> hints)
+      : m_hints(std::move(hints)) {
+    buildIndexes();
+  }
+
+  [[nodiscard]] const VGMMetadataHint* findHint(
+      const VGMMetadataHintQuery& query) const override {
+    if (query.songIndex) {
+      if (const auto* hint = findIndexed(m_bySongIndex, query.targetFormat, *query.songIndex);
+          hint && matchesQuery(*hint, query)) {
+        return hint;
+      }
+    }
+
+    if (query.romAddress) {
+      if (const auto* hint = findIndexed(m_byRomAddress, query.targetFormat, *query.romAddress);
+          hint && matchesQuery(*hint, query)) {
+        return hint;
+      }
+    }
+
+    if (query.fileOffset) {
+      if (const auto* hint = findIndexed(m_byFileOffset, query.targetFormat, *query.fileOffset);
+          hint && matchesQuery(*hint, query)) {
+        return hint;
+      }
+    }
+
+    if (query.lookupKey) {
+      if (const auto* hint = findIndexed(m_byLookupKey, query.targetFormat, *query.lookupKey);
+          hint && matchesQuery(*hint, query)) {
+        return hint;
+      }
+    }
+
+    for (const auto& hint : m_hints) {
+      if (matchesQuery(hint, query)) {
+        return &hint;
+      }
+    }
+
+    return nullptr;
+  }
+
+  [[nodiscard]] const std::vector<VGMMetadataHint>& allHints() const override {
+    return m_hints;
+  }
+
+private:
+  using Index = std::unordered_map<std::string, std::unordered_map<u32, size_t>>;
+  using StringIndex = std::unordered_map<std::string, std::unordered_map<std::string, size_t>>;
+
+  std::vector<VGMMetadataHint> m_hints;
+  Index m_bySongIndex;
+  Index m_byRomAddress;
+  Index m_byFileOffset;
+  StringIndex m_byLookupKey;
+
+  static bool matchesQuery(const VGMMetadataHint& hint, const VGMMetadataHintQuery& query) {
+    if (!query.targetFormat.empty() && hint.targetFormat != query.targetFormat) {
+      return false;
+    }
+    if (query.songIndex && hint.songIndex != query.songIndex) {
+      return false;
+    }
+    if (query.romAddress && hint.romAddress != query.romAddress) {
+      return false;
+    }
+    if (query.fileOffset && hint.fileOffset != query.fileOffset) {
+      return false;
+    }
+    if (query.lookupKey && hint.lookupKey != query.lookupKey) {
+      return false;
+    }
+    return true;
+  }
+
+  void buildIndexes() {
+    for (size_t i = 0; i < m_hints.size(); i++) {
+      const auto& hint = m_hints[i];
+      if (hint.songIndex) {
+        m_bySongIndex[hint.targetFormat].try_emplace(*hint.songIndex, i);
+      }
+      if (hint.romAddress) {
+        m_byRomAddress[hint.targetFormat].try_emplace(*hint.romAddress, i);
+      }
+      if (hint.fileOffset) {
+        m_byFileOffset[hint.targetFormat].try_emplace(*hint.fileOffset, i);
+      }
+      if (hint.lookupKey) {
+        m_byLookupKey[hint.targetFormat].try_emplace(*hint.lookupKey, i);
+      }
+    }
+  }
+
+  [[nodiscard]] const VGMMetadataHint* findIndexed(
+      const Index& index, const std::string& targetFormat, u32 key) const {
+    const auto formatIt = index.find(targetFormat);
+    if (formatIt == index.end()) {
+      return nullptr;
+    }
+
+    const auto valueIt = formatIt->second.find(key);
+    if (valueIt == formatIt->second.end()) {
+      return nullptr;
+    }
+
+    return &m_hints[valueIt->second];
+  }
+
+  [[nodiscard]] const VGMMetadataHint* findIndexed(
+      const StringIndex& index, const std::string& targetFormat, const std::string& key) const {
+    const auto formatIt = index.find(targetFormat);
+    if (formatIt == index.end()) {
+      return nullptr;
+    }
+
+    const auto valueIt = formatIt->second.find(key);
+    if (valueIt == formatIt->second.end()) {
+      return nullptr;
+    }
+
+    return &m_hints[valueIt->second];
+  }
+};

--- a/src/main/formats/MP2k/MP2kScanner.cpp
+++ b/src/main/formats/MP2k/MP2kScanner.cpp
@@ -20,6 +20,7 @@
 #include "MP2kInstrSet.h"
 #include "MP2kSeq.h"
 #include "ScannerManager.h"
+#include "VGMMetadataHint.h"
 #include "VGMColl.h"
 
 #include <array>
@@ -28,6 +29,7 @@
 #include <optional>
 #include <set>
 #include <span>
+#include <string>
 #include <vector>
 
 #include <spdlog/fmt/fmt.h>
@@ -57,8 +59,33 @@ struct EngineParams {
 
 struct MP2kSeqWithIndex {
   u32 song_index;
+  std::string collection_name;
   MP2kSeq *seq;
 };
+
+constexpr auto MP2K_FORMAT_NAME = "MP2k";
+constexpr u32 GBA_ROM_BASE = 0x08000000;
+
+const VGMMetadataHint* findMP2kMetadataHint(RawFile* file, u32 song_index, u32 song_pointer) {
+  if (const auto* hint = file->findMetadataHint(VGMMetadataHintQuery{
+      .targetFormat = MP2K_FORMAT_NAME,
+      .songIndex = song_index,
+  })) {
+    return hint;
+  }
+
+  if (const auto* hint = file->findMetadataHint(VGMMetadataHintQuery{
+      .targetFormat = MP2K_FORMAT_NAME,
+      .romAddress = GBA_ROM_BASE | song_pointer,
+  })) {
+    return hint;
+  }
+
+  return file->findMetadataHint(VGMMetadataHintQuery{
+      .targetFormat = MP2K_FORMAT_NAME,
+      .fileOffset = song_pointer,
+  });
+}
 
 /* Test if an area of ROM is eligible to be the base pointer */
 static bool test_pointer_validity(RawFile *file, size_t offset, u32 inGBA_length) {
@@ -121,7 +148,11 @@ void MP2kScanner::scan(RawFile *file, void *) {
       break;
     }
 
-    auto* nseq = pRoot->loadVGMFile<MP2kSeq>(file, song_pointer);
+    const auto* hint = findMP2kMetadataHint(file, song_index, song_pointer);
+    const bool hasHintTitle = hint != nullptr && hint->tag.hasTitle();
+    const auto seq_name = hasHintTitle ? hint->tag.title : std::string("MP2kSeq");
+
+    auto* nseq = pRoot->loadVGMFile<MP2kSeq>(file, song_pointer, seq_name);
     if (!nseq) {
       continue;
     }
@@ -129,11 +160,13 @@ void MP2kScanner::scan(RawFile *file, void *) {
     /* Load the soundbanks later because we need to know the number of instruments in each of
      * them */
     u32 inst_pointer = file->get<u32>(song_pointer + 4) & 0x1FFFFFF;
+    const auto collection_name =
+        hasHintTitle ? hint->tag.title : fmt::format("MP2k Collection #{}", song_index);
     soundbanks.insert(inst_pointer);
     if (auto inst = seqs.find(inst_pointer); inst != seqs.end()) {
-      inst->second.push_back({song_index, nseq});
+      inst->second.push_back({song_index, collection_name, nseq});
     } else {
-      seqs.insert({inst_pointer, std::vector<MP2kSeqWithIndex>{{song_index, nseq}}});
+      seqs.insert({inst_pointer, std::vector<MP2kSeqWithIndex>{{song_index, collection_name, nseq}}});
     }
   }
 
@@ -151,7 +184,7 @@ void MP2kScanner::scan(RawFile *file, void *) {
       auto seq = seqs.find(*it);
       if (seq != seqs.end()) {
         for (auto seqval : seq->second) {
-          auto coll = std::make_unique<VGMColl>(fmt::format("MP2k Collection #{}", seqval.song_index));
+          auto coll = std::make_unique<VGMColl>(seqval.collection_name);
           coll->attachSeq(seqval.seq);
           coll->attachInstrSet(rawInstrSet);
           if (rawInstrSet->sampColl() != nullptr && rawInstrSet->sampColl()->hasSamples()) {

--- a/src/main/formats/NDS/NDSScanner.cpp
+++ b/src/main/formats/NDS/NDSScanner.cpp
@@ -7,6 +7,7 @@
 #include "NDSScanner.h"
 
 #include "base/Types.h"
+#include "components/VGMMetadataHint.h"
 #include "NDSInstrSet.h"
 #include "NDSSeq.h"
 #include "ScannerManager.h"
@@ -24,6 +25,45 @@ namespace vgmtrans::scanners {
 
 /* Observed from multiple samples, the maximum length of standard archives is 127 + null terminator */
 constexpr auto MAX_NAME_LEN = 128;
+constexpr auto NDS_FORMAT_NAME = "NDS";
+
+const VGMMetadataHint* findNDSMetadataHint(RawFile* file,
+                                           u32 seqIndex,
+                                           const std::string& seqName,
+                                           u32 seqOffset) {
+  if (!seqName.empty()) {
+    if (const auto* hint = file->findMetadataHint(VGMMetadataHintQuery{
+        .targetFormat = NDS_FORMAT_NAME,
+        .lookupKey = seqName,
+    })) {
+      return hint;
+    }
+  }
+
+  if (const auto* hint = file->findMetadataHint(VGMMetadataHintQuery{
+      .targetFormat = NDS_FORMAT_NAME,
+      .songIndex = seqIndex,
+  })) {
+    return hint;
+  }
+
+  return file->findMetadataHint(VGMMetadataHintQuery{
+      .targetFormat = NDS_FORMAT_NAME,
+      .fileOffset = seqOffset,
+  });
+}
+
+std::string displayNameForNDSSeq(RawFile* file,
+                                 u32 seqIndex,
+                                 const std::string& seqName,
+                                 u32 seqOffset) {
+  const auto* hint = findNDSMetadataHint(file, seqIndex, seqName, seqOffset);
+  if (hint && hint->tag.hasTitle()) {
+    return hint->tag.title;
+  }
+
+  return seqName;
+}
 
 void NDSScanner::scan(RawFile* file, void* /*info*/) {
   searchForSDAT(file);
@@ -248,13 +288,14 @@ u32 NDSScanner::loadFromSDAT(RawFile *file, u32 baseOff) {
       u32 pSeqFatData = file->readWord(offset) + baseOff;
       offset += 4;
       u32 fileSize = file->readWord(offset);
-      auto* NewNDSSeq = pRoot->loadVGMFile<NDSSeq>(file, pSeqFatData, fileSize, seqNames[i]);
+      const auto displayName = displayNameForNDSSeq(file, i, seqNames[i], pSeqFatData);
+      auto* NewNDSSeq = pRoot->loadVGMFile<NDSSeq>(file, pSeqFatData, fileSize, displayName);
       if (!NewNDSSeq) {
         L_ERROR("Failed to load NDSSeq at 0x{:08X}", pSeqFatData);
         continue;
       }
 
-      auto coll = std::make_unique<VGMColl>(seqNames[i]);
+      auto coll = std::make_unique<VGMColl>(displayName);
       coll->attachSeq(NewNDSSeq);
       u32 bnkIndex = 0;
       for (u32 j = 0; j < BNKs.size(); j++) {

--- a/src/main/io/RawFile.cpp
+++ b/src/main/io/RawFile.cpp
@@ -82,8 +82,10 @@ VirtFile::VirtFile(const RawFile &file, size_t offset, size_t limit)
 }
 
 VirtFile::VirtFile(const u8 *data, u32 fileSize, std::string name,
-                   std::filesystem::path parent_fullpath, const VGMTag& tag)
+                   std::filesystem::path parent_fullpath, const VGMTag& tag,
+                   std::shared_ptr<const VGMMetadataHintProvider> metadataHintProvider)
     : m_name(std::move(name)), m_lpath(std::move(parent_fullpath)) {
   std::copy_n(data, fileSize, std::back_inserter(m_data));
   this->tag = tag;
+  setMetadataHintProvider(std::move(metadataHintProvider));
 }

--- a/src/main/io/RawFile.h
+++ b/src/main/io/RawFile.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "base/Types.h"
+#include "components/VGMMetadataHint.h"
 #include "components/VGMTag.h"
 #include "Root.h"
 #include "util/Path.h"
@@ -124,10 +125,22 @@ class RawFile {
     void addContainedVGMFile(VGMFileVariant);
     void removeContainedVGMFile(VGMFileVariant);
 
+    void setMetadataHintProvider(std::shared_ptr<const VGMMetadataHintProvider> provider) {
+      m_metadataHintProvider = std::move(provider);
+    }
+    [[nodiscard]] std::shared_ptr<const VGMMetadataHintProvider> metadataHintProvider() const {
+      return m_metadataHintProvider;
+    }
+    [[nodiscard]] const VGMMetadataHint* findMetadataHint(
+        const VGMMetadataHintQuery& query) const {
+      return m_metadataHintProvider ? m_metadataHintProvider->findHint(query) : nullptr;
+    }
+
     VGMTag tag;
 
    private:
     std::vector<VGMFileVariant> m_vgmfiles;
+    std::shared_ptr<const VGMMetadataHintProvider> m_metadataHintProvider;
     enum ProcessFlags { UseLoaders = 1, UseScanners = 2 };
     unsigned m_flags = UseLoaders | UseScanners;
 };
@@ -169,7 +182,8 @@ class VirtFile final : public RawFile {
     VirtFile(const RawFile &, size_t offset = 0);
     VirtFile(const RawFile &, size_t offset, size_t limit);
     VirtFile(const u8 *data, u32 size, std::string name, std::filesystem::path parent_fullpath = "",
-             const VGMTag& tag = VGMTag());
+             const VGMTag& tag = VGMTag(),
+             std::shared_ptr<const VGMMetadataHintProvider> metadataHintProvider = nullptr);
     ~VirtFile() override = default;
 
     [[nodiscard]] std::string name() const override { return m_name; };

--- a/src/main/loaders/PSFLoader.cpp
+++ b/src/main/loaders/PSFLoader.cpp
@@ -152,14 +152,13 @@ std::optional<VGMMetadataHint> hintFromGsf(const PSFFile& psf,
   }
 
   return VGMMetadataHint{
-      .targetFormat = MP2K_FORMAT_NAME,
+      .target = {
+          .targetFormat = MP2K_FORMAT_NAME,
+          .songIndex = songIndex,
+      },
       .sourceFormat = "GSF",
       .sourcePath = sourcePath,
       .tag = PSFFile::tagFromPSFFile(psf),
-      .songIndex = songIndex,
-      .romAddress = std::nullopt,
-      .fileOffset = std::nullopt,
-      .lookupKey = std::nullopt,
   };
 }
 
@@ -236,14 +235,13 @@ std::optional<VGMMetadataHint> hintFromNdsPsf(const PSFFile& psf,
   }
 
   return VGMMetadataHint{
-      .targetFormat = NDS_FORMAT_NAME,
+      .target = {
+          .targetFormat = NDS_FORMAT_NAME,
+          .lookupKey = origFilename->second,
+      },
       .sourceFormat = ndsSourceFormat(psf.version()),
       .sourcePath = sourcePath,
       .tag = PSFFile::tagFromPSFFile(psf),
-      .songIndex = std::nullopt,
-      .romAddress = std::nullopt,
-      .fileOffset = std::nullopt,
-      .lookupKey = origFilename->second,
   };
 }
 

--- a/src/main/loaders/PSFLoader.cpp
+++ b/src/main/loaders/PSFLoader.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <string>
@@ -52,6 +53,7 @@ struct Image {
 constexpr int MAX_RECURSION = 10;
 constexpr u32 GBA_ROM_BASE = 0x08000000;
 constexpr auto MP2K_FORMAT_NAME = "MP2k";
+constexpr auto NDS_FORMAT_NAME = "NDS";
 
 void overlay(Image &img, u32 addr, const u8 *data, size_t size) {
   if (!size)
@@ -93,6 +95,19 @@ std::filesystem::path resolveLibPath(const std::filesystem::path& basepath,
 bool isGsfMetadataCandidate(const std::filesystem::path& path) {
   const auto ext = toLower(pathToUtf8String(path.extension()));
   return ext == ".gsf" || ext == ".minigsf";
+}
+
+bool isNdsMetadataCandidate(const std::filesystem::path& path) {
+  const auto ext = toLower(pathToUtf8String(path.extension()));
+  return ext == ".2sf" || ext == ".mini2sf" || ext == ".ncsf" || ext == ".minincsf";
+}
+
+bool isNdsPsfVersion(int version) {
+  return version == NDS2SF_VERSION || version == NCSF_VERSION;
+}
+
+const char* ndsSourceFormat(int version) {
+  return version == NCSF_VERSION ? "NCSF" : "2SF";
 }
 
 std::optional<u32> selectedSongIndexFromGsf(const PSFFile& psf) {
@@ -209,6 +224,91 @@ std::vector<VGMMetadataHint> collectGsfMetadataHints(const RawFile* file, const 
   return hints;
 }
 
+std::optional<VGMMetadataHint> hintFromNdsPsf(const PSFFile& psf,
+                                             const std::filesystem::path& sourcePath) {
+  if (!isNdsPsfVersion(psf.version())) {
+    return std::nullopt;
+  }
+
+  const auto origFilename = psf.tags().find("origFilename");
+  if (origFilename == psf.tags().end() || origFilename->second.empty()) {
+    return std::nullopt;
+  }
+
+  return VGMMetadataHint{
+      .targetFormat = NDS_FORMAT_NAME,
+      .sourceFormat = ndsSourceFormat(psf.version()),
+      .sourcePath = sourcePath,
+      .tag = PSFFile::tagFromPSFFile(psf),
+      .songIndex = std::nullopt,
+      .romAddress = std::nullopt,
+      .fileOffset = std::nullopt,
+      .lookupKey = origFilename->second,
+  };
+}
+
+std::vector<VGMMetadataHint> collectNdsMetadataHints(const RawFile* file, const PSFFile& psf) {
+  std::vector<VGMMetadataHint> hints;
+  if (!isNdsPsfVersion(psf.version())) {
+    return hints;
+  }
+
+  auto lib = findLibTag(psf);
+  if (!lib) {
+    return hints;
+  }
+
+  if (auto hint = hintFromNdsPsf(psf, file->path())) {
+    hints.emplace_back(std::move(*hint));
+  }
+
+  const auto basepath = file->path().parent_path();
+  std::error_code ec;
+  if (basepath.empty() || !std::filesystem::is_directory(basepath, ec)) {
+    return hints;
+  }
+
+  const auto expectedLibPath = resolveLibPath(basepath, *lib);
+  const auto openedPath = std::filesystem::absolute(file->path()).lexically_normal();
+
+  for (const auto& entry : std::filesystem::directory_iterator(basepath, ec)) {
+    if (ec) {
+      break;
+    }
+    if (!entry.is_regular_file(ec) || !isNdsMetadataCandidate(entry.path())) {
+      continue;
+    }
+
+    const auto siblingPath = std::filesystem::absolute(entry.path()).lexically_normal();
+    if (siblingPath == openedPath) {
+      continue;
+    }
+
+    try {
+      DiskFile siblingFile(entry.path());
+      PSFFile siblingPsf(siblingFile);
+      if (!isNdsPsfVersion(siblingPsf.version())) {
+        continue;
+      }
+
+      auto siblingLib = findLibTag(siblingPsf);
+      if (!siblingLib ||
+          resolveLibPath(entry.path().parent_path(), *siblingLib) != expectedLibPath) {
+        continue;
+      }
+
+      if (auto hint = hintFromNdsPsf(siblingPsf, entry.path())) {
+        hints.emplace_back(std::move(*hint));
+      }
+    } catch (const std::exception& e) {
+      L_DEBUG("Ignoring NDS PSF metadata candidate '{}': {}",
+              pathToUtf8String(entry.path()), e.what());
+    }
+  }
+
+  return hints;
+}
+
 void load_with_libs(const PSFFile &psf, const std::filesystem::path &basepath, Image &img,
                     int depth = 0) {
   if (depth >= MAX_RECURSION)
@@ -287,6 +387,9 @@ void PSFLoader::psf_read_exe(const RawFile *file) {
       auto tag = PSFFile::tagFromPSFFile(psf);
       std::shared_ptr<const VGMMetadataHintProvider> metadataProvider;
       auto hints = collectGsfMetadataHints(file, psf);
+      auto ndsHints = collectNdsMetadataHints(file, psf);
+      hints.insert(hints.end(), std::make_move_iterator(ndsHints.begin()),
+                   std::make_move_iterator(ndsHints.end()));
       if (!hints.empty()) {
         metadataProvider = std::make_shared<IndexedMetadataHintProvider>(std::move(hints));
       }

--- a/src/main/loaders/PSFLoader.cpp
+++ b/src/main/loaders/PSFLoader.cpp
@@ -7,13 +7,18 @@
 #include "PSFLoader.h"
 
 #include "base/Types.h"
+#include "components/VGMMetadataHint.h"
 #include "LoaderManager.h"
 #include "LogManager.h"
 #include "PSFFile.h"
+#include "util/Path.h"
+#include "util/Text.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -45,6 +50,8 @@ struct Image {
 };
 
 constexpr int MAX_RECURSION = 10;
+constexpr u32 GBA_ROM_BASE = 0x08000000;
+constexpr auto MP2K_FORMAT_NAME = "MP2k";
 
 void overlay(Image &img, u32 addr, const u8 *data, size_t size) {
   if (!size)
@@ -66,6 +73,140 @@ void overlay(Image &img, u32 addr, const u8 *data, size_t size) {
     img.end = new_end;
   }
   std::copy(data, data + size, img.data.begin() + (addr - img.start));
+}
+
+std::optional<std::string> findLibTag(const PSFFile& psf) {
+  if (auto it = psf.tags().find("_lib"); it != psf.tags().end()) {
+    return it->second;
+  }
+  if (auto it = psf.tags().find("_Lib"); it != psf.tags().end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
+std::filesystem::path resolveLibPath(const std::filesystem::path& basepath,
+                                     const std::string& libname) {
+  return std::filesystem::absolute(basepath / libname).lexically_normal();
+}
+
+bool isGsfMetadataCandidate(const std::filesystem::path& path) {
+  const auto ext = toLower(pathToUtf8String(path.extension()));
+  return ext == ".gsf" || ext == ".minigsf";
+}
+
+std::optional<u32> selectedSongIndexFromGsf(const PSFFile& psf) {
+  if (psf.version() != GSF_VERSION) {
+    return std::nullopt;
+  }
+
+  const auto& exe = psf.exe();
+  const auto payloadOffset = data_offset.at(GSF_VERSION);
+  if (exe.size() <= payloadOffset) {
+    return std::nullopt;
+  }
+
+  const u32 address = psf.getExe<u32>(0);
+  if (address != GBA_ROM_BASE) {
+    return std::nullopt;
+  }
+
+  const auto* payload = exe.data() + payloadOffset;
+  const size_t payloadSize = exe.size() - payloadOffset;
+  if (payloadSize == sizeof(u32)) {
+    return static_cast<u32>(payload[0]) |
+           (static_cast<u32>(payload[1]) << 8) |
+           (static_cast<u32>(payload[2]) << 16) |
+           (static_cast<u32>(payload[3]) << 24);
+  }
+  if (payloadSize == sizeof(u16)) {
+    return static_cast<u32>(payload[0]) | (static_cast<u32>(payload[1]) << 8);
+  }
+  if (payloadSize == sizeof(u8)) {
+    return static_cast<u32>(payload[0]);
+  }
+
+  return std::nullopt;
+}
+
+std::optional<VGMMetadataHint> hintFromGsf(const PSFFile& psf,
+                                           const std::filesystem::path& sourcePath) {
+  auto songIndex = selectedSongIndexFromGsf(psf);
+  if (!songIndex) {
+    return std::nullopt;
+  }
+
+  return VGMMetadataHint{
+      .targetFormat = MP2K_FORMAT_NAME,
+      .sourceFormat = "GSF",
+      .sourcePath = sourcePath,
+      .tag = PSFFile::tagFromPSFFile(psf),
+      .songIndex = songIndex,
+      .romAddress = std::nullopt,
+      .fileOffset = std::nullopt,
+      .lookupKey = std::nullopt,
+  };
+}
+
+std::vector<VGMMetadataHint> collectGsfMetadataHints(const RawFile* file, const PSFFile& psf) {
+  std::vector<VGMMetadataHint> hints;
+  if (psf.version() != GSF_VERSION) {
+    return hints;
+  }
+
+  auto lib = findLibTag(psf);
+  if (!lib) {
+    return hints;
+  }
+
+  if (auto hint = hintFromGsf(psf, file->path())) {
+    hints.emplace_back(std::move(*hint));
+  }
+
+  const auto basepath = file->path().parent_path();
+  std::error_code ec;
+  if (basepath.empty() || !std::filesystem::is_directory(basepath, ec)) {
+    return hints;
+  }
+
+  const auto expectedLibPath = resolveLibPath(basepath, *lib);
+  const auto openedPath = std::filesystem::absolute(file->path()).lexically_normal();
+
+  for (const auto& entry : std::filesystem::directory_iterator(basepath, ec)) {
+    if (ec) {
+      break;
+    }
+    if (!entry.is_regular_file(ec) || !isGsfMetadataCandidate(entry.path())) {
+      continue;
+    }
+
+    const auto siblingPath = std::filesystem::absolute(entry.path()).lexically_normal();
+    if (siblingPath == openedPath) {
+      continue;
+    }
+
+    try {
+      DiskFile siblingFile(entry.path());
+      PSFFile siblingPsf(siblingFile);
+      if (siblingPsf.version() != GSF_VERSION) {
+        continue;
+      }
+
+      auto siblingLib = findLibTag(siblingPsf);
+      if (!siblingLib ||
+          resolveLibPath(entry.path().parent_path(), *siblingLib) != expectedLibPath) {
+        continue;
+      }
+
+      if (auto hint = hintFromGsf(siblingPsf, entry.path())) {
+        hints.emplace_back(std::move(*hint));
+      }
+    } catch (const std::exception& e) {
+      L_DEBUG("Ignoring GSF metadata candidate '{}': {}", pathToUtf8String(entry.path()), e.what());
+    }
+  }
+
+  return hints;
 }
 
 void load_with_libs(const PSFFile &psf, const std::filesystem::path &basepath, Image &img,
@@ -144,7 +285,14 @@ void PSFLoader::psf_read_exe(const RawFile *file) {
     load_with_libs(psf, file->path().parent_path(), img);
     if (!img.data.empty()) {
       auto tag = PSFFile::tagFromPSFFile(psf);
-      enqueue(std::make_unique<VirtFile>(img.data.data(), img.data.size(), file->name(), file->path(), tag));
+      std::shared_ptr<const VGMMetadataHintProvider> metadataProvider;
+      auto hints = collectGsfMetadataHints(file, psf);
+      if (!hints.empty()) {
+        metadataProvider = std::make_shared<IndexedMetadataHintProvider>(std::move(hints));
+      }
+
+      enqueue(std::make_unique<VirtFile>(img.data.data(), img.data.size(), file->name(),
+                                         file->path(), tag, std::move(metadataProvider)));
     }
   } catch (std::exception &e) {
     L_ERROR(e.what());


### PR DESCRIPTION
## Description
Adds a generic metadata hint provider system for `RawFile`, then uses it to preserve PSF-family soundtrack metadata when scanners operate on reconstructed virtual ROM/SDAT contents.

This change adds indexed metadata hints that loaders can attach to derived `VirtFile`s. `PSFLoader` now harvests sibling  files sharing the same `_lib`, extracts relevant tags and attaches hints for:
- GSF/miniGSF MP2k tracks, indexed primarily by MP2k song index
- 2SF/NCSF NDS tracks, indexed by SDAT sequence lookup key from `origFilename`

`MP2kScanner` and `NDSScanner` consume those hints to name matching sequences/collections from soundtrack tags while still scanning all valid entries.

Also adds reading the length tag from PSF files.

`VGMMetadataHintTarget`/`VGMMetadataHintQuery` describe how a scanner can identify a track-like object inside the reconstructed data. 

Scanners build one when they want to ask, “do we have metadata for this thing I just found?”. For example, MP2k can query by song-table index, while NDS can query by SDAT sequence name via `lookupKey`.

`VGMMetadataHint` wraps that target with the metadata source:

```cpp
target
sourceFormat
sourcePath
tag
```

So the hint says both “what scanned object this applies to” and “which source file/tag produced it.”

`VGMMetadataHintProvider` is the lookup interface attached to `RawFile`. Loaders can attach a provider to a derived `VirtFile`; scanners then call `file->findMetadataHint(query)` without needing to know where the hints came from.

The current implementation, `IndexedMetadataHintProvider`, builds indexes at construction time for O(1) lookup by song index, ROM address, file offset, or lookup key. Its stored hints and indexes are immutable after construction. If an indexed lookup is unavailable or ambiguous, it can still fall back to checking the stored hints using the full query match.

## Motivation and Context
Sometimes, opening *SF files results in many songs being loaded and the user doesn't know which collection maps to which collection. This results in a very time consuming process to go find the right sequence by converting them en masse (e.g. certain Mother 3 rips).

Opening files such as `.minigsf` or `.minincsf` reconstructs the whole backing ROM/SDAT, so scanners lose the per-track metadata from the file the user actually opened. This made MP2k tracks show as generic `MP2k Collection #n`, and NDS tracks show internal SDAT names (when available) like `BGM_JOHN`.

## How Has This Been Tested?
Tested on macOS.

- miniGSF Advance Wars shows soundtrack titles like `Opening`, `Eagle's Theme`
- direct `.gsflib` still shows fallback `MP2k Collection #...`
- miniNCSF Advance Wars Dual Strike shows soundtrack titles like `Jake's Theme`
- direct `.ncsflib` still shows internal names like `BGM_JOHN`
- PS1 PSF loading remains unchanged

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.