### PR TITLE
VGMSamp: Correctly account for PCM8 signedness on export

### DIFF
--- a/src/main/components/instr/VGMSamp.cpp
+++ b/src/main/components/instr/VGMSamp.cpp
@@ -131,7 +131,8 @@ bool VGMSamp::onSaveAsWav() {
 bool VGMSamp::saveAsWav(const std::filesystem::path &filepath) {
   u32 bufSize = uncompressedSize();
 
-  std::vector<u8> uncompSampBuf = toPcm(Signedness::Signed, Endianness::Little, m_bps);
+  const auto wavSignedness = (m_bps == BPS::PCM8) ? Signedness::Unsigned : Signedness::Signed;
+  std::vector<u8> uncompSampBuf = toPcm(wavSignedness, Endianness::Little, m_bps);
   bufSize = static_cast<u32>(uncompSampBuf.size());
 
   u16 blockAlign = bytesPerSample() * channels;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`saveAsWav()` always wants signed PCM but we store PCM8 as unsigned, hence disaster.
This is not the cleanest fix.. 

## Motivation and Context
- Fixes #926 
- Fixes #917 

## How Has This Been Tested?
Manually verified the samples sound accurate

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
