### PR TITLE
Bump Flatpak KDE runtime to 6.11

### DIFF
--- a/build-aux/flatpak/io.github.vgmtrans.vgmtrans.yaml
+++ b/build-aux/flatpak/io.github.vgmtrans.vgmtrans.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.vgmtrans.vgmtrans
 runtime: org.kde.Platform
-runtime-version: '6.10'
+runtime-version: '6.11'
 sdk: org.kde.Sdk
 command: vgmtrans
 finish-args:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bumps the Flatpak KDE runtime to 6.11.

## Motivation and Context
To address linter message.

## How Has This Been Tested?
Ran on Linux, seems fine

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
